### PR TITLE
1. bumped version of System.Text.Json from 8.0.4 to 8.0.5, syncing up…

### DIFF
--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -30,7 +30,7 @@
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="YamlDotnet" Version="13.7.1" />
 		<!-- upgrade because of transitive dependency vulnerability https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
-		<PackageReference Include="System.Text.Json" Version="8.0.4" />
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 		<!-- upgrade because of transitive dependency vulnerability https://github.com/advisories/GHSA-447r-wph3-92pm -->
 		<PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
 	</ItemGroup>

--- a/src/EventStore.SourceGenerators/EventStore.SourceGenerators.csproj
+++ b/src/EventStore.SourceGenerators/EventStore.SourceGenerators.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<!-- <TargetFramework>netstandard2.0</TargetFramework> -->
 		<RunAnalyzers>false</RunAnalyzers>
 	</PropertyGroup>
 	<ItemGroup>

--- a/src/qodana.yaml
+++ b/src/qodana.yaml
@@ -1,0 +1,29 @@
+#-------------------------------------------------------------------------------#
+#               Qodana analysis is configured by qodana.yaml file               #
+#             https://www.jetbrains.com/help/qodana/qodana-yaml.html            #
+#-------------------------------------------------------------------------------#
+version: "1.0"
+
+#Specify IDE code to run analysis without container (Applied in CI/CD pipeline)
+ide: QDNET
+
+#Specify inspection profile for code analysis
+profile:
+  name: qodana.starter
+
+#Enable inspections
+#include:
+#  - name: <SomeEnabledInspectionId>
+
+#Disable inspections
+#exclude:
+#  - name: <SomeDisabledInspectionId>
+#    paths:
+#      - <path/where/not/run/inspection>
+
+#Execute shell command before Qodana execution (Applied in CI/CD pipeline)
+#bootstrap: sh ./prepare-qodana.sh
+
+#Install IDE plugins before Qodana execution (Applied in CI/CD pipeline)
+#plugins:
+#  - id: <plugin.id> #(plugin id can be found at https://plugins.jetbrains.com)


### PR DESCRIPTION
1. bumped version of System.Text.Json from 8.0.4 to 8.0.5

~> version 8.0.4 made the compiler complain about security vulnerabilities, so we bumped it to 8.0.5

2. commented out (marked for removal) the build target override in  EventStore.CodeGenerators.csproj 

~> EventStore.CodeGenerators.csproj/TargetFrameworks explicitly pointed to NETStandard2.0, this made build.sh fail. Commenting it out fixed this.