### PR TITLE
refactor: update HashListMemTable and related interfaces for improved concurrency and readability

### DIFF
--- a/src/EventStore.Core/Index/HashListMemTable.cs
+++ b/src/EventStore.Core/Index/HashListMemTable.cs
@@ -3,343 +3,381 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using DotNext.Threading;
 using EventStore.Common.Utils;
 using EventStore.Core.Exceptions;
 
-namespace EventStore.Core.Index {
-	public class HashListMemTable : IMemTable, ISearchTable {
-		private static readonly IComparer<Entry> MemTableComparer = new EventNumberComparer();
-		private static readonly IComparer<Entry> LogPosComparer = new LogPositionComparer();
+namespace EventStore.Core.Index;
 
-		public long Count {
-			get { return _count; }
-		}
+public class HashListMemTable : IMemTable
+{
+	private static readonly IComparer<Entry> MemTableComparer = new EventNumberComparer();
+	private static readonly IComparer<Entry> LogPosComparer = new LogPositionComparer();
+	private static readonly TimeSpan DefaultLockTimeout = TimeSpan.FromMilliseconds(10_000);
 
-		public Guid Id {
-			get { return _id; }
-		}
+	public long Count
+	{
+		get { return _count; }
+	}
 
-		public byte Version {
-			get { return _version; }
-		}
+	public Guid Id
+	{
+		get { return _id; }
+	}
 
-		private readonly ConcurrentDictionary<ulong, SortedList<Entry, byte>> _hash;
-		private readonly Guid _id = Guid.NewGuid();
-		private readonly byte _version;
-		private int _count;
+	public byte Version
+	{
+		get { return _version; }
+	}
 
-		private int _isConverting;
+	private readonly ConcurrentDictionary<ulong, EntryList> _hash;
+	private readonly Guid _id = Guid.NewGuid();
+	private readonly byte _version;
+	private int _count;
 
-		public HashListMemTable(byte version, int maxSize) {
-			_version = version;
-			_hash = new ConcurrentDictionary<ulong, SortedList<Entry, byte>>();
-		}
+	private int _isConverting;
 
-		public bool MarkForConversion() {
-			return Interlocked.CompareExchange(ref _isConverting, 1, 0) == 0;
-		}
+	public HashListMemTable(byte version, int maxSize)
+	{
+		_version = version;
+		_hash = new();
+	}
 
-		public void Add(ulong stream, long version, long position) {
-			AddEntries(new[] {new IndexEntry(stream, version, position)});
-		}
+	public bool MarkForConversion() =>
+		Interlocked.CompareExchange(ref _isConverting, 1, 0) is 0;
 
-		public void AddEntries(IList<IndexEntry> entries) {
-			Ensure.NotNull(entries, "entries");
-			Ensure.Positive(entries.Count, "entries.Count");
+	public void Add(ulong stream, long version, long position) =>
+		AddEntries([new IndexEntry(stream, version, position)]);
 
-			var collection = entries.Select(x => new IndexEntry(GetHash(x.Stream), x.Version, x.Position)).ToList();
+	public void AddEntries(IReadOnlyList<IndexEntry> entries)
+	{
+		Ensure.NotNull(entries, "entries");
+		Ensure.Positive(entries.Count, "entries.Count");
 
-			// only one thread at a time can write
-			Interlocked.Add(ref _count, collection.Count);
+		var collection = entries.Select(x => new IndexEntry(GetHash(x.Stream), x.Version, x.Position)).ToList();
 
-			var stream = collection[0].Stream; // NOTE: all entries should have the same stream
-			SortedList<Entry, byte> list = null;
-			try {
+		// only one thread at a time can write
+		Interlocked.Add(ref _count, collection.Count);
 
-			if (!_hash.TryGetValue(stream, out list)) {
-				list = new SortedList<Entry, byte>(MemTableComparer);
-				if (!Monitor.TryEnter(list, 10000))
+		var stream = collection[0].Stream; // NOTE: all entries should have the same stream
+		EntryList list = null;
+		try
+		{
+
+			if (!_hash.TryGetValue(stream, out list))
+			{
+				list = new EntryList(MemTableComparer);
+				if (!list.Lock.TryEnterWriteLock(DefaultLockTimeout))
 					throw new UnableToAcquireLockInReasonableTimeException();
 				_hash.AddOrUpdate(stream, list,
-					(x, y) => {
-						throw new Exception("This should never happen as MemTable updates are single-threaded.");
-					});
-			} else{
-				if (!Monitor.TryEnter(list, 10000))
+					(x, y) => throw new Exception("This should never happen as MemTable updates are single-threaded."));
+			}
+			else
+			{
+				if (!list.Lock.TryEnterWriteLock(DefaultLockTimeout))
 					throw new UnableToAcquireLockInReasonableTimeException();
 			}
 
-				for (int i = 0, n = collection.Count; i < n; ++i) {
-					var entry = collection[i];
-					if (entry.Stream != stream)
-						throw new Exception("Not all index entries in a bulk have the same stream hash.");
-					Ensure.Nonnegative(entry.Version, "entry.Version");
-					Ensure.Nonnegative(entry.Position, "entry.Position");
-					list.Add(new Entry(entry.Version, entry.Position), 0);
-				}
-			} finally {
-				if(list != null)
-					Monitor.Exit(list);
+			for (int i = 0, n = collection.Count; i < n; ++i)
+			{
+				var entry = collection[i];
+				if (entry.Stream != stream)
+					throw new Exception("Not all index entries in a bulk have the same stream hash.");
+				Ensure.Nonnegative(entry.Version, "entry.Version");
+				Ensure.Nonnegative(entry.Position, "entry.Position");
+				list.Add(new Entry(entry.Version, entry.Position), 0);
 			}
 		}
-
-		public bool TryGetOneValue(ulong stream, long number, out long position) {
-			if (number < 0)
-				throw new ArgumentOutOfRangeException("number");
-			ulong hash = GetHash(stream);
-
-			position = 0;
-
-			SortedList<Entry, byte> list;
-			if (_hash.TryGetValue(hash, out list)) {
-				if (!Monitor.TryEnter(list, 10000)) throw new UnableToAcquireLockInReasonableTimeException();
-				try {
-					int endIdx = list.UpperBound(new Entry(number, long.MaxValue));
-					if (endIdx == -1)
-						return false;
-
-					var key = list.Keys[endIdx];
-					if (key.EvNum == number) {
-						position = key.LogPos;
-						return true;
-					}
-				} finally {
-					Monitor.Exit(list);
-				}
-			}
-
-			return false;
+		finally
+		{
+			list?.Lock.Release();
 		}
+	}
 
-		public bool TryGetLatestEntry(ulong stream, out IndexEntry entry) {
-			ulong hash = GetHash(stream);
-			entry = TableIndex.InvalidIndexEntry;
+	public bool TryGetOneValue(ulong stream, long number, out long position)
+	{
+		ArgumentOutOfRangeException.ThrowIfNegative(number);
 
-			SortedList<Entry, byte> list;
-			if (_hash.TryGetValue(hash, out list)) {
-				if (!Monitor.TryEnter(list, 10000))
-					throw new UnableToAcquireLockInReasonableTimeException();
-				try {
-					var latest = list.Keys[list.Count - 1];
-					entry = new IndexEntry(hash, latest.EvNum, latest.LogPos);
-					return true;
-				} finally {
-					Monitor.Exit(list);
-				}
-			}
+		ulong hash = GetHash(stream);
+		position = 0;
 
-			return false;
-		}
+		if (!_hash.TryGetValue(hash, out var list)) return false;
 
-		public bool TryGetLatestEntry(ulong stream, long beforePosition, Func<IndexEntry, bool> isForThisStream, out IndexEntry entry) {
-			if (beforePosition < 0)
-				throw new ArgumentOutOfRangeException(nameof(beforePosition));
+		if (!list.Lock.TryEnterReadLock(DefaultLockTimeout))
+			throw new UnableToAcquireLockInReasonableTimeException();
 
-			ulong hash = GetHash(stream);
-			entry = TableIndex.InvalidIndexEntry;
-
-			if (!_hash.TryGetValue(hash, out var list))
+		try
+		{
+			int endIdx = list.UpperBound(new Entry(number, long.MaxValue));
+			if (endIdx is -1)
 				return false;
 
-			if (!Monitor.TryEnter(list, 10000))
+			var key = list.Keys[endIdx];
+			if (key.EvNum == number)
+			{
+				position = key.LogPos;
+				return true;
+			}
+		}
+		finally
+		{
+			list.Lock.Release();
+		}
+
+		return false;
+	}
+
+	public bool TryGetLatestEntry(ulong stream, out IndexEntry entry)
+	{
+		ulong hash = GetHash(stream);
+		entry = TableIndex.InvalidIndexEntry;
+
+		if (_hash.TryGetValue(hash, out var list))
+		{
+			if (!list.Lock.TryEnterReadLock(DefaultLockTimeout))
 				throw new UnableToAcquireLockInReasonableTimeException();
-
-			try {
-				// we use LogPosComparer here so that it only compares the position part of the key we
-				// are passing in and not the evNum (maxvalue) which is meaningless
-				int endIdx = list.UpperBound(
-					key: new Entry(long.MaxValue, beforePosition - 1),
-					comparer: LogPosComparer,
-					continueSearch: e => isForThisStream(new IndexEntry(hash, e.EvNum, e.LogPos)));
-
-				if (endIdx == -1)
-					return false;
-
-				var latestBeforePosition = list.Keys[endIdx];
-				entry = new IndexEntry(hash, latestBeforePosition.EvNum, latestBeforePosition.LogPos);
+			try
+			{
+				var latest = list.Keys[list.Count - 1];
+				entry = new IndexEntry(hash, latest.EvNum, latest.LogPos);
 				return true;
-			} catch (SearchStoppedException) {
-				// fall back to linear search if there was a hash collision
-				int maxIdx = list.FindMax(e =>
-					e.LogPos < beforePosition &&
-					isForThisStream(new IndexEntry(hash, e.EvNum, e.LogPos)));
-
-				if (maxIdx == -1)
-					return false;
-
-				var latestBeforePosition = list.Keys[maxIdx];
-				entry = new IndexEntry(hash, latestBeforePosition.EvNum, latestBeforePosition.LogPos);
-				return true;
-			} finally {
-				Monitor.Exit(list);
+			}
+			finally
+			{
+				list.Lock.Release();
 			}
 		}
 
-		public bool TryGetOldestEntry(ulong stream, out IndexEntry entry) {
-			ulong hash = GetHash(stream);
-			entry = TableIndex.InvalidIndexEntry;
+		return false;
+	}
 
-			SortedList<Entry, byte> list;
-			if (_hash.TryGetValue(hash, out list)) {
-				if (!Monitor.TryEnter(list, 10000))
-					throw new UnableToAcquireLockInReasonableTimeException();
-				try {
-					var oldest = list.Keys[0];
-					entry = new IndexEntry(hash, oldest.EvNum, oldest.LogPos);
-					return true;
-				} finally {
-					Monitor.Exit(list);
-				}
-			}
+	public bool TryGetLatestEntry(ulong stream, long beforePosition, Func<IndexEntry, bool> isForThisStream,
+		out IndexEntry entry)
+	{
+		ArgumentOutOfRangeException.ThrowIfNegative(beforePosition);
 
+		ulong hash = GetHash(stream);
+		entry = TableIndex.InvalidIndexEntry;
+
+		if (!_hash.TryGetValue(hash, out var list))
 			return false;
-		}
 
-		public bool TryGetNextEntry(ulong stream, long afterNumber, out IndexEntry entry) {
-			if (afterNumber < 0)
-				throw new ArgumentOutOfRangeException(nameof(afterNumber));
+		if (!list.Lock.TryEnterReadLock(DefaultLockTimeout))
+			throw new UnableToAcquireLockInReasonableTimeException();
 
-			ulong hash = GetHash(stream);
-			entry = TableIndex.InvalidIndexEntry;
+		try
+		{
+			// we use LogPosComparer here so that it only compares the position part of the key we
+			// are passing in and not the evNum (maxvalue) which is meaningless
+			int endIdx = list.UpperBound(
+				key: new Entry(long.MaxValue, beforePosition - 1),
+				comparer: LogPosComparer,
+				continueSearch: e => isForThisStream(new IndexEntry(hash, e.EvNum, e.LogPos)));
 
-			if (afterNumber >= long.MaxValue)
+			if (endIdx is -1)
 				return false;
 
-			SortedList<Entry, byte> list;
-			if (_hash.TryGetValue(hash, out list)) {
-				if (!Monitor.TryEnter(list, 10000))
-					throw new UnableToAcquireLockInReasonableTimeException();
-				try {
-					int endIdx = list.LowerBound(new Entry(afterNumber + 1, 0));
-					if (endIdx == -1)
-						return false;
-
-					var e = list.Keys[endIdx];
-					entry = new IndexEntry(hash, e.EvNum, e.LogPos);
-					return true;
-				} finally {
-					Monitor.Exit(list);
-				}
-			}
-
-			return false;
+			var latestBeforePosition = list.Keys[endIdx];
+			entry = new IndexEntry(hash, latestBeforePosition.EvNum, latestBeforePosition.LogPos);
+			return true;
 		}
+		catch (SearchStoppedException)
+		{
+			// fall back to linear search if there was a hash collision
+			int maxIdx = list.FindMax(e =>
+				e.LogPos < beforePosition &&
+				isForThisStream(new IndexEntry(hash, e.EvNum, e.LogPos)));
 
-		public bool TryGetPreviousEntry(ulong stream, long beforeNumber, out IndexEntry entry) {
-			if (beforeNumber < 0)
-				throw new ArgumentOutOfRangeException(nameof(beforeNumber));
-
-			ulong hash = GetHash(stream);
-			entry = TableIndex.InvalidIndexEntry;
-
-			if (beforeNumber <= 0)
+			if (maxIdx is -1)
 				return false;
 
-			SortedList<Entry, byte> list;
-			if (_hash.TryGetValue(hash, out list)) {
-				if (!Monitor.TryEnter(list, 10000))
-					throw new UnableToAcquireLockInReasonableTimeException();
-				try {
-					int endIdx = list.UpperBound(new Entry(beforeNumber - 1, long.MaxValue));
-					if (endIdx == -1)
-						return false;
-
-					var e = list.Keys[endIdx];
-					entry = new IndexEntry(hash, e.EvNum, e.LogPos);
-					return true;
-				} finally {
-					Monitor.Exit(list);
-				}
-			}
-
-			return false;
+			var latestBeforePosition = list.Keys[maxIdx];
+			entry = new IndexEntry(hash, latestBeforePosition.EvNum, latestBeforePosition.LogPos);
+			return true;
 		}
-
-		public IEnumerable<IndexEntry> IterateAllInOrder() {
-			//Log.Trace("Sorting array in HashListMemTable.IterateAllInOrder...");
-
-			var keys = _hash.Keys.ToArray();
-			Array.Sort(keys, new ReverseComparer<ulong>());
-
-			foreach (var key in keys) {
-				var list = _hash[key];
-				for (int i = list.Count - 1; i >= 0; --i) {
-					var x = list.Keys[i];
-					yield return new IndexEntry(key, x.EvNum, x.LogPos);
-				}
-			}
-
-			//Log.Trace("Sorting array in HashListMemTable.IterateAllInOrder... DONE!");
-		}
-
-		public void Clear() {
-			_hash.Clear();
-		}
-
-		public IList<IndexEntry> GetRange(ulong stream, long startNumber, long endNumber, int? limit = null) {
-			if (startNumber < 0)
-				throw new ArgumentOutOfRangeException("startNumber");
-			if (endNumber < 0)
-				throw new ArgumentOutOfRangeException("endNumber");
-
-			ulong hash = GetHash(stream);
-			var ret = new List<IndexEntry>();
-
-			SortedList<Entry, byte> list;
-			if (_hash.TryGetValue(hash, out list)) {
-				if (!Monitor.TryEnter(list, 10000)) throw new UnableToAcquireLockInReasonableTimeException();
-				try {
-					var endIdx = list.UpperBound(new Entry(endNumber, long.MaxValue));
-					for (int i = endIdx; i >= 0; i--) {
-						var key = list.Keys[i];
-						if (key.EvNum < startNumber || ret.Count == limit)
-							break;
-						ret.Add(new IndexEntry(hash, version: key.EvNum, position: key.LogPos));
-					}
-				} finally {
-					Monitor.Exit(list);
-				}
-			}
-
-			return ret;
-		}
-
-		private ulong GetHash(ulong hash) {
-			return _version == PTableVersions.IndexV1 ? hash >> 32 : hash;
-		}
-
-		private struct Entry {
-			public readonly long EvNum;
-			public readonly long LogPos;
-
-			public Entry(long evNum, long logPos) {
-				EvNum = evNum;
-				LogPos = logPos;
-			}
-		}
-
-		private class EventNumberComparer : IComparer<Entry> {
-			public int Compare(Entry x, Entry y) {
-				if (x.EvNum < y.EvNum) return -1;
-				if (x.EvNum > y.EvNum) return 1;
-				if (x.LogPos < y.LogPos) return -1;
-				if (x.LogPos > y.LogPos) return 1;
-				return 0;
-			}
-		}
-
-		private class LogPositionComparer : IComparer<Entry> {
-			public int Compare(Entry x, Entry y) {
-				if (x.LogPos < y.LogPos) return -1;
-				if (x.LogPos > y.LogPos) return 1;
-				return 0;
-			}
+		finally
+		{
+			list.Lock.Release();
 		}
 	}
 
-	public class ReverseComparer<T> : IComparer<T> where T : IComparable {
-		public int Compare(T x, T y) {
-			return -x.CompareTo(y);
+	public bool TryGetOldestEntry(ulong stream, out IndexEntry entry)
+	{
+		ulong hash = GetHash(stream);
+		entry = TableIndex.InvalidIndexEntry;
+
+		if (_hash.TryGetValue(hash, out var list))
+		{
+			if (!list.Lock.TryEnterReadLock(DefaultLockTimeout))
+				throw new UnableToAcquireLockInReasonableTimeException();
+			try
+			{
+				var oldest = list.Keys[0];
+				entry = new IndexEntry(hash, oldest.EvNum, oldest.LogPos);
+				return true;
+			}
+			finally
+			{
+				list.Lock.Release();
+			}
+		}
+
+		return false;
+	}
+
+	public bool TryGetNextEntry(ulong stream, long afterNumber, out IndexEntry entry)
+	{
+		ArgumentOutOfRangeException.ThrowIfNegative(afterNumber);
+
+		ulong hash = GetHash(stream);
+		entry = TableIndex.InvalidIndexEntry;
+
+		if (afterNumber >= long.MaxValue)
+			return false;
+
+		if (_hash.TryGetValue(hash, out var list))
+		{
+			if (!list.Lock.TryEnterReadLock(DefaultLockTimeout))
+				throw new UnableToAcquireLockInReasonableTimeException();
+			try
+			{
+				int endIdx = list.LowerBound(new Entry(afterNumber + 1, 0));
+				if (endIdx is -1)
+					return false;
+
+				var e = list.Keys[endIdx];
+				entry = new IndexEntry(hash, e.EvNum, e.LogPos);
+				return true;
+			}
+			finally
+			{
+				list.Lock.Release();
+			}
+		}
+
+		return false;
+	}
+
+	public bool TryGetPreviousEntry(ulong stream, long beforeNumber, out IndexEntry entry)
+	{
+		ArgumentOutOfRangeException.ThrowIfNegative(beforeNumber);
+
+		ulong hash = GetHash(stream);
+		entry = TableIndex.InvalidIndexEntry;
+
+		if (beforeNumber <= 0)
+			return false;
+
+		if (_hash.TryGetValue(hash, out var list))
+		{
+			if (!list.Lock.TryEnterReadLock(DefaultLockTimeout))
+				throw new UnableToAcquireLockInReasonableTimeException();
+			try
+			{
+				int endIdx = list.UpperBound(new Entry(beforeNumber - 1, long.MaxValue));
+				if (endIdx is -1)
+					return false;
+
+				var e = list.Keys[endIdx];
+				entry = new IndexEntry(hash, e.EvNum, e.LogPos);
+				return true;
+			}
+			finally
+			{
+				list.Lock.Release();
+			}
+		}
+
+		return false;
+	}
+
+	public IEnumerable<IndexEntry> IterateAllInOrder()
+	{
+		//Log.Trace("Sorting array in HashListMemTable.IterateAllInOrder...");
+
+		var keys = _hash.Keys.ToArray();
+		Array.Sort(keys, new ReverseComparer<ulong>());
+
+		foreach (var key in keys)
+		{
+			var list = _hash[key];
+			for (int i = list.Count - 1; i >= 0; --i)
+			{
+				var x = list.Keys[i];
+				yield return new IndexEntry(key, x.EvNum, x.LogPos);
+			}
+		}
+
+		//Log.Trace("Sorting array in HashListMemTable.IterateAllInOrder... DONE!");
+	}
+
+	public void Clear() => _hash.Clear();
+
+	public IReadOnlyList<IndexEntry> GetRange(ulong stream, long startNumber, long endNumber, int? limit = null)
+	{
+		ArgumentOutOfRangeException.ThrowIfNegative(startNumber);
+		ArgumentOutOfRangeException.ThrowIfNegative(endNumber);
+
+		ulong hash = GetHash(stream);
+		var ret = new List<IndexEntry>();
+
+		if (_hash.TryGetValue(hash, out var list))
+		{
+			if (!list.Lock.TryEnterReadLock(DefaultLockTimeout))
+				throw new UnableToAcquireLockInReasonableTimeException();
+			try
+			{
+				var endIdx = list.UpperBound(new Entry(endNumber, long.MaxValue));
+				for (int i = endIdx; i >= 0; i--)
+				{
+					var key = list.Keys[i];
+					if (key.EvNum < startNumber || ret.Count == limit)
+						break;
+					ret.Add(new IndexEntry(hash, version: key.EvNum, position: key.LogPos));
+				}
+			}
+			finally
+			{
+				list.Lock.Release();
+			}
+		}
+
+		return ret;
+	}
+
+	private ulong GetHash(ulong hash) =>
+		_version is PTableVersions.IndexV1 ? hash >> 32 : hash;
+
+	private readonly record struct Entry(long EvNum, long LogPos);
+
+	private sealed class EntryList(IComparer<Entry> comparer) : SortedList<Entry, byte>(comparer) {
+		internal readonly AsyncReaderWriterLock Lock = new();
+	}
+
+	private class EventNumberComparer : IComparer<Entry>
+	{
+		public int Compare(Entry x, Entry y)
+		{
+			if (x.EvNum < y.EvNum) return -1;
+			if (x.EvNum > y.EvNum) return 1;
+			if (x.LogPos < y.LogPos) return -1;
+			if (x.LogPos > y.LogPos) return 1;
+			return 0;
 		}
 	}
+
+	private class LogPositionComparer : IComparer<Entry>
+	{
+		public int Compare(Entry x, Entry y)
+		{
+			if (x.LogPos < y.LogPos) return -1;
+			if (x.LogPos > y.LogPos) return 1;
+			return 0;
+		}
+	}
+}
+
+public class ReverseComparer<T> : IComparer<T> where T : IComparable
+{
+	public int Compare(T x, T y) => -x.CompareTo(y);
 }

--- a/src/EventStore.Core/Index/IMemTable.cs
+++ b/src/EventStore.Core/Index/IMemTable.cs
@@ -1,9 +1,10 @@
 using System.Collections.Generic;
 
-namespace EventStore.Core.Index {
-	public interface IMemTable : ISearchTable {
-		bool MarkForConversion();
-		void Add(ulong stream, long version, long position);
-		void AddEntries(IList<IndexEntry> entries);
-	}
+namespace EventStore.Core.Index;
+
+public interface IMemTable : ISearchTable
+{
+	bool MarkForConversion();
+	void Add(ulong stream, long version, long position);
+	void AddEntries(IReadOnlyList<IndexEntry> entries);
 }

--- a/src/EventStore.Core/Index/ISearchTable.cs
+++ b/src/EventStore.Core/Index/ISearchTable.cs
@@ -1,19 +1,23 @@
 using System;
 using System.Collections.Generic;
 
-namespace EventStore.Core.Index {
-	public interface ISearchTable {
-		Guid Id { get; }
-		long Count { get; }
-		byte Version { get; }
+namespace EventStore.Core.Index;
 
-		bool TryGetOneValue(ulong stream, long number, out long position);
-		bool TryGetLatestEntry(ulong stream, out IndexEntry entry);
-		bool TryGetLatestEntry(ulong stream, long beforePosition, Func<IndexEntry,bool> isForThisStream, out IndexEntry entry);
-		bool TryGetOldestEntry(ulong stream, out IndexEntry entry);
-		bool TryGetNextEntry(ulong stream, long afterVersion, out IndexEntry entry);
-		bool TryGetPreviousEntry(ulong stream, long beforeVersion, out IndexEntry entry);
-		IList<IndexEntry> GetRange(ulong stream, long startNumber, long endNumber, int? limit = null);
-		IEnumerable<IndexEntry> IterateAllInOrder();
-	}
+public interface ISearchTable
+{
+	Guid Id { get; }
+	long Count { get; }
+	byte Version { get; }
+
+	bool TryGetOneValue(ulong stream, long number, out long position);
+	bool TryGetLatestEntry(ulong stream, out IndexEntry entry);
+
+	bool TryGetLatestEntry(ulong stream, long beforePosition, Func<IndexEntry, bool> isForThisStream,
+		out IndexEntry entry);
+
+	bool TryGetOldestEntry(ulong stream, out IndexEntry entry);
+	bool TryGetNextEntry(ulong stream, long afterVersion, out IndexEntry entry);
+	bool TryGetPreviousEntry(ulong stream, long beforeVersion, out IndexEntry entry);
+	IReadOnlyList<IndexEntry> GetRange(ulong stream, long startNumber, long endNumber, int? limit = null);
+	IEnumerable<IndexEntry> IterateAllInOrder();
 }

--- a/src/EventStore.Core/Index/PTable.cs
+++ b/src/EventStore.Core/Index/PTable.cs
@@ -15,1352 +15,1625 @@ using System.Security.Cryptography;
 using MD5 = EventStore.Core.Hashing.MD5;
 using RuntimeInformation = System.Runtime.RuntimeInformation;
 
-namespace EventStore.Core.Index {
-	public class PTableVersions {
-		// original
-		public const byte IndexV1 = 1;
+namespace EventStore.Core.Index;
 
-		// 64bit hashes
-		public const byte IndexV2 = 2;
+public class PTableVersions
+{
+	// original
+	public const byte IndexV1 = 1;
 
-		// 64bit versions
-		public const byte IndexV3 = 3;
+	// 64bit hashes
+	public const byte IndexV2 = 2;
 
-		// cached midpoints
-		public const byte IndexV4 = 4;
+	// 64bit versions
+	public const byte IndexV3 = 3;
+
+	// cached midpoints
+	public const byte IndexV4 = 4;
+}
+
+public partial class PTable : ISearchTable, IDisposable
+{
+	public const int IndexEntryV1Size = sizeof(int) + sizeof(int) + sizeof(long);
+	public const int IndexEntryV2Size = sizeof(int) + sizeof(long) + sizeof(long);
+	public const int IndexEntryV3Size = sizeof(long) + sizeof(long) + sizeof(long);
+	public const int IndexEntryV4Size = IndexEntryV3Size;
+
+	public const int IndexKeyV1Size = sizeof(int) + sizeof(int);
+	public const int IndexKeyV2Size = sizeof(int) + sizeof(long);
+	public const int IndexKeyV3Size = sizeof(long) + sizeof(long);
+	public const int IndexKeyV4Size = IndexKeyV3Size;
+	public const int MD5Size = 16;
+	public const int DefaultBufferSize = 8192;
+	public const int DefaultSequentialBufferSize = 65536;
+	private static readonly ILogger Log = Serilog.Log.ForContext<PTable>();
+
+	public Guid Id
+	{
+		get { return _id; }
 	}
 
-	public partial class PTable : ISearchTable, IDisposable {
-		public const int IndexEntryV1Size = sizeof(int) + sizeof(int) + sizeof(long);
-		public const int IndexEntryV2Size = sizeof(int) + sizeof(long) + sizeof(long);
-		public const int IndexEntryV3Size = sizeof(long) + sizeof(long) + sizeof(long);
-		public const int IndexEntryV4Size = IndexEntryV3Size;
+	public long Count
+	{
+		get { return _count; }
+	}
 
-		public const int IndexKeyV1Size = sizeof(int) + sizeof(int);
-		public const int IndexKeyV2Size = sizeof(int) + sizeof(long);
-		public const int IndexKeyV3Size = sizeof(long) + sizeof(long);
-		public const int IndexKeyV4Size = IndexKeyV3Size;
-		public const int MD5Size = 16;
-		public const int DefaultBufferSize = 8192;
-		public const int DefaultSequentialBufferSize = 65536;
-		private static readonly ILogger Log = Serilog.Log.ForContext<PTable>();
+	public string Filename
+	{
+		get { return _filename; }
+	}
 
-		public Guid Id {
-			get { return _id; }
-		}
+	public byte Version
+	{
+		get { return _version; }
+	}
 
-		public long Count {
-			get { return _count; }
-		}
+	public string BloomFilterFilename => GenBloomFilterFilename(_filename);
 
-		public string Filename {
-			get { return _filename; }
-		}
+	public bool HasBloomFilter => _bloomFilter is not null;
 
-		public byte Version {
-			get { return _version; }
-		}
+	public static string GenBloomFilterFilename(string filename) => $"{filename}.bloomfilter";
 
-		public string BloomFilterFilename => GenBloomFilterFilename(_filename);
+	private static long GenBloomFilterSizeBytes(long entryCount)
+	{
+		// Fewer events per stream will require a larger bloom filter (or incur more false positives)
+		// We could count them to be precise, but a reasonable estimate will be faster.
+		const int averageEventsPerStreamPerFile = 4;
+		long size = entryCount / averageEventsPerStreamPerFile;
+		size = Math.Clamp(
+			value: size,
+			min: BloomFilterAccessor.MinSizeKB * 1000,
+			max: BloomFilterAccessor.MaxSizeKB * 1000);
+		return size;
+	}
 
-		public bool HasBloomFilter => _bloomFilter is not null;
+	private readonly Guid _id;
+	private readonly string _filename;
+	private readonly long _count;
+	private readonly long _size;
+	private readonly UnmanagedMemoryAppendOnlyList<Midpoint> _midpoints = null;
+	private readonly uint _midpointsCached = 0;
+	private readonly long _midpointsCacheSize = 0;
 
-		public static string GenBloomFilterFilename(string filename) => $"{filename}.bloomfilter";
+	private readonly PersistentBloomFilter _bloomFilter;
+	private readonly LRUCache<StreamHash, CacheEntry> _lruCache;
+	private readonly LRUCache<StreamHash, bool> _lruConfirmedNotPresent;
 
-		private static long GenBloomFilterSizeBytes(long entryCount) {
-			// Fewer events per stream will require a larger bloom filter (or incur more false positives)
-			// We could count them to be precise, but a reasonable estimate will be faster.
-			const int averageEventsPerStreamPerFile = 4;
-			long size = entryCount / averageEventsPerStreamPerFile;
-			size = Math.Clamp(
-				value: size,
-				min: BloomFilterAccessor.MinSizeKB * 1000,
-				max: BloomFilterAccessor.MaxSizeKB * 1000);
-			return size;
-		}
+	private readonly IndexEntryKey _minEntry, _maxEntry;
+	private readonly ObjectPool<WorkItem> _workItems;
+	private readonly byte _version;
+	private readonly int _indexEntrySize;
+	private readonly int _indexKeySize;
 
-		private readonly Guid _id;
-		private readonly string _filename;
-		private readonly long _count;
-		private readonly long _size;
-		private readonly UnmanagedMemoryAppendOnlyList<Midpoint> _midpoints = null;
-		private readonly uint _midpointsCached = 0;
-		private readonly long _midpointsCacheSize = 0;
+	private readonly ManualResetEventSlim _destroyEvent = new ManualResetEventSlim(false);
+	private volatile bool _deleteFile;
+	private bool _disposed;
 
-		private readonly PersistentBloomFilter _bloomFilter;
-		private readonly LRUCache<StreamHash, CacheEntry> _lruCache;
-		private readonly LRUCache<StreamHash, bool> _lruConfirmedNotPresent;
+	public ReadOnlySpan<Midpoint> GetMidPoints()
+	{
+		if (_midpoints == null)
+			return ReadOnlySpan<Midpoint>.Empty;
 
-		private readonly IndexEntryKey _minEntry, _maxEntry;
-		private readonly ObjectPool<WorkItem> _workItems;
-		private readonly byte _version;
-		private readonly int _indexEntrySize;
-		private readonly int _indexKeySize;
+		return _midpoints.AsSpan();
+	}
 
-		private readonly ManualResetEventSlim _destroyEvent = new ManualResetEventSlim(false);
-		private volatile bool _deleteFile;
-		private bool _disposed;
+	private PTable(string filename,
+		Guid id,
+		int initialReaders,
+		int maxReaders,
+		int depth = 16,
+		bool skipIndexVerify = false,
+		bool useBloomFilter = true,
+		int lruCacheSize = 1_000_000)
+	{
 
-		public ReadOnlySpan<Midpoint> GetMidPoints() {
-			if(_midpoints == null)
-				return ReadOnlySpan<Midpoint>.Empty;
+		Ensure.NotNullOrEmpty(filename, "filename");
+		Ensure.NotEmptyGuid(id, "id");
+		Ensure.Positive(maxReaders, "maxReaders");
+		Ensure.Nonnegative(depth, "depth");
 
-			return _midpoints.AsSpan();
-		}
+		if (!File.Exists(filename))
+			throw new CorruptIndexException(new PTableNotFoundException(filename));
 
-		private PTable(string filename,
-			Guid id,
-			int initialReaders,
-			int maxReaders,
-			int depth = 16,
-			bool skipIndexVerify = false,
-			bool useBloomFilter = true,
-			int lruCacheSize = 1_000_000) {
+		_id = id;
+		_filename = filename;
 
-			Ensure.NotNullOrEmpty(filename, "filename");
-			Ensure.NotEmptyGuid(id, "id");
-			Ensure.Positive(maxReaders, "maxReaders");
-			Ensure.Nonnegative(depth, "depth");
+		Log.Debug("Loading " + (skipIndexVerify ? "" : "and Verification ") + "of PTable '{pTable}' started...",
+			Path.GetFileName(Filename));
+		var sw = Stopwatch.StartNew();
+		_size = new FileInfo(_filename).Length;
 
-			if (!File.Exists(filename))
-				throw new CorruptIndexException(new PTableNotFoundException(filename));
+		Helper.EatException(() =>
+		{
+			// this action will fail if the file is created on a Unix system that does not have permissions to make files read-only
+			File.SetAttributes(_filename, FileAttributes.ReadOnly | FileAttributes.NotContentIndexed);
+		});
 
-			_id = id;
-			_filename = filename;
+		_workItems = new ObjectPool<WorkItem>(string.Format("PTable {0} work items", _id),
+			initialReaders,
+			maxReaders,
+			() => new WorkItem(filename, DefaultBufferSize),
+			workItem => workItem.Dispose(),
+			pool => OnAllWorkItemsDisposed());
 
-			Log.Debug("Loading " + (skipIndexVerify ? "" : "and Verification ") + "of PTable '{pTable}' started...",
-				Path.GetFileName(Filename));
-			var sw = Stopwatch.StartNew();
-			_size = new FileInfo(_filename).Length;
+		var readerWorkItem = GetWorkItem();
+		try
+		{
+			readerWorkItem.Stream.Seek(0, SeekOrigin.Begin);
+			var header = PTableHeader.FromStream(readerWorkItem.Stream);
 
-			Helper.EatException(() => {
-				// this action will fail if the file is created on a Unix system that does not have permissions to make files read-only
-				File.SetAttributes(_filename, FileAttributes.ReadOnly | FileAttributes.NotContentIndexed);
-			});
-
-			_workItems = new ObjectPool<WorkItem>(string.Format("PTable {0} work items", _id),
-				initialReaders,
-				maxReaders,
-				() => new WorkItem(filename, DefaultBufferSize),
-				workItem => workItem.Dispose(),
-				pool => OnAllWorkItemsDisposed());
-
-			var readerWorkItem = GetWorkItem();
-			try {
-				readerWorkItem.Stream.Seek(0, SeekOrigin.Begin);
-				var header = PTableHeader.FromStream(readerWorkItem.Stream);
-
-				if (header.Version == PTableVersions.IndexV1) {
-					throw new CorruptIndexException(new UnsupportedFileVersionException(
-						_filename, header.Version, Version,
-						"Detected a V1 index file, which is no longer supported. " +
-						"The index will be backed up and rebuilt in a supported format. " +
-						"This may take a long time for large databases. " +
-						"You can also use a version of ESDB (>= 3.9.0 and < 24.10.0) to upgrade the " +
-						"indexes to a supported format by performing an index merge."));
-				}
-
-				if ((header.Version != PTableVersions.IndexV2) &&
-					(header.Version != PTableVersions.IndexV3) &&
-					(header.Version != PTableVersions.IndexV4))
-					throw new CorruptIndexException(new UnsupportedFileVersionException(_filename, header.Version, Version));
-				_version = header.Version;
-
-				if (_version == PTableVersions.IndexV1) {
-					_indexEntrySize = IndexEntryV1Size;
-					_indexKeySize = IndexKeyV1Size;
-				}
-
-				if (_version == PTableVersions.IndexV2) {
-					_indexEntrySize = IndexEntryV2Size;
-					_indexKeySize = IndexKeyV2Size;
-				}
-
-				if (_version == PTableVersions.IndexV3) {
-					_indexEntrySize = IndexEntryV3Size;
-					_indexKeySize = IndexKeyV3Size;
-				}
-
-				if (_version >= PTableVersions.IndexV4) {
-					//read the PTable footer
-					var previousPosition = readerWorkItem.Stream.Position;
-					readerWorkItem.Stream.Seek(readerWorkItem.Stream.Length - MD5Size - PTableFooter.GetSize(_version),
-						SeekOrigin.Begin);
-					var footer = PTableFooter.FromStream(readerWorkItem.Stream);
-					if (footer.Version != header.Version)
-						throw new CorruptIndexException(
-							String.Format("PTable header/footer version mismatch: {0}/{1}", header.Version,
-								footer.Version), new InvalidFileException("Invalid PTable file."));
-
-					if (_version == PTableVersions.IndexV4) {
-						_indexEntrySize = IndexEntryV4Size;
-						_indexKeySize = IndexKeyV4Size;
-					} else
-						throw new InvalidOperationException("Unknown PTable version: " + _version);
-
-					_midpointsCached = footer.NumMidpointsCached;
-					_midpointsCacheSize = _midpointsCached * _indexEntrySize;
-					readerWorkItem.Stream.Seek(previousPosition, SeekOrigin.Begin);
-				}
-
-				long indexEntriesTotalSize = (_size - PTableHeader.Size - _midpointsCacheSize -
-											  PTableFooter.GetSize(_version) - MD5Size);
-
-				if (indexEntriesTotalSize < 0) {
-					throw new CorruptIndexException(String.Format(
-						"Total size of index entries < 0: {0}. _size: {1}, header size: {2}, _midpointsCacheSize: {3}, footer size: {4}, md5 size: {5}",
-						indexEntriesTotalSize, _size, PTableHeader.Size, _midpointsCacheSize,
-						PTableFooter.GetSize(_version), MD5Size));
-				} else if (indexEntriesTotalSize % _indexEntrySize != 0) {
-					throw new CorruptIndexException(String.Format(
-						"Total size of index entries: {0} is not divisible by index entry size: {1}",
-						indexEntriesTotalSize, _indexEntrySize));
-				}
-
-				_count = indexEntriesTotalSize / _indexEntrySize;
-
-				if (_version >= PTableVersions.IndexV4 && _count > 0 && _midpointsCached > 0 && _midpointsCached < 2) {
-					//if there is at least 1 index entry with version>=4 and there are cached midpoints, there should always be at least 2 midpoints cached
-					throw new CorruptIndexException(String.Format(
-						"Less than 2 midpoints cached in PTable. Index entries: {0}, Midpoints cached: {1}", _count,
-						_midpointsCached));
-				} else if (_count >= 2 && _midpointsCached > _count) {
-					//if there are at least 2 index entries, midpoints count should be at most the number of index entries
-					throw new CorruptIndexException(String.Format(
-						"More midpoints cached in PTable than index entries. Midpoints: {0} , Index entries: {1}",
-						_midpointsCached, _count));
-				}
-
-				if (Count == 0) {
-					_minEntry = new IndexEntryKey(ulong.MaxValue, long.MaxValue);
-					_maxEntry = new IndexEntryKey(ulong.MinValue, long.MinValue);
-				} else {
-					var minEntry = ReadEntry(_indexEntrySize, Count - 1, readerWorkItem, _version);
-					_minEntry = new IndexEntryKey(minEntry.Stream, minEntry.Version);
-					var maxEntry = ReadEntry(_indexEntrySize, 0, readerWorkItem, _version);
-					_maxEntry = new IndexEntryKey(maxEntry.Stream, maxEntry.Version);
-				}
-			} catch (Exception) {
-				Dispose();
-				throw;
-			} finally {
-				ReturnWorkItem(readerWorkItem);
+			if (header.Version == PTableVersions.IndexV1)
+			{
+				throw new CorruptIndexException(new UnsupportedFileVersionException(
+					_filename, header.Version, Version,
+					"Detected a V1 index file, which is no longer supported. " +
+					"The index will be backed up and rebuilt in a supported format. " +
+					"This may take a long time for large databases. " +
+					"You can also use a version of ESDB (>= 3.9.0 and < 24.10.0) to upgrade the " +
+					"indexes to a supported format by performing an index merge."));
 			}
 
-			int calcdepth = 0;
-			try {
-				calcdepth = GetDepth(_count * _indexEntrySize, depth);
-				_midpoints = CacheMidpointsAndVerifyHash(calcdepth, skipIndexVerify);
+			if ((header.Version != PTableVersions.IndexV2) &&
+			    (header.Version != PTableVersions.IndexV3) &&
+			    (header.Version != PTableVersions.IndexV4))
+				throw new CorruptIndexException(
+					new UnsupportedFileVersionException(_filename, header.Version, Version));
+			_version = header.Version;
 
-				// the bloom filter is important to the efficient functioning of the cache because without it
-				// any cache miss request for data not contained in this file will cause two fruitless searches
-				// to populate the _lruConfirmedNotPresent cache, which itself will become heavily used.
-				if (lruCacheSize > 0 && !useBloomFilter) {
-					Log.Warning("Index cache is enabled (--index-cache-size > 0) but will not be used because --use-index-bloom-filters is false");
-				}
-
-				if (useBloomFilter)
-					_bloomFilter = TryOpenBloomFilter();
-
-				if (lruCacheSize > 0) {
-					if (_bloomFilter is not null) {
-						_lruCache = new("ConfirmedPresent", lruCacheSize);
-						_lruConfirmedNotPresent = new("ConfirmedNotPresent", lruCacheSize);
-					} else {
-						Log.Information("Not enabling LRU cache for index {file} because it has no bloom filter", _filename);
-					}
-				}
-			} catch (PossibleToHandleOutOfMemoryException) {
-				Log.Error(
-					"Unable to create midpoints for PTable '{pTable}' ({count} entries, depth {depth} requested). "
-					+ "Performance hit will occur. OOM Exception.", Path.GetFileName(Filename), Count, depth);
+			if (_version == PTableVersions.IndexV1)
+			{
+				_indexEntrySize = IndexEntryV1Size;
+				_indexKeySize = IndexKeyV1Size;
 			}
 
-			Log.Debug(
-				"Loading PTable (Version: {version}) '{pTable}' ({count} entries, cache depth {depth}) done in {elapsed}.",
-				_version, Path.GetFileName(Filename), Count, calcdepth, sw.Elapsed);
+			if (_version == PTableVersions.IndexV2)
+			{
+				_indexEntrySize = IndexEntryV2Size;
+				_indexKeySize = IndexKeyV2Size;
+			}
+
+			if (_version == PTableVersions.IndexV3)
+			{
+				_indexEntrySize = IndexEntryV3Size;
+				_indexKeySize = IndexKeyV3Size;
+			}
+
+			if (_version >= PTableVersions.IndexV4)
+			{
+				//read the PTable footer
+				var previousPosition = readerWorkItem.Stream.Position;
+				readerWorkItem.Stream.Seek(readerWorkItem.Stream.Length - MD5Size - PTableFooter.GetSize(_version),
+					SeekOrigin.Begin);
+				var footer = PTableFooter.FromStream(readerWorkItem.Stream);
+				if (footer.Version != header.Version)
+					throw new CorruptIndexException(
+						String.Format("PTable header/footer version mismatch: {0}/{1}", header.Version,
+							footer.Version), new InvalidFileException("Invalid PTable file."));
+
+				if (_version == PTableVersions.IndexV4)
+				{
+					_indexEntrySize = IndexEntryV4Size;
+					_indexKeySize = IndexKeyV4Size;
+				}
+				else
+					throw new InvalidOperationException("Unknown PTable version: " + _version);
+
+				_midpointsCached = footer.NumMidpointsCached;
+				_midpointsCacheSize = _midpointsCached * _indexEntrySize;
+				readerWorkItem.Stream.Seek(previousPosition, SeekOrigin.Begin);
+			}
+
+			long indexEntriesTotalSize = (_size - PTableHeader.Size - _midpointsCacheSize -
+			                              PTableFooter.GetSize(_version) - MD5Size);
+
+			if (indexEntriesTotalSize < 0)
+			{
+				throw new CorruptIndexException(String.Format(
+					"Total size of index entries < 0: {0}. _size: {1}, header size: {2}, _midpointsCacheSize: {3}, footer size: {4}, md5 size: {5}",
+					indexEntriesTotalSize, _size, PTableHeader.Size, _midpointsCacheSize,
+					PTableFooter.GetSize(_version), MD5Size));
+			}
+			else if (indexEntriesTotalSize % _indexEntrySize != 0)
+			{
+				throw new CorruptIndexException(String.Format(
+					"Total size of index entries: {0} is not divisible by index entry size: {1}",
+					indexEntriesTotalSize, _indexEntrySize));
+			}
+
+			_count = indexEntriesTotalSize / _indexEntrySize;
+
+			if (_version >= PTableVersions.IndexV4 && _count > 0 && _midpointsCached > 0 && _midpointsCached < 2)
+			{
+				//if there is at least 1 index entry with version>=4 and there are cached midpoints, there should always be at least 2 midpoints cached
+				throw new CorruptIndexException(String.Format(
+					"Less than 2 midpoints cached in PTable. Index entries: {0}, Midpoints cached: {1}", _count,
+					_midpointsCached));
+			}
+			else if (_count >= 2 && _midpointsCached > _count)
+			{
+				//if there are at least 2 index entries, midpoints count should be at most the number of index entries
+				throw new CorruptIndexException(String.Format(
+					"More midpoints cached in PTable than index entries. Midpoints: {0} , Index entries: {1}",
+					_midpointsCached, _count));
+			}
+
+			if (Count == 0)
+			{
+				_minEntry = new IndexEntryKey(ulong.MaxValue, long.MaxValue);
+				_maxEntry = new IndexEntryKey(ulong.MinValue, long.MinValue);
+			}
+			else
+			{
+				var minEntry = ReadEntry(_indexEntrySize, Count - 1, readerWorkItem, _version);
+				_minEntry = new IndexEntryKey(minEntry.Stream, minEntry.Version);
+				var maxEntry = ReadEntry(_indexEntrySize, 0, readerWorkItem, _version);
+				_maxEntry = new IndexEntryKey(maxEntry.Stream, maxEntry.Version);
+			}
+		}
+		catch (Exception)
+		{
+			Dispose();
+			throw;
+		}
+		finally
+		{
+			ReturnWorkItem(readerWorkItem);
 		}
 
-		~PTable() => Dispose(false);
+		int calcdepth = 0;
+		try
+		{
+			calcdepth = GetDepth(_count * _indexEntrySize, depth);
+			_midpoints = CacheMidpointsAndVerifyHash(calcdepth, skipIndexVerify);
 
-		internal UnmanagedMemoryAppendOnlyList<Midpoint> CacheMidpointsAndVerifyHash(int depth, bool skipIndexVerify) {
-			var buffer = new byte[4096];
-			if (depth < 0 || depth > 30)
-				throw new ArgumentOutOfRangeException("depth");
-			var count = Count;
-			if (count == 0 || depth == 0)
-				return null;
-
-			if (skipIndexVerify) {
-				Log.Debug("Disabling Verification of PTable");
+			// the bloom filter is important to the efficient functioning of the cache because without it
+			// any cache miss request for data not contained in this file will cause two fruitless searches
+			// to populate the _lruConfirmedNotPresent cache, which itself will become heavily used.
+			if (lruCacheSize > 0 && !useBloomFilter)
+			{
+				Log.Warning(
+					"Index cache is enabled (--index-cache-size > 0) but will not be used because --use-index-bloom-filters is false");
 			}
 
-			Stream stream = null;
-			WorkItem workItem = null;
-			if (RuntimeInformation.IsUnix) {
-				workItem = GetWorkItem();
-				stream = workItem.Stream;
-			} else {
-				stream = UnbufferedFileStream.Create(_filename, FileMode.Open, FileAccess.Read, FileShare.Read,
-					4096, 4096, false, 4096);
+			if (useBloomFilter)
+				_bloomFilter = TryOpenBloomFilter();
+
+			if (lruCacheSize > 0)
+			{
+				if (_bloomFilter is not null)
+				{
+					_lruCache = new("ConfirmedPresent", lruCacheSize);
+					_lruConfirmedNotPresent = new("ConfirmedNotPresent", lruCacheSize);
+				}
+				else
+				{
+					Log.Information("Not enabling LRU cache for index {file} because it has no bloom filter",
+						_filename);
+				}
 			}
+		}
+		catch (PossibleToHandleOutOfMemoryException)
+		{
+			Log.Error(
+				"Unable to create midpoints for PTable '{pTable}' ({count} entries, depth {depth} requested). "
+				+ "Performance hit will occur. OOM Exception.", Path.GetFileName(Filename), Count, depth);
+		}
 
-			UnmanagedMemoryAppendOnlyList<Midpoint> midpoints = null;
+		Log.Debug(
+			"Loading PTable (Version: {version}) '{pTable}' ({count} entries, cache depth {depth}) done in {elapsed}.",
+			_version, Path.GetFileName(Filename), Count, calcdepth, sw.Elapsed);
+	}
 
-			try {
-				using (var md5 = MD5.Create()) {
-					int midpointsCount;
-					try {
-						midpointsCount = (int)Math.Max(2L, Math.Min((long)1 << depth, count));
-						midpoints = new UnmanagedMemoryAppendOnlyList<Midpoint>(midpointsCount);
-					} catch (OutOfMemoryException exc) {
-						throw new PossibleToHandleOutOfMemoryException("Failed to allocate memory for Midpoint cache.",
-							exc);
-					}
+	~PTable() => Dispose(false);
 
-					if (skipIndexVerify && (_version >= PTableVersions.IndexV4)) {
-						if (_midpointsCached == midpointsCount) {
-							//index verification is disabled and cached midpoints with the same depth requested are available
-							//so, we can load them directly from the PTable file
-							Log.Debug("Loading {midpointsCached} cached midpoints from PTable", _midpointsCached);
-							long startOffset = stream.Length - MD5Size - PTableFooter.GetSize(_version) -
-											   _midpointsCacheSize;
-							stream.Seek(startOffset, SeekOrigin.Begin);
-							for (int k = 0; k < (int)_midpointsCached; k++) {
-								stream.Read(buffer, 0, _indexEntrySize);
-								IndexEntryKey key;
-								long index;
-								if (_version == PTableVersions.IndexV4) {
-									key = new IndexEntryKey(BitConverter.ToUInt64(buffer, 8),
-										BitConverter.ToInt64(buffer, 0));
-									index = BitConverter.ToInt64(buffer, 8 + 8);
-								} else
-									throw new InvalidOperationException("Unknown PTable version: " + _version);
+	internal UnmanagedMemoryAppendOnlyList<Midpoint> CacheMidpointsAndVerifyHash(int depth, bool skipIndexVerify)
+	{
+		var buffer = new byte[4096];
+		if (depth < 0 || depth > 30)
+			throw new ArgumentOutOfRangeException("depth");
+		var count = Count;
+		if (count == 0 || depth == 0)
+			return null;
 
-								midpoints.Add(new Midpoint(key, index));
+		if (skipIndexVerify)
+		{
+			Log.Debug("Disabling Verification of PTable");
+		}
 
-								if (k > 0) {
-									if (midpoints[k].Key.GreaterThan(midpoints[k - 1].Key)) {
-										throw new CorruptIndexException(String.Format(
-											"Index entry key for midpoint {0} (stream: {1}, version: {2}) < index entry key for midpoint {3} (stream: {4}, version: {5})",
-											k - 1, midpoints[k - 1].Key.Stream, midpoints[k - 1].Key.Version, k,
-											midpoints[k].Key.Stream, midpoints[k].Key.Version));
-									} else if (midpoints[k - 1].ItemIndex > midpoints[k].ItemIndex) {
-										throw new CorruptIndexException(String.Format(
-											"Item index for midpoint {0} ({1}) > Item index for midpoint {2} ({3})",
-											k - 1, midpoints[k - 1].ItemIndex, k, midpoints[k].ItemIndex));
-									}
-								}
-							}
+		Stream stream = null;
+		WorkItem workItem = null;
+		if (RuntimeInformation.IsUnix)
+		{
+			workItem = GetWorkItem();
+			stream = workItem.Stream;
+		}
+		else
+		{
+			stream = UnbufferedFileStream.Create(_filename, FileMode.Open, FileAccess.Read, FileShare.Read,
+				4096, 4096, false, 4096);
+		}
 
-							return midpoints;
-						} else
-							Log.Debug(
-								"Skipping loading of cached midpoints from PTable due to count mismatch, cached midpoints: {midpointsCached} / required midpoints: {midpointsCount}",
-								_midpointsCached, midpointsCount);
-					}
+		UnmanagedMemoryAppendOnlyList<Midpoint> midpoints = null;
 
-					if (!skipIndexVerify) {
-						stream.Seek(0, SeekOrigin.Begin);
-						stream.Read(buffer, 0, PTableHeader.Size);
-						md5.TransformBlock(buffer, 0, PTableHeader.Size, null, 0);
-					}
+		try
+		{
+			using (var md5 = MD5.Create())
+			{
+				int midpointsCount;
+				try
+				{
+					midpointsCount = (int)Math.Max(2L, Math.Min((long)1 << depth, count));
+					midpoints = new UnmanagedMemoryAppendOnlyList<Midpoint>(midpointsCount);
+				}
+				catch (OutOfMemoryException exc)
+				{
+					throw new PossibleToHandleOutOfMemoryException("Failed to allocate memory for Midpoint cache.",
+						exc);
+				}
 
-					long previousNextIndex = long.MinValue;
-					var previousKey = new IndexEntryKey(long.MaxValue, long.MaxValue);
-					for (int k = 0; k < midpointsCount; ++k) {
-						long nextIndex = GetMidpointIndex(k, count, midpointsCount);
-						if (previousNextIndex != nextIndex) {
-							if (!skipIndexVerify) {
-								ReadUntilWithMd5(PTableHeader.Size + _indexEntrySize * nextIndex, stream, md5);
-								stream.Read(buffer, 0, _indexKeySize);
-								md5.TransformBlock(buffer, 0, _indexKeySize, null, 0);
-							} else {
-								stream.Seek(PTableHeader.Size + _indexEntrySize * nextIndex, SeekOrigin.Begin);
-								stream.Read(buffer, 0, _indexKeySize);
-							}
-
+				if (skipIndexVerify && (_version >= PTableVersions.IndexV4))
+				{
+					if (_midpointsCached == midpointsCount)
+					{
+						//index verification is disabled and cached midpoints with the same depth requested are available
+						//so, we can load them directly from the PTable file
+						Log.Debug("Loading {midpointsCached} cached midpoints from PTable", _midpointsCached);
+						long startOffset = stream.Length - MD5Size - PTableFooter.GetSize(_version) -
+						                   _midpointsCacheSize;
+						stream.Seek(startOffset, SeekOrigin.Begin);
+						for (int k = 0; k < (int)_midpointsCached; k++)
+						{
+							stream.Read(buffer, 0, _indexEntrySize);
 							IndexEntryKey key;
-							if (_version == PTableVersions.IndexV1) {
-								key = new IndexEntryKey(BitConverter.ToUInt32(buffer, 4),
-									BitConverter.ToInt32(buffer, 0));
-							} else if (_version == PTableVersions.IndexV2) {
-								key = new IndexEntryKey(BitConverter.ToUInt64(buffer, 4),
-									BitConverter.ToInt32(buffer, 0));
-							} else {
+							long index;
+							if (_version == PTableVersions.IndexV4)
+							{
 								key = new IndexEntryKey(BitConverter.ToUInt64(buffer, 8),
 									BitConverter.ToInt64(buffer, 0));
+								index = BitConverter.ToInt64(buffer, 8 + 8);
 							}
+							else
+								throw new InvalidOperationException("Unknown PTable version: " + _version);
 
-							midpoints.Add(new Midpoint(key, nextIndex));
-							previousNextIndex = nextIndex;
-							previousKey = key;
-						} else {
-							midpoints.Add(new Midpoint(previousKey, previousNextIndex));
+							midpoints.Add(new Midpoint(key, index));
+
+							if (k > 0)
+							{
+								if (midpoints[k].Key.GreaterThan(midpoints[k - 1].Key))
+								{
+									throw new CorruptIndexException(String.Format(
+										"Index entry key for midpoint {0} (stream: {1}, version: {2}) < index entry key for midpoint {3} (stream: {4}, version: {5})",
+										k - 1, midpoints[k - 1].Key.Stream, midpoints[k - 1].Key.Version, k,
+										midpoints[k].Key.Stream, midpoints[k].Key.Version));
+								}
+								else if (midpoints[k - 1].ItemIndex > midpoints[k].ItemIndex)
+								{
+									throw new CorruptIndexException(String.Format(
+										"Item index for midpoint {0} ({1}) > Item index for midpoint {2} ({3})",
+										k - 1, midpoints[k - 1].ItemIndex, k, midpoints[k].ItemIndex));
+								}
+							}
 						}
 
-						if (k > 0) {
-							if (midpoints[k].Key.GreaterThan(midpoints[k - 1].Key)) {
-								throw new CorruptIndexException(String.Format(
-									"Index entry key for midpoint {0} (stream: {1}, version: {2}) < index entry key for midpoint {3} (stream: {4}, version: {5})",
-									k - 1, midpoints[k - 1].Key.Stream, midpoints[k - 1].Key.Version, k,
-									midpoints[k].Key.Stream, midpoints[k].Key.Version));
-							} else if (midpoints[k - 1].ItemIndex > midpoints[k].ItemIndex) {
-								throw new CorruptIndexException(String.Format(
-									"Item index for midpoint {0} ({1}) > Item index for midpoint {2} ({3})", k - 1,
-									midpoints[k - 1].ItemIndex, k, midpoints[k].ItemIndex));
-							}
+						return midpoints;
+					}
+					else
+						Log.Debug(
+							"Skipping loading of cached midpoints from PTable due to count mismatch, cached midpoints: {midpointsCached} / required midpoints: {midpointsCount}",
+							_midpointsCached, midpointsCount);
+				}
+
+				if (!skipIndexVerify)
+				{
+					stream.Seek(0, SeekOrigin.Begin);
+					stream.Read(buffer, 0, PTableHeader.Size);
+					md5.TransformBlock(buffer, 0, PTableHeader.Size, null, 0);
+				}
+
+				long previousNextIndex = long.MinValue;
+				var previousKey = new IndexEntryKey(long.MaxValue, long.MaxValue);
+				for (int k = 0; k < midpointsCount; ++k)
+				{
+					long nextIndex = GetMidpointIndex(k, count, midpointsCount);
+					if (previousNextIndex != nextIndex)
+					{
+						if (!skipIndexVerify)
+						{
+							ReadUntilWithMd5(PTableHeader.Size + _indexEntrySize * nextIndex, stream, md5);
+							stream.Read(buffer, 0, _indexKeySize);
+							md5.TransformBlock(buffer, 0, _indexKeySize, null, 0);
+						}
+						else
+						{
+							stream.Seek(PTableHeader.Size + _indexEntrySize * nextIndex, SeekOrigin.Begin);
+							stream.Read(buffer, 0, _indexKeySize);
+						}
+
+						IndexEntryKey key;
+						if (_version == PTableVersions.IndexV1)
+						{
+							key = new IndexEntryKey(BitConverter.ToUInt32(buffer, 4),
+								BitConverter.ToInt32(buffer, 0));
+						}
+						else if (_version == PTableVersions.IndexV2)
+						{
+							key = new IndexEntryKey(BitConverter.ToUInt64(buffer, 4),
+								BitConverter.ToInt32(buffer, 0));
+						}
+						else
+						{
+							key = new IndexEntryKey(BitConverter.ToUInt64(buffer, 8),
+								BitConverter.ToInt64(buffer, 0));
+						}
+
+						midpoints.Add(new Midpoint(key, nextIndex));
+						previousNextIndex = nextIndex;
+						previousKey = key;
+					}
+					else
+					{
+						midpoints.Add(new Midpoint(previousKey, previousNextIndex));
+					}
+
+					if (k > 0)
+					{
+						if (midpoints[k].Key.GreaterThan(midpoints[k - 1].Key))
+						{
+							throw new CorruptIndexException(String.Format(
+								"Index entry key for midpoint {0} (stream: {1}, version: {2}) < index entry key for midpoint {3} (stream: {4}, version: {5})",
+								k - 1, midpoints[k - 1].Key.Stream, midpoints[k - 1].Key.Version, k,
+								midpoints[k].Key.Stream, midpoints[k].Key.Version));
+						}
+						else if (midpoints[k - 1].ItemIndex > midpoints[k].ItemIndex)
+						{
+							throw new CorruptIndexException(String.Format(
+								"Item index for midpoint {0} ({1}) > Item index for midpoint {2} ({3})", k - 1,
+								midpoints[k - 1].ItemIndex, k, midpoints[k].ItemIndex));
 						}
 					}
-
-					if (!skipIndexVerify) {
-						ReadUntilWithMd5(stream.Length - MD5Size, stream, md5);
-						//verify hash (should be at stream.length - MD5Size)
-						md5.TransformFinalBlock(Empty.ByteArray, 0, 0);
-						var fileHash = new byte[MD5Size];
-						stream.Read(fileHash, 0, MD5Size);
-						ValidateHash(md5.Hash, fileHash);
-					}
-
-					return midpoints;
 				}
-			} catch (PossibleToHandleOutOfMemoryException) {
-				midpoints?.Dispose();
-				throw;
-			} catch {
-				midpoints?.Dispose();
-				Dispose();
-				throw;
-			} finally {
-				if (RuntimeInformation.IsUnix) {
-					if (workItem != null)
-						ReturnWorkItem(workItem);
-				} else {
-					stream?.Dispose();
+
+				if (!skipIndexVerify)
+				{
+					ReadUntilWithMd5(stream.Length - MD5Size, stream, md5);
+					//verify hash (should be at stream.length - MD5Size)
+					md5.TransformFinalBlock(Empty.ByteArray, 0, 0);
+					var fileHash = new byte[MD5Size];
+					stream.Read(fileHash, 0, MD5Size);
+					ValidateHash(md5.Hash, fileHash);
 				}
+
+				return midpoints;
 			}
 		}
-
-		private PersistentBloomFilter TryOpenBloomFilter() {
-			try {
-				// use existing filter without specifying what size it needs to be
-				// for scavenged ptables in particular we do not know exactly what size the bloom filter
-				// is because it is based on the pre-scavenge size
-				var bloomFilter = new PersistentBloomFilter(
-					FileStreamPersistence.FromFile(BloomFilterFilename));
-
-				return bloomFilter;
-			} catch (FileNotFoundException) {
-				Log.Information("Bloom filter for index file {file} does not exist", _filename);
-				return null;
-			} catch (CorruptedFileException ex) {
-				Log.Error(ex, "Bloom filter for index file {file} is corrupt. Performance will be degraded", _filename);
-				return null;
-			} catch (CorruptedHashException ex) {
-				Log.Error(ex, "Bloom filter contents for index file {file} are corrupt. Performance will be degraded", _filename);
-				return null;
-			} catch (OutOfMemoryException ex) {
-				Log.Warning(ex, "Could not allocate enough memory for Bloom filter for index file {file}. Performance will be degraded", _filename);
-				return null;
-			} catch (Exception ex) {
-				Log.Error(ex, "Unexpected error opening bloom filter for index file {file}. Performance will be degraded", _filename);
-				return null;
+		catch (PossibleToHandleOutOfMemoryException)
+		{
+			midpoints?.Dispose();
+			throw;
+		}
+		catch
+		{
+			midpoints?.Dispose();
+			Dispose();
+			throw;
+		}
+		finally
+		{
+			if (RuntimeInformation.IsUnix)
+			{
+				if (workItem != null)
+					ReturnWorkItem(workItem);
+			}
+			else
+			{
+				stream?.Dispose();
 			}
 		}
+	}
 
-		private readonly byte[] TmpReadBuf = new byte[DefaultBufferSize];
+	private PersistentBloomFilter TryOpenBloomFilter()
+	{
+		try
+		{
+			// use existing filter without specifying what size it needs to be
+			// for scavenged ptables in particular we do not know exactly what size the bloom filter
+			// is because it is based on the pre-scavenge size
+			var bloomFilter = new PersistentBloomFilter(
+				FileStreamPersistence.FromFile(BloomFilterFilename));
 
-		private void ReadUntilWithMd5(long nextPos, Stream fileStream, HashAlgorithm md5) {
-			long toRead = nextPos - fileStream.Position;
-			if (toRead < 0)
-				throw new Exception("should not do negative reads.");
-			while (toRead > 0) {
-				var localReadCount = Math.Min(toRead, TmpReadBuf.Length);
-				int read = fileStream.Read(TmpReadBuf, 0, (int)localReadCount);
-				md5.TransformBlock(TmpReadBuf, 0, read, null, 0);
-				toRead -= read;
-			}
+			return bloomFilter;
 		}
+		catch (FileNotFoundException)
+		{
+			Log.Information("Bloom filter for index file {file} does not exist", _filename);
+			return null;
+		}
+		catch (CorruptedFileException ex)
+		{
+			Log.Error(ex, "Bloom filter for index file {file} is corrupt. Performance will be degraded", _filename);
+			return null;
+		}
+		catch (CorruptedHashException ex)
+		{
+			Log.Error(ex, "Bloom filter contents for index file {file} are corrupt. Performance will be degraded",
+				_filename);
+			return null;
+		}
+		catch (OutOfMemoryException ex)
+		{
+			Log.Warning(ex,
+				"Could not allocate enough memory for Bloom filter for index file {file}. Performance will be degraded",
+				_filename);
+			return null;
+		}
+		catch (Exception ex)
+		{
+			Log.Error(ex,
+				"Unexpected error opening bloom filter for index file {file}. Performance will be degraded",
+				_filename);
+			return null;
+		}
+	}
 
-		void ValidateHash(byte[] fromFile, byte[] computed) {
-			if (computed == null)
-				throw new CorruptIndexException(new HashValidationException("Calculated MD5 hash is null!"));
-			if (fromFile == null)
-				throw new CorruptIndexException(new HashValidationException("Read from file MD5 hash is null!"));
+	private readonly byte[] TmpReadBuf = new byte[DefaultBufferSize];
 
-			if (computed.Length != fromFile.Length)
+	private void ReadUntilWithMd5(long nextPos, Stream fileStream, HashAlgorithm md5)
+	{
+		long toRead = nextPos - fileStream.Position;
+		if (toRead < 0)
+			throw new Exception("should not do negative reads.");
+		while (toRead > 0)
+		{
+			var localReadCount = Math.Min(toRead, TmpReadBuf.Length);
+			int read = fileStream.Read(TmpReadBuf, 0, (int)localReadCount);
+			md5.TransformBlock(TmpReadBuf, 0, read, null, 0);
+			toRead -= read;
+		}
+	}
+
+	void ValidateHash(byte[] fromFile, byte[] computed)
+	{
+		if (computed == null)
+			throw new CorruptIndexException(new HashValidationException("Calculated MD5 hash is null!"));
+		if (fromFile == null)
+			throw new CorruptIndexException(new HashValidationException("Read from file MD5 hash is null!"));
+
+		if (computed.Length != fromFile.Length)
+			throw new CorruptIndexException(
+				new HashValidationException(
+					string.Format(
+						"Hash sizes differ! FileHash({0}): {1}, hash({2}): {3}.",
+						computed.Length,
+						BitConverter.ToString(computed),
+						fromFile.Length,
+						BitConverter.ToString(fromFile))));
+
+		for (int i = 0; i < fromFile.Length; i++)
+		{
+			if (fromFile[i] != computed[i])
 				throw new CorruptIndexException(
 					new HashValidationException(
 						string.Format(
-							"Hash sizes differ! FileHash({0}): {1}, hash({2}): {3}.",
-							computed.Length,
+							"Hashes are different! computed: {0}, hash: {1}.",
 							BitConverter.ToString(computed),
-							fromFile.Length,
 							BitConverter.ToString(fromFile))));
+		}
+	}
 
-			for (int i = 0; i < fromFile.Length; i++) {
-				if (fromFile[i] != computed[i])
-					throw new CorruptIndexException(
-						new HashValidationException(
-							string.Format(
-								"Hashes are different! computed: {0}, hash: {1}.",
-								BitConverter.ToString(computed),
-								BitConverter.ToString(fromFile))));
+	public IEnumerable<IndexEntry> IterateAllInOrder()
+	{
+		var workItem = GetWorkItem();
+		try
+		{
+			workItem.Stream.Position = PTableHeader.Size;
+			for (long i = 0, n = Count; i < n; i++)
+			{
+				yield return ReadNextNoSeek(workItem, _version);
 			}
 		}
-
-		public IEnumerable<IndexEntry> IterateAllInOrder() {
-			var workItem = GetWorkItem();
-			try {
-				workItem.Stream.Position = PTableHeader.Size;
-				for (long i = 0, n = Count; i < n; i++) {
-					yield return ReadNextNoSeek(workItem, _version);
-				}
-			} finally {
-				ReturnWorkItem(workItem);
-			}
+		finally
+		{
+			ReturnWorkItem(workItem);
 		}
+	}
 
-		public bool TryGetOneValue(ulong stream, long number, out long position) {
-			if (TryGetLatestEntryNoCache(GetHash(stream), number, number, out var entry)) {
-				position = entry.Position;
-				return true;
-			}
-
-			position = -1;
-			return false;
-		}
-
-		public bool TryGetLatestEntry(ulong stream, out IndexEntry entry) =>
-			_lruCache == null
-				? TryGetLatestEntryNoCache(GetHash(stream), 0, long.MaxValue, out entry)
-				: TryGetLatestEntryWithCache(GetHash(stream), out entry);
-
-		private bool TryGetLatestEntryWithCache(StreamHash stream, out IndexEntry entry) {
-			if (!TryLookThroughLru(stream, out var value)) {
-				// stream not present
-				entry = TableIndex.InvalidIndexEntry;
-				return false;
-			}
-
-			entry = ReadEntry(_indexEntrySize, value.LatestOffset, _version);
+	public bool TryGetOneValue(ulong stream, long number, out long position)
+	{
+		if (TryGetLatestEntryNoCache(GetHash(stream), number, number, out var entry))
+		{
+			position = entry.Position;
 			return true;
 		}
 
-		public bool TryGetLatestEntry(
-			ulong stream,
-			long beforePosition,
-			Func<IndexEntry, bool> isForThisStream,
-			out IndexEntry entry) {
+		position = -1;
+		return false;
+	}
 
-			Ensure.Nonnegative(beforePosition, nameof(beforePosition));
-			var streamHash = GetHash(stream);
+	public bool TryGetLatestEntry(ulong stream, out IndexEntry entry) =>
+		_lruCache == null
+			? TryGetLatestEntryNoCache(GetHash(stream), 0, long.MaxValue, out entry)
+			: TryGetLatestEntryWithCache(GetHash(stream), out entry);
 
-			entry = TableIndex.InvalidIndexEntry;
-
-			var startKey = BuildKey(streamHash, 0);
-			var endKey = BuildKey(streamHash, long.MaxValue);
-
-			if (startKey.GreaterThan(_maxEntry) || endKey.SmallerThan(_minEntry))
-				return false;
-
-			if (!MightContainStream(streamHash))
-				return false;
-
-			var workItem = GetWorkItem();
-			try {
-				var recordRange = LocateRecordRange(endKey, startKey, out var lowBoundsCheck, out var highBoundsCheck);
-
-				try {
-					if (!TryGetLatestEntryFast(
-							streamHash,
-							beforePosition,
-							isForThisStream,
-							recordRange,
-							lowBoundsCheck,
-							highBoundsCheck,
-							workItem,
-							out entry))
-						return false;
-				} catch (HashCollisionException) {
-					// fall back to linear search if there's a hash collision
-					if (!TryGetLatestEntrySlow(
-							streamHash,
-							beforePosition,
-							isForThisStream,
-							recordRange,
-							lowBoundsCheck,
-							highBoundsCheck,
-							workItem,
-							out entry))
-						return false;
-				}
-
-				return true;
-			} finally {
-				ReturnWorkItem(workItem);
-			}
-		}
-
-		// linearly search the whole range for the entry with the greatest position that
-		// is for this stream and before the beforePosition.
-		private bool TryGetLatestEntrySlow(
-			StreamHash stream,
-			long beforePosition,
-			Func<IndexEntry, bool> isForThisStream,
-			Range recordRange,
-			IndexEntryKey lowBoundsCheck,
-			IndexEntryKey highBoundsCheck,
-			WorkItem workItem,
-			out IndexEntry entry) {
-
-			long maxBeforePosition = long.MinValue;
-			IndexEntry maxEntry = default;
-
-			for (var idx = recordRange.Lower; idx <= recordRange.Upper; idx++) {
-				var candidateEntry = ReadEntry(_indexEntrySize, idx, workItem, _version);
-				var candidateEntryKey = new IndexEntryKey(candidateEntry.Stream, candidateEntry.Version);
-
-				if (candidateEntryKey.GreaterThan(lowBoundsCheck)) {
-					throw new MaybeCorruptIndexException(
-						$"Candidate entry key (stream: {candidateEntryKey.Stream}, version: {candidateEntryKey.Version}) > "
-						+ $"low bounds check key (stream: {lowBoundsCheck.Stream}, version: {lowBoundsCheck.Version})");
-				}
-
-				if (candidateEntryKey.SmallerThan(highBoundsCheck)) {
-					throw new MaybeCorruptIndexException(
-						$"Candidate entry key (stream: {candidateEntryKey.Stream}, version: {candidateEntryKey.Version}) < "
-						+ $"high bounds check key (stream: {highBoundsCheck.Stream}, version: {highBoundsCheck.Version})");
-				}
-
-				if (candidateEntry.Stream == stream.Hash &&
-					candidateEntry.Position < beforePosition &&
-					candidateEntry.Position > maxBeforePosition &&
-					isForThisStream(candidateEntry)) {
-
-					maxBeforePosition = candidateEntry.Position;
-					maxEntry = candidateEntry;
-				}
-			}
-
-			if (maxBeforePosition != long.MinValue) {
-				entry = maxEntry;
-				return true;
-			}
-
+	private bool TryGetLatestEntryWithCache(StreamHash stream, out IndexEntry entry)
+	{
+		if (!TryLookThroughLru(stream, out var value))
+		{
+			// stream not present
 			entry = TableIndex.InvalidIndexEntry;
 			return false;
 		}
 
-		private bool TryGetLatestEntryFast(
-			StreamHash stream,
-			long beforePosition,
-			Func<IndexEntry,bool> isForThisStream,
-			Range recordRange,
-			IndexEntryKey lowBoundsCheck,
-			IndexEntryKey highBoundsCheck,
-			WorkItem workItem,
-			out IndexEntry entry) {
+		entry = ReadEntry(_indexEntrySize, value.LatestOffset, _version);
+		return true;
+	}
 
-			var startKey = BuildKey(stream, 0);
-			var endKey = BuildKey(stream, long.MaxValue);
+	public bool TryGetLatestEntry(
+		ulong stream,
+		long beforePosition,
+		Func<IndexEntry, bool> isForThisStream,
+		out IndexEntry entry)
+	{
 
-			var low = recordRange.Lower;
-			var high = recordRange.Upper;
+		Ensure.Nonnegative(beforePosition, nameof(beforePosition));
+		var streamHash = GetHash(stream);
 
-			while (low < high) {
-				var mid = low + (high - low) / 2;
-				IndexEntry midpoint = ReadEntry(_indexEntrySize, mid, workItem, _version);
+		entry = TableIndex.InvalidIndexEntry;
 
-				var midpointKey = new IndexEntryKey(midpoint.Stream, midpoint.Version);
-				if (midpointKey.GreaterThan(lowBoundsCheck)) {
-					throw new MaybeCorruptIndexException(
-						$"Midpoint key (stream: {midpointKey.Stream}, version: {midpointKey.Version}) > "
+		var startKey = BuildKey(streamHash, 0);
+		var endKey = BuildKey(streamHash, long.MaxValue);
+
+		if (startKey.GreaterThan(_maxEntry) || endKey.SmallerThan(_minEntry))
+			return false;
+
+		if (!MightContainStream(streamHash))
+			return false;
+
+		var workItem = GetWorkItem();
+		try
+		{
+			var recordRange = LocateRecordRange(endKey, startKey, out var lowBoundsCheck, out var highBoundsCheck);
+
+			try
+			{
+				if (!TryGetLatestEntryFast(
+					    streamHash,
+					    beforePosition,
+					    isForThisStream,
+					    recordRange,
+					    lowBoundsCheck,
+					    highBoundsCheck,
+					    workItem,
+					    out entry))
+					return false;
+			}
+			catch (HashCollisionException)
+			{
+				// fall back to linear search if there's a hash collision
+				if (!TryGetLatestEntrySlow(
+					    streamHash,
+					    beforePosition,
+					    isForThisStream,
+					    recordRange,
+					    lowBoundsCheck,
+					    highBoundsCheck,
+					    workItem,
+					    out entry))
+					return false;
+			}
+
+			return true;
+		}
+		finally
+		{
+			ReturnWorkItem(workItem);
+		}
+	}
+
+	// linearly search the whole range for the entry with the greatest position that
+	// is for this stream and before the beforePosition.
+	private bool TryGetLatestEntrySlow(
+		StreamHash stream,
+		long beforePosition,
+		Func<IndexEntry, bool> isForThisStream,
+		Range recordRange,
+		IndexEntryKey lowBoundsCheck,
+		IndexEntryKey highBoundsCheck,
+		WorkItem workItem,
+		out IndexEntry entry)
+	{
+
+		long maxBeforePosition = long.MinValue;
+		IndexEntry maxEntry = default;
+
+		for (var idx = recordRange.Lower; idx <= recordRange.Upper; idx++)
+		{
+			var candidateEntry = ReadEntry(_indexEntrySize, idx, workItem, _version);
+			var candidateEntryKey = new IndexEntryKey(candidateEntry.Stream, candidateEntry.Version);
+
+			if (candidateEntryKey.GreaterThan(lowBoundsCheck))
+			{
+				throw new MaybeCorruptIndexException(
+					$"Candidate entry key (stream: {candidateEntryKey.Stream}, version: {candidateEntryKey.Version}) > "
 					+ $"low bounds check key (stream: {lowBoundsCheck.Stream}, version: {lowBoundsCheck.Version})");
-				}
+			}
 
-				if (midpointKey.SmallerThan(highBoundsCheck)) {
-					throw new MaybeCorruptIndexException(
-						$"Midpoint key (stream: {midpointKey.Stream}, version: {midpointKey.Version}) < "
+			if (candidateEntryKey.SmallerThan(highBoundsCheck))
+			{
+				throw new MaybeCorruptIndexException(
+					$"Candidate entry key (stream: {candidateEntryKey.Stream}, version: {candidateEntryKey.Version}) < "
 					+ $"high bounds check key (stream: {highBoundsCheck.Stream}, version: {highBoundsCheck.Version})");
-				}
+			}
 
-				if (midpointKey.Stream != stream.Hash) {
-					if (midpointKey.GreaterThan(endKey)) {
-						low = mid + 1;
-						lowBoundsCheck = midpointKey;
-					} else if (midpointKey.SmallerThan(startKey)){
-						high = mid - 1;
-						highBoundsCheck = midpointKey;
-					} else 	throw new MaybeCorruptIndexException(
+			if (candidateEntry.Stream == stream.Hash &&
+			    candidateEntry.Position < beforePosition &&
+			    candidateEntry.Position > maxBeforePosition &&
+			    isForThisStream(candidateEntry))
+			{
+
+				maxBeforePosition = candidateEntry.Position;
+				maxEntry = candidateEntry;
+			}
+		}
+
+		if (maxBeforePosition != long.MinValue)
+		{
+			entry = maxEntry;
+			return true;
+		}
+
+		entry = TableIndex.InvalidIndexEntry;
+		return false;
+	}
+
+	private bool TryGetLatestEntryFast(
+		StreamHash stream,
+		long beforePosition,
+		Func<IndexEntry, bool> isForThisStream,
+		Range recordRange,
+		IndexEntryKey lowBoundsCheck,
+		IndexEntryKey highBoundsCheck,
+		WorkItem workItem,
+		out IndexEntry entry)
+	{
+
+		var startKey = BuildKey(stream, 0);
+		var endKey = BuildKey(stream, long.MaxValue);
+
+		var low = recordRange.Lower;
+		var high = recordRange.Upper;
+
+		while (low < high)
+		{
+			var mid = low + (high - low) / 2;
+			IndexEntry midpoint = ReadEntry(_indexEntrySize, mid, workItem, _version);
+
+			var midpointKey = new IndexEntryKey(midpoint.Stream, midpoint.Version);
+			if (midpointKey.GreaterThan(lowBoundsCheck))
+			{
+				throw new MaybeCorruptIndexException(
+					$"Midpoint key (stream: {midpointKey.Stream}, version: {midpointKey.Version}) > "
+					+ $"low bounds check key (stream: {lowBoundsCheck.Stream}, version: {lowBoundsCheck.Version})");
+			}
+
+			if (midpointKey.SmallerThan(highBoundsCheck))
+			{
+				throw new MaybeCorruptIndexException(
+					$"Midpoint key (stream: {midpointKey.Stream}, version: {midpointKey.Version}) < "
+					+ $"high bounds check key (stream: {highBoundsCheck.Stream}, version: {highBoundsCheck.Version})");
+			}
+
+			if (midpointKey.Stream != stream.Hash)
+			{
+				if (midpointKey.GreaterThan(endKey))
+				{
+					low = mid + 1;
+					lowBoundsCheck = midpointKey;
+				}
+				else if (midpointKey.SmallerThan(startKey))
+				{
+					high = mid - 1;
+					highBoundsCheck = midpointKey;
+				}
+				else
+					throw new MaybeCorruptIndexException(
 						$"Midpoint key (stream: {midpointKey.Stream}, version: {midpointKey.Version}) >= "
 						+ $"start key (stream: {startKey.Stream}, version: {startKey.Version}) and <= "
 						+ $"end key (stream: {endKey.Stream}, version: {endKey.Version}) "
 						+ "but the stream hashes do not match.");
-					continue;
-				}
 
-				if (!isForThisStream(midpoint))
-					throw new HashCollisionException();
-
-				if (midpoint.Position >= beforePosition) {
-					low = mid + 1;
-					lowBoundsCheck = midpointKey;
-				} else {
-					high = mid;
-					highBoundsCheck = midpointKey;
-				}
+				continue;
 			}
 
-			var candidateEntry = ReadEntry(_indexEntrySize, high, workItem, _version);
-
-			// index entry is for a different hash
-			if (candidateEntry.Stream != stream.Hash) {
-				entry = TableIndex.InvalidIndexEntry;
-				return false;
-			}
-
-			// index entry is for the correct hash but for a colliding stream
-			if (!isForThisStream(candidateEntry))
+			if (!isForThisStream(midpoint))
 				throw new HashCollisionException();
 
-			// index entry is for the correct stream but does not respect the position limit
-			if (candidateEntry.Position >= beforePosition) {
-				entry = TableIndex.InvalidIndexEntry;
-				return false;
+			if (midpoint.Position >= beforePosition)
+			{
+				low = mid + 1;
+				lowBoundsCheck = midpointKey;
 			}
-
-			// index entry is for the correct stream and respects the position limit
-			entry = candidateEntry;
-			return true;
+			else
+			{
+				high = mid;
+				highBoundsCheck = midpointKey;
+			}
 		}
 
-		private bool TryGetLatestEntryNoCache(StreamHash stream, long startNumber, long endNumber, out IndexEntry entry) {
-			Ensure.Nonnegative(startNumber, "startNumber");
-			Ensure.Nonnegative(endNumber, "endNumber");
+		var candidateEntry = ReadEntry(_indexEntrySize, high, workItem, _version);
 
-			if (!MightContainStream(stream)) {
-				entry = TableIndex.InvalidIndexEntry;
-				return false;
-			}
-
-			return TrySearchForLatestEntry(stream, startNumber, endNumber, out entry, out _);
-		}
-
-		private bool TrySearchForLatestEntry(StreamHash stream, long startNumber, long endNumber,
-			out IndexEntry entry, out long offset) {
-
+		// index entry is for a different hash
+		if (candidateEntry.Stream != stream.Hash)
+		{
 			entry = TableIndex.InvalidIndexEntry;
+			return false;
+		}
 
-			var startKey = BuildKey(stream, startNumber);
-			var endKey = BuildKey(stream, endNumber);
+		// index entry is for the correct hash but for a colliding stream
+		if (!isForThisStream(candidateEntry))
+			throw new HashCollisionException();
 
-			if (startKey.GreaterThan(_maxEntry) || endKey.SmallerThan(_minEntry)) {
+		// index entry is for the correct stream but does not respect the position limit
+		if (candidateEntry.Position >= beforePosition)
+		{
+			entry = TableIndex.InvalidIndexEntry;
+			return false;
+		}
+
+		// index entry is for the correct stream and respects the position limit
+		entry = candidateEntry;
+		return true;
+	}
+
+	private bool TryGetLatestEntryNoCache(StreamHash stream, long startNumber, long endNumber, out IndexEntry entry)
+	{
+		Ensure.Nonnegative(startNumber, "startNumber");
+		Ensure.Nonnegative(endNumber, "endNumber");
+
+		if (!MightContainStream(stream))
+		{
+			entry = TableIndex.InvalidIndexEntry;
+			return false;
+		}
+
+		return TrySearchForLatestEntry(stream, startNumber, endNumber, out entry, out _);
+	}
+
+	private bool TrySearchForLatestEntry(StreamHash stream, long startNumber, long endNumber,
+		out IndexEntry entry, out long offset)
+	{
+
+		entry = TableIndex.InvalidIndexEntry;
+
+		var startKey = BuildKey(stream, startNumber);
+		var endKey = BuildKey(stream, endNumber);
+
+		if (startKey.GreaterThan(_maxEntry) || endKey.SmallerThan(_minEntry))
+		{
+			offset = default;
+			return false;
+		}
+
+		var workItem = GetWorkItem();
+		try
+		{
+			var high = ChopForLatest(workItem, endKey);
+			var candEntry = ReadEntry(_indexEntrySize, high, workItem, _version);
+			var candKey = new IndexEntryKey(candEntry.Stream, candEntry.Version);
+
+			if (candKey.GreaterThan(endKey))
+				throw new MaybeCorruptIndexException(string.Format(
+					"candEntry ({0}@{1}) > startKey {2}, stream {3}, startNum {4}, endNum {5}, PTable: {6}.",
+					candEntry.Stream, candEntry.Version, startKey, stream, startNumber, endNumber, Filename));
+			if (candKey.SmallerThan(startKey))
+			{
 				offset = default;
 				return false;
 			}
 
-			var workItem = GetWorkItem();
-			try {
-				var high = ChopForLatest(workItem, endKey);
-				var candEntry = ReadEntry(_indexEntrySize, high, workItem, _version);
-				var candKey = new IndexEntryKey(candEntry.Stream, candEntry.Version);
-
-				if (candKey.GreaterThan(endKey))
-					throw new MaybeCorruptIndexException(string.Format(
-						"candEntry ({0}@{1}) > startKey {2}, stream {3}, startNum {4}, endNum {5}, PTable: {6}.",
-						candEntry.Stream, candEntry.Version, startKey, stream, startNumber, endNumber, Filename));
-				if (candKey.SmallerThan(startKey)) {
-					offset = default;
-					return false;
-				}
-
-				entry = candEntry;
-				offset = high;
-				return true;
-			} finally {
-				ReturnWorkItem(workItem);
-			}
-		}
-
-		public bool TryGetOldestEntry(ulong stream, out IndexEntry entry) =>
-			_lruCache == null
-				? TryGetOldestEntryNoCache(GetHash(stream), out entry)
-				: TryGetOldestEntryWithCache(GetHash(stream), out entry);
-
-		private bool TryGetOldestEntryWithCache(StreamHash stream, out IndexEntry entry) {
-			if (!TryLookThroughLru(stream, out var value)) {
-				// stream not present
-				entry = TableIndex.InvalidIndexEntry;
-				return false;
-			}
-
-			entry = ReadEntry(_indexEntrySize, value.OldestOffset, _version);
+			entry = candEntry;
+			offset = high;
 			return true;
 		}
-
-		private bool TryGetOldestEntryNoCache(StreamHash stream, out IndexEntry entry) {
-			if (!MightContainStream(stream)) {
-				entry = TableIndex.InvalidIndexEntry;
-				return false;
-			}
-
-			return TrySearchForOldestEntry(stream, 0, long.MaxValue, out entry, out _);
+		finally
+		{
+			ReturnWorkItem(workItem);
 		}
+	}
 
-		public bool TryGetNextEntry(ulong stream, long afterVersion, out IndexEntry entry) {
-			var hash = GetHash(stream);
-			if (afterVersion >= long.MaxValue || !MightContainStream(hash)) {
-				entry = TableIndex.InvalidIndexEntry;
-				return false;
-			}
-			return TrySearchForOldestEntry(hash, afterVersion + 1, long.MaxValue, out entry, out _);
-		}
+	public bool TryGetOldestEntry(ulong stream, out IndexEntry entry) =>
+		_lruCache == null
+			? TryGetOldestEntryNoCache(GetHash(stream), out entry)
+			: TryGetOldestEntryWithCache(GetHash(stream), out entry);
 
-		public bool TryGetPreviousEntry(ulong stream, long beforeVersion, out IndexEntry entry) {
-			var hash = GetHash(stream);
-			if (beforeVersion <= 0 || !MightContainStream(hash)) {
-				entry = TableIndex.InvalidIndexEntry;
-				return false;
-			}
-			return TrySearchForLatestEntry(hash, 0, beforeVersion - 1, out entry, out _);
-		}
-
-		private bool TrySearchForOldestEntry(StreamHash stream, long startNumber, long endNumber,
-			out IndexEntry entry, out long offset) {
-			Ensure.Nonnegative(startNumber, "startNumber");
-			Ensure.Nonnegative(endNumber, "endNumber");
-
+	private bool TryGetOldestEntryWithCache(StreamHash stream, out IndexEntry entry)
+	{
+		if (!TryLookThroughLru(stream, out var value))
+		{
+			// stream not present
 			entry = TableIndex.InvalidIndexEntry;
+			return false;
+		}
 
-			var startKey = BuildKey(stream, startNumber);
-			var endKey = BuildKey(stream, endNumber);
+		entry = ReadEntry(_indexEntrySize, value.OldestOffset, _version);
+		return true;
+	}
 
-			if (startKey.GreaterThan(_maxEntry) || endKey.SmallerThan(_minEntry)) {
+	private bool TryGetOldestEntryNoCache(StreamHash stream, out IndexEntry entry)
+	{
+		if (!MightContainStream(stream))
+		{
+			entry = TableIndex.InvalidIndexEntry;
+			return false;
+		}
+
+		return TrySearchForOldestEntry(stream, 0, long.MaxValue, out entry, out _);
+	}
+
+	public bool TryGetNextEntry(ulong stream, long afterVersion, out IndexEntry entry)
+	{
+		var hash = GetHash(stream);
+		if (afterVersion >= long.MaxValue || !MightContainStream(hash))
+		{
+			entry = TableIndex.InvalidIndexEntry;
+			return false;
+		}
+
+		return TrySearchForOldestEntry(hash, afterVersion + 1, long.MaxValue, out entry, out _);
+	}
+
+	public bool TryGetPreviousEntry(ulong stream, long beforeVersion, out IndexEntry entry)
+	{
+		var hash = GetHash(stream);
+		if (beforeVersion <= 0 || !MightContainStream(hash))
+		{
+			entry = TableIndex.InvalidIndexEntry;
+			return false;
+		}
+
+		return TrySearchForLatestEntry(hash, 0, beforeVersion - 1, out entry, out _);
+	}
+
+	private bool TrySearchForOldestEntry(StreamHash stream, long startNumber, long endNumber,
+		out IndexEntry entry, out long offset)
+	{
+		Ensure.Nonnegative(startNumber, "startNumber");
+		Ensure.Nonnegative(endNumber, "endNumber");
+
+		entry = TableIndex.InvalidIndexEntry;
+
+		var startKey = BuildKey(stream, startNumber);
+		var endKey = BuildKey(stream, endNumber);
+
+		if (startKey.GreaterThan(_maxEntry) || endKey.SmallerThan(_minEntry))
+		{
+			offset = default;
+			return false;
+		}
+
+		var workItem = GetWorkItem();
+		try
+		{
+			var high = ChopForOldest(workItem, startKey);
+			var candEntry = ReadEntry(_indexEntrySize, high, workItem, _version);
+			var candidateKey = new IndexEntryKey(candEntry.Stream, candEntry.Version);
+			if (candidateKey.SmallerThan(startKey))
+				throw new MaybeCorruptIndexException(string.Format(
+					"candEntry ({0}@{1}) < startKey {2}, stream {3}, startNum {4}, endNum {5}, PTable: {6}.",
+					candEntry.Stream, candEntry.Version, startKey, stream, startNumber, endNumber, Filename));
+			if (candidateKey.GreaterThan(endKey))
+			{
 				offset = default;
 				return false;
 			}
 
-			var workItem = GetWorkItem();
-			try {
-				var high = ChopForOldest(workItem, startKey);
-				var candEntry = ReadEntry(_indexEntrySize, high, workItem, _version);
-				var candidateKey = new IndexEntryKey(candEntry.Stream, candEntry.Version);
-				if (candidateKey.SmallerThan(startKey))
-					throw new MaybeCorruptIndexException(string.Format(
-						"candEntry ({0}@{1}) < startKey {2}, stream {3}, startNum {4}, endNum {5}, PTable: {6}.",
-						candEntry.Stream, candEntry.Version, startKey, stream, startNumber, endNumber, Filename));
-				if (candidateKey.GreaterThan(endKey)) {
-					offset = default;
-					return false;
-				}
+			entry = candEntry;
+			offset = high;
+			return true;
+		}
+		finally
+		{
+			ReturnWorkItem(workItem);
+		}
+	}
 
-				entry = candEntry;
-				offset = high;
-				return true;
-			} finally {
-				ReturnWorkItem(workItem);
+	public IReadOnlyList<IndexEntry> GetRange(ulong stream, long startNumber, long endNumber, int? limit = null)
+	{
+		Ensure.Nonnegative(startNumber, "startNumber");
+		Ensure.Nonnegative(endNumber, "endNumber");
+
+		return _lruCache == null
+			? GetRangeNoCache(GetHash(stream), startNumber, endNumber, limit)
+			: GetRangeWithCache(GetHash(stream), startNumber, endNumber, limit);
+	}
+
+	private StreamHash GetHash(ulong hash)
+	{
+		return new(_version, hash);
+	}
+
+	private static IndexEntryKey BuildKey(StreamHash stream, long version)
+	{
+		return new IndexEntryKey(stream.Hash, version);
+	}
+
+	// use the midpoints (if they exist) to narrow the search range.
+	// returns a range of indexes to search and corresponding IndexEntryKeys
+	private Range LocateRecordRange(IndexEntryKey key, out IndexEntryKey lowKey, out IndexEntryKey highKey) =>
+		LocateRecordRange(key, key, out lowKey, out highKey);
+
+	private Range LocateRecordRange(IndexEntryKey lowKey, IndexEntryKey highKey, out IndexEntryKey lowKeyOut,
+		out IndexEntryKey highKeyOut)
+	{
+		lowKeyOut = new IndexEntryKey(ulong.MaxValue, long.MaxValue);
+		highKeyOut = new IndexEntryKey(ulong.MinValue, long.MinValue);
+
+		ReadOnlySpan<Midpoint> midpoints = null;
+		if (_midpoints != null)
+		{
+			midpoints = _midpoints.AsSpan();
+		}
+
+		if (midpoints == null)
+			return new Range(0, Count - 1);
+
+		long lowerMidpoint = LowerMidpointBound(midpoints, lowKey);
+		long upperMidpoint = UpperMidpointBound(midpoints, highKey);
+
+		lowKeyOut = midpoints[(int)lowerMidpoint].Key;
+		highKeyOut = midpoints[(int)upperMidpoint].Key;
+
+		return new Range(midpoints[(int)lowerMidpoint].ItemIndex, midpoints[(int)upperMidpoint].ItemIndex);
+	}
+
+	private long LowerMidpointBound(ReadOnlySpan<Midpoint> midpoints, IndexEntryKey key)
+	{
+		long l = 0;
+		long r = midpoints.Length - 1;
+		while (l < r)
+		{
+			long m = l + (r - l + 1) / 2;
+			if (midpoints[(int)m].Key.GreaterThan(key))
+				l = m;
+			else
+				r = m - 1;
+		}
+
+		return l;
+	}
+
+	private long UpperMidpointBound(ReadOnlySpan<Midpoint> midpoints, IndexEntryKey key)
+	{
+		long l = 0;
+		long r = midpoints.Length - 1;
+		while (l < r)
+		{
+			long m = l + (r - l) / 2;
+			if (midpoints[(int)m].Key.SmallerThan(key))
+				r = m;
+			else
+				l = m + 1;
+		}
+
+		return r;
+	}
+
+	private static void PositionAtEntry(int indexEntrySize, long indexNum, WorkItem workItem)
+	{
+		workItem.Stream.Seek(indexEntrySize * indexNum + PTableHeader.Size, SeekOrigin.Begin);
+	}
+
+	private static IndexEntry ReadEntry(int indexEntrySize, long indexNum, WorkItem workItem, int ptableVersion)
+	{
+		long seekTo = indexEntrySize * indexNum + PTableHeader.Size;
+		workItem.Stream.Seek(seekTo, SeekOrigin.Begin);
+		return ReadNextNoSeek(workItem, ptableVersion);
+	}
+
+	private IndexEntry ReadEntry(int indexEntrySize, long indexNum, int ptableVersion)
+	{
+		var workItem = GetWorkItem();
+		try
+		{
+			return ReadEntry(_indexEntrySize, indexNum, workItem, ptableVersion);
+		}
+		finally
+		{
+			ReturnWorkItem(workItem);
+		}
+	}
+
+	private static IndexEntry ReadNextNoSeek(WorkItem workItem, int ptableVersion)
+	{
+		long version = (ptableVersion >= PTableVersions.IndexV3)
+			? workItem.Reader.ReadInt64()
+			: workItem.Reader.ReadInt32();
+		ulong stream = ptableVersion == PTableVersions.IndexV1
+			? workItem.Reader.ReadUInt32()
+			: workItem.Reader.ReadUInt64();
+		long position = workItem.Reader.ReadInt64();
+		return new IndexEntry(stream, version, position);
+	}
+
+	private WorkItem GetWorkItem()
+	{
+		try
+		{
+			return _workItems.Get();
+		}
+		catch (ObjectPoolDisposingException)
+		{
+			throw new FileBeingDeletedException();
+		}
+		catch (ObjectPoolMaxLimitReachedException)
+		{
+			throw new Exception("Unable to acquire work item.");
+		}
+	}
+
+	private void ReturnWorkItem(WorkItem workItem)
+	{
+		_workItems.Return(workItem);
+	}
+
+	public void MarkForDestruction()
+	{
+		_deleteFile = true;
+		_workItems.MarkForDisposal();
+	}
+
+	public void Dispose()
+	{
+		_deleteFile = false;
+		_workItems.MarkForDisposal();
+	}
+
+	protected virtual void Dispose(bool disposing)
+	{
+		if (_disposed)
+		{
+			return;
+		}
+
+		if (disposing)
+		{
+			//dispose any managed objects here
+			_midpoints?.Dispose();
+			_bloomFilter?.Dispose();
+		}
+
+		_disposed = true;
+	}
+
+	private void OnAllWorkItemsDisposed()
+	{
+		File.SetAttributes(_filename, FileAttributes.Normal);
+		if (_deleteFile)
+		{
+			_bloomFilter?.Dispose();
+			File.Delete(_filename);
+			File.Delete(BloomFilterFilename);
+		}
+
+		_destroyEvent.Set();
+		Dispose(true);
+		GC.SuppressFinalize(this);
+	}
+
+	public void WaitForDisposal(int timeout)
+	{
+		if (!_destroyEvent.Wait(timeout))
+			throw new TimeoutException();
+	}
+
+	public void WaitForDisposal(TimeSpan timeout)
+	{
+		if (!_destroyEvent.Wait(timeout))
+			throw new TimeoutException();
+	}
+
+	public List<IndexEntry> GetRangeWithCache(StreamHash stream, long startNumber, long endNumber,
+		int? limit = null)
+	{
+		if (!OverlapsRange(stream, startNumber, endNumber, out var tableLatestNumber, out var tableLatestOffset))
+			return new List<IndexEntry>();
+
+		// it does overlap.
+		// if the requested end version is greater than or equal to what we have in this ptable
+		// then we can jump to tableLatestOffset and read the file forwards from there without binary chopping.
+		if (endNumber >= tableLatestNumber)
+		{
+			return PositionAndReadForward(stream, startNumber, endNumber, limit,
+				tableLatestOffset: tableLatestOffset);
+		}
+		// todo: else if the requested start version is less than or equal to what we have in this ptable
+		// then we could jump to tableStartOffset and read the file backwards.
+
+		// otherwise the request is contained strictly within what we have in this ptable
+		// and we must chop for it
+		return ChopAndReadForward(stream, startNumber, endNumber, limit);
+	}
+
+	public List<IndexEntry> GetRangeNoCache(StreamHash stream, long startNumber, long endNumber, int? limit = null)
+	{
+		if (!MightContainStream(stream))
+			return new List<IndexEntry>();
+
+		return ChopAndReadForward(stream, startNumber, endNumber, limit);
+	}
+
+	private List<IndexEntry> ChopAndReadForward(StreamHash stream, long startNumber, long endNumber, int? limit)
+	{
+		return PositionAndReadForward(stream, startNumber, endNumber, limit: limit, tableLatestOffset: null);
+	}
+
+	private List<IndexEntry> PositionAndReadForward(StreamHash stream, long startNumber, long endNumber, int? limit,
+		long? tableLatestOffset)
+	{
+		var result = new List<IndexEntry>();
+
+		var startKey = BuildKey(stream, startNumber);
+		var endKey = BuildKey(stream, endNumber);
+
+		if (startKey.GreaterThan(_maxEntry) || endKey.SmallerThan(_minEntry))
+			return result;
+
+		var workItem = GetWorkItem();
+		try
+		{
+			var high = tableLatestOffset ?? ChopForLatest(workItem, endKey);
+			PositionAtEntry(_indexEntrySize, high, workItem);
+			result = ReadForward(workItem, high, startKey, endKey, limit);
+			return result;
+		}
+		catch (MaybeCorruptIndexException ex)
+		{
+			throw new MaybeCorruptIndexException(
+				$"{ex.Message}. stream {stream}, startNum {startNumber}, endNum {endNumber}, PTable: {Filename}.");
+		}
+		finally
+		{
+			ReturnWorkItem(workItem);
+		}
+	}
+
+	// forward here meaning forward in the file. towards the older records.
+	private List<IndexEntry> ReadForward(WorkItem workItem, long high, IndexEntryKey startKey, IndexEntryKey endKey,
+		int? limit)
+	{
+
+		var result = new List<IndexEntry>();
+
+		for (long i = high, n = Count; i < n; ++i)
+		{
+			var entry = ReadNextNoSeek(workItem, _version);
+
+			var candidateKey = new IndexEntryKey(entry.Stream, entry.Version);
+
+			if (candidateKey.GreaterThan(endKey))
+				throw new MaybeCorruptIndexException($"candidateKey ({candidateKey}) > endKey ({endKey})");
+
+			if (candidateKey.SmallerThan(startKey))
+				return result;
+
+			result.Add(entry);
+
+			if (result.Count == limit)
+				break;
+		}
+
+		return result;
+	}
+
+	private long ChopForLatest(WorkItem workItem, IndexEntryKey endKey)
+	{
+		var recordRange = LocateRecordRange(endKey, out var lowBoundsCheck, out var highBoundsCheck);
+		long low = recordRange.Lower;
+		long high = recordRange.Upper;
+		while (low < high)
+		{
+			var mid = low + (high - low) / 2;
+			var midpoint = ReadEntry(_indexEntrySize, mid, workItem, _version);
+			var midpointKey = new IndexEntryKey(midpoint.Stream, midpoint.Version);
+
+			if (midpointKey.GreaterThan(lowBoundsCheck))
+			{
+				throw new MaybeCorruptIndexException(String.Format(
+					"Midpoint key (stream: {0}, version: {1}) > low bounds check key (stream: {2}, version: {3})",
+					midpointKey.Stream, midpointKey.Version, lowBoundsCheck.Stream, lowBoundsCheck.Version));
+			}
+			else if (!midpointKey.GreaterEqualsThan(highBoundsCheck))
+			{
+				throw new MaybeCorruptIndexException(String.Format(
+					"Midpoint key (stream: {0}, version: {1}) < high bounds check key (stream: {2}, version: {3})",
+					midpointKey.Stream, midpointKey.Version, highBoundsCheck.Stream, highBoundsCheck.Version));
+			}
+
+			if (midpointKey.GreaterThan(endKey))
+			{
+				low = mid + 1;
+				lowBoundsCheck = midpointKey;
+			}
+			else
+			{
+				high = mid;
+				highBoundsCheck = midpointKey;
 			}
 		}
 
-		public IList<IndexEntry> GetRange(ulong stream, long startNumber, long endNumber, int? limit = null) {
-			Ensure.Nonnegative(startNumber, "startNumber");
-			Ensure.Nonnegative(endNumber, "endNumber");
+		return high;
+	}
 
-			return _lruCache == null
-				? GetRangeNoCache(GetHash(stream), startNumber, endNumber, limit)
-				: GetRangeWithCache(GetHash(stream), startNumber, endNumber, limit);
-		}
+	private long ChopForOldest(WorkItem workItem, IndexEntryKey startKey)
+	{
+		var recordRange = LocateRecordRange(startKey, out var lowBoundsCheck, out var highBoundsCheck);
+		long low = recordRange.Lower;
+		long high = recordRange.Upper;
+		while (low < high)
+		{
+			var mid = low + (high - low + 1) / 2;
+			var midpoint = ReadEntry(_indexEntrySize, mid, workItem, _version);
+			var midpointKey = new IndexEntryKey(midpoint.Stream, midpoint.Version);
 
-		private StreamHash GetHash(ulong hash) {
-			return new(_version, hash);
-		}
-
-		private static IndexEntryKey BuildKey(StreamHash stream, long version) {
-			return new IndexEntryKey(stream.Hash, version);
-		}
-
-		// use the midpoints (if they exist) to narrow the search range.
-		// returns a range of indexes to search and corresponding IndexEntryKeys
-		private Range LocateRecordRange(IndexEntryKey key, out IndexEntryKey lowKey, out IndexEntryKey highKey) =>
-			LocateRecordRange(key, key, out lowKey, out highKey);
-
-		private Range LocateRecordRange(IndexEntryKey lowKey, IndexEntryKey highKey, out IndexEntryKey lowKeyOut, out IndexEntryKey highKeyOut) {
-			lowKeyOut = new IndexEntryKey(ulong.MaxValue, long.MaxValue);
-			highKeyOut = new IndexEntryKey(ulong.MinValue, long.MinValue);
-
-			ReadOnlySpan<Midpoint> midpoints = null;
-			if (_midpoints != null) {
-				midpoints = _midpoints.AsSpan();
+			if (midpointKey.GreaterThan(lowBoundsCheck))
+			{
+				throw new MaybeCorruptIndexException(String.Format(
+					"Midpoint key (stream: {0}, version: {1}) > low bounds check key (stream: {2}, version: {3})",
+					midpointKey.Stream, midpointKey.Version, lowBoundsCheck.Stream, lowBoundsCheck.Version));
+			}
+			else if (!midpointKey.GreaterEqualsThan(highBoundsCheck))
+			{
+				throw new MaybeCorruptIndexException(String.Format(
+					"Midpoint key (stream: {0}, version: {1}) < high bounds check key (stream: {2}, version: {3})",
+					midpointKey.Stream, midpointKey.Version, highBoundsCheck.Stream, highBoundsCheck.Version));
 			}
 
-			if (midpoints == null)
-				return new Range(0, Count - 1);
-
-			long lowerMidpoint = LowerMidpointBound(midpoints, lowKey);
-			long upperMidpoint = UpperMidpointBound(midpoints, highKey);
-
-			lowKeyOut = midpoints[(int)lowerMidpoint].Key;
-			highKeyOut = midpoints[(int)upperMidpoint].Key;
-
-			return new Range(midpoints[(int)lowerMidpoint].ItemIndex, midpoints[(int)upperMidpoint].ItemIndex);
-		}
-
-		private long LowerMidpointBound(ReadOnlySpan<Midpoint> midpoints, IndexEntryKey key) {
-			long l = 0;
-			long r = midpoints.Length - 1;
-			while (l < r) {
-				long m = l + (r - l + 1) / 2;
-				if (midpoints[(int)m].Key.GreaterThan(key))
-					l = m;
-				else
-					r = m - 1;
+			if (midpointKey.SmallerThan(startKey))
+			{
+				high = mid - 1;
+				highBoundsCheck = midpointKey;
 			}
-
-			return l;
-		}
-
-		private long UpperMidpointBound(ReadOnlySpan<Midpoint> midpoints, IndexEntryKey key) {
-			long l = 0;
-			long r = midpoints.Length - 1;
-			while (l < r) {
-				long m = l + (r - l) / 2;
-				if (midpoints[(int)m].Key.SmallerThan(key))
-					r = m;
-				else
-					l = m + 1;
-			}
-
-			return r;
-		}
-
-		private static void PositionAtEntry(int indexEntrySize, long indexNum, WorkItem workItem) {
-			workItem.Stream.Seek(indexEntrySize * indexNum + PTableHeader.Size, SeekOrigin.Begin);
-		}
-
-		private static IndexEntry ReadEntry(int indexEntrySize, long indexNum, WorkItem workItem, int ptableVersion) {
-			long seekTo = indexEntrySize * indexNum + PTableHeader.Size;
-			workItem.Stream.Seek(seekTo, SeekOrigin.Begin);
-			return ReadNextNoSeek(workItem, ptableVersion);
-		}
-
-		private IndexEntry ReadEntry(int indexEntrySize, long indexNum, int ptableVersion) {
-			var workItem = GetWorkItem();
-			try {
-				return ReadEntry(_indexEntrySize, indexNum, workItem, ptableVersion);
-			} finally {
-				ReturnWorkItem(workItem);
+			else
+			{
+				low = mid;
+				lowBoundsCheck = midpointKey;
 			}
 		}
 
-		private static IndexEntry ReadNextNoSeek(WorkItem workItem, int ptableVersion) {
-			long version = (ptableVersion >= PTableVersions.IndexV3)
-				? workItem.Reader.ReadInt64()
-				: workItem.Reader.ReadInt32();
-			ulong stream = ptableVersion == PTableVersions.IndexV1
-				? workItem.Reader.ReadUInt32()
-				: workItem.Reader.ReadUInt64();
-			long position = workItem.Reader.ReadInt64();
-			return new IndexEntry(stream, version, position);
+		return high;
+	}
+
+	// Checks if this file might contain any of the range from start to end inclusive.
+	private bool OverlapsRange(
+		StreamHash stream,
+		long startNumber,
+		long endNumber,
+		out long tableLatestNumber,
+		out long tableLatestOffset)
+	{
+
+		if (!TryLookThroughLru(stream, out var cacheEntry))
+		{
+			// no range present
+			tableLatestNumber = default;
+			tableLatestOffset = default;
+			return false;
 		}
 
-		private WorkItem GetWorkItem() {
-			try {
-				return _workItems.Get();
-			} catch (ObjectPoolDisposingException) {
-				throw new FileBeingDeletedException();
-			} catch (ObjectPoolMaxLimitReachedException) {
-				throw new Exception("Unable to acquire work item.");
+		tableLatestNumber = cacheEntry.LatestNumber;
+		tableLatestOffset = cacheEntry.LatestOffset;
+
+		// there is a range for this stream, does it overlap?
+		return startNumber <= cacheEntry.LatestNumber && cacheEntry.OldestNumber <= endNumber;
+	}
+
+	// Gets the value from the lru cache. Populate the cache if necessary
+	// returns true iff we managed to get a CacheEntry. i.e. if any events are
+	// present for this stream in this file.
+	private bool TryLookThroughLru(StreamHash stream, out CacheEntry value)
+	{
+		Ensure.NotNull(_lruCache, nameof(_lruCache));
+
+		if (_lruCache.TryGet(stream, out value))
+		{
+			return true;
+		}
+
+		if (!MightContainStream(stream))
+		{
+			value = default;
+			return false;
+		}
+
+		if (_lruConfirmedNotPresent.TryGet(stream, out _))
+		{
+			value = default;
+			return false;
+		}
+
+		// its not in either of the LRU caches. add it to one or the other
+		// so that subsequent calls do not require searching.
+		if (TrySearchForLatestEntry(stream, 0, long.MaxValue, out var latestEntry, out var latestOffset) &&
+		    TrySearchForOldestEntry(stream, 0, long.MaxValue, out var oldestEntry, out var oldestOffset))
+		{
+
+			value = new(
+				oldestNumber: oldestEntry.Version,
+				latestNumber: latestEntry.Version,
+				oldestOffset: oldestOffset,
+				latestOffset: latestOffset);
+
+			_lruCache.Put(stream, value);
+			return true;
+		}
+		else
+		{
+			// in case of false positive in the bloom filter
+			_lruConfirmedNotPresent.Put(stream, true);
+			value = default;
+			return false;
+		}
+	}
+
+	private bool MightContainStream(StreamHash stream)
+	{
+		if (_bloomFilter == null)
+			return true;
+
+		// with a workitem checked out the ptable (and bloom filter specifically)
+		// wont get disposed
+		var workItem = GetWorkItem();
+		try
+		{
+			var streamHash = stream.Hash;
+			return _bloomFilter.MightContain(GetSpan(ref streamHash));
+		}
+		finally
+		{
+			ReturnWorkItem(workItem);
+		}
+	}
+
+	private static ReadOnlySpan<byte> GetSpan(ref ulong streamHash) =>
+		MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref streamHash, 1));
+
+	// construct this struct with a 64 bit hash and it will convert it to a hash
+	// for the specified table version
+	public readonly struct StreamHash : IEquatable<StreamHash>
+	{
+		public StreamHash(byte version, ulong hash)
+		{
+			Hash = version == PTableVersions.IndexV1 ? hash >> 32 : hash;
+		}
+
+		public ulong Hash { get; init; }
+
+		public override int GetHashCode() =>
+			Hash.GetHashCode();
+
+		public bool Equals(StreamHash other) =>
+			Hash == other.Hash;
+
+		public override bool Equals(object obj) =>
+			obj is StreamHash streamHash && Equals(streamHash);
+	}
+
+	public struct CacheEntry
+	{
+		public readonly long OldestNumber;
+		public readonly long LatestNumber;
+		public readonly long OldestOffset;
+		public readonly long LatestOffset;
+
+		public CacheEntry(long oldestNumber, long latestNumber, long oldestOffset, long latestOffset)
+		{
+			OldestNumber = oldestNumber;
+			LatestNumber = latestNumber;
+			OldestOffset = oldestOffset;
+			LatestOffset = latestOffset;
+		}
+	}
+
+	public struct Midpoint
+	{
+		public readonly IndexEntryKey Key;
+		public readonly long ItemIndex;
+
+		public Midpoint(IndexEntryKey key, long itemIndex)
+		{
+			Key = key;
+			ItemIndex = itemIndex;
+		}
+	}
+
+	public readonly struct IndexEntryKey
+	{
+		public readonly ulong Stream;
+		public readonly long Version;
+
+		public IndexEntryKey(ulong stream, long version)
+		{
+			Stream = stream;
+			Version = version;
+		}
+
+		public bool GreaterThan(IndexEntryKey other)
+		{
+			if (Stream == other.Stream)
+			{
+				return Version > other.Version;
 			}
+
+			return Stream > other.Stream;
 		}
 
-		private void ReturnWorkItem(WorkItem workItem) {
-			_workItems.Return(workItem);
-		}
-
-		public void MarkForDestruction() {
-			_deleteFile = true;
-			_workItems.MarkForDisposal();
-		}
-
-		public void Dispose() {
-			_deleteFile = false;
-			_workItems.MarkForDisposal();
-		}
-
-		protected virtual void Dispose(bool disposing) {
-			if (_disposed) {
-				return;
+		public bool SmallerThan(IndexEntryKey other)
+		{
+			if (Stream == other.Stream)
+			{
+				return Version < other.Version;
 			}
 
-			if (disposing) {
-				//dispose any managed objects here
-				_midpoints?.Dispose();
-				_bloomFilter?.Dispose();
-			}
-
-			_disposed = true;
+			return Stream < other.Stream;
 		}
 
-		private void OnAllWorkItemsDisposed() {
-			File.SetAttributes(_filename, FileAttributes.Normal);
-			if (_deleteFile) {
-				_bloomFilter?.Dispose();
-				File.Delete(_filename);
-				File.Delete(BloomFilterFilename);
+		public bool GreaterEqualsThan(IndexEntryKey other)
+		{
+			if (Stream == other.Stream)
+			{
+				return Version >= other.Version;
 			}
-			_destroyEvent.Set();
+
+			return Stream >= other.Stream;
+		}
+
+		public bool SmallerEqualsThan(IndexEntryKey other)
+		{
+			if (Stream == other.Stream)
+			{
+				return Version <= other.Version;
+			}
+
+			return Stream <= other.Stream;
+		}
+
+		public override string ToString()
+		{
+			return string.Format("Stream: {0}, Version: {1}", Stream, Version);
+		}
+	}
+
+	private class WorkItem : IDisposable
+	{
+		public readonly FileStream Stream;
+		public readonly BinaryReader Reader;
+
+		public WorkItem(string filename, int bufferSize)
+		{
+			Stream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize,
+				FileOptions.RandomAccess);
+			Reader = new BinaryReader(Stream);
+		}
+
+		~WorkItem()
+		{
+			Dispose(false);
+		}
+
+		public void Dispose()
+		{
 			Dispose(true);
 			GC.SuppressFinalize(this);
 		}
 
-		public void WaitForDisposal(int timeout) {
-			if (!_destroyEvent.Wait(timeout))
-				throw new TimeoutException();
-		}
-
-		public void WaitForDisposal(TimeSpan timeout) {
-			if (!_destroyEvent.Wait(timeout))
-				throw new TimeoutException();
-		}
-
-		public List<IndexEntry> GetRangeWithCache(StreamHash stream, long startNumber, long endNumber, int? limit = null) {
-			if (!OverlapsRange(stream, startNumber, endNumber, out var tableLatestNumber, out var tableLatestOffset))
-				return new List<IndexEntry>();
-
-			// it does overlap.
-			// if the requested end version is greater than or equal to what we have in this ptable
-			// then we can jump to tableLatestOffset and read the file forwards from there without binary chopping.
-			if (endNumber >= tableLatestNumber) {
-				return PositionAndReadForward(stream, startNumber, endNumber, limit, tableLatestOffset: tableLatestOffset);
-			}
-			// todo: else if the requested start version is less than or equal to what we have in this ptable
-			// then we could jump to tableStartOffset and read the file backwards.
-
-			// otherwise the request is contained strictly within what we have in this ptable
-			// and we must chop for it
-			return ChopAndReadForward(stream, startNumber, endNumber, limit);
-		}
-
-		public List<IndexEntry> GetRangeNoCache(StreamHash stream, long startNumber, long endNumber, int? limit = null) {
-			if (!MightContainStream(stream))
-				return new List<IndexEntry>();
-
-			return ChopAndReadForward(stream, startNumber, endNumber, limit);
-		}
-
-		private List<IndexEntry> ChopAndReadForward(StreamHash stream, long startNumber, long endNumber, int? limit) {
-			return PositionAndReadForward(stream, startNumber, endNumber, limit: limit, tableLatestOffset: null);
-		}
-
-		private List<IndexEntry> PositionAndReadForward(StreamHash stream, long startNumber, long endNumber, int? limit, long? tableLatestOffset) {
-			var result = new List<IndexEntry>();
-
-			var startKey = BuildKey(stream, startNumber);
-			var endKey = BuildKey(stream, endNumber);
-
-			if (startKey.GreaterThan(_maxEntry) || endKey.SmallerThan(_minEntry))
-				return result;
-
-			var workItem = GetWorkItem();
-			try {
-				var high = tableLatestOffset ?? ChopForLatest(workItem, endKey);
-				PositionAtEntry(_indexEntrySize, high, workItem);
-				result = ReadForward(workItem, high, startKey, endKey, limit);
-				return result;
-			} catch (MaybeCorruptIndexException ex) {
-				throw new MaybeCorruptIndexException(
-					$"{ex.Message}. stream {stream}, startNum {startNumber}, endNum {endNumber}, PTable: {Filename}.");
-			} finally {
-				ReturnWorkItem(workItem);
+		private void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				Stream.Dispose();
+				Reader.Dispose();
 			}
 		}
-
-		// forward here meaning forward in the file. towards the older records.
-		private List<IndexEntry> ReadForward(WorkItem workItem, long high, IndexEntryKey startKey, IndexEntryKey endKey, int? limit) {
-
-			var result = new List<IndexEntry>();
-
-			for (long i = high, n = Count; i < n; ++i) {
-				var entry = ReadNextNoSeek(workItem, _version);
-
-				var candidateKey = new IndexEntryKey(entry.Stream, entry.Version);
-
-				if (candidateKey.GreaterThan(endKey))
-					throw new MaybeCorruptIndexException($"candidateKey ({candidateKey}) > endKey ({endKey})");
-
-				if (candidateKey.SmallerThan(startKey))
-					return result;
-
-				result.Add(entry);
-
-				if (result.Count == limit)
-					break;
-			}
-
-			return result;
-		}
-
-		private long ChopForLatest(WorkItem workItem, IndexEntryKey endKey) {
-			var recordRange = LocateRecordRange(endKey, out var lowBoundsCheck, out var highBoundsCheck);
-			long low = recordRange.Lower;
-			long high = recordRange.Upper;
-			while (low < high) {
-				var mid = low + (high - low) / 2;
-				var midpoint = ReadEntry(_indexEntrySize, mid, workItem, _version);
-				var midpointKey = new IndexEntryKey(midpoint.Stream, midpoint.Version);
-
-				if (midpointKey.GreaterThan(lowBoundsCheck)) {
-					throw new MaybeCorruptIndexException(String.Format(
-						"Midpoint key (stream: {0}, version: {1}) > low bounds check key (stream: {2}, version: {3})",
-						midpointKey.Stream, midpointKey.Version, lowBoundsCheck.Stream, lowBoundsCheck.Version));
-				} else if (!midpointKey.GreaterEqualsThan(highBoundsCheck)) {
-					throw new MaybeCorruptIndexException(String.Format(
-						"Midpoint key (stream: {0}, version: {1}) < high bounds check key (stream: {2}, version: {3})",
-						midpointKey.Stream, midpointKey.Version, highBoundsCheck.Stream, highBoundsCheck.Version));
-				}
-
-				if (midpointKey.GreaterThan(endKey)) {
-					low = mid + 1;
-					lowBoundsCheck = midpointKey;
-				} else {
-					high = mid;
-					highBoundsCheck = midpointKey;
-				}
-			}
-
-			return high;
-		}
-
-		private long ChopForOldest(WorkItem workItem, IndexEntryKey startKey) {
-			var recordRange = LocateRecordRange(startKey, out var lowBoundsCheck, out var highBoundsCheck);
-			long low = recordRange.Lower;
-			long high = recordRange.Upper;
-			while (low < high) {
-				var mid = low + (high - low + 1) / 2;
-				var midpoint = ReadEntry(_indexEntrySize, mid, workItem, _version);
-				var midpointKey = new IndexEntryKey(midpoint.Stream, midpoint.Version);
-
-				if (midpointKey.GreaterThan(lowBoundsCheck)) {
-					throw new MaybeCorruptIndexException(String.Format(
-						"Midpoint key (stream: {0}, version: {1}) > low bounds check key (stream: {2}, version: {3})",
-						midpointKey.Stream, midpointKey.Version, lowBoundsCheck.Stream, lowBoundsCheck.Version));
-				} else if (!midpointKey.GreaterEqualsThan(highBoundsCheck)) {
-					throw new MaybeCorruptIndexException(String.Format(
-						"Midpoint key (stream: {0}, version: {1}) < high bounds check key (stream: {2}, version: {3})",
-						midpointKey.Stream, midpointKey.Version, highBoundsCheck.Stream, highBoundsCheck.Version));
-				}
-
-				if (midpointKey.SmallerThan(startKey)) {
-					high = mid - 1;
-					highBoundsCheck = midpointKey;
-				} else {
-					low = mid;
-					lowBoundsCheck = midpointKey;
-				}
-			}
-
-			return high;
-		}
-
-		// Checks if this file might contain any of the range from start to end inclusive.
-		private bool OverlapsRange(
-			StreamHash stream,
-			long startNumber,
-			long endNumber,
-			out long tableLatestNumber,
-			out long tableLatestOffset) {
-
-			if (!TryLookThroughLru(stream, out var cacheEntry)) {
-				// no range present
-				tableLatestNumber = default;
-				tableLatestOffset = default;
-				return false;
-			}
-
-			tableLatestNumber = cacheEntry.LatestNumber;
-			tableLatestOffset = cacheEntry.LatestOffset;
-
-			// there is a range for this stream, does it overlap?
-			return startNumber <= cacheEntry.LatestNumber && cacheEntry.OldestNumber <= endNumber;
-		}
-
-		// Gets the value from the lru cache. Populate the cache if necessary
-		// returns true iff we managed to get a CacheEntry. i.e. if any events are
-		// present for this stream in this file.
-		private bool TryLookThroughLru(StreamHash stream, out CacheEntry value) {
-			Ensure.NotNull(_lruCache, nameof(_lruCache));
-
-			if (_lruCache.TryGet(stream, out value)) {
-				return true;
-			}
-
-			if (!MightContainStream(stream)) {
-				value = default;
-				return false;
-			}
-
-			if (_lruConfirmedNotPresent.TryGet(stream, out _)) {
-				value = default;
-				return false;
-			}
-
-			// its not in either of the LRU caches. add it to one or the other
-			// so that subsequent calls do not require searching.
-			if (TrySearchForLatestEntry(stream, 0, long.MaxValue, out var latestEntry, out var latestOffset) &&
-				TrySearchForOldestEntry(stream, 0, long.MaxValue, out var oldestEntry, out var oldestOffset)) {
-
-				value = new(
-					oldestNumber: oldestEntry.Version,
-					latestNumber: latestEntry.Version,
-					oldestOffset: oldestOffset,
-					latestOffset: latestOffset);
-
-				_lruCache.Put(stream, value);
-				return true;
-			} else {
-				// in case of false positive in the bloom filter
-				_lruConfirmedNotPresent.Put(stream, true);
-				value = default;
-				return false;
-			}
-		}
-
-		private bool MightContainStream(StreamHash stream) {
-			if (_bloomFilter == null)
-				return true;
-
-			// with a workitem checked out the ptable (and bloom filter specifically)
-			// wont get disposed
-			var workItem = GetWorkItem();
-			try {
-				var streamHash = stream.Hash;
-				return _bloomFilter.MightContain(GetSpan(ref streamHash));
-			} finally {
-				ReturnWorkItem(workItem);
-			}
-		}
-
-		private static ReadOnlySpan<byte> GetSpan(ref ulong streamHash) =>
-			MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref streamHash, 1));
-
-		// construct this struct with a 64 bit hash and it will convert it to a hash
-		// for the specified table version
-		public readonly struct StreamHash : IEquatable<StreamHash> {
-			public StreamHash(byte version, ulong hash) {
-				Hash = version == PTableVersions.IndexV1 ? hash >> 32 : hash;
-			}
-
-			public ulong Hash { get; init; }
-
-			public override int GetHashCode() =>
-				Hash.GetHashCode();
-
-			public bool Equals(StreamHash other) =>
-				Hash == other.Hash;
-
-			public override bool Equals(object obj) =>
-				obj is StreamHash streamHash && Equals(streamHash);
-		}
-
-		public struct CacheEntry {
-			public readonly long OldestNumber;
-			public readonly long LatestNumber;
-			public readonly long OldestOffset;
-			public readonly long LatestOffset;
-
-			public CacheEntry(long oldestNumber, long latestNumber, long oldestOffset, long latestOffset) {
-				OldestNumber = oldestNumber;
-				LatestNumber = latestNumber;
-				OldestOffset = oldestOffset;
-				LatestOffset = latestOffset;
-			}
-		}
-
-		public struct Midpoint {
-			public readonly IndexEntryKey Key;
-			public readonly long ItemIndex;
-
-			public Midpoint(IndexEntryKey key, long itemIndex) {
-				Key = key;
-				ItemIndex = itemIndex;
-			}
-		}
-
-		public readonly struct IndexEntryKey {
-			public readonly ulong Stream;
-			public readonly long Version;
-
-			public IndexEntryKey(ulong stream, long version) {
-				Stream = stream;
-				Version = version;
-			}
-
-			public bool GreaterThan(IndexEntryKey other) {
-				if (Stream == other.Stream) {
-					return Version > other.Version;
-				}
-
-				return Stream > other.Stream;
-			}
-
-			public bool SmallerThan(IndexEntryKey other) {
-				if (Stream == other.Stream) {
-					return Version < other.Version;
-				}
-
-				return Stream < other.Stream;
-			}
-
-			public bool GreaterEqualsThan(IndexEntryKey other) {
-				if (Stream == other.Stream) {
-					return Version >= other.Version;
-				}
-
-				return Stream >= other.Stream;
-			}
-
-			public bool SmallerEqualsThan(IndexEntryKey other) {
-				if (Stream == other.Stream) {
-					return Version <= other.Version;
-				}
-
-				return Stream <= other.Stream;
-			}
-
-			public override string ToString() {
-				return string.Format("Stream: {0}, Version: {1}", Stream, Version);
-			}
-		}
-
-		private class WorkItem : IDisposable {
-			public readonly FileStream Stream;
-			public readonly BinaryReader Reader;
-
-			public WorkItem(string filename, int bufferSize) {
-				Stream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize,
-					FileOptions.RandomAccess);
-				Reader = new BinaryReader(Stream);
-			}
-
-			~WorkItem() {
-				Dispose(false);
-			}
-
-			public void Dispose() {
-				Dispose(true);
-				GC.SuppressFinalize(this);
-			}
-
-			private void Dispose(bool disposing) {
-				if (disposing) {
-					Stream.Dispose();
-					Reader.Dispose();
-				}
-			}
-		}
-	}
-
-	internal class HashCollisionException : Exception {
 	}
 }
+
+internal class HashCollisionException : Exception;

--- a/src/EventStore.Core/Index/TableIndex.cs
+++ b/src/EventStore.Core/Index/TableIndex.cs
@@ -427,7 +427,7 @@ namespace EventStore.Core.Index {
 				Log.Information("Starting scavenge of TableIndex.");
 				ScavengeInternal(shouldKeep, log, ct);
 			} finally {
-				// Since scavenging indexes is the only place the ExistsAt optimization makes sense (and takes up a lot of memory), we can clear it after an index scavenge has completed. 
+				// Since scavenging indexes is the only place the ExistsAt optimization makes sense (and takes up a lot of memory), we can clear it after an index scavenge has completed.
 				TFChunkReaderExistsAtOptimizer.Instance.DeOptimizeAll();
 
 				lock (_awaitingTablesLock) {
@@ -825,7 +825,7 @@ namespace EventStore.Core.Index {
 
 			// 1. assemble results per table for memtables and ptables
 			// discard any results with 0 entries.
-			var resultsPerTable = new List<IList<IndexEntry>>(16);
+			var resultsPerTable = new List<IReadOnlyList<IndexEntry>>(16);
 
 			var awaiting = _awaitingMemTables;
 			for (int index = 0; index < awaiting.Count; index++) {


### PR DESCRIPTION
Changed: update HashListMemTable and related interfaces for improved concurrency and readability

- Refactored HashListMemTable to utilize AsyncReaderWriterLock for better concurrency control.
- Method signatures in IMemTable and ISearchTable to use IReadOnlyList instead of IList for improved immutability.
- Exception handling and code readability throughout the HashListMemTable implementation.