### PR TITLE
Disable timeouts on critical reads to ensure startup stability

### DIFF
--- a/src/EventStore.Core/Helpers/IODispatcher.cs
+++ b/src/EventStore.Core/Helpers/IODispatcher.cs
@@ -12,388 +12,388 @@ using EventStore.Common.Utils;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
 
-namespace EventStore.Core.Helpers {
-	
-	public sealed class IODispatcher : IHandle<IODispatcherDelayedMessage>, IHandle<ClientMessage.NotHandled> {
-		public sealed class RequestTracking {
-			public RequestTracking(bool trackPendingRequests) {
-				_trackPendingRequests = trackPendingRequests;
-			}
+namespace EventStore.Core.Helpers;
 
-			private readonly WriterQueueSet _writerQueueSet = new WriterQueueSet();
-			private readonly PendingWrites _pendingWrites = new PendingWrites();
-			private readonly PendingReads _pendingReads = new PendingReads();
-			private readonly bool _trackPendingRequests;
-			private readonly HashSet<Guid> _allPendingRequests = new HashSet<Guid>();
-			private bool _draining;
-			private Action _onRequestsDrained;
-			private readonly object _lockObject = new object();
+public sealed class IODispatcher : IHandle<IODispatcherDelayedMessage>, IHandle<ClientMessage.NotHandled>
+{
+	public sealed class RequestTracking(bool trackPendingRequests)
+	{
+		private readonly WriterQueueSet _writerQueueSet = new WriterQueueSet();
+		private readonly PendingWrites _pendingWrites = new PendingWrites();
+		private readonly PendingReads _pendingReads = new PendingReads();
+		private readonly HashSet<Guid> _allPendingRequests = new HashSet<Guid>();
+		private bool _draining;
+		private Action _onRequestsDrained;
+		private readonly object _lockObject = new object();
 
-			public void StartDraining(Action onRequestsDrained) {
-				lock (_lockObject) {
-					if (_allPendingRequests.IsEmpty()) {
-						onRequestsDrained?.Invoke();
-						return;
-					}
-					_draining = true;
-					_onRequestsDrained = onRequestsDrained;
-				}
-			}
-
-			public void AddPendingRequest(Guid correlationId) {
-				lock (_lockObject) {
-					if (!_trackPendingRequests)
-						return;
-			
-					_allPendingRequests.Add(correlationId);
-				}
-			}
-
-			public void RemovePendingRequest(Guid correlationId) {
-				lock (_lockObject) {
-					if (!_trackPendingRequests)
-						return;
-
-					_allPendingRequests.Remove(correlationId);
-					if (_draining && _allPendingRequests.IsEmpty()) {
-						_onRequestsDrained?.Invoke();
-						_onRequestsDrained = null;
-						_draining = false;
-					}
-				}
-			}
-
-			public void AddPendingRead(Guid corrId) {
-				lock (_lockObject) {
-					AddPendingRequest(corrId);
-					_pendingReads.Register(corrId);
-				}
-			}
-
-			public bool RemovePendingRead(Guid corrId) {
-				lock (_lockObject) {
-					RemovePendingRequest(corrId);
-					if (!_pendingReads.IsRegistered(corrId))
-						return false;
-					_pendingReads.Remove(corrId);
-					return true;
-				}
-			}
-
-			private void WorkQueue(
-				Guid key,
-				RequestResponseDispatcher<ClientMessage.WriteEvents, ClientMessage.WriteEventsCompleted> writer) {
-
-				if (_writerQueueSet.IsBusy(key))
+		public void StartDraining(Action onRequestsDrained)
+		{
+			lock (_lockObject)
+			{
+				if (_allPendingRequests.IsEmpty())
+				{
+					onRequestsDrained?.Invoke();
 					return;
-				if (!_writerQueueSet.HasPendingWrites(key))
+				}
+
+				_draining = true;
+				_onRequestsDrained = onRequestsDrained;
+			}
+		}
+
+		public void AddPendingRequest(Guid correlationId)
+		{
+			lock (_lockObject)
+			{
+				if (!trackPendingRequests)
 					return;
-				var write = _writerQueueSet.Dequeue(key);
-				if (write != null) {
-					writer.Publish(write, (msg) => Handle(key, msg, writer));
-				}
+
+				_allPendingRequests.Add(correlationId);
 			}
+		}
 
-			private void Handle(
-				Guid key,
-				ClientMessage.WriteEventsCompleted message,
-				RequestResponseDispatcher<ClientMessage.WriteEvents, ClientMessage.WriteEventsCompleted> writer) {
+		public void RemovePendingRequest(Guid correlationId)
+		{
+			lock (_lockObject)
+			{
+				if (!trackPendingRequests)
+					return;
 
-				lock (_lockObject) {
-					_writerQueueSet.Finish(key);
-
-					_pendingWrites.CompleteRequest(message);
-					RemovePendingRequest(message.CorrelationId);
-
-					WorkQueue(key, writer);
-				}
-			}
-
-			public void QueuePendingWrite(
-				Guid key,
-				Guid corrId,
-				Action<ClientMessage.WriteEventsCompleted> action,
-				ClientMessage.WriteEvents message,
-				RequestResponseDispatcher<ClientMessage.WriteEvents, ClientMessage.WriteEventsCompleted> writer) {
-
-				lock (_lockObject) {
-					AddPendingRequest(corrId);
-					_pendingWrites.CaptureCallback(corrId, action);
-
-					_writerQueueSet.AddToQueue(key, message);
-
-					WorkQueue(key, writer);
+				_allPendingRequests.Remove(correlationId);
+				if (_draining && _allPendingRequests.IsEmpty())
+				{
+					_onRequestsDrained?.Invoke();
+					_onRequestsDrained = null;
+					_draining = false;
 				}
 			}
 		}
 
-		public const int ReadTimeoutMs = 10000;
+		public void AddPendingRead(Guid corrId)
+		{
+			lock (_lockObject)
+			{
+				AddPendingRequest(corrId);
+				_pendingReads.Register(corrId);
+			}
+		}
 
-		private readonly Guid _selfId = Guid.NewGuid();
-		private readonly IPublisher _publisher;
-		private readonly IEnvelope _inputQueueEnvelope;
-		private readonly RequestTracking _requestTracker;
+		public bool RemovePendingRead(Guid corrId)
+		{
+			lock (_lockObject)
+			{
+				RemovePendingRequest(corrId);
+				if (!_pendingReads.IsRegistered(corrId))
+					return false;
+				_pendingReads.Remove(corrId);
+				return true;
+			}
+		}
 
-		public readonly
-			RequestResponseDispatcher
-			<ClientMessage.ReadStreamEventsForward, ClientMessage.ReadStreamEventsForwardCompleted> ForwardReader;
+		private void WorkQueue(
+			Guid key,
+			RequestResponseDispatcher<ClientMessage.WriteEvents, ClientMessage.WriteEventsCompleted> writer)
+		{
 
-		public ReadDispatcher BackwardReader { get; }
+			if (_writerQueueSet.IsBusy(key))
+				return;
+			if (!_writerQueueSet.HasPendingWrites(key))
+				return;
+			var write = _writerQueueSet.Dequeue(key);
+			if (write != null)
+			{
+				writer.Publish(write, (msg) => Handle(key, msg, writer));
+			}
+		}
 
-		public readonly RequestResponseDispatcher<ClientMessage.WriteEvents, ClientMessage.WriteEventsCompleted> Writer;
+		private void Handle(
+			Guid key,
+			ClientMessage.WriteEventsCompleted message,
+			RequestResponseDispatcher<ClientMessage.WriteEvents, ClientMessage.WriteEventsCompleted> writer)
+		{
 
-		public readonly RequestResponseDispatcher<ClientMessage.DeleteStream, ClientMessage.DeleteStreamCompleted>
-			StreamDeleter;
+			lock (_lockObject)
+			{
+				_writerQueueSet.Finish(key);
 
-		public readonly RequestResponseDispatcher<AwakeServiceMessage.SubscribeAwake, IODispatcherDelayedMessage>
-			Awaker;
+				_pendingWrites.CompleteRequest(message);
+				RemovePendingRequest(message.CorrelationId);
 
-		public readonly RequestResponseDispatcher<ClientMessage.ReadEvent, ClientMessage.ReadEventCompleted> EventReader;
-		
-		public readonly
-			RequestResponseDispatcher
-			<ClientMessage.ReadAllEventsForward, ClientMessage.ReadAllEventsForwardCompleted> AllForwardReader;
+				WorkQueue(key, writer);
+			}
+		}
 
-		public readonly
-			RequestResponseDispatcher
-			<ClientMessage.ReadAllEventsBackward, ClientMessage.ReadAllEventsBackwardCompleted> AllBackwardReader;
+		public void QueuePendingWrite(
+			Guid key,
+			Guid corrId,
+			Action<ClientMessage.WriteEventsCompleted> action,
+			ClientMessage.WriteEvents message,
+			RequestResponseDispatcher<ClientMessage.WriteEvents, ClientMessage.WriteEventsCompleted> writer)
+		{
 
-		public readonly
-			RequestResponseDispatcher
-			<ClientMessage.FilteredReadAllEventsForward, ClientMessage.FilteredReadAllEventsForwardCompleted> AllForwardFilteredReader;
+			lock (_lockObject)
+			{
+				AddPendingRequest(corrId);
+				_pendingWrites.CaptureCallback(corrId, action);
 
-		public readonly
-			RequestResponseDispatcher
-			<ClientMessage.FilteredReadAllEventsBackward, ClientMessage.FilteredReadAllEventsBackwardCompleted> AllBackwardFilteredReader;
+				_writerQueueSet.AddToQueue(key, message);
 
-		public IODispatcher(IPublisher publisher, IEnvelope envelope, bool trackPendingRequests=false) {
-			_publisher = publisher;
-			_inputQueueEnvelope = envelope;
-			_requestTracker = new RequestTracking(trackPendingRequests);
-			
-			ForwardReader =
-				new RequestResponseDispatcher
-					<ClientMessage.ReadStreamEventsForward, ClientMessage.ReadStreamEventsForwardCompleted>(
-						publisher,
-						v => v.CorrelationId,
-						v => v.CorrelationId,
-						envelope);
+				WorkQueue(key, writer);
+			}
+		}
+	}
 
-			BackwardReader = new ReadDispatcher(
+	public const int ReadTimeoutMs = 10000;
+
+	private readonly Guid _selfId = Guid.NewGuid();
+	private readonly IPublisher _publisher;
+	private readonly IEnvelope _inputQueueEnvelope;
+	private readonly RequestTracking _requestTracker;
+
+	public readonly
+		RequestResponseDispatcher
+		<ClientMessage.ReadStreamEventsForward, ClientMessage.ReadStreamEventsForwardCompleted> ForwardReader;
+
+	public ReadDispatcher BackwardReader { get; }
+
+	public readonly RequestResponseDispatcher<ClientMessage.WriteEvents, ClientMessage.WriteEventsCompleted> Writer;
+
+	public readonly RequestResponseDispatcher<ClientMessage.DeleteStream, ClientMessage.DeleteStreamCompleted>
+		StreamDeleter;
+
+	public readonly RequestResponseDispatcher<AwakeServiceMessage.SubscribeAwake, IODispatcherDelayedMessage>
+		Awaker;
+
+	public readonly RequestResponseDispatcher<ClientMessage.ReadEvent, ClientMessage.ReadEventCompleted> EventReader;
+
+	public readonly
+		RequestResponseDispatcher
+		<ClientMessage.ReadAllEventsForward, ClientMessage.ReadAllEventsForwardCompleted> AllForwardReader;
+
+	public readonly
+		RequestResponseDispatcher
+		<ClientMessage.ReadAllEventsBackward, ClientMessage.ReadAllEventsBackwardCompleted> AllBackwardReader;
+
+	public readonly
+		RequestResponseDispatcher
+		<ClientMessage.FilteredReadAllEventsForward, ClientMessage.FilteredReadAllEventsForwardCompleted>
+		AllForwardFilteredReader;
+
+	public readonly
+		RequestResponseDispatcher
+		<ClientMessage.FilteredReadAllEventsBackward, ClientMessage.FilteredReadAllEventsBackwardCompleted>
+		AllBackwardFilteredReader;
+
+	public IODispatcher(IPublisher publisher, IEnvelope envelope, bool trackPendingRequests = false)
+	{
+		_publisher = publisher;
+		_inputQueueEnvelope = envelope;
+		_requestTracker = new RequestTracking(trackPendingRequests);
+
+		ForwardReader =
+			new RequestResponseDispatcher
+				<ClientMessage.ReadStreamEventsForward, ClientMessage.ReadStreamEventsForwardCompleted>(
+					publisher,
+					v => v.CorrelationId,
+					v => v.CorrelationId,
+					envelope);
+
+		BackwardReader = new ReadDispatcher(
+			publisher,
+			v => v.CorrelationId,
+			v => v.CorrelationId,
+			v => v.CorrelationId,
+			envelope);
+
+		Writer =
+			new RequestResponseDispatcher<ClientMessage.WriteEvents, ClientMessage.WriteEventsCompleted>(
 				publisher,
-				v => v.CorrelationId,
 				v => v.CorrelationId,
 				v => v.CorrelationId,
 				envelope);
 
-			Writer =
-				new RequestResponseDispatcher<ClientMessage.WriteEvents, ClientMessage.WriteEventsCompleted>(
+		StreamDeleter =
+			new RequestResponseDispatcher<ClientMessage.DeleteStream, ClientMessage.DeleteStreamCompleted>(
+				publisher,
+				v => v.CorrelationId,
+				v => v.CorrelationId,
+				envelope);
+
+		Awaker =
+			new RequestResponseDispatcher<AwakeServiceMessage.SubscribeAwake, IODispatcherDelayedMessage>(
+				publisher,
+				v => v.CorrelationId,
+				v => v.CorrelationId,
+				envelope,
+				cancelMessageFactory: requestId => new AwakeServiceMessage.UnsubscribeAwake(requestId));
+
+		EventReader =
+			new RequestResponseDispatcher<ClientMessage.ReadEvent, ClientMessage.ReadEventCompleted>(
+				publisher,
+				v => v.CorrelationId,
+				v => v.CorrelationId,
+				envelope);
+
+		AllForwardReader =
+			new RequestResponseDispatcher
+				<ClientMessage.ReadAllEventsForward, ClientMessage.ReadAllEventsForwardCompleted>(
 					publisher,
 					v => v.CorrelationId,
 					v => v.CorrelationId,
 					envelope);
 
-			StreamDeleter =
-				new RequestResponseDispatcher<ClientMessage.DeleteStream, ClientMessage.DeleteStreamCompleted>(
+		AllBackwardReader =
+			new RequestResponseDispatcher
+				<ClientMessage.ReadAllEventsBackward, ClientMessage.ReadAllEventsBackwardCompleted>(
 					publisher,
 					v => v.CorrelationId,
 					v => v.CorrelationId,
 					envelope);
 
-			Awaker =
-				new RequestResponseDispatcher<AwakeServiceMessage.SubscribeAwake, IODispatcherDelayedMessage>(
-					publisher,
-					v => v.CorrelationId,
-					v => v.CorrelationId,
-					envelope,
-					cancelMessageFactory: requestId => new AwakeServiceMessage.UnsubscribeAwake(requestId));
-
-			EventReader =
-				new RequestResponseDispatcher<ClientMessage.ReadEvent, ClientMessage.ReadEventCompleted>(
+		AllForwardFilteredReader =
+			new RequestResponseDispatcher
+				<ClientMessage.FilteredReadAllEventsForward, ClientMessage.FilteredReadAllEventsForwardCompleted>(
 					publisher,
 					v => v.CorrelationId,
 					v => v.CorrelationId,
 					envelope);
-			
-			AllForwardReader =
-				new RequestResponseDispatcher
-					<ClientMessage.ReadAllEventsForward, ClientMessage.ReadAllEventsForwardCompleted>(
-						publisher,
-						v => v.CorrelationId,
-						v => v.CorrelationId,
-						envelope);
 
-			AllBackwardReader =
-				new RequestResponseDispatcher
-					<ClientMessage.ReadAllEventsBackward, ClientMessage.ReadAllEventsBackwardCompleted>(
-						publisher,
-						v => v.CorrelationId,
-						v => v.CorrelationId,
-						envelope);
+		AllBackwardFilteredReader =
+			new RequestResponseDispatcher
+				<ClientMessage.FilteredReadAllEventsBackward, ClientMessage.FilteredReadAllEventsBackwardCompleted>(
+					publisher,
+					v => v.CorrelationId,
+					v => v.CorrelationId,
+					envelope);
+	}
 
-			AllForwardFilteredReader =
-				new RequestResponseDispatcher
-					<ClientMessage.FilteredReadAllEventsForward, ClientMessage.FilteredReadAllEventsForwardCompleted>(
-						publisher,
-						v => v.CorrelationId,
-						v => v.CorrelationId,
-						envelope);
+	public void StartDraining(Action onRequestsDrained)
+	{
+		_requestTracker.StartDraining(onRequestsDrained);
+	}
 
-			AllBackwardFilteredReader =
-				new RequestResponseDispatcher
-					<ClientMessage.FilteredReadAllEventsBackward, ClientMessage.FilteredReadAllEventsBackwardCompleted>(
-						publisher,
-						v => v.CorrelationId,
-						v => v.CorrelationId,
-						envelope);
-		}
+	private void AddPendingRequest(Guid correlationId)
+	{
+		_requestTracker.AddPendingRequest(correlationId);
+	}
 
-		public void StartDraining(Action onRequestsDrained) {
-			_requestTracker.StartDraining(onRequestsDrained);
-		}
+	private void RemovePendingRequest(Guid correlationId)
+	{
+		_requestTracker.RemovePendingRequest(correlationId);
+	}
 
-		private void AddPendingRequest(Guid correlationId) {
-			_requestTracker.AddPendingRequest(correlationId);
-		}
-		
-		private void RemovePendingRequest(Guid correlationId) {
-			_requestTracker.RemovePendingRequest(correlationId);
-		}
+	public Guid ReadBackward(
+		string streamId,
+		long fromEventNumber,
+		int maxCount,
+		bool resolveLinks,
+		ClaimsPrincipal principal,
+		Action<ClientMessage.ReadStreamEventsBackwardCompleted> action,
+		Guid? corrId = null,
+		DateTime? expires = null)
+	{
+		corrId ??= Guid.NewGuid();
 
-		public Guid ReadBackward(
-			string streamId,
-			long fromEventNumber,
-			int maxCount,
-			bool resolveLinks,
-			ClaimsPrincipal principal,
-			Action<ClientMessage.ReadStreamEventsBackwardCompleted> action,
-			Guid? corrId = null) {
-			if (!corrId.HasValue)
-				corrId = Guid.NewGuid();
+		return BackwardReader.Publish(
+			new ClientMessage.ReadStreamEventsBackward(
+				corrId.Value,
+				corrId.Value,
+				BackwardReader.Envelope,
+				streamId,
+				fromEventNumber,
+				maxCount,
+				resolveLinks,
+				false,
+				null,
+				principal,
+				expires: expires),
+			new ReadStreamEventsBackwardHandlers.Optimistic(action));
+	}
 
-			return BackwardReader.Publish(
-				new ClientMessage.ReadStreamEventsBackward(
-						corrId.Value,
-						corrId.Value,
-						BackwardReader.Envelope,
-						streamId,
-						fromEventNumber,
-						maxCount,
-						resolveLinks,
-						false,
-						null,
-						principal),
-				new ReadStreamEventsBackwardHandlers.Optimistic(action));
-		}
+	public Guid ReadBackward(
+		string streamId,
+		long fromEventNumber,
+		int maxCount,
+		bool resolveLinks,
+		ClaimsPrincipal principal,
+		Action<ClientMessage.ReadStreamEventsBackwardCompleted> action,
+		Action timeoutAction,
+		Guid corrId)
+	{
 
-		public Guid ReadBackward(
-			string streamId,
-			long fromEventNumber,
-			int maxCount,
-			bool resolveLinks,
-			ClaimsPrincipal principal,
-			Action<ClientMessage.ReadStreamEventsBackwardCompleted> action,
-			Action timeoutAction,
-			Guid corrId) {
+		var handler = new ReadStreamEventsBackwardHandlers.Tracking(
+			corrId,
+			_requestTracker,
+			new ReadStreamEventsBackwardHandlers.AdHoc(
+				handled: action,
+				notHandled: null,
+				timedout: timeoutAction));
 
-			var handler = new ReadStreamEventsBackwardHandlers.Tracking(
+		BackwardReader.Publish(
+			new ClientMessage.ReadStreamEventsBackward(
 				corrId,
-				_requestTracker,
-				new ReadStreamEventsBackwardHandlers.AdHoc(
-					handled: action,
-					notHandled: null,
-					timedout: timeoutAction));
+				corrId,
+				BackwardReader.Envelope,
+				streamId,
+				fromEventNumber,
+				maxCount,
+				resolveLinks,
+				false,
+				null,
+				principal),
+			handler);
 
-			BackwardReader.Publish(
-				new ClientMessage.ReadStreamEventsBackward(
-					corrId,
-					corrId,
-					BackwardReader.Envelope,
-					streamId,
-					fromEventNumber,
-					maxCount,
-					resolveLinks,
-					false,
-					null,
-					principal),
-				handler);
+		Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), BackwardReader, corrId);
+		return corrId;
+	}
 
-			Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), BackwardReader, corrId);
-			return corrId;
-		}
+	public Guid ReadBackward(
+		string streamId,
+		long fromEventNumber,
+		int maxCount,
+		bool resolveLinks,
+		ClaimsPrincipal principal,
+		IReadStreamEventsBackwardHandler handler,
+		Guid corrId)
+	{
 
-		public Guid ReadBackward(
-			string streamId,
-			long fromEventNumber,
-			int maxCount,
-			bool resolveLinks,
-			ClaimsPrincipal principal,
-			IReadStreamEventsBackwardHandler handler,
-			Guid corrId) {
+		var trackingHandler = new ReadStreamEventsBackwardHandlers.Tracking(
+			corrId, _requestTracker, handler);
 
-			var trackingHandler = new ReadStreamEventsBackwardHandlers.Tracking(
-				corrId, _requestTracker, handler);
+		BackwardReader.Publish(
+			new ClientMessage.ReadStreamEventsBackward(
+				corrId,
+				corrId,
+				BackwardReader.Envelope,
+				streamId,
+				fromEventNumber,
+				maxCount,
+				resolveLinks,
+				false,
+				null,
+				principal),
+			trackingHandler);
 
-			BackwardReader.Publish(
-				new ClientMessage.ReadStreamEventsBackward(
-					corrId,
-					corrId,
-					BackwardReader.Envelope,
-					streamId,
-					fromEventNumber,
-					maxCount,
-					resolveLinks,
-					false,
-					null,
-					principal),
-				trackingHandler);
+		Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), BackwardReader, corrId);
+		return corrId;
+	}
 
-			Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), BackwardReader, corrId);
-			return corrId;
-		}
-
-		public Guid ReadForward(
-			string streamId,
-			long fromEventNumber,
-			int maxCount,
-			bool resolveLinks,
-			ClaimsPrincipal principal,
-			Action<ClientMessage.ReadStreamEventsForwardCompleted> action,
-			Guid? corrId = null) {
-			if (!corrId.HasValue)
-				corrId = Guid.NewGuid();
-			return
-				ForwardReader.Publish(
-					new ClientMessage.ReadStreamEventsForward(
-						corrId.Value,
-						corrId.Value,
-						ForwardReader.Envelope,
-						streamId,
-						fromEventNumber,
-						maxCount,
-						resolveLinks,
-						false,
-						null,
-						principal,
-						replyOnExpired: false),
-					action);
-		}
-
-		public Guid ReadForward(
-			string streamId,
-			long fromEventNumber,
-			int maxCount,
-			bool resolveLinks,
-			ClaimsPrincipal principal,
-			Action<ClientMessage.ReadStreamEventsForwardCompleted> action,
-			Action timeoutAction,
-			Guid corrId) {
-			_requestTracker.AddPendingRead(corrId);
-
+	public Guid ReadForward(
+		string streamId,
+		long fromEventNumber,
+		int maxCount,
+		bool resolveLinks,
+		ClaimsPrincipal principal,
+		Action<ClientMessage.ReadStreamEventsForwardCompleted> action,
+		Guid? corrId = null)
+	{
+		if (!corrId.HasValue)
+			corrId = Guid.NewGuid();
+		return
 			ForwardReader.Publish(
 				new ClientMessage.ReadStreamEventsForward(
-					corrId,
-					corrId,
+					corrId.Value,
+					corrId.Value,
 					ForwardReader.Envelope,
 					streamId,
 					fromEventNumber,
@@ -403,547 +403,641 @@ namespace EventStore.Core.Helpers {
 					null,
 					principal,
 					replyOnExpired: false),
-				res => {
-					if (_requestTracker.RemovePendingRead(res.CorrelationId)) {
-						action(res);
-					}
-				},
-				() => {
-					if (_requestTracker.RemovePendingRead(corrId)) {
-						timeoutAction();
-					}
-				});
-			Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), ForwardReader, corrId);
-			return corrId;
-		}
-		
-		public Guid ReadEvent(
-			string streamId,
-			long fromEventNumber,
-			ClaimsPrincipal principal,
-			Action<ClientMessage.ReadEventCompleted> action,
-			Action timeoutAction,
-			Guid corrId) {
-			_requestTracker.AddPendingRead(corrId);
+				action);
+	}
 
-			EventReader.Publish(
-				new ClientMessage.ReadEvent(
-					corrId,
-					corrId,
-					EventReader.Envelope,
-					streamId,
-					fromEventNumber,
-					false,
-					false,
-					principal),
-				res => {
-					if (_requestTracker.RemovePendingRead(res.CorrelationId)) {
-						action(res);
-					}
-				},
-				() => {
-					if (_requestTracker.RemovePendingRead(corrId)) {
-						timeoutAction();
-					}
-				});
-			Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), EventReader, corrId);
-			return corrId;
-		}
+	public Guid ReadForward(
+		string streamId,
+		long fromEventNumber,
+		int maxCount,
+		bool resolveLinks,
+		ClaimsPrincipal principal,
+		Action<ClientMessage.ReadStreamEventsForwardCompleted> action,
+		Action timeoutAction,
+		Guid corrId)
+	{
+		_requestTracker.AddPendingRead(corrId);
 
-		public Guid ReadAllForward(
-			long commitPosition,
-			long preparePosition,
-			int maxCount,
-			bool resolveLinks,
-			bool requireLeader,
-			long? validationTfLastCommitPosition,
-			ClaimsPrincipal user,
-			TimeSpan? longPollTimeout,
-			Action<ClientMessage.ReadAllEventsForwardCompleted> action,
-			Action timeoutAction,
-			Guid corrId) {
-			_requestTracker.AddPendingRead(corrId);
-
-			AllForwardReader.Publish(
-				new ClientMessage.ReadAllEventsForward(
-					corrId,
-					corrId,
-					AllForwardReader.Envelope,
-					commitPosition,
-					preparePosition,
-					maxCount,
-					resolveLinks,
-					requireLeader,
-					validationTfLastCommitPosition,
-					user,
-					replyOnExpired: false,
-					longPollTimeout: longPollTimeout
-					),
-				res => {
-					if (_requestTracker.RemovePendingRead(res.CorrelationId)) {
-						action(res);
-					}
-				},
-				() => {
-					if (_requestTracker.RemovePendingRead(corrId)) {
-						timeoutAction();
-					}
-				});
-			Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), AllForwardReader, corrId);
-			return corrId;
-		}
-
-		public Guid ReadAllBackward(
-			long commitPosition,
-			long preparePosition,
-			int maxCount,
-			bool resolveLinks,
-			bool requireLeader,
-			long? validationTfLastCommitPosition,
-			ClaimsPrincipal user,
-			TimeSpan? longPollTimeout,
-			Action<ClientMessage.ReadAllEventsBackwardCompleted> action,
-			Action timeoutAction,
-			Guid corrId) {
-			_requestTracker.AddPendingRead(corrId);
-
-			AllBackwardReader.Publish(
-				new ClientMessage.ReadAllEventsBackward(
-					corrId,
-					corrId,
-					AllBackwardReader.Envelope,
-					commitPosition,
-					preparePosition,
-					maxCount,
-					resolveLinks,
-					requireLeader,
-					validationTfLastCommitPosition,
-					user
-				),
-				res => {
-					if (_requestTracker.RemovePendingRead(res.CorrelationId)) {
-						action(res);
-					}
-				},
-				() => {
-					if (_requestTracker.RemovePendingRead(corrId)) {
-						timeoutAction();
-					}
-				});
-			Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), AllBackwardReader, corrId);
-			return corrId;
-		}
-
-		public Guid ReadAllForwardFiltered(
-			long commitPosition,
-			long preparePosition,
-			int maxCount,
-			bool resolveLinks,
-			bool requireLeader,
-			int maxSearchWindow,
-			long? validationTfLastCommitPosition,
-			IEventFilter eventFilter,
-			ClaimsPrincipal user,
-			TimeSpan? longPollTimeout,
-			Action<ClientMessage.FilteredReadAllEventsForwardCompleted> action,
-			Action timeoutAction,
-			Guid corrId) {
-			_requestTracker.AddPendingRead(corrId);
-
-			AllForwardFilteredReader.Publish(
-				new ClientMessage.FilteredReadAllEventsForward(
-					corrId,
-					corrId,
-					AllForwardFilteredReader.Envelope,
-					commitPosition,
-					preparePosition,
-					maxCount,
-					resolveLinks,
-					requireLeader,
-					maxSearchWindow,
-					validationTfLastCommitPosition,
-					eventFilter,
-					user,
-					replyOnExpired: false,
-					longPollTimeout: longPollTimeout
-				),
-				res => {
-					if (_requestTracker.RemovePendingRead(res.CorrelationId)) {
-						action(res);
-					}
-				},
-				() => {
-					if (_requestTracker.RemovePendingRead(corrId)) {
-						timeoutAction();
-					}
-				});
-			Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), AllForwardFilteredReader, corrId);
-			return corrId;
-		}
-		
-		public Guid ReadAllBackwardFiltered(
-			long commitPosition,
-			long preparePosition,
-			int maxCount,
-			bool resolveLinks,
-			bool requireLeader,
-			int maxSearchWindow,
-			long? validationTfLastCommitPosition,
-			IEventFilter eventFilter,
-			ClaimsPrincipal user,
-			Action<ClientMessage.FilteredReadAllEventsBackwardCompleted> action,
-			Action timeoutAction,
-			Guid corrId) {
-			_requestTracker.AddPendingRead(corrId);
-
-			AllBackwardFilteredReader.Publish(
-				new ClientMessage.FilteredReadAllEventsBackward(
-					corrId,
-					corrId,
-					AllBackwardFilteredReader.Envelope,
-					commitPosition,
-					preparePosition,
-					maxCount,
-					resolveLinks,
-					requireLeader,
-					maxSearchWindow,
-					validationTfLastCommitPosition,
-					eventFilter,
-					user
-				),
-				res => {
-					if (_requestTracker.RemovePendingRead(res.CorrelationId)) {
-						action(res);
-					}
-				},
-				() => {
-					if (_requestTracker.RemovePendingRead(corrId)) {
-						timeoutAction();
-					}
-				});
-			Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), AllBackwardFilteredReader, corrId);
-			return corrId;
-		}
-
-		public void ConfigureStreamAndWriteEvents(
-			string streamId,
-			long expectedVersion,
-			Lazy<StreamMetadata> streamMetadata,
-			Event[] events,
-			ClaimsPrincipal principal,
-			Action<ClientMessage.WriteEventsCompleted> action) {
-			if (expectedVersion != ExpectedVersion.Any && expectedVersion != ExpectedVersion.NoStream)
-				WriteEvents(streamId, expectedVersion, events, principal, action);
-			else
-				ReadBackward(
-					streamId,
-					-1,
-					1,
-					false,
-					principal,
-					completed => {
-						switch (completed.Result) {
-							case ReadStreamResult.Success:
-							case ReadStreamResult.NoStream:
-								if (completed.Events != null && completed.Events.Length > 0)
-									WriteEvents(streamId, expectedVersion, events, principal, action);
-								else
-									UpdateStreamAcl(
-										streamId,
-										ExpectedVersion.Any,
-										principal,
-										streamMetadata.Value,
-										metaCompleted =>
-											WriteEvents(streamId, expectedVersion, events, principal, action));
-								break;
-							case ReadStreamResult.AccessDenied:
-								action(
-									new ClientMessage.WriteEventsCompleted(
-										Guid.NewGuid(),
-										OperationResult.AccessDenied,
-										""));
-								break;
-							case ReadStreamResult.StreamDeleted:
-								action(
-									new ClientMessage.WriteEventsCompleted(
-										Guid.NewGuid(),
-										OperationResult.StreamDeleted,
-										""));
-								break;
-							default:
-								throw new NotSupportedException();
-						}
-					});
-		}
-
-		public Guid WriteEvents(
-			string streamId,
-			long expectedVersion,
-			Event[] events,
-			ClaimsPrincipal principal,
-			Action<ClientMessage.WriteEventsCompleted> action) {
-			var corrId = Guid.NewGuid();
-			AddPendingRequest(corrId);
-			return
-				Writer.Publish(
-					new ClientMessage.WriteEvents(
-						corrId,
-						corrId,
-						Writer.Envelope,
-						false,
-						streamId,
-						expectedVersion,
-						events,
-						principal),
-					res => {
-						RemovePendingRequest(res.CorrelationId);
-						action(res);
-					});
-		}
-
-		private class PendingWrites {
-			private readonly Dictionary<Guid, Action<ClientMessage.WriteEventsCompleted>> _map;
-
-			public PendingWrites() {
-				_map = new Dictionary<Guid, Action<ClientMessage.WriteEventsCompleted>>();
-			}
-
-			public void CaptureCallback(Guid correlationId, Action<ClientMessage.WriteEventsCompleted> action) {
-				_map.Add(correlationId, action);
-			}
-
-			public void CompleteRequest(ClientMessage.WriteEventsCompleted message) {
-				Action<ClientMessage.WriteEventsCompleted> action;
-				if (_map.TryGetValue(message.CorrelationId, out action)) {
-					_map.Remove(message.CorrelationId);
-					action(message);
-				}
-			}
-		}
-
-		private class PendingReads {
-			private readonly HashSet<Guid> _pendingReads = new HashSet<Guid>();
-
-			public void Register(Guid id) {
-				_pendingReads.Add(id);
-			}
-
-			public bool IsRegistered(Guid id) {
-				var ret = _pendingReads.Contains(id);
-				return ret;
-			}
-
-			public void Remove(Guid id) {
-				_pendingReads.Remove(id);
-			}
-		}
-
-		private class WriterQueueSet {
-			private readonly Dictionary<Guid, WriterQueue> _queues;
-
-			public WriterQueueSet() {
-				_queues = new Dictionary<Guid, WriterQueue>();
-			}
-
-			public void AddToQueue(Guid key, ClientMessage.WriteEvents message) {
-				WriterQueue writerQueue;
-				if (!_queues.TryGetValue(key, out writerQueue)) {
-					writerQueue = new WriterQueue();
-					_queues.Add(key, writerQueue);
-				}
-
-				writerQueue.Enqueue(message);
-			}
-
-			public void Finish(Guid key) {
-				var queue = GetQueue(key);
-				if (queue == null) return;
-				queue.IsBusy = false;
-
-				CleanupQueue(key, queue);
-			}
-
-			public bool IsBusy(Guid key) =>
-				GetQueue(key)?.IsBusy ?? false;
-
-			public bool HasPendingWrites(Guid key) =>
-				GetQueue(key)?.Count > 0;
-
-			public ClientMessage.WriteEvents Dequeue(Guid key) =>
-				GetQueue(key)?.Dequeue();
-
-			private WriterQueue GetQueue(Guid key) {
-				WriterQueue queue;
-				_queues.TryGetValue(key, out queue);
-				return queue;
-			}
-
-			private void CleanupQueue(Guid key, WriterQueue queue) {
-				if (queue.IsBusy) return;
-				if (queue.Count > 0) return;
-				_queues.Remove(key);
-			}
-		}
-
-		private class WriterQueue {
-			private readonly Queue<ClientMessage.WriteEvents> _queue;
-			public bool IsBusy;
-			public int Count => _queue.Count;
-
-			public WriterQueue() {
-				IsBusy = false;
-				_queue = new Queue<ClientMessage.WriteEvents>();
-			}
-
-			public void Enqueue(ClientMessage.WriteEvents message) {
-				_queue.Enqueue(message);
-			}
-
-			public ClientMessage.WriteEvents Dequeue() {
-				if (_queue.Count == 0) return null;
-
-				IsBusy = true;
-
-				return _queue.Dequeue();
-			}
-		}
-
-		public Guid QueueWriteEvents(
-			Guid key,
-			string streamId,
-			long expectedVersion,
-			Event[] events,
-			ClaimsPrincipal principal,
-			Action<ClientMessage.WriteEventsCompleted> action) {
-			var corrId = Guid.NewGuid();
-			
-			var message = new ClientMessage.WriteEvents(
+		ForwardReader.Publish(
+			new ClientMessage.ReadStreamEventsForward(
 				corrId,
 				corrId,
-				Writer.Envelope,
-				false,
+				ForwardReader.Envelope,
 				streamId,
-				expectedVersion,
-				events,
-				principal);
-			_requestTracker.QueuePendingWrite(key, corrId, action, message, Writer);
-			
-			return corrId;
-		}
+				fromEventNumber,
+				maxCount,
+				resolveLinks,
+				false,
+				null,
+				principal,
+				replyOnExpired: false),
+			res =>
+			{
+				if (_requestTracker.RemovePendingRead(res.CorrelationId))
+				{
+					action(res);
+				}
+			},
+			() =>
+			{
+				if (_requestTracker.RemovePendingRead(corrId))
+				{
+					timeoutAction();
+				}
+			});
+		Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), ForwardReader, corrId);
+		return corrId;
+	}
 
-		public Guid WriteEvent(
-			string streamId,
-			long expectedVersion,
-			Event @event,
-			ClaimsPrincipal principal,
-			Action<ClientMessage.WriteEventsCompleted> action) {
-			var corrId = Guid.NewGuid();
-			AddPendingRequest(corrId);
-			return
-				Writer.Publish(
-					new ClientMessage.WriteEvents(
-						corrId,
-						corrId,
-						Writer.Envelope,
-						false,
-						streamId,
-						expectedVersion,
-						new[] {@event},
-						principal),
-					res => {
-						RemovePendingRequest(res.CorrelationId);
-						action(res);
-					});
-		}
+	public Guid ReadEvent(
+		string streamId,
+		long fromEventNumber,
+		ClaimsPrincipal principal,
+		Action<ClientMessage.ReadEventCompleted> action,
+		Action timeoutAction,
+		Guid corrId)
+	{
+		_requestTracker.AddPendingRead(corrId);
 
-		public Guid DeleteStream(
-			string streamId,
-			long expectedVersion,
-			bool hardDelete,
-			ClaimsPrincipal principal,
-			Action<ClientMessage.DeleteStreamCompleted> action) {
-			var corrId = Guid.NewGuid();
-			AddPendingRequest(corrId);
-			return StreamDeleter.Publish(
-				new ClientMessage.DeleteStream(
+		EventReader.Publish(
+			new ClientMessage.ReadEvent(
+				corrId,
+				corrId,
+				EventReader.Envelope,
+				streamId,
+				fromEventNumber,
+				false,
+				false,
+				principal),
+			res =>
+			{
+				if (_requestTracker.RemovePendingRead(res.CorrelationId))
+				{
+					action(res);
+				}
+			},
+			() =>
+			{
+				if (_requestTracker.RemovePendingRead(corrId))
+				{
+					timeoutAction();
+				}
+			});
+		Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), EventReader, corrId);
+		return corrId;
+	}
+
+	public Guid ReadAllForward(
+		long commitPosition,
+		long preparePosition,
+		int maxCount,
+		bool resolveLinks,
+		bool requireLeader,
+		long? validationTfLastCommitPosition,
+		ClaimsPrincipal user,
+		TimeSpan? longPollTimeout,
+		Action<ClientMessage.ReadAllEventsForwardCompleted> action,
+		Action timeoutAction,
+		Guid corrId)
+	{
+		_requestTracker.AddPendingRead(corrId);
+
+		AllForwardReader.Publish(
+			new ClientMessage.ReadAllEventsForward(
+				corrId,
+				corrId,
+				AllForwardReader.Envelope,
+				commitPosition,
+				preparePosition,
+				maxCount,
+				resolveLinks,
+				requireLeader,
+				validationTfLastCommitPosition,
+				user,
+				replyOnExpired: false,
+				longPollTimeout: longPollTimeout
+			),
+			res =>
+			{
+				if (_requestTracker.RemovePendingRead(res.CorrelationId))
+				{
+					action(res);
+				}
+			},
+			() =>
+			{
+				if (_requestTracker.RemovePendingRead(corrId))
+				{
+					timeoutAction();
+				}
+			});
+		Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), AllForwardReader, corrId);
+		return corrId;
+	}
+
+	public Guid ReadAllBackward(
+		long commitPosition,
+		long preparePosition,
+		int maxCount,
+		bool resolveLinks,
+		bool requireLeader,
+		long? validationTfLastCommitPosition,
+		ClaimsPrincipal user,
+		TimeSpan? longPollTimeout,
+		Action<ClientMessage.ReadAllEventsBackwardCompleted> action,
+		Action timeoutAction,
+		Guid corrId)
+	{
+		_requestTracker.AddPendingRead(corrId);
+
+		AllBackwardReader.Publish(
+			new ClientMessage.ReadAllEventsBackward(
+				corrId,
+				corrId,
+				AllBackwardReader.Envelope,
+				commitPosition,
+				preparePosition,
+				maxCount,
+				resolveLinks,
+				requireLeader,
+				validationTfLastCommitPosition,
+				user
+			),
+			res =>
+			{
+				if (_requestTracker.RemovePendingRead(res.CorrelationId))
+				{
+					action(res);
+				}
+			},
+			() =>
+			{
+				if (_requestTracker.RemovePendingRead(corrId))
+				{
+					timeoutAction();
+				}
+			});
+		Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), AllBackwardReader, corrId);
+		return corrId;
+	}
+
+	public Guid ReadAllForwardFiltered(
+		long commitPosition,
+		long preparePosition,
+		int maxCount,
+		bool resolveLinks,
+		bool requireLeader,
+		int maxSearchWindow,
+		long? validationTfLastCommitPosition,
+		IEventFilter eventFilter,
+		ClaimsPrincipal user,
+		TimeSpan? longPollTimeout,
+		Action<ClientMessage.FilteredReadAllEventsForwardCompleted> action,
+		Action timeoutAction,
+		Guid corrId)
+	{
+		_requestTracker.AddPendingRead(corrId);
+
+		AllForwardFilteredReader.Publish(
+			new ClientMessage.FilteredReadAllEventsForward(
+				corrId,
+				corrId,
+				AllForwardFilteredReader.Envelope,
+				commitPosition,
+				preparePosition,
+				maxCount,
+				resolveLinks,
+				requireLeader,
+				maxSearchWindow,
+				validationTfLastCommitPosition,
+				eventFilter,
+				user,
+				replyOnExpired: false,
+				longPollTimeout: longPollTimeout
+			),
+			res =>
+			{
+				if (_requestTracker.RemovePendingRead(res.CorrelationId))
+				{
+					action(res);
+				}
+			},
+			() =>
+			{
+				if (_requestTracker.RemovePendingRead(corrId))
+				{
+					timeoutAction();
+				}
+			});
+		Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), AllForwardFilteredReader, corrId);
+		return corrId;
+	}
+
+	public Guid ReadAllBackwardFiltered(
+		long commitPosition,
+		long preparePosition,
+		int maxCount,
+		bool resolveLinks,
+		bool requireLeader,
+		int maxSearchWindow,
+		long? validationTfLastCommitPosition,
+		IEventFilter eventFilter,
+		ClaimsPrincipal user,
+		Action<ClientMessage.FilteredReadAllEventsBackwardCompleted> action,
+		Action timeoutAction,
+		Guid corrId)
+	{
+		_requestTracker.AddPendingRead(corrId);
+
+		AllBackwardFilteredReader.Publish(
+			new ClientMessage.FilteredReadAllEventsBackward(
+				corrId,
+				corrId,
+				AllBackwardFilteredReader.Envelope,
+				commitPosition,
+				preparePosition,
+				maxCount,
+				resolveLinks,
+				requireLeader,
+				maxSearchWindow,
+				validationTfLastCommitPosition,
+				eventFilter,
+				user
+			),
+			res =>
+			{
+				if (_requestTracker.RemovePendingRead(res.CorrelationId))
+				{
+					action(res);
+				}
+			},
+			() =>
+			{
+				if (_requestTracker.RemovePendingRead(corrId))
+				{
+					timeoutAction();
+				}
+			});
+		Delay(TimeSpan.FromMilliseconds(ReadTimeoutMs), AllBackwardFilteredReader, corrId);
+		return corrId;
+	}
+
+	public void ConfigureStreamAndWriteEvents(
+		string streamId,
+		long expectedVersion,
+		Lazy<StreamMetadata> streamMetadata,
+		Event[] events,
+		ClaimsPrincipal principal,
+		Action<ClientMessage.WriteEventsCompleted> action)
+	{
+		if (expectedVersion != ExpectedVersion.Any && expectedVersion != ExpectedVersion.NoStream)
+			WriteEvents(streamId, expectedVersion, events, principal, action);
+		else
+			ReadBackward(
+				streamId,
+				-1,
+				1,
+				false,
+				principal,
+				completed =>
+				{
+					switch (completed.Result)
+					{
+						case ReadStreamResult.Success:
+						case ReadStreamResult.NoStream:
+							if (completed.Events != null && completed.Events.Length > 0)
+								WriteEvents(streamId, expectedVersion, events, principal, action);
+							else
+								UpdateStreamAcl(
+									streamId,
+									ExpectedVersion.Any,
+									principal,
+									streamMetadata.Value,
+									metaCompleted =>
+										WriteEvents(streamId, expectedVersion, events, principal, action));
+							break;
+						case ReadStreamResult.AccessDenied:
+							action(
+								new ClientMessage.WriteEventsCompleted(
+									Guid.NewGuid(),
+									OperationResult.AccessDenied,
+									""));
+							break;
+						case ReadStreamResult.StreamDeleted:
+							action(
+								new ClientMessage.WriteEventsCompleted(
+									Guid.NewGuid(),
+									OperationResult.StreamDeleted,
+									""));
+							break;
+						default:
+							throw new NotSupportedException();
+					}
+				});
+	}
+
+	public Guid WriteEvents(
+		string streamId,
+		long expectedVersion,
+		Event[] events,
+		ClaimsPrincipal principal,
+		Action<ClientMessage.WriteEventsCompleted> action)
+	{
+		var corrId = Guid.NewGuid();
+		AddPendingRequest(corrId);
+		return
+			Writer.Publish(
+				new ClientMessage.WriteEvents(
 					corrId,
 					corrId,
 					Writer.Envelope,
 					false,
 					streamId,
 					expectedVersion,
-					hardDelete,
+					events,
 					principal),
-				res => {
+				res =>
+				{
 					RemovePendingRequest(res.CorrelationId);
 					action(res);
 				});
+	}
+
+	private class PendingWrites
+	{
+		private readonly Dictionary<Guid, Action<ClientMessage.WriteEventsCompleted>> _map;
+
+		public PendingWrites()
+		{
+			_map = new Dictionary<Guid, Action<ClientMessage.WriteEventsCompleted>>();
 		}
 
-		public void SubscribeAwake(
-			string streamId,
-			TFPos from,
-			Action<IODispatcherDelayedMessage> action,
-			Guid? correlationId = null) {
-			var corrId = correlationId ?? Guid.NewGuid();
-			AddPendingRequest(corrId);
-			Awaker.Publish(
-				new AwakeServiceMessage.SubscribeAwake(
-					Awaker.Envelope,
+		public void CaptureCallback(Guid correlationId, Action<ClientMessage.WriteEventsCompleted> action)
+		{
+			_map.Add(correlationId, action);
+		}
+
+		public void CompleteRequest(ClientMessage.WriteEventsCompleted message)
+		{
+			Action<ClientMessage.WriteEventsCompleted> action;
+			if (_map.TryGetValue(message.CorrelationId, out action))
+			{
+				_map.Remove(message.CorrelationId);
+				action(message);
+			}
+		}
+	}
+
+	private class PendingReads
+	{
+		private readonly HashSet<Guid> _pendingReads = new HashSet<Guid>();
+
+		public void Register(Guid id)
+		{
+			_pendingReads.Add(id);
+		}
+
+		public bool IsRegistered(Guid id)
+		{
+			var ret = _pendingReads.Contains(id);
+			return ret;
+		}
+
+		public void Remove(Guid id)
+		{
+			_pendingReads.Remove(id);
+		}
+	}
+
+	private class WriterQueueSet
+	{
+		private readonly Dictionary<Guid, WriterQueue> _queues;
+
+		public WriterQueueSet()
+		{
+			_queues = new Dictionary<Guid, WriterQueue>();
+		}
+
+		public void AddToQueue(Guid key, ClientMessage.WriteEvents message)
+		{
+			WriterQueue writerQueue;
+			if (!_queues.TryGetValue(key, out writerQueue))
+			{
+				writerQueue = new WriterQueue();
+				_queues.Add(key, writerQueue);
+			}
+
+			writerQueue.Enqueue(message);
+		}
+
+		public void Finish(Guid key)
+		{
+			var queue = GetQueue(key);
+			if (queue == null) return;
+			queue.IsBusy = false;
+
+			CleanupQueue(key, queue);
+		}
+
+		public bool IsBusy(Guid key) =>
+			GetQueue(key)?.IsBusy ?? false;
+
+		public bool HasPendingWrites(Guid key) =>
+			GetQueue(key)?.Count > 0;
+
+		public ClientMessage.WriteEvents Dequeue(Guid key) =>
+			GetQueue(key)?.Dequeue();
+
+		private WriterQueue GetQueue(Guid key)
+		{
+			WriterQueue queue;
+			_queues.TryGetValue(key, out queue);
+			return queue;
+		}
+
+		private void CleanupQueue(Guid key, WriterQueue queue)
+		{
+			if (queue.IsBusy) return;
+			if (queue.Count > 0) return;
+			_queues.Remove(key);
+		}
+	}
+
+	private class WriterQueue
+	{
+		private readonly Queue<ClientMessage.WriteEvents> _queue;
+		public bool IsBusy;
+		public int Count => _queue.Count;
+
+		public WriterQueue()
+		{
+			IsBusy = false;
+			_queue = new Queue<ClientMessage.WriteEvents>();
+		}
+
+		public void Enqueue(ClientMessage.WriteEvents message)
+		{
+			_queue.Enqueue(message);
+		}
+
+		public ClientMessage.WriteEvents Dequeue()
+		{
+			if (_queue.Count == 0) return null;
+
+			IsBusy = true;
+
+			return _queue.Dequeue();
+		}
+	}
+
+	public Guid QueueWriteEvents(
+		Guid key,
+		string streamId,
+		long expectedVersion,
+		Event[] events,
+		ClaimsPrincipal principal,
+		Action<ClientMessage.WriteEventsCompleted> action)
+	{
+		var corrId = Guid.NewGuid();
+
+		var message = new ClientMessage.WriteEvents(
+			corrId,
+			corrId,
+			Writer.Envelope,
+			false,
+			streamId,
+			expectedVersion,
+			events,
+			principal);
+		_requestTracker.QueuePendingWrite(key, corrId, action, message, Writer);
+
+		return corrId;
+	}
+
+	public Guid WriteEvent(
+		string streamId,
+		long expectedVersion,
+		Event @event,
+		ClaimsPrincipal principal,
+		Action<ClientMessage.WriteEventsCompleted> action)
+	{
+		var corrId = Guid.NewGuid();
+		AddPendingRequest(corrId);
+		return
+			Writer.Publish(
+				new ClientMessage.WriteEvents(
 					corrId,
+					corrId,
+					Writer.Envelope,
+					false,
 					streamId,
-					from,
-					new IODispatcherDelayedMessage(corrId, null)),
-				res => {
+					expectedVersion,
+					new[] { @event },
+					principal),
+				res =>
+				{
 					RemovePendingRequest(res.CorrelationId);
 					action(res);
 				});
-		}
+	}
 
-		public void UnsubscribeAwake(Guid correlationId) {
-			Awaker.Cancel(correlationId);
-		}
-
-		public void UpdateStreamAcl(
-			string streamId,
-			long expectedVersion,
-			ClaimsPrincipal principal,
-			StreamMetadata metadata,
-			Action<ClientMessage.WriteEventsCompleted> completed) {
-			WriteEvents(
-				SystemStreams.MetastreamOf(streamId),
+	public Guid DeleteStream(
+		string streamId,
+		long expectedVersion,
+		bool hardDelete,
+		ClaimsPrincipal principal,
+		Action<ClientMessage.DeleteStreamCompleted> action)
+	{
+		var corrId = Guid.NewGuid();
+		AddPendingRequest(corrId);
+		return StreamDeleter.Publish(
+			new ClientMessage.DeleteStream(
+				corrId,
+				corrId,
+				Writer.Envelope,
+				false,
+				streamId,
 				expectedVersion,
-				new[] {new Event(Guid.NewGuid(), SystemEventTypes.StreamMetadata, true, metadata.ToJsonBytes(), null)},
-				principal,
-				completed);
-		}
+				hardDelete,
+				principal),
+			res =>
+			{
+				RemovePendingRequest(res.CorrelationId);
+				action(res);
+			});
+	}
 
-		public void Delay(TimeSpan delay, Action<Guid> timeout) {
-			_publisher.Publish(
-				TimerMessage.Schedule.Create(
-					delay,
-					_inputQueueEnvelope,
-					new IODispatcherDelayedMessage(_selfId, new AdHocCorrelatedTimeout(timeout))));
-		}
+	public void SubscribeAwake(
+		string streamId,
+		TFPos from,
+		Action<IODispatcherDelayedMessage> action,
+		Guid? correlationId = null)
+	{
+		var corrId = correlationId ?? Guid.NewGuid();
+		AddPendingRequest(corrId);
+		Awaker.Publish(
+			new AwakeServiceMessage.SubscribeAwake(
+				Awaker.Envelope,
+				corrId,
+				streamId,
+				from,
+				new IODispatcherDelayedMessage(corrId, null)),
+			res =>
+			{
+				RemovePendingRequest(res.CorrelationId);
+				action(res);
+			});
+	}
 
-		private void Delay(TimeSpan delay, ICorrelatedTimeout timeout, Guid messageCorrelationId) {
-			_publisher.Publish(
-				TimerMessage.Schedule.Create(
-					delay,
-					_inputQueueEnvelope,
-					new IODispatcherDelayedMessage(_selfId, timeout, messageCorrelationId)));
-		}
+	public void UnsubscribeAwake(Guid correlationId)
+	{
+		Awaker.Cancel(correlationId);
+	}
 
-		public void Handle(IODispatcherDelayedMessage message) {
-			if (_selfId != message.CorrelationId)
-				return;
-			message.Timeout();
-		}
+	public void UpdateStreamAcl(
+		string streamId,
+		long expectedVersion,
+		ClaimsPrincipal principal,
+		StreamMetadata metadata,
+		Action<ClientMessage.WriteEventsCompleted> completed)
+	{
+		WriteEvents(
+			SystemStreams.MetastreamOf(streamId),
+			expectedVersion,
+			new[] { new Event(Guid.NewGuid(), SystemEventTypes.StreamMetadata, true, metadata.ToJsonBytes(), null) },
+			principal,
+			completed);
+	}
 
-		public void Handle(ClientMessage.NotHandled message) {
-			// we do not remove the pending read here but only the pending request.
-			// the pending read will be removed when calling the timeout action
-			_requestTracker.RemovePendingRequest(message.CorrelationId);
-		}
+	public void Delay(TimeSpan delay, Action<Guid> timeout)
+	{
+		_publisher.Publish(
+			TimerMessage.Schedule.Create(
+				delay,
+				_inputQueueEnvelope,
+				new IODispatcherDelayedMessage(_selfId, new AdHocCorrelatedTimeout(timeout))));
+	}
+
+	private void Delay(TimeSpan delay, ICorrelatedTimeout timeout, Guid messageCorrelationId)
+	{
+		_publisher.Publish(
+			TimerMessage.Schedule.Create(
+				delay,
+				_inputQueueEnvelope,
+				new IODispatcherDelayedMessage(_selfId, timeout, messageCorrelationId)));
+	}
+
+	public void Handle(IODispatcherDelayedMessage message)
+	{
+		if (_selfId != message.CorrelationId)
+			return;
+		message.Timeout();
+	}
+
+	public void Handle(ClientMessage.NotHandled message)
+	{
+		// we do not remove the pending read here but only the pending request.
+		// the pending read will be removed when calling the timeout action
+		_requestTracker.RemovePendingRequest(message.CorrelationId);
 	}
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -17,254 +17,539 @@ using EventStore.Core.Telemetry;
 using ILogger = Serilog.ILogger;
 using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
 
-namespace EventStore.Core.Services.PersistentSubscription {
-	public abstract class PersistentSubscriptionService {
-		protected static readonly ILogger Log = Serilog.Log.ForContext<PersistentSubscriptionService>();
+namespace EventStore.Core.Services.PersistentSubscription;
+
+public abstract class PersistentSubscriptionService {
+	protected static readonly ILogger Log = Serilog.Log.ForContext<PersistentSubscriptionService>();
+}
+
+public class PersistentSubscriptionService<TStreamId> :
+	PersistentSubscriptionService,
+	IHandle<SystemMessage.BecomeShuttingDown>,
+	IHandle<TcpMessage.ConnectionClosed>,
+	IHandle<SystemMessage.BecomeLeader>,
+	IHandle<SubscriptionMessage.PersistentSubscriptionsRestart>,
+	IHandle<SubscriptionMessage.PersistentSubscriptionTimerTick>,
+	IHandle<ClientMessage.ReplayParkedMessages>,
+	IHandle<ClientMessage.ReplayParkedMessage>,
+	IHandle<SystemMessage.StateChangeMessage>,
+	IHandle<ClientMessage.ConnectToPersistentSubscriptionToStream>,
+	IHandle<ClientMessage.ConnectToPersistentSubscriptionToAll>,
+	IHandle<StorageMessage.EventCommitted>,
+	IHandle<ClientMessage.UnsubscribeFromStream>,
+	IHandle<ClientMessage.PersistentSubscriptionAckEvents>,
+	IHandle<ClientMessage.PersistentSubscriptionNackEvents>,
+	IHandle<ClientMessage.CreatePersistentSubscriptionToStream>,
+	IHandle<ClientMessage.UpdatePersistentSubscriptionToStream>,
+	IHandle<ClientMessage.DeletePersistentSubscriptionToStream>,
+	IHandle<ClientMessage.CreatePersistentSubscriptionToAll>,
+	IHandle<ClientMessage.UpdatePersistentSubscriptionToAll>,
+	IHandle<ClientMessage.DeletePersistentSubscriptionToAll>,
+	IHandle<ClientMessage.ReadNextNPersistentMessages>,
+	IHandle<TelemetryMessage.Request>,
+	IHandle<MonitoringMessage.GetAllPersistentSubscriptionStats>,
+	IHandle<MonitoringMessage.GetPersistentSubscriptionStats>,
+	IHandle<MonitoringMessage.GetStreamPersistentSubscriptionStats>
+{
+
+	private Dictionary<string, List<PersistentSubscription>> _subscriptionTopics;
+	private Dictionary<string, PersistentSubscription> _subscriptionsById;
+
+	private readonly IQueuedHandler _queuedHandler;
+	private readonly IReadIndex<TStreamId> _readIndex;
+	private readonly IODispatcher _ioDispatcher;
+	private readonly IPublisher _bus;
+	private readonly PersistentSubscriptionConsumerStrategyRegistry _consumerStrategyRegistry;
+	private readonly IPersistentSubscriptionCheckpointReader _checkpointReader;
+	private readonly IPersistentSubscriptionStreamReader _streamReader;
+	private PersistentSubscriptionConfig _config = new PersistentSubscriptionConfig();
+	private bool _started = false;
+	private VNodeState _state;
+	private Guid _timerTickCorrelationId;
+	private bool _handleTick;
+	private readonly IPersistentSubscriptionTracker _persistentSubscriptionTracker;
+	private static List<MonitoringMessage.PersistentSubscriptionInfo> SubscriptionStats = [];
+	private readonly TimeSpan _interval = TimeSpan.FromSeconds(1);
+	private readonly TimerMessage.Schedule _getStats;
+
+	public PersistentSubscriptionService(IQueuedHandler queuedHandler, IReadIndex<TStreamId> readIndex,
+		IODispatcher ioDispatcher, IPublisher bus,
+		PersistentSubscriptionConsumerStrategyRegistry consumerStrategyRegistry,
+		IPersistentSubscriptionTracker persistentSubscriptionTracker)
+	{
+		Ensure.NotNull(queuedHandler, "queuedHandler");
+		Ensure.NotNull(readIndex, "readIndex");
+		Ensure.NotNull(ioDispatcher, "ioDispatcher");
+
+		_queuedHandler = queuedHandler;
+		_readIndex = readIndex;
+		_ioDispatcher = ioDispatcher;
+		_bus = bus;
+		_consumerStrategyRegistry = consumerStrategyRegistry;
+		_checkpointReader = new PersistentSubscriptionCheckpointReader(_ioDispatcher);
+		_streamReader = new PersistentSubscriptionStreamReader(_ioDispatcher, 100);
+		_timerTickCorrelationId = Guid.NewGuid();
+		_persistentSubscriptionTracker = persistentSubscriptionTracker;
+		_getStats = TimerMessage.Schedule.Create(_interval, _bus,
+			new MonitoringMessage.GetAllPersistentSubscriptionStats(
+				new CallbackEnvelope(PushStatsToPersistentSubscriptionTracker)));
 	}
 
-	public class PersistentSubscriptionService<TStreamId> :
-		PersistentSubscriptionService,
-		IHandle<SystemMessage.BecomeShuttingDown>,
-		IHandle<TcpMessage.ConnectionClosed>,
-		IHandle<SystemMessage.BecomeLeader>,
-		IHandle<SubscriptionMessage.PersistentSubscriptionsRestart>,
-		IHandle<SubscriptionMessage.PersistentSubscriptionTimerTick>,
-		IHandle<ClientMessage.ReplayParkedMessages>,
-		IHandle<ClientMessage.ReplayParkedMessage>,
-		IHandle<SystemMessage.StateChangeMessage>,
-		IHandle<ClientMessage.ConnectToPersistentSubscriptionToStream>,
-		IHandle<ClientMessage.ConnectToPersistentSubscriptionToAll>,
-		IHandle<StorageMessage.EventCommitted>,
-		IHandle<ClientMessage.UnsubscribeFromStream>,
-		IHandle<ClientMessage.PersistentSubscriptionAckEvents>,
-		IHandle<ClientMessage.PersistentSubscriptionNackEvents>,
-		IHandle<ClientMessage.CreatePersistentSubscriptionToStream>,
-		IHandle<ClientMessage.UpdatePersistentSubscriptionToStream>,
-		IHandle<ClientMessage.DeletePersistentSubscriptionToStream>,
-		IHandle<ClientMessage.CreatePersistentSubscriptionToAll>,
-		IHandle<ClientMessage.UpdatePersistentSubscriptionToAll>,
-		IHandle<ClientMessage.DeletePersistentSubscriptionToAll>,
-		IHandle<ClientMessage.ReadNextNPersistentMessages>,
-		IHandle<TelemetryMessage.Request>,
-		IHandle<MonitoringMessage.GetAllPersistentSubscriptionStats>,
-		IHandle<MonitoringMessage.GetPersistentSubscriptionStats>,
-		IHandle<MonitoringMessage.GetStreamPersistentSubscriptionStats> {
-
-		private Dictionary<string, List<PersistentSubscription>> _subscriptionTopics;
-		private Dictionary<string, PersistentSubscription> _subscriptionsById;
-
-		private readonly IQueuedHandler _queuedHandler;
-		private readonly IReadIndex<TStreamId> _readIndex;
-		private readonly IODispatcher _ioDispatcher;
-		private readonly IPublisher _bus;
-		private readonly PersistentSubscriptionConsumerStrategyRegistry _consumerStrategyRegistry;
-		private readonly IPersistentSubscriptionCheckpointReader _checkpointReader;
-		private readonly IPersistentSubscriptionStreamReader _streamReader;
-		private PersistentSubscriptionConfig _config = new PersistentSubscriptionConfig();
-		private bool _started = false;
-		private VNodeState _state;
-		private Guid _timerTickCorrelationId;
-		private bool _handleTick;
-		private readonly IPersistentSubscriptionTracker _persistentSubscriptionTracker;
-		private static List<MonitoringMessage.PersistentSubscriptionInfo> SubscriptionStats = [];
-		private readonly TimeSpan _interval = TimeSpan.FromSeconds(1);
-		private readonly TimerMessage.Schedule _getStats;
-
-		public PersistentSubscriptionService(IQueuedHandler queuedHandler, IReadIndex<TStreamId> readIndex,
-			IODispatcher ioDispatcher, IPublisher bus,
-			PersistentSubscriptionConsumerStrategyRegistry consumerStrategyRegistry,
-			IPersistentSubscriptionTracker persistentSubscriptionTracker) {
-			Ensure.NotNull(queuedHandler, "queuedHandler");
-			Ensure.NotNull(readIndex, "readIndex");
-			Ensure.NotNull(ioDispatcher, "ioDispatcher");
-
-			_queuedHandler = queuedHandler;
-			_readIndex = readIndex;
-			_ioDispatcher = ioDispatcher;
-			_bus = bus;
-			_consumerStrategyRegistry = consumerStrategyRegistry;
-			_checkpointReader = new PersistentSubscriptionCheckpointReader(_ioDispatcher);
-			_streamReader = new PersistentSubscriptionStreamReader(_ioDispatcher, 100);
-			_timerTickCorrelationId = Guid.NewGuid();
-			_persistentSubscriptionTracker = persistentSubscriptionTracker;
-			_getStats = TimerMessage.Schedule.Create(_interval, _bus,
-				new MonitoringMessage.GetAllPersistentSubscriptionStats(
-					new CallbackEnvelope(PushStatsToPersistentSubscriptionTracker)));
-		}
-
-		private void PushStatsToPersistentSubscriptionTracker(Message message) {
-			if (message is MonitoringMessage.GetPersistentSubscriptionStatsCompleted stats) {
-				SubscriptionStats = stats.SubscriptionStats;
-				if (SubscriptionStats != null) {
-					_persistentSubscriptionTracker.OnNewStats(SubscriptionStats);
-				}
-			}
-			_bus.Publish(_getStats);
-		}
-
-		public List<MonitoringMessage.PersistentSubscriptionInfo> GetPersistentSubscriptionStats() {
-			return SubscriptionStats;
-		}
-
-		public void InitToEmpty() {
-			_handleTick = false;
-			_subscriptionTopics = new Dictionary<string, List<PersistentSubscription>>();
-			_subscriptionsById = new Dictionary<string, PersistentSubscription>();
-		}
-
-		public void Handle(SystemMessage.StateChangeMessage message) {
-			_state = message.State;
-
-			if (message.State == VNodeState.Leader) return;
-			Log.Debug("Persistent subscriptions received state change to {state}. Stopping listening", _state);
-			ShutdownSubscriptions();
-			Stop();
-		}
-
-		public void Handle(SystemMessage.BecomeLeader message) {
-			Log.Debug("Persistent subscriptions Became Leader so now handling subscriptions");
-			StartSubscriptions();
-		}
-
-		public void Handle(SubscriptionMessage.PersistentSubscriptionsRestart message) {
-			if (!_started) {
-				message.ReplyEnvelope.ReplyWith(new SubscriptionMessage.InvalidPersistentSubscriptionsRestart("The Persistent Subscriptions subsystem cannot be restarted because it is not started."));
-				return;
-			}
-
-			Log.Debug("Persistent Subscriptions are being restarted");
-			message.ReplyEnvelope.ReplyWith(new SubscriptionMessage.PersistentSubscriptionsRestarting());
-
-			Stop();
-			ShutdownSubscriptions();
-			StartSubscriptions();
-		}
-
-		private void StartSubscriptions() {
-			InitToEmpty();
-			_handleTick = true;
-			_timerTickCorrelationId = Guid.NewGuid();
-			_bus.Publish(TimerMessage.Schedule.Create(TimeSpan.FromMilliseconds(1000),
-				_bus,
-				new SubscriptionMessage.PersistentSubscriptionTimerTick(_timerTickCorrelationId)));
-			LoadConfiguration(Start);
-		}
-
-		public void Handle(SystemMessage.BecomeShuttingDown message) {
-			ShutdownSubscriptions();
-			Stop();
-			_queuedHandler.RequestStop();
-		}
-
-		private void ShutdownSubscriptions() {
-			if (_subscriptionsById == null) return;
-			foreach (var subscription in _subscriptionsById.Values) {
-				subscription.Shutdown();
-			}
-		}
-
-		public void Start() {
-			_started = true;
-			_bus.Publish(new SubscriptionMessage.PersistentSubscriptionsStarted());
-			_bus.Publish(_getStats);
-			Log.Debug("Persistent Subscriptions have been started.");
-		}
-
-		public void Stop() {
-			_started = false;
-			_bus.Publish(new SubscriptionMessage.PersistentSubscriptionsStopped());
-			Log.Debug("Persistent Subscriptions have been stopped.");
-		}
-
-		public void Handle(ClientMessage.UnsubscribeFromStream message) {
-			if (!_started) return;
-			UnsubscribeFromStream(message.CorrelationId, true);
-		}
-
-		private bool ValidateStartFrom(IPersistentSubscriptionStreamPosition startFromPosition, out string error) {
-			switch (startFromPosition)
+	private void PushStatsToPersistentSubscriptionTracker(Message message)
+	{
+		if (message is MonitoringMessage.GetPersistentSubscriptionStatsCompleted stats)
+		{
+			SubscriptionStats = stats.SubscriptionStats;
+			if (SubscriptionStats != null)
 			{
-				case PersistentSubscriptionSingleStreamPosition startFromStream:
-				{
-					if (startFromStream.StreamEventNumber < -1) {
-						error = "Invalid Start From position: event number must be greater than or equal to -1.";
-						return false;
-					}
-
-					error = null;
-					return true;
-				}
-				case PersistentSubscriptionAllStreamPosition startFromAll:
-				{
-					var (commit, prepare) = startFromAll.TFPosition;
-
-					if (prepare > commit) {
-						error = "Invalid Start From position: prepare position must be less than or equal to the commit position.";
-						return false;
-					}
-
-					if (commit > _readIndex.LastIndexedPosition) {
-						error =
-							"Invalid Start From position: commit position must be less than or equal to the last commit position in the transaction file.";
-						return false;
-					}
-
-					if ((prepare <= -1 || commit <= -1) && !(prepare == -1 && commit == -1)) {
-						error =
-							"Invalid Start From position: prepare and commit positions must be greater than or equal to 0 or both equal to -1.";
-						return false;
-					}
-
-					error = null;
-					return true;
-				}
-				default:
-					throw new InvalidOperationException();
+				_persistentSubscriptionTracker.OnNewStats(SubscriptionStats);
 			}
 		}
 
-		private void CreatePersistentSubscription(
-				IPersistentSubscriptionEventSource eventSource,
-				string groupName,
-				IPersistentSubscriptionStreamPosition startFrom,
-				int messageTimeoutMilliseconds,
-				bool resolveLinkTos,
-				int maxRetryCount,
-				int bufferSize,
-				int liveBufferSize,
-				int readBatchSize,
-				int maxSubscriberCount,
-				string namedConsumerStrategy,
-				int maxCheckPointCount,
-				int minCheckPointCount,
-				int checkPointAfterMilliseconds,
-				bool recordStatistics,
-				Action<string> onSuccess,
-				Action<string> onFail,
-				Action<string> onExists,
-				Action<string> onAccessDenied,
-				string user
-		) {
-			if (!_started) return;
-			var stream = eventSource.ToString();
-			var key = BuildSubscriptionGroupKey(stream, groupName);
-			Log.Debug("Creating persistent subscription {subscriptionKey}", key);
+		_bus.Publish(_getStats);
+	}
 
-			if (!_consumerStrategyRegistry.ValidateStrategy(namedConsumerStrategy)) {
-				onFail($"Consumer strategy {namedConsumerStrategy} does not exist.");
-				return;
+	public List<MonitoringMessage.PersistentSubscriptionInfo> GetPersistentSubscriptionStats()
+	{
+		return SubscriptionStats;
+	}
+
+	public void InitToEmpty()
+	{
+		_handleTick = false;
+		_subscriptionTopics = new Dictionary<string, List<PersistentSubscription>>();
+		_subscriptionsById = new Dictionary<string, PersistentSubscription>();
+	}
+
+	public void Handle(SystemMessage.StateChangeMessage message)
+	{
+		_state = message.State;
+
+		if (message.State == VNodeState.Leader) return;
+		Log.Debug("Persistent subscriptions received state change to {state}. Stopping listening", _state);
+		ShutdownSubscriptions();
+		Stop();
+	}
+
+	public void Handle(SystemMessage.BecomeLeader message)
+	{
+		Log.Debug("Persistent subscriptions Became Leader so now handling subscriptions");
+		StartSubscriptions();
+	}
+
+	public void Handle(SubscriptionMessage.PersistentSubscriptionsRestart message)
+	{
+		if (!_started)
+		{
+			message.ReplyEnvelope.ReplyWith(new SubscriptionMessage.InvalidPersistentSubscriptionsRestart(
+				"The Persistent Subscriptions subsystem cannot be restarted because it is not started."));
+			return;
+		}
+
+		Log.Debug("Persistent Subscriptions are being restarted");
+		message.ReplyEnvelope.ReplyWith(new SubscriptionMessage.PersistentSubscriptionsRestarting());
+
+		Stop();
+		ShutdownSubscriptions();
+		StartSubscriptions();
+	}
+
+	private void StartSubscriptions()
+	{
+		InitToEmpty();
+		_handleTick = true;
+		_timerTickCorrelationId = Guid.NewGuid();
+		_bus.Publish(TimerMessage.Schedule.Create(TimeSpan.FromMilliseconds(1000),
+			_bus,
+			new SubscriptionMessage.PersistentSubscriptionTimerTick(_timerTickCorrelationId)));
+		LoadConfiguration(Start);
+	}
+
+	public void Handle(SystemMessage.BecomeShuttingDown message)
+	{
+		ShutdownSubscriptions();
+		Stop();
+		_queuedHandler.RequestStop();
+	}
+
+	private void ShutdownSubscriptions()
+	{
+		if (_subscriptionsById == null) return;
+		foreach (var subscription in _subscriptionsById.Values)
+		{
+			subscription.Shutdown();
+		}
+	}
+
+	public void Start()
+	{
+		_started = true;
+		_bus.Publish(new SubscriptionMessage.PersistentSubscriptionsStarted());
+		_bus.Publish(_getStats);
+		Log.Debug("Persistent Subscriptions have been started.");
+	}
+
+	public void Stop()
+	{
+		_started = false;
+		_bus.Publish(new SubscriptionMessage.PersistentSubscriptionsStopped());
+		Log.Debug("Persistent Subscriptions have been stopped.");
+	}
+
+	public void Handle(ClientMessage.UnsubscribeFromStream message)
+	{
+		if (!_started) return;
+		UnsubscribeFromStream(message.CorrelationId, true);
+	}
+
+	private bool ValidateStartFrom(IPersistentSubscriptionStreamPosition startFromPosition, out string error)
+	{
+		switch (startFromPosition)
+		{
+			case PersistentSubscriptionSingleStreamPosition startFromStream:
+			{
+				if (startFromStream.StreamEventNumber < -1)
+				{
+					error = "Invalid Start From position: event number must be greater than or equal to -1.";
+					return false;
+				}
+
+				error = null;
+				return true;
 			}
+			case PersistentSubscriptionAllStreamPosition startFromAll:
+			{
+				var (commit, prepare) = startFromAll.TFPosition;
 
-			if (!ValidateStartFrom(startFrom, out var startFromValidationError)) {
-				onFail(startFromValidationError);
-				return;
+				if (prepare > commit)
+				{
+					error =
+						"Invalid Start From position: prepare position must be less than or equal to the commit position.";
+					return false;
+				}
+
+				if (commit > _readIndex.LastIndexedPosition)
+				{
+					error =
+						"Invalid Start From position: commit position must be less than or equal to the last commit position in the transaction file.";
+					return false;
+				}
+
+				if ((prepare <= -1 || commit <= -1) && !(prepare == -1 && commit == -1))
+				{
+					error =
+						"Invalid Start From position: prepare and commit positions must be greater than or equal to 0 or both equal to -1.";
+					return false;
+				}
+
+				error = null;
+				return true;
 			}
+			default:
+				throw new InvalidOperationException();
+		}
+	}
 
-			var result = TryCreateSubscriptionGroup(eventSource,
-				groupName,
+	private void CreatePersistentSubscription(
+		IPersistentSubscriptionEventSource eventSource,
+		string groupName,
+		IPersistentSubscriptionStreamPosition startFrom,
+		int messageTimeoutMilliseconds,
+		bool resolveLinkTos,
+		int maxRetryCount,
+		int bufferSize,
+		int liveBufferSize,
+		int readBatchSize,
+		int maxSubscriberCount,
+		string namedConsumerStrategy,
+		int maxCheckPointCount,
+		int minCheckPointCount,
+		int checkPointAfterMilliseconds,
+		bool recordStatistics,
+		Action<string> onSuccess,
+		Action<string> onFail,
+		Action<string> onExists,
+		Action<string> onAccessDenied,
+		string user
+	)
+	{
+		if (!_started) return;
+		var stream = eventSource.ToString();
+		var key = BuildSubscriptionGroupKey(stream, groupName);
+		Log.Debug("Creating persistent subscription {subscriptionKey}", key);
+
+		if (!_consumerStrategyRegistry.ValidateStrategy(namedConsumerStrategy))
+		{
+			onFail($"Consumer strategy {namedConsumerStrategy} does not exist.");
+			return;
+		}
+
+		if (!ValidateStartFrom(startFrom, out var startFromValidationError))
+		{
+			onFail(startFromValidationError);
+			return;
+		}
+
+		var result = TryCreateSubscriptionGroup(eventSource,
+			groupName,
+			resolveLinkTos,
+			startFrom,
+			recordStatistics,
+			maxRetryCount,
+			liveBufferSize,
+			bufferSize,
+			readBatchSize,
+			ToCheckPointAfterTimeout(checkPointAfterMilliseconds),
+			minCheckPointCount,
+			maxCheckPointCount,
+			maxSubscriberCount,
+			namedConsumerStrategy,
+			ToMessageTimeout(messageTimeoutMilliseconds)
+		);
+
+		if (!result)
+		{
+			onExists($"Group '{groupName}' already exists.");
+			return;
+		}
+
+		Log.Debug("New persistent subscription {subscriptionKey}", key);
+		var createEntry = new PersistentSubscriptionEntry
+		{
+			Stream = stream, //'Stream' name kept for backward compatibility
+			Filter = EventFilter.ParseToDto(eventSource.EventFilter),
+			Group = groupName,
+			ResolveLinkTos = resolveLinkTos,
+			CheckPointAfter = checkPointAfterMilliseconds,
+			ExtraStatistics = recordStatistics,
+			HistoryBufferSize = bufferSize,
+			LiveBufferSize = liveBufferSize,
+			MaxCheckPointCount = maxCheckPointCount,
+			MinCheckPointCount = minCheckPointCount,
+			MaxRetryCount = maxRetryCount,
+			ReadBatchSize = readBatchSize,
+			MaxSubscriberCount = maxSubscriberCount,
+			MessageTimeout = messageTimeoutMilliseconds,
+			NamedConsumerStrategy = namedConsumerStrategy,
+#pragma warning disable 612
+			StartFrom = startFrom is PersistentSubscriptionSingleStreamPosition x ? x.StreamEventNumber : long.MinValue,
+#pragma warning restore 612
+			StartPosition = startFrom.ToString()
+		};
+		UpdateSubscriptionConfig(user, stream, groupName, createEntry);
+		SaveConfiguration(() => onSuccess(""));
+	}
+
+	public void Handle(ClientMessage.CreatePersistentSubscriptionToStream message)
+	{
+		if (string.IsNullOrEmpty(message.EventStreamId))
+		{
+			message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
+				message.CorrelationId,
+				ClientMessage.CreatePersistentSubscriptionToStreamCompleted
+					.CreatePersistentSubscriptionToStreamResult.Fail,
+				"Bad stream name."));
+			return;
+		}
+
+		if (message.EventStreamId == SystemStreams.AllStream)
+		{
+			message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
+				message.CorrelationId,
+				ClientMessage.CreatePersistentSubscriptionToStreamCompleted
+					.CreatePersistentSubscriptionToStreamResult.Fail,
+				"Persistent subscriptions to $all are only supported over gRPC through gRPC clients"));
+			return;
+		}
+
+		try
+		{
+			CreatePersistentSubscription(
+				new PersistentSubscriptionSingleStreamEventSource(message.EventStreamId),
+				message.GroupName,
+				new PersistentSubscriptionSingleStreamPosition(message.StartFrom),
+				message.MessageTimeoutMilliseconds,
+				message.ResolveLinkTos,
+				message.MaxRetryCount,
+				message.BufferSize,
+				message.LiveBufferSize,
+				message.ReadBatchSize,
+				message.MaxSubscriberCount,
+				message.NamedConsumerStrategy,
+				message.MaxCheckPointCount,
+				message.MinCheckPointCount,
+				message.CheckPointAfterMilliseconds,
+				message.RecordStatistics,
+				(msg) =>
+				{
+					message.Envelope.ReplyWith(
+						new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
+							message.CorrelationId,
+							ClientMessage.CreatePersistentSubscriptionToStreamCompleted
+								.CreatePersistentSubscriptionToStreamResult.Success,
+							msg));
+				},
+				(error) =>
+				{
+					message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
+						message.CorrelationId,
+						ClientMessage.CreatePersistentSubscriptionToStreamCompleted
+							.CreatePersistentSubscriptionToStreamResult.Fail,
+						error));
+				},
+				(error) =>
+				{
+					message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
+						message.CorrelationId,
+						ClientMessage.CreatePersistentSubscriptionToStreamCompleted
+							.CreatePersistentSubscriptionToStreamResult.AlreadyExists,
+						error));
+				},
+				(error) =>
+				{
+					message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
+						message.CorrelationId,
+						ClientMessage.CreatePersistentSubscriptionToStreamCompleted
+							.CreatePersistentSubscriptionToStreamResult.AccessDenied,
+						error));
+				},
+				message.User?.Identity?.Name
+			);
+		}
+		catch (Exception ex)
+		{
+			message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
+				message.CorrelationId,
+				ClientMessage.CreatePersistentSubscriptionToStreamCompleted
+					.CreatePersistentSubscriptionToStreamResult.Fail,
+				ex.Message));
+		}
+	}
+
+	public void Handle(ClientMessage.CreatePersistentSubscriptionToAll message)
+	{
+		try
+		{
+			CreatePersistentSubscription(
+				new PersistentSubscriptionAllStreamEventSource(message.EventFilter),
+				message.GroupName,
+				new PersistentSubscriptionAllStreamPosition(message.StartFrom.CommitPosition,
+					message.StartFrom.PreparePosition),
+				message.MessageTimeoutMilliseconds,
+				message.ResolveLinkTos,
+				message.MaxRetryCount,
+				message.BufferSize,
+				message.LiveBufferSize,
+				message.ReadBatchSize,
+				message.MaxSubscriberCount,
+				message.NamedConsumerStrategy,
+				message.MaxCheckPointCount,
+				message.MinCheckPointCount,
+				message.CheckPointAfterMilliseconds,
+				message.RecordStatistics,
+				(msg) =>
+				{
+					message.Envelope.ReplyWith(
+						new ClientMessage.CreatePersistentSubscriptionToAllCompleted(
+							message.CorrelationId,
+							ClientMessage.CreatePersistentSubscriptionToAllCompleted
+								.CreatePersistentSubscriptionToAllResult.Success,
+							msg));
+				},
+				(error) =>
+				{
+					message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToAllCompleted(
+						message.CorrelationId,
+						ClientMessage.CreatePersistentSubscriptionToAllCompleted
+							.CreatePersistentSubscriptionToAllResult.Fail,
+						error));
+				},
+				(error) =>
+				{
+					message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToAllCompleted(
+						message.CorrelationId,
+						ClientMessage.CreatePersistentSubscriptionToAllCompleted
+							.CreatePersistentSubscriptionToAllResult.AlreadyExists,
+						error));
+				},
+				(error) =>
+				{
+					message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToAllCompleted(
+						message.CorrelationId,
+						ClientMessage.CreatePersistentSubscriptionToAllCompleted
+							.CreatePersistentSubscriptionToAllResult.AccessDenied,
+						error));
+				},
+				message.User?.Identity?.Name
+			);
+		}
+		catch (Exception ex)
+		{
+			message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToAllCompleted(
+				message.CorrelationId,
+				ClientMessage.CreatePersistentSubscriptionToAllCompleted.CreatePersistentSubscriptionToAllResult.Fail,
+				ex.Message));
+		}
+
+	}
+
+	private void UpdatePersistentSubscription(
+		string stream,
+		Func<PersistentSubscription, IPersistentSubscriptionEventSource> genEventSource,
+		string groupName,
+		IPersistentSubscriptionStreamPosition startFrom,
+		int messageTimeoutMilliseconds,
+		bool resolveLinkTos,
+		int maxRetryCount,
+		int bufferSize,
+		int liveBufferSize,
+		int readBatchSize,
+		int maxSubscriberCount,
+		string namedConsumerStrategy,
+		int maxCheckPointCount,
+		int minCheckPointCount,
+		int checkPointAfterMilliseconds,
+		bool recordStatistics,
+		Action<string> onSuccess,
+		Action<string> onFail,
+		Action<string> onNotExist,
+		Action<string> onAccessDenied,
+		string user
+	)
+	{
+		if (!_started) return;
+
+		var key = BuildSubscriptionGroupKey(stream, groupName);
+		Log.Debug("Updating persistent subscription {subscriptionKey}", key);
+
+		if (!_subscriptionsById.TryGetValue(key, out var oldSubscription))
+		{
+			onNotExist($"Group '{groupName}' does not exist.");
+			return;
+		}
+
+		if (!_consumerStrategyRegistry.ValidateStrategy(namedConsumerStrategy))
+		{
+			onFail($"Consumer strategy {namedConsumerStrategy} does not exist.");
+			return;
+		}
+
+		if (!ValidateStartFrom(startFrom, out var startFromValidationError))
+		{
+			onFail(startFromValidationError);
+			return;
+		}
+
+		var eventSource = genEventSource(oldSubscription);
+		var subscription = new PersistentSubscription(
+			new PersistentSubscriptionParams(
 				resolveLinkTos,
+				key,
+				eventSource,
+				groupName,
 				startFrom,
 				recordStatistics,
+				ToMessageTimeout(messageTimeoutMilliseconds),
 				maxRetryCount,
 				liveBufferSize,
 				bufferSize,
@@ -273,1105 +558,1009 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				minCheckPointCount,
 				maxCheckPointCount,
 				maxSubscriberCount,
-				namedConsumerStrategy,
-				ToMessageTimeout(messageTimeoutMilliseconds)
+				_consumerStrategyRegistry.GetInstance(namedConsumerStrategy, key),
+				_streamReader,
+				_checkpointReader,
+				new PersistentSubscriptionCheckpointWriter(key, _ioDispatcher),
+				new PersistentSubscriptionMessageParker(key, _ioDispatcher)));
+
+		var updateEntry = new PersistentSubscriptionEntry
+		{
+			Stream = stream, //'Stream' name kept for backward compatibility
+			Group = groupName,
+			Filter = EventFilter.ParseToDto(eventSource.EventFilter),
+			ResolveLinkTos = resolveLinkTos,
+			CheckPointAfter = checkPointAfterMilliseconds,
+			ExtraStatistics = recordStatistics,
+			HistoryBufferSize = bufferSize,
+			LiveBufferSize = liveBufferSize,
+			MaxCheckPointCount = maxCheckPointCount,
+			MinCheckPointCount = minCheckPointCount,
+			MaxRetryCount = maxRetryCount,
+			ReadBatchSize = readBatchSize,
+			MaxSubscriberCount = maxSubscriberCount,
+			MessageTimeout = messageTimeoutMilliseconds,
+			NamedConsumerStrategy = namedConsumerStrategy,
+#pragma warning disable 612
+			StartFrom = startFrom is PersistentSubscriptionSingleStreamPosition x
+				? x.StreamEventNumber
+				: long.MinValue,
+#pragma warning restore 612
+			StartPosition = startFrom.ToString()
+		};
+
+		UpdateSubscription(stream, groupName, subscription);
+		UpdateSubscriptionConfig(user, stream, groupName, updateEntry);
+		SaveConfiguration(() => onSuccess(""));
+	}
+
+	public void Handle(ClientMessage.UpdatePersistentSubscriptionToStream message)
+	{
+		if (string.IsNullOrEmpty(message.EventStreamId))
+		{
+			message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
+				message.CorrelationId,
+				ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
+					.UpdatePersistentSubscriptionToStreamResult.Fail,
+				"Bad stream name."));
+			return;
+		}
+
+		if (message.EventStreamId == SystemStreams.AllStream)
+		{
+			message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
+				message.CorrelationId,
+				ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
+					.UpdatePersistentSubscriptionToStreamResult.Fail,
+				"Persistent subscriptions to $all are only supported over gRPC through gRPC clients"));
+			return;
+		}
+
+		try
+		{
+			UpdatePersistentSubscription(
+				message.EventStreamId,
+				_ => new PersistentSubscriptionSingleStreamEventSource(message.EventStreamId),
+				message.GroupName,
+				new PersistentSubscriptionSingleStreamPosition(message.StartFrom),
+				message.MessageTimeoutMilliseconds,
+				message.ResolveLinkTos,
+				message.MaxRetryCount,
+				message.BufferSize,
+				message.LiveBufferSize,
+				message.ReadBatchSize,
+				message.MaxSubscriberCount,
+				message.NamedConsumerStrategy,
+				message.MaxCheckPointCount,
+				message.MinCheckPointCount,
+				message.CheckPointAfterMilliseconds,
+				message.RecordStatistics,
+				(msg) =>
+				{
+					message.Envelope.ReplyWith(
+						new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
+							message.CorrelationId,
+							ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
+								.UpdatePersistentSubscriptionToStreamResult.Success,
+							msg));
+				},
+				(error) =>
+				{
+					message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
+						message.CorrelationId,
+						ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
+							.UpdatePersistentSubscriptionToStreamResult.Fail,
+						error));
+				},
+				(error) =>
+				{
+					message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
+						message.CorrelationId,
+						ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
+							.UpdatePersistentSubscriptionToStreamResult.DoesNotExist,
+						error));
+				},
+				(error) =>
+				{
+					message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
+						message.CorrelationId,
+						ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
+							.UpdatePersistentSubscriptionToStreamResult.AccessDenied,
+						error));
+				},
+				message.User?.Identity?.Name
 			);
-
-			if (!result) {
-				onExists($"Group '{groupName}' already exists.");
-				return;
-			}
-
-			Log.Debug("New persistent subscription {subscriptionKey}", key);
-			var createEntry = new PersistentSubscriptionEntry {
-				Stream = stream, //'Stream' name kept for backward compatibility
-				Filter = EventFilter.ParseToDto(eventSource.EventFilter),
-				Group = groupName,
-				ResolveLinkTos = resolveLinkTos,
-				CheckPointAfter = checkPointAfterMilliseconds,
-				ExtraStatistics = recordStatistics,
-				HistoryBufferSize = bufferSize,
-				LiveBufferSize = liveBufferSize,
-				MaxCheckPointCount = maxCheckPointCount,
-				MinCheckPointCount = minCheckPointCount,
-				MaxRetryCount = maxRetryCount,
-				ReadBatchSize = readBatchSize,
-				MaxSubscriberCount = maxSubscriberCount,
-				MessageTimeout = messageTimeoutMilliseconds,
-				NamedConsumerStrategy = namedConsumerStrategy,
-				#pragma warning disable 612
-				StartFrom = startFrom is PersistentSubscriptionSingleStreamPosition x ? x.StreamEventNumber : long.MinValue,
-				#pragma warning restore 612
-				StartPosition = startFrom.ToString()
-			};
-			UpdateSubscriptionConfig(user, stream, groupName, createEntry);
-			SaveConfiguration(() => onSuccess(""));
 		}
-
-		public void Handle(ClientMessage.CreatePersistentSubscriptionToStream message) {
-			if (string.IsNullOrEmpty(message.EventStreamId)) {
-				message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
-					message.CorrelationId,
-					ClientMessage.CreatePersistentSubscriptionToStreamCompleted
-						.CreatePersistentSubscriptionToStreamResult.Fail,
-					"Bad stream name."));
-				return;
-			}
-
-			if (message.EventStreamId == SystemStreams.AllStream) {
-				message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
-					message.CorrelationId,
-					ClientMessage.CreatePersistentSubscriptionToStreamCompleted
-						.CreatePersistentSubscriptionToStreamResult.Fail,
-					"Persistent subscriptions to $all are only supported over gRPC through gRPC clients"));
-				return;
-			}
-
-			try {
-				CreatePersistentSubscription(
-					new PersistentSubscriptionSingleStreamEventSource(message.EventStreamId),
-					message.GroupName,
-					new PersistentSubscriptionSingleStreamPosition(message.StartFrom),
-					message.MessageTimeoutMilliseconds,
-					message.ResolveLinkTos,
-					message.MaxRetryCount,
-					message.BufferSize,
-					message.LiveBufferSize,
-					message.ReadBatchSize,
-					message.MaxSubscriberCount,
-					message.NamedConsumerStrategy,
-					message.MaxCheckPointCount,
-					message.MinCheckPointCount,
-					message.CheckPointAfterMilliseconds,
-					message.RecordStatistics,
-					(msg) => {
-						message.Envelope.ReplyWith(
-							new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
-								message.CorrelationId,
-								ClientMessage.CreatePersistentSubscriptionToStreamCompleted
-									.CreatePersistentSubscriptionToStreamResult.Success,
-								msg));
-					},
-					(error) => {
-						message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
-							message.CorrelationId,
-							ClientMessage.CreatePersistentSubscriptionToStreamCompleted
-								.CreatePersistentSubscriptionToStreamResult.Fail,
-							error));
-					},
-					(error) => {
-						message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
-							message.CorrelationId,
-							ClientMessage.CreatePersistentSubscriptionToStreamCompleted
-								.CreatePersistentSubscriptionToStreamResult.AlreadyExists,
-							error));
-					},
-					(error) => {
-						message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
-							message.CorrelationId,
-							ClientMessage.CreatePersistentSubscriptionToStreamCompleted
-								.CreatePersistentSubscriptionToStreamResult.AccessDenied,
-							error));
-					},
-					message.User?.Identity?.Name
-				);
-			} catch (Exception ex) {
-				message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
-					message.CorrelationId,
-					ClientMessage.CreatePersistentSubscriptionToStreamCompleted
-						.CreatePersistentSubscriptionToStreamResult.Fail,
-					ex.Message));
-			}
+		catch (Exception ex)
+		{
+			message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
+				message.CorrelationId,
+				ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
+					.UpdatePersistentSubscriptionToStreamResult.Fail,
+				ex.Message));
 		}
+	}
 
-		public void Handle(ClientMessage.CreatePersistentSubscriptionToAll message) {
-			try {
-				CreatePersistentSubscription(
-					new PersistentSubscriptionAllStreamEventSource(message.EventFilter),
-					message.GroupName,
-					new PersistentSubscriptionAllStreamPosition(message.StartFrom.CommitPosition,
-						message.StartFrom.PreparePosition),
-					message.MessageTimeoutMilliseconds,
-					message.ResolveLinkTos,
-					message.MaxRetryCount,
-					message.BufferSize,
-					message.LiveBufferSize,
-					message.ReadBatchSize,
-					message.MaxSubscriberCount,
-					message.NamedConsumerStrategy,
-					message.MaxCheckPointCount,
-					message.MinCheckPointCount,
-					message.CheckPointAfterMilliseconds,
-					message.RecordStatistics,
-					(msg) => {
-						message.Envelope.ReplyWith(
-							new ClientMessage.CreatePersistentSubscriptionToAllCompleted(
-								message.CorrelationId,
-								ClientMessage.CreatePersistentSubscriptionToAllCompleted
-									.CreatePersistentSubscriptionToAllResult.Success,
-								msg));
-					},
-					(error) => {
-						message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToAllCompleted(
-							message.CorrelationId,
-							ClientMessage.CreatePersistentSubscriptionToAllCompleted
-								.CreatePersistentSubscriptionToAllResult.Fail,
-							error));
-					},
-					(error) => {
-						message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToAllCompleted(
-							message.CorrelationId,
-							ClientMessage.CreatePersistentSubscriptionToAllCompleted
-								.CreatePersistentSubscriptionToAllResult.AlreadyExists,
-							error));
-					},
-					(error) => {
-						message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToAllCompleted(
-							message.CorrelationId,
-							ClientMessage.CreatePersistentSubscriptionToAllCompleted
-								.CreatePersistentSubscriptionToAllResult.AccessDenied,
-							error));
-					},
-					message.User?.Identity?.Name
-				);
-			} catch (Exception ex) {
-				message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToAllCompleted(
-					message.CorrelationId,
-					ClientMessage.CreatePersistentSubscriptionToAllCompleted.CreatePersistentSubscriptionToAllResult.Fail,
-					ex.Message));
-			}
-
-		}
-
-		private void UpdatePersistentSubscription(
-				string stream,
-				Func<PersistentSubscription, IPersistentSubscriptionEventSource> genEventSource,
-				string groupName,
-				IPersistentSubscriptionStreamPosition startFrom,
-				int messageTimeoutMilliseconds,
-				bool resolveLinkTos,
-				int maxRetryCount,
-				int bufferSize,
-				int liveBufferSize,
-				int readBatchSize,
-				int maxSubscriberCount,
-				string namedConsumerStrategy,
-				int maxCheckPointCount,
-				int minCheckPointCount,
-				int checkPointAfterMilliseconds,
-				bool recordStatistics,
-				Action<string> onSuccess,
-				Action<string> onFail,
-				Action<string> onNotExist,
-				Action<string> onAccessDenied,
-				string user
-		) {
-			if (!_started) return;
-
-			var key = BuildSubscriptionGroupKey(stream, groupName);
-			Log.Debug("Updating persistent subscription {subscriptionKey}", key);
-
-			if (!_subscriptionsById.TryGetValue(key, out var oldSubscription)) {
-				onNotExist($"Group '{groupName}' does not exist.");
-				return;
-			}
-
-			if (!_consumerStrategyRegistry.ValidateStrategy(namedConsumerStrategy)) {
-				onFail($"Consumer strategy {namedConsumerStrategy} does not exist.");
-				return;
-			}
-
-			if (!ValidateStartFrom(startFrom, out var startFromValidationError)) {
-				onFail(startFromValidationError);
-				return;
-			}
-
-			var eventSource = genEventSource(oldSubscription);
-			var subscription = new PersistentSubscription(
-				new PersistentSubscriptionParams(
-					resolveLinkTos,
-					key,
-					eventSource,
-					groupName,
-					startFrom,
-					recordStatistics,
-					ToMessageTimeout(messageTimeoutMilliseconds),
-					maxRetryCount,
-					liveBufferSize,
-					bufferSize,
-					readBatchSize,
-					ToCheckPointAfterTimeout(checkPointAfterMilliseconds),
-					minCheckPointCount,
-					maxCheckPointCount,
-					maxSubscriberCount,
-					_consumerStrategyRegistry.GetInstance(namedConsumerStrategy, key),
-					_streamReader,
-					_checkpointReader,
-					new PersistentSubscriptionCheckpointWriter(key, _ioDispatcher),
-					new PersistentSubscriptionMessageParker(key, _ioDispatcher)));
-
-			var updateEntry = new PersistentSubscriptionEntry {
-				Stream = stream, //'Stream' name kept for backward compatibility
-				Group = groupName,
-				Filter = EventFilter.ParseToDto(eventSource.EventFilter),
-				ResolveLinkTos = resolveLinkTos,
-				CheckPointAfter = checkPointAfterMilliseconds,
-				ExtraStatistics = recordStatistics,
-				HistoryBufferSize = bufferSize,
-				LiveBufferSize = liveBufferSize,
-				MaxCheckPointCount = maxCheckPointCount,
-				MinCheckPointCount = minCheckPointCount,
-				MaxRetryCount = maxRetryCount,
-				ReadBatchSize = readBatchSize,
-				MaxSubscriberCount = maxSubscriberCount,
-				MessageTimeout = messageTimeoutMilliseconds,
-				NamedConsumerStrategy = namedConsumerStrategy,
-				#pragma warning disable 612
-				StartFrom = startFrom is PersistentSubscriptionSingleStreamPosition x
-					? x.StreamEventNumber
-					: long.MinValue,
-				#pragma warning restore 612
-				StartPosition = startFrom.ToString()
-			};
-
-			UpdateSubscription(stream, groupName, subscription);
-			UpdateSubscriptionConfig(user, stream, groupName, updateEntry);
-			SaveConfiguration(() => onSuccess(""));
-		}
-
-		public void Handle(ClientMessage.UpdatePersistentSubscriptionToStream message) {
-			if (string.IsNullOrEmpty(message.EventStreamId)) {
-				message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
-					message.CorrelationId,
-					ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
-						.UpdatePersistentSubscriptionToStreamResult.Fail,
-					"Bad stream name."));
-				return;
-			}
-
-			if (message.EventStreamId == SystemStreams.AllStream) {
-				message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
-					message.CorrelationId,
-					ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
-						.UpdatePersistentSubscriptionToStreamResult.Fail,
-					"Persistent subscriptions to $all are only supported over gRPC through gRPC clients"));
-				return;
-			}
-
-			try {
-				UpdatePersistentSubscription(
-					message.EventStreamId,
-					_ => new PersistentSubscriptionSingleStreamEventSource(message.EventStreamId),
-					message.GroupName,
-					new PersistentSubscriptionSingleStreamPosition(message.StartFrom),
-					message.MessageTimeoutMilliseconds,
-					message.ResolveLinkTos,
-					message.MaxRetryCount,
-					message.BufferSize,
-					message.LiveBufferSize,
-					message.ReadBatchSize,
-					message.MaxSubscriberCount,
-					message.NamedConsumerStrategy,
-					message.MaxCheckPointCount,
-					message.MinCheckPointCount,
-					message.CheckPointAfterMilliseconds,
-					message.RecordStatistics,
-					(msg) => {
-						message.Envelope.ReplyWith(
-							new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
-								message.CorrelationId,
-								ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
-									.UpdatePersistentSubscriptionToStreamResult.Success,
-								msg));
-					},
-					(error) => {
-						message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
-							message.CorrelationId,
-							ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
-								.UpdatePersistentSubscriptionToStreamResult.Fail,
-							error));
-					},
-					(error) => {
-						message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
-							message.CorrelationId,
-							ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
-								.UpdatePersistentSubscriptionToStreamResult.DoesNotExist,
-							error));
-					},
-					(error) => {
-						message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
-							message.CorrelationId,
-							ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
-								.UpdatePersistentSubscriptionToStreamResult.AccessDenied,
-							error));
-					},
-					message.User?.Identity?.Name
-				);
-			} catch (Exception ex) {
-				message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
-					message.CorrelationId,
-					ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
-						.UpdatePersistentSubscriptionToStreamResult.Fail,
-					ex.Message));
-			}
-		}
-
-		public void Handle(ClientMessage.UpdatePersistentSubscriptionToAll message) {
-			try {
-				UpdatePersistentSubscription(
-					SystemStreams.AllStream,
-					sub => new PersistentSubscriptionAllStreamEventSource(sub.EventSource?.EventFilter),
-					message.GroupName,
-					new PersistentSubscriptionAllStreamPosition(message.StartFrom.CommitPosition,
-						message.StartFrom.PreparePosition),
-					message.MessageTimeoutMilliseconds,
-					message.ResolveLinkTos,
-					message.MaxRetryCount,
-					message.BufferSize,
-					message.LiveBufferSize,
-					message.ReadBatchSize,
-					message.MaxSubscriberCount,
-					message.NamedConsumerStrategy,
-					message.MaxCheckPointCount,
-					message.MinCheckPointCount,
-					message.CheckPointAfterMilliseconds,
-					message.RecordStatistics,
-					(msg) => {
-						message.Envelope.ReplyWith(
-							new ClientMessage.UpdatePersistentSubscriptionToAllCompleted(
-								message.CorrelationId,
-								ClientMessage.UpdatePersistentSubscriptionToAllCompleted
-									.UpdatePersistentSubscriptionToAllResult.Success,
-								msg));
-					},
-					(error) => {
-						message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToAllCompleted(
+	public void Handle(ClientMessage.UpdatePersistentSubscriptionToAll message)
+	{
+		try
+		{
+			UpdatePersistentSubscription(
+				SystemStreams.AllStream,
+				sub => new PersistentSubscriptionAllStreamEventSource(sub.EventSource?.EventFilter),
+				message.GroupName,
+				new PersistentSubscriptionAllStreamPosition(message.StartFrom.CommitPosition,
+					message.StartFrom.PreparePosition),
+				message.MessageTimeoutMilliseconds,
+				message.ResolveLinkTos,
+				message.MaxRetryCount,
+				message.BufferSize,
+				message.LiveBufferSize,
+				message.ReadBatchSize,
+				message.MaxSubscriberCount,
+				message.NamedConsumerStrategy,
+				message.MaxCheckPointCount,
+				message.MinCheckPointCount,
+				message.CheckPointAfterMilliseconds,
+				message.RecordStatistics,
+				(msg) =>
+				{
+					message.Envelope.ReplyWith(
+						new ClientMessage.UpdatePersistentSubscriptionToAllCompleted(
 							message.CorrelationId,
 							ClientMessage.UpdatePersistentSubscriptionToAllCompleted
-								.UpdatePersistentSubscriptionToAllResult.Fail,
-							error));
-					},
-					(error) => {
-						message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToAllCompleted(
-							message.CorrelationId,
-							ClientMessage.UpdatePersistentSubscriptionToAllCompleted
-								.UpdatePersistentSubscriptionToAllResult.DoesNotExist,
-							error));
-					},
-					(error) => {
-						message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToAllCompleted(
-							message.CorrelationId,
-							ClientMessage.UpdatePersistentSubscriptionToAllCompleted
-								.UpdatePersistentSubscriptionToAllResult.AccessDenied,
-							error));
-					},
-					message.User?.Identity?.Name
-				);
-			} catch (Exception ex) {
-				message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToAllCompleted(
+								.UpdatePersistentSubscriptionToAllResult.Success,
+							msg));
+				},
+				(error) =>
+				{
+					message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToAllCompleted(
+						message.CorrelationId,
+						ClientMessage.UpdatePersistentSubscriptionToAllCompleted
+							.UpdatePersistentSubscriptionToAllResult.Fail,
+						error));
+				},
+				(error) =>
+				{
+					message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToAllCompleted(
+						message.CorrelationId,
+						ClientMessage.UpdatePersistentSubscriptionToAllCompleted
+							.UpdatePersistentSubscriptionToAllResult.DoesNotExist,
+						error));
+				},
+				(error) =>
+				{
+					message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToAllCompleted(
+						message.CorrelationId,
+						ClientMessage.UpdatePersistentSubscriptionToAllCompleted
+							.UpdatePersistentSubscriptionToAllResult.AccessDenied,
+						error));
+				},
+				message.User?.Identity?.Name
+			);
+		}
+		catch (Exception ex)
+		{
+			message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToAllCompleted(
+				message.CorrelationId,
+				ClientMessage.UpdatePersistentSubscriptionToAllCompleted.UpdatePersistentSubscriptionToAllResult
+					.Fail,
+				ex.Message));
+		}
+	}
+
+	private bool TryCreateSubscriptionGroup(IPersistentSubscriptionEventSource eventSource,
+		string groupName,
+		bool resolveLinkTos,
+		IPersistentSubscriptionStreamPosition startFrom,
+		bool extraStatistics,
+		int maxRetryCount,
+		int liveBufferSize,
+		int historyBufferSize,
+		int readBatchSize,
+		TimeSpan checkPointAfter,
+		int minCheckPointCount,
+		int maxCheckPointCount,
+		int maxSubscriberCount,
+		string namedConsumerStrategy,
+		TimeSpan messageTimeout)
+	{
+		var stream = eventSource.ToString();
+		var key = BuildSubscriptionGroupKey(stream, groupName);
+
+		if (_subscriptionsById.ContainsKey(key))
+			return false;
+
+		var subscription = new PersistentSubscription(
+			new PersistentSubscriptionParams(
+				resolveLinkTos,
+				key,
+				eventSource,
+				groupName,
+				startFrom,
+				extraStatistics,
+				messageTimeout,
+				maxRetryCount,
+				liveBufferSize,
+				historyBufferSize,
+				readBatchSize,
+				checkPointAfter,
+				minCheckPointCount,
+				maxCheckPointCount,
+				maxSubscriberCount,
+				_consumerStrategyRegistry.GetInstance(namedConsumerStrategy, key),
+				_streamReader,
+				_checkpointReader,
+				new PersistentSubscriptionCheckpointWriter(key, _ioDispatcher),
+				new PersistentSubscriptionMessageParker(key, _ioDispatcher)));
+
+		UpdateSubscription(stream, groupName, subscription);
+		return true;
+
+	}
+
+	private void DeletePersistentSubscription(
+		IPersistentSubscriptionEventSource eventSource,
+		string groupName,
+		Action<string> onSuccess,
+		Action<string> onFail,
+		Action<string> onNotExist,
+		Action<string> onAccessDenied,
+		string user
+	)
+	{
+		if (!_started) return;
+		var stream = eventSource.ToString();
+		var key = BuildSubscriptionGroupKey(stream, groupName);
+		Log.Debug("Deleting persistent subscription {subscriptionKey}", key);
+
+		PersistentSubscription subscription;
+		if (!_subscriptionsById.TryGetValue(key, out subscription))
+		{
+			onNotExist($"Group '{groupName}' does not exist.");
+			return;
+		}
+
+		if (!_subscriptionTopics.ContainsKey(stream))
+		{
+			onFail($"Group '{groupName}' does not exist.");
+			return;
+		}
+
+		UpdateSubscription(stream, groupName, null);
+		UpdateSubscriptionConfig(user, stream, groupName, null);
+		subscription.Delete();
+		SaveConfiguration(() => onSuccess(""));
+	}
+
+
+	public void Handle(ClientMessage.DeletePersistentSubscriptionToStream message)
+	{
+		if (string.IsNullOrEmpty(message.EventStreamId))
+		{
+			message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
+				message.CorrelationId,
+				ClientMessage.DeletePersistentSubscriptionToStreamCompleted
+					.DeletePersistentSubscriptionToStreamResult.Fail,
+				"Bad stream name."));
+			return;
+		}
+
+		if (message.EventStreamId == SystemStreams.AllStream)
+		{
+			message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
+				message.CorrelationId,
+				ClientMessage.DeletePersistentSubscriptionToStreamCompleted
+					.DeletePersistentSubscriptionToStreamResult.Fail,
+				"Persistent subscriptions to $all are only supported over gRPC through gRPC clients"));
+			return;
+		}
+
+		DeletePersistentSubscription(
+			new PersistentSubscriptionSingleStreamEventSource(message.EventStreamId),
+			message.GroupName,
+			(msg) =>
+			{
+				message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
 					message.CorrelationId,
-					ClientMessage.UpdatePersistentSubscriptionToAllCompleted.UpdatePersistentSubscriptionToAllResult
+					ClientMessage.DeletePersistentSubscriptionToStreamCompleted
+						.DeletePersistentSubscriptionToStreamResult.Success, msg));
+			},
+			(error) =>
+			{
+				message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
+					message.CorrelationId,
+					ClientMessage.DeletePersistentSubscriptionToStreamCompleted
+						.DeletePersistentSubscriptionToStreamResult.Fail,
+					error));
+			},
+			(error) =>
+			{
+				message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
+					message.CorrelationId,
+					ClientMessage.DeletePersistentSubscriptionToStreamCompleted
+						.DeletePersistentSubscriptionToStreamResult.DoesNotExist,
+					error));
+			},
+			(error) =>
+			{
+				message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
+					message.CorrelationId,
+					ClientMessage.DeletePersistentSubscriptionToStreamCompleted
+						.DeletePersistentSubscriptionToStreamResult.AccessDenied,
+					error));
+			},
+			message.User?.Identity?.Name
+		);
+	}
+
+	public void Handle(ClientMessage.DeletePersistentSubscriptionToAll message)
+	{
+		DeletePersistentSubscription(
+			new PersistentSubscriptionAllStreamEventSource(),
+			message.GroupName,
+			(msg) =>
+			{
+				message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToAllCompleted(
+					message.CorrelationId,
+					ClientMessage.DeletePersistentSubscriptionToAllCompleted
+						.DeletePersistentSubscriptionToAllResult.Success, msg));
+			},
+			(error) =>
+			{
+				message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToAllCompleted(
+					message.CorrelationId,
+					ClientMessage.DeletePersistentSubscriptionToAllCompleted.DeletePersistentSubscriptionToAllResult
 						.Fail,
-					ex.Message));
-			}
-		}
-
-		private bool TryCreateSubscriptionGroup(IPersistentSubscriptionEventSource eventSource,
-			string groupName,
-			bool resolveLinkTos,
-			IPersistentSubscriptionStreamPosition startFrom,
-			bool extraStatistics,
-			int maxRetryCount,
-			int liveBufferSize,
-			int historyBufferSize,
-			int readBatchSize,
-			TimeSpan checkPointAfter,
-			int minCheckPointCount,
-			int maxCheckPointCount,
-			int maxSubscriberCount,
-			string namedConsumerStrategy,
-			TimeSpan messageTimeout) {
-			var stream = eventSource.ToString();
-			var key = BuildSubscriptionGroupKey(stream, groupName);
-
-			if (_subscriptionsById.ContainsKey(key))
-				return false;
-
-			var subscription = new PersistentSubscription(
-				new PersistentSubscriptionParams(
-					resolveLinkTos,
-					key,
-					eventSource,
-					groupName,
-					startFrom,
-					extraStatistics,
-					messageTimeout,
-					maxRetryCount,
-					liveBufferSize,
-					historyBufferSize,
-					readBatchSize,
-					checkPointAfter,
-					minCheckPointCount,
-					maxCheckPointCount,
-					maxSubscriberCount,
-					_consumerStrategyRegistry.GetInstance(namedConsumerStrategy, key),
-					_streamReader,
-					_checkpointReader,
-					new PersistentSubscriptionCheckpointWriter(key, _ioDispatcher),
-					new PersistentSubscriptionMessageParker(key, _ioDispatcher)));
-
-			UpdateSubscription(stream, groupName, subscription);
-			return true;
-
-		}
-
-		private void DeletePersistentSubscription(
-				IPersistentSubscriptionEventSource eventSource,
-				string groupName,
-				Action<string> onSuccess,
-				Action<string> onFail,
-				Action<string> onNotExist,
-				Action<string> onAccessDenied,
-				string user
-		) {
-			if (!_started) return;
-			var stream = eventSource.ToString();
-			var key = BuildSubscriptionGroupKey(stream, groupName);
-			Log.Debug("Deleting persistent subscription {subscriptionKey}", key);
-
-			PersistentSubscription subscription;
-			if (!_subscriptionsById.TryGetValue(key, out subscription)) {
-				onNotExist($"Group '{groupName}' does not exist.");
-				return;
-			}
-
-			if (!_subscriptionTopics.ContainsKey(stream)) {
-				onFail($"Group '{groupName}' does not exist.");
-				return;
-			}
-
-			UpdateSubscription(stream, groupName, null);
-			UpdateSubscriptionConfig(user, stream, groupName, null);
-			subscription.Delete();
-			SaveConfiguration(() => onSuccess(""));
-		}
-
-
-		public void Handle(ClientMessage.DeletePersistentSubscriptionToStream message) {
-			if (string.IsNullOrEmpty(message.EventStreamId)) {
-				message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
+					error));
+			},
+			(error) =>
+			{
+				message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToAllCompleted(
 					message.CorrelationId,
-					ClientMessage.DeletePersistentSubscriptionToStreamCompleted
-						.DeletePersistentSubscriptionToStreamResult.Fail,
-					"Bad stream name."));
-				return;
-			}
-
-			if (message.EventStreamId == SystemStreams.AllStream) {
-				message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
+					ClientMessage.DeletePersistentSubscriptionToAllCompleted.DeletePersistentSubscriptionToAllResult
+						.DoesNotExist,
+					error));
+			},
+			(error) =>
+			{
+				message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToAllCompleted(
 					message.CorrelationId,
-					ClientMessage.DeletePersistentSubscriptionToStreamCompleted
-						.DeletePersistentSubscriptionToStreamResult.Fail,
-					"Persistent subscriptions to $all are only supported over gRPC through gRPC clients"));
-				return;
+					ClientMessage.DeletePersistentSubscriptionToAllCompleted.DeletePersistentSubscriptionToAllResult
+						.AccessDenied,
+					error));
+			},
+			message.User?.Identity?.Name
+		);
+	}
+
+	private void UpdateSubscriptionConfig(string username, string eventSource, string groupName,
+		PersistentSubscriptionEntry replaceBy)
+	{
+		_config.Updated = DateTime.Now;
+		_config.UpdatedBy = username;
+		var index = _config.Entries.FindLastIndex(x => x.Stream == eventSource && x.Group == groupName);
+
+		if (index < 0)
+		{
+			if (replaceBy == null)
+			{
+				var key = BuildSubscriptionGroupKey(eventSource, groupName);
+				throw new ArgumentException($"Config for subscription: '{key}' does not exist");
 			}
 
-			DeletePersistentSubscription(
-				new PersistentSubscriptionSingleStreamEventSource(message.EventStreamId),
-				message.GroupName,
-				(msg) => {
-					message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
-						message.CorrelationId,
-						ClientMessage.DeletePersistentSubscriptionToStreamCompleted
-							.DeletePersistentSubscriptionToStreamResult.Success, msg));
-				},
-				(error) => {
-					message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
-						message.CorrelationId,
-						ClientMessage.DeletePersistentSubscriptionToStreamCompleted
-							.DeletePersistentSubscriptionToStreamResult.Fail,
-						error));
-				},
-				(error) => {
-					message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
-						message.CorrelationId,
-						ClientMessage.DeletePersistentSubscriptionToStreamCompleted
-							.DeletePersistentSubscriptionToStreamResult.DoesNotExist,
-						error));
-				},
-				(error) => {
-					message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
-						message.CorrelationId,
-						ClientMessage.DeletePersistentSubscriptionToStreamCompleted
-							.DeletePersistentSubscriptionToStreamResult.AccessDenied,
-						error));
-				},
-				message.User?.Identity?.Name
-			);
+			// create
+			_config.Entries.Add(replaceBy);
+		}
+		else
+		{
+			if (replaceBy != null) // update
+				_config.Entries[index] = replaceBy;
+			else // delete
+				_config.Entries.RemoveAt(index);
+		}
+	}
+
+	private void UpdateSubscription(string eventSource, string groupName, PersistentSubscription replaceBy)
+	{
+		var key = BuildSubscriptionGroupKey(eventSource, groupName);
+
+		if (!_subscriptionTopics.TryGetValue(eventSource, out var subscribers))
+		{
+			subscribers = new List<PersistentSubscription>();
+			_subscriptionTopics.Add(eventSource, subscribers);
 		}
 
-		public void Handle(ClientMessage.DeletePersistentSubscriptionToAll message) {
-			DeletePersistentSubscription(
-				new PersistentSubscriptionAllStreamEventSource(),
-				message.GroupName,
-				(msg) => {
-					message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToAllCompleted(
-						message.CorrelationId,
-						ClientMessage.DeletePersistentSubscriptionToAllCompleted
-							.DeletePersistentSubscriptionToAllResult.Success, msg));
-				},
-				(error) => {
-					message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToAllCompleted(
-						message.CorrelationId,
-						ClientMessage.DeletePersistentSubscriptionToAllCompleted.DeletePersistentSubscriptionToAllResult.Fail,
-						error));
-				},
-				(error) => {
-					message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToAllCompleted(
-						message.CorrelationId,
-						ClientMessage.DeletePersistentSubscriptionToAllCompleted.DeletePersistentSubscriptionToAllResult.DoesNotExist,
-						error));
-				},
-				(error) => {
-					message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToAllCompleted(
-						message.CorrelationId,
-						ClientMessage.DeletePersistentSubscriptionToAllCompleted.DeletePersistentSubscriptionToAllResult.AccessDenied,
-						error));
-				},
-				message.User?.Identity?.Name
-			);
+		// shut down any existing subscription
+		var subscriptionIndex = -1;
+		for (int i = 0; i < subscribers.Count; i++)
+		{
+			if (subscribers[i].SubscriptionId != key) continue;
+
+			subscriptionIndex = i;
+			var sub = subscribers[i];
+			try
+			{
+				sub.Shutdown();
+			}
+			catch (Exception ex)
+			{
+				Log.Error(ex, "Failed to shut down subscription with id: {subscriptionId}",
+					sub.SubscriptionId);
+			}
+
+			break;
 		}
 
-		private void UpdateSubscriptionConfig(string username, string eventSource, string groupName, PersistentSubscriptionEntry replaceBy) {
-			_config.Updated = DateTime.Now;
-			_config.UpdatedBy = username;
-			var index = _config.Entries.FindLastIndex(x => x.Stream == eventSource && x.Group == groupName);
+		if (_subscriptionsById.ContainsKey(key))
+		{
+			if (subscriptionIndex == -1)
+				throw new ArgumentException(
+					$"Subscription: '{key}' exists but it's not present in the list of subscribers");
 
-			if (index < 0) {
-				if (replaceBy == null) {
-					var key = BuildSubscriptionGroupKey(eventSource, groupName);
-					throw new ArgumentException($"Config for subscription: '{key}' does not exist");
-				}
-				// create
-				_config.Entries.Add(replaceBy);
-			} else {
-				if (replaceBy != null) // update
-					_config.Entries[index] = replaceBy;
-				else // delete
-					_config.Entries.RemoveAt(index);
+			if (replaceBy != null)
+			{
+				// update
+				_subscriptionsById[key] = replaceBy;
+				subscribers[subscriptionIndex] = replaceBy;
+			}
+			else
+			{
+				// delete
+				_subscriptionsById.Remove(key);
+				subscribers.RemoveAt(subscriptionIndex);
 			}
 		}
+		else
+		{
+			if (subscriptionIndex != -1)
+				throw new ArgumentException(
+					$"Subscription: '{key}' does not exist but it's present in the list of subscribers");
 
-		private void UpdateSubscription(string eventSource, string groupName, PersistentSubscription replaceBy) {
-			var key = BuildSubscriptionGroupKey(eventSource, groupName);
+			// create
+			_subscriptionsById.Add(key, replaceBy);
+			subscribers.Add(replaceBy);
+		}
+	}
 
-			if (!_subscriptionTopics.TryGetValue(eventSource, out var subscribers)) {
-				subscribers = new List<PersistentSubscription>();
-				_subscriptionTopics.Add(eventSource, subscribers);
-			}
+	private void UnsubscribeFromStream(Guid correlationId, bool sendDropNotification)
+	{
+		foreach (var subscription in _subscriptionsById.Values)
+		{
+			subscription.RemoveClientByCorrelationId(correlationId, sendDropNotification);
+		}
+	}
 
-			// shut down any existing subscription
-			var subscriptionIndex = -1;
-			for (int i = 0; i < subscribers.Count; i++) {
-				if (subscribers[i].SubscriptionId != key) continue;
+	public void Handle(TcpMessage.ConnectionClosed message)
+	{
+		if (_subscriptionsById == null) return; //haven't built yet.
 
-				subscriptionIndex = i;
-				var sub = subscribers[i];
-				try {
-					sub.Shutdown();
-				} catch (Exception ex) {
-					Log.Error(ex, "Failed to shut down subscription with id: {subscriptionId}",
-						sub.SubscriptionId);
-				}
-				break;
-			}
+		foreach (var subscription in _subscriptionsById.Values)
+		{
+			if (subscription.RemoveClientByConnectionId(message.Connection.ConnectionId))
+				Log.Debug("Persistent subscription {subscription} lost connection from {remoteEndPoint}",
+					subscription.SubscriptionId,
+					message.Connection.RemoteEndPoint);
+		}
+	}
 
-			if (_subscriptionsById.ContainsKey(key)) {
-				if (subscriptionIndex == -1)
-					throw new ArgumentException($"Subscription: '{key}' exists but it's not present in the list of subscribers");
+	public void ConnectToPersistentSubscription(
+		IPersistentSubscriptionEventSource eventSource,
+		string groupName,
+		int allowedInFlightMessages,
+		Guid connectionId,
+		string connectionName,
+		string from,
+		Guid correlationId,
+		IEnvelope envelope,
+		string user)
+	{
+		if (!_started) return;
 
-				if (replaceBy != null) { // update
-					_subscriptionsById[key] = replaceBy;
-					subscribers[subscriptionIndex] = replaceBy;
-				} else { // delete
-					_subscriptionsById.Remove(key);
-					subscribers.RemoveAt(subscriptionIndex);
-				}
-			} else {
-				if (subscriptionIndex != -1)
-					throw new ArgumentException($"Subscription: '{key}' does not exist but it's present in the list of subscribers");
-
-				// create
-				_subscriptionsById.Add(key, replaceBy);
-				subscribers.Add(replaceBy);
-			}
+		var stream = eventSource.ToString();
+		List<PersistentSubscription> subscribers;
+		if (!_subscriptionTopics.TryGetValue(stream, out subscribers))
+		{
+			envelope.ReplyWith(new ClientMessage.SubscriptionDropped(correlationId,
+				SubscriptionDropReason.NotFound));
+			return;
 		}
 
-		private void UnsubscribeFromStream(Guid correlationId, bool sendDropNotification) {
-			foreach (var subscription in _subscriptionsById.Values) {
-				subscription.RemoveClientByCorrelationId(correlationId, sendDropNotification);
-			}
+		var key = BuildSubscriptionGroupKey(stream, groupName);
+		PersistentSubscription subscription;
+		if (!_subscriptionsById.TryGetValue(key, out subscription))
+		{
+			envelope.ReplyWith(new ClientMessage.SubscriptionDropped(correlationId, SubscriptionDropReason.NotFound));
+			return;
 		}
 
-		public void Handle(TcpMessage.ConnectionClosed message) {
-			if (_subscriptionsById == null) return; //haven't built yet.
-
-			foreach (var subscription in _subscriptionsById.Values) {
-				if (subscription.RemoveClientByConnectionId(message.Connection.ConnectionId))
-					Log.Debug("Persistent subscription {subscription} lost connection from {remoteEndPoint}",
-						subscription.SubscriptionId,
-						message.Connection.RemoteEndPoint);
-			}
+		if (subscription.HasReachedMaxClientCount)
+		{
+			envelope.ReplyWith(new ClientMessage.SubscriptionDropped(correlationId,
+				SubscriptionDropReason.SubscriberMaxCountReached));
+			return;
 		}
 
-		public void ConnectToPersistentSubscription(
-			IPersistentSubscriptionEventSource eventSource,
-			string groupName,
-			int allowedInFlightMessages,
-			Guid connectionId,
-			string connectionName,
-			string from,
-			Guid correlationId,
-			IEnvelope envelope,
-			string user) {
-			if (!_started) return;
-
-			var stream = eventSource.ToString();
-			List<PersistentSubscription> subscribers;
-			if (!_subscriptionTopics.TryGetValue(stream, out subscribers)) {
-				envelope.ReplyWith(new ClientMessage.SubscriptionDropped(correlationId,
-					SubscriptionDropReason.NotFound));
-				return;
-			}
-
-			var key = BuildSubscriptionGroupKey(stream, groupName);
-			PersistentSubscription subscription;
-			if (!_subscriptionsById.TryGetValue(key, out subscription)) {
-				envelope.ReplyWith(new ClientMessage.SubscriptionDropped(correlationId, SubscriptionDropReason.NotFound));
-				return;
-			}
-
-			if (subscription.HasReachedMaxClientCount) {
-				envelope.ReplyWith(new ClientMessage.SubscriptionDropped(correlationId,
-					SubscriptionDropReason.SubscriberMaxCountReached));
-				return;
-			}
-
-			Log.Debug("New connection to persistent subscription {subscriptionKey} by {connectionId}", key, connectionId);
-			long? lastEventNumber = null;
-			if (eventSource.FromStream) {
-				var streamId = _readIndex.GetStreamId(eventSource.EventStreamId);
-				lastEventNumber = _readIndex.GetStreamLastEventNumber(streamId);
-			}
-			var lastCommitPos = _readIndex.LastIndexedPosition;
-			var subscribedMessage =
-				new ClientMessage.PersistentSubscriptionConfirmation(key, correlationId, lastCommitPos, lastEventNumber);
-			envelope.ReplyWith(subscribedMessage);
-			var name = user ?? "anonymous";
-			subscription.AddClient(correlationId, connectionId, connectionName, envelope,
-				allowedInFlightMessages, name, from);
-
+		Log.Debug("New connection to persistent subscription {subscriptionKey} by {connectionId}", key, connectionId);
+		long? lastEventNumber = null;
+		if (eventSource.FromStream)
+		{
+			var streamId = _readIndex.GetStreamId(eventSource.EventStreamId);
+			lastEventNumber = _readIndex.GetStreamLastEventNumber(streamId);
 		}
 
-		public void Handle(ClientMessage.ConnectToPersistentSubscriptionToStream message) {
-			ConnectToPersistentSubscription(
-				new PersistentSubscriptionSingleStreamEventSource(message.EventStreamId),
-				message.GroupName,
-				message.AllowedInFlightMessages,
-				message.ConnectionId,
-				message.ConnectionName,
-				message.From,
+		var lastCommitPos = _readIndex.LastIndexedPosition;
+		var subscribedMessage =
+			new ClientMessage.PersistentSubscriptionConfirmation(key, correlationId, lastCommitPos, lastEventNumber);
+		envelope.ReplyWith(subscribedMessage);
+		var name = user ?? "anonymous";
+		subscription.AddClient(correlationId, connectionId, connectionName, envelope,
+			allowedInFlightMessages, name, from);
+
+	}
+
+	public void Handle(ClientMessage.ConnectToPersistentSubscriptionToStream message)
+	{
+		ConnectToPersistentSubscription(
+			new PersistentSubscriptionSingleStreamEventSource(message.EventStreamId),
+			message.GroupName,
+			message.AllowedInFlightMessages,
+			message.ConnectionId,
+			message.ConnectionName,
+			message.From,
+			message.CorrelationId,
+			message.Envelope,
+			message.User?.Identity?.Name);
+	}
+
+	public void Handle(ClientMessage.ConnectToPersistentSubscriptionToAll message)
+	{
+		ConnectToPersistentSubscription(
+			new PersistentSubscriptionAllStreamEventSource(),
+			message.GroupName,
+			message.AllowedInFlightMessages,
+			message.ConnectionId,
+			message.ConnectionName,
+			message.From,
+			message.CorrelationId,
+			message.Envelope,
+			message.User?.Identity?.Name);
+	}
+
+	private static string BuildSubscriptionGroupKey(string stream, string groupName)
+	{
+		return stream + "::" + groupName;
+	}
+
+	public void Handle(StorageMessage.EventCommitted message)
+	{
+		if (!_started) return;
+		ProcessEventCommited(message.Event.EventStreamId, message.CommitPosition, message.Event);
+	}
+
+	private void ProcessEventCommited(string eventStreamId, long commitPosition, EventRecord evnt)
+	{
+		var subscriptions = new List<PersistentSubscription>();
+		if (EventFilter.DefaultStreamFilter.IsEventAllowed(evnt)
+		    && _subscriptionTopics.TryGetValue(eventStreamId, out var subscriptionsToStream))
+		{
+			subscriptions.AddRange(subscriptionsToStream);
+		}
+
+		if (EventFilter.DefaultAllFilter.IsEventAllowed(evnt)
+		    && _subscriptionTopics.TryGetValue(SystemStreams.AllStream, out var subscriptionsToAll))
+		{
+			subscriptions.AddRange(subscriptionsToAll);
+		}
+
+		for (int i = 0, n = subscriptions.Count; i < n; i++)
+		{
+			var subscr = subscriptions[i];
+			var pair = ResolvedEvent.ForUnresolvedEvent(evnt, commitPosition);
+			if (subscr.ResolveLinkTos)
+				pair = ResolveLinkToEvent(evnt, commitPosition); //TODO this can be cached
+			subscr.NotifyLiveSubscriptionMessage(pair);
+		}
+	}
+
+	private ResolvedEvent ResolveLinkToEvent(EventRecord eventRecord, long commitPosition)
+	{
+		if (eventRecord.EventType == SystemEventTypes.LinkTo)
+		{
+			try
+			{
+				string[] parts = Helper.UTF8NoBom.GetString(eventRecord.Data.Span).Split('@', 2);
+				long eventNumber = long.Parse(parts[0]);
+				string streamName = parts[1];
+				var streamId = _readIndex.GetStreamId(streamName);
+				var res = _readIndex.ReadEvent(streamName, streamId, eventNumber);
+				if (res.Result == ReadEventResult.Success)
+					return ResolvedEvent.ForResolvedLink(res.Record, eventRecord, commitPosition);
+
+				return ResolvedEvent.ForFailedResolvedLink(eventRecord, res.Result, commitPosition);
+			}
+			catch (Exception exc)
+			{
+				Log.Error(exc, "Error while resolving link for event record: {eventRecord}",
+					eventRecord.ToString());
+			}
+
+			return ResolvedEvent.ForFailedResolvedLink(eventRecord, ReadEventResult.Error, commitPosition);
+		}
+
+		return ResolvedEvent.ForUnresolvedEvent(eventRecord, commitPosition);
+	}
+
+	public void Handle(ClientMessage.PersistentSubscriptionAckEvents message)
+	{
+		if (!_started) return;
+		PersistentSubscription subscription;
+		if (_subscriptionsById.TryGetValue(message.SubscriptionId, out subscription))
+		{
+			subscription.AcknowledgeMessagesProcessed(message.CorrelationId, message.ProcessedEventIds);
+		}
+	}
+
+	public void Handle(ClientMessage.PersistentSubscriptionNackEvents message)
+	{
+		if (!_started) return;
+		PersistentSubscription subscription;
+		if (_subscriptionsById.TryGetValue(message.SubscriptionId, out subscription))
+		{
+			subscription.NotAcknowledgeMessagesProcessed(message.CorrelationId, message.ProcessedEventIds,
+				(NakAction)message.Action, message.Message);
+		}
+	}
+
+	public void Handle(ClientMessage.ReadNextNPersistentMessages message)
+	{
+		if (!_started) return;
+
+		if (string.IsNullOrEmpty(message.EventStreamId))
+		{
+			message.Envelope.ReplyWith(new ClientMessage.ReadNextNPersistentMessagesCompleted(
 				message.CorrelationId,
-				message.Envelope,
-				message.User?.Identity?.Name);
+				ClientMessage.ReadNextNPersistentMessagesCompleted.ReadNextNPersistentMessagesResult.Fail,
+				"Bad stream name.", null));
+			return;
 		}
 
-		public void Handle(ClientMessage.ConnectToPersistentSubscriptionToAll message) {
-			ConnectToPersistentSubscription(
-				new PersistentSubscriptionAllStreamEventSource(),
-				message.GroupName,
-				message.AllowedInFlightMessages,
-				message.ConnectionId,
-				message.ConnectionName,
-				message.From,
+		if (message.EventStreamId == SystemStreams.AllStream)
+		{
+			message.Envelope.ReplyWith(new ClientMessage.ReadNextNPersistentMessagesCompleted(
 				message.CorrelationId,
-				message.Envelope,
-				message.User?.Identity?.Name);
+				ClientMessage.ReadNextNPersistentMessagesCompleted.ReadNextNPersistentMessagesResult.Fail,
+				"Persistent subscriptions to $all are only supported over gRPC through gRPC clients", null));
+			return;
 		}
 
-		private static string BuildSubscriptionGroupKey(string stream, string groupName) {
-			return stream + "::" + groupName;
-		}
-
-		public void Handle(StorageMessage.EventCommitted message) {
-			if (!_started) return;
-			ProcessEventCommited(message.Event.EventStreamId, message.CommitPosition, message.Event);
-		}
-
-		private void ProcessEventCommited(string eventStreamId, long commitPosition, EventRecord evnt) {
-			var subscriptions = new List<PersistentSubscription>();
-			if (EventFilter.DefaultStreamFilter.IsEventAllowed(evnt)
-				&& _subscriptionTopics.TryGetValue(eventStreamId, out var subscriptionsToStream)) {
-				subscriptions.AddRange(subscriptionsToStream);
-			}
-
-			if (EventFilter.DefaultAllFilter.IsEventAllowed(evnt)
-			    && _subscriptionTopics.TryGetValue(SystemStreams.AllStream, out var subscriptionsToAll)) {
-				subscriptions.AddRange(subscriptionsToAll);
-			}
-
-			for (int i = 0, n = subscriptions.Count; i < n; i++) {
-				var subscr = subscriptions[i];
-				var pair = ResolvedEvent.ForUnresolvedEvent(evnt, commitPosition);
-				if (subscr.ResolveLinkTos)
-					pair = ResolveLinkToEvent(evnt, commitPosition); //TODO this can be cached
-				subscr.NotifyLiveSubscriptionMessage(pair);
-			}
-		}
-
-		private ResolvedEvent ResolveLinkToEvent(EventRecord eventRecord, long commitPosition) {
-			if (eventRecord.EventType == SystemEventTypes.LinkTo) {
-				try {
-					string[] parts = Helper.UTF8NoBom.GetString(eventRecord.Data.Span).Split('@', 2);
-					long eventNumber = long.Parse(parts[0]);
-					string streamName = parts[1];
-					var streamId = _readIndex.GetStreamId(streamName);
-					var res = _readIndex.ReadEvent(streamName, streamId, eventNumber);
-					if (res.Result == ReadEventResult.Success)
-						return ResolvedEvent.ForResolvedLink(res.Record, eventRecord, commitPosition);
-
-					return ResolvedEvent.ForFailedResolvedLink(eventRecord, res.Result, commitPosition);
-				} catch (Exception exc) {
-					Log.Error(exc, "Error while resolving link for event record: {eventRecord}",
-						eventRecord.ToString());
-				}
-
-				return ResolvedEvent.ForFailedResolvedLink(eventRecord, ReadEventResult.Error, commitPosition);
-			}
-
-			return ResolvedEvent.ForUnresolvedEvent(eventRecord, commitPosition);
-		}
-
-		public void Handle(ClientMessage.PersistentSubscriptionAckEvents message) {
-			if (!_started) return;
-			PersistentSubscription subscription;
-			if (_subscriptionsById.TryGetValue(message.SubscriptionId, out subscription)) {
-				subscription.AcknowledgeMessagesProcessed(message.CorrelationId, message.ProcessedEventIds);
-			}
-		}
-
-		public void Handle(ClientMessage.PersistentSubscriptionNackEvents message) {
-			if (!_started) return;
-			PersistentSubscription subscription;
-			if (_subscriptionsById.TryGetValue(message.SubscriptionId, out subscription)) {
-				subscription.NotAcknowledgeMessagesProcessed(message.CorrelationId, message.ProcessedEventIds,
-					(NakAction)message.Action, message.Message);
-			}
-		}
-
-		public void Handle(ClientMessage.ReadNextNPersistentMessages message) {
-			if (!_started) return;
-
-			if (string.IsNullOrEmpty(message.EventStreamId)) {
-				message.Envelope.ReplyWith(new ClientMessage.ReadNextNPersistentMessagesCompleted(
-					message.CorrelationId,
-					ClientMessage.ReadNextNPersistentMessagesCompleted.ReadNextNPersistentMessagesResult.Fail,
-					"Bad stream name.", null));
-				return;
-			}
-
-			if (message.EventStreamId == SystemStreams.AllStream) {
-				message.Envelope.ReplyWith(new ClientMessage.ReadNextNPersistentMessagesCompleted(
-					message.CorrelationId,
-					ClientMessage.ReadNextNPersistentMessagesCompleted.ReadNextNPersistentMessagesResult.Fail,
-					"Persistent subscriptions to $all are only supported over gRPC through gRPC clients", null));
-				return;
-			}
-
-			List<PersistentSubscription> subscribers;
-			if (!_subscriptionTopics.TryGetValue(message.EventStreamId, out subscribers)) {
-				message.Envelope.ReplyWith(
-					new ClientMessage.ReadNextNPersistentMessagesCompleted(message.CorrelationId,
-						ClientMessage.ReadNextNPersistentMessagesCompleted.ReadNextNPersistentMessagesResult
-							.DoesNotExist,
-						"Not found.",
-						null));
-				return;
-			}
-
-			var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
-			PersistentSubscription subscription;
-			if (!_subscriptionsById.TryGetValue(key, out subscription)) {
-				message.Envelope.ReplyWith(
-					new ClientMessage.ReadNextNPersistentMessagesCompleted(message.CorrelationId,
-						ClientMessage.ReadNextNPersistentMessagesCompleted.ReadNextNPersistentMessagesResult
-							.DoesNotExist,
-						"Not found.",
-						null));
-				return;
-			}
-
-			var messages = subscription.GetNextNOrLessMessages(message.Count).ToArray();
+		List<PersistentSubscription> subscribers;
+		if (!_subscriptionTopics.TryGetValue(message.EventStreamId, out subscribers))
+		{
 			message.Envelope.ReplyWith(
 				new ClientMessage.ReadNextNPersistentMessagesCompleted(message.CorrelationId,
-					ClientMessage.ReadNextNPersistentMessagesCompleted.ReadNextNPersistentMessagesResult.Success,
-					string.Format("{0} read.", messages.Length),
-					messages));
+					ClientMessage.ReadNextNPersistentMessagesCompleted.ReadNextNPersistentMessagesResult
+						.DoesNotExist,
+					"Not found.",
+					null));
+			return;
 		}
 
-		public void Handle(ClientMessage.ReplayParkedMessages message) {
-			PersistentSubscription subscription;
-			var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
-			Log.Debug("Replaying parked messages for persistent subscription {subscriptionKey} {to}",
-				key,
-				message.StopAt.HasValue ? $" (To: '{message.StopAt.ToString()}')" : " (All)");
+		var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
+		PersistentSubscription subscription;
+		if (!_subscriptionsById.TryGetValue(key, out subscription))
+		{
+			message.Envelope.ReplyWith(
+				new ClientMessage.ReadNextNPersistentMessagesCompleted(message.CorrelationId,
+					ClientMessage.ReadNextNPersistentMessagesCompleted.ReadNextNPersistentMessagesResult
+						.DoesNotExist,
+					"Not found.",
+					null));
+			return;
+		}
 
-			if (message.StopAt.HasValue && message.StopAt.Value < 0) {
-				message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,
-					ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Fail,
-					"Cannot stop replaying parked message at a negative version."));
-				return;
-			}
+		var messages = subscription.GetNextNOrLessMessages(message.Count).ToArray();
+		message.Envelope.ReplyWith(
+			new ClientMessage.ReadNextNPersistentMessagesCompleted(message.CorrelationId,
+				ClientMessage.ReadNextNPersistentMessagesCompleted.ReadNextNPersistentMessagesResult.Success,
+				string.Format("{0} read.", messages.Length),
+				messages));
+	}
 
-			if (!_subscriptionsById.TryGetValue(key, out subscription)) {
-				message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,
-					ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.DoesNotExist,
-					"Unable to locate '" + key + "'"));
-				return;
-			}
+	public void Handle(ClientMessage.ReplayParkedMessages message)
+	{
+		PersistentSubscription subscription;
+		var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
+		Log.Debug("Replaying parked messages for persistent subscription {subscriptionKey} {to}",
+			key,
+			message.StopAt.HasValue ? $" (To: '{message.StopAt.ToString()}')" : " (All)");
 
-			subscription.RetryParkedMessages(message.StopAt);
+		if (message.StopAt.HasValue && message.StopAt.Value < 0)
+		{
 			message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,
-				ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Success, ""));
+				ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Fail,
+				"Cannot stop replaying parked message at a negative version."));
+			return;
 		}
 
-		public void Handle(ClientMessage.ReplayParkedMessage message) {
-			var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
-			PersistentSubscription subscription;
-
-			if (!_subscriptionsById.TryGetValue(key, out subscription)) {
-				message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,
-					ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.DoesNotExist,
-					"Unable to locate '" + key + "'"));
-				return;
-			}
-
-			subscription.RetrySingleParkedMessage(message.Event);
+		if (!_subscriptionsById.TryGetValue(key, out subscription))
+		{
 			message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,
-				ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Success, ""));
+				ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.DoesNotExist,
+				"Unable to locate '" + key + "'"));
+			return;
 		}
 
-		private void LoadConfiguration(Action continueWith) {
-			_ioDispatcher.ReadBackward(SystemStreams.PersistentSubscriptionConfig, -1, 1, false,
-				SystemAccounts.System, x => HandleLoadCompleted(continueWith, x));
+		subscription.RetryParkedMessages(message.StopAt);
+		message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,
+			ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Success, ""));
+	}
+
+	public void Handle(ClientMessage.ReplayParkedMessage message)
+	{
+		var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
+		PersistentSubscription subscription;
+
+		if (!_subscriptionsById.TryGetValue(key, out subscription))
+		{
+			message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,
+				ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.DoesNotExist,
+				"Unable to locate '" + key + "'"));
+			return;
 		}
 
-		private void HandleLoadCompleted(Action continueWith,
-			ClientMessage.ReadStreamEventsBackwardCompleted readStreamEventsBackwardCompleted) {
-			switch (readStreamEventsBackwardCompleted.Result) {
-				case ReadStreamResult.Success:
-					try {
-						_config =
-							PersistentSubscriptionConfig.FromSerializedForm(
-								readStreamEventsBackwardCompleted.Events[0].Event.Data);
-						foreach (var entry in _config.Entries) {
-							if (!_consumerStrategyRegistry.ValidateStrategy(entry.NamedConsumerStrategy)) {
-								Log.Error(
-									"A persistent subscription exists with an invalid consumer strategy '{strategy}'. Ignoring it.",
-									entry.NamedConsumerStrategy);
-								continue;
-							}
+		subscription.RetrySingleParkedMessage(message.Event);
+		message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,
+			ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Success, ""));
+	}
 
-							IPersistentSubscriptionEventSource eventSource;
-							if (entry.Stream == SystemStreams.AllStream) {
-								IEventFilter filter = null;
-								if (entry.Filter != null) {
-									var (success, reason) = EventFilter.TryParse(entry.Filter, out filter);
-									if (!success) {
-										Log.Error(
-											"Could not load filtered persistent subscription to $all for group {group}. The filter could not be parsed: '{reason}",
-											entry.Group, reason);
-										continue;
-									}
-								}
+	private void LoadConfiguration(Action continueWith) =>
+		_ioDispatcher.ReadBackward(
+			SystemStreams.PersistentSubscriptionConfig,
+			-1,
+			1,
+			false,
+			SystemAccounts.System, x =>
+				HandleLoadCompleted(continueWith, x), expires: DateTime.MaxValue);
 
-								eventSource = new PersistentSubscriptionAllStreamEventSource(filter);
-							} else {
-								eventSource = new PersistentSubscriptionSingleStreamEventSource(entry.Stream);
-							}
-
-							var result = TryCreateSubscriptionGroup(eventSource,
-								entry.Group,
-								entry.ResolveLinkTos,
-								#pragma warning disable 612
-								eventSource.GetStreamPositionFor(entry.StartPosition ?? entry.StartFrom.ToString()),
-								#pragma warning restore 612
-								entry.ExtraStatistics,
-								entry.MaxRetryCount,
-								entry.LiveBufferSize,
-								entry.HistoryBufferSize,
-								entry.ReadBatchSize,
-								ToCheckPointAfterTimeout(entry.CheckPointAfter),
-								entry.MinCheckPointCount,
-								entry.MaxCheckPointCount,
-								entry.MaxSubscriberCount,
-								entry.NamedConsumerStrategy,
-								ToMessageTimeout(entry.MessageTimeout));
-
-							if (!result) {
-								var key = BuildSubscriptionGroupKey(eventSource.ToString(), entry.Group);
-								Log.Warning("A duplicate persistent subscription: {subscriptionKey} was found in the configuration. Ignoring it.", key);
-							}
-
+	private void HandleLoadCompleted(Action continueWith,
+		ClientMessage.ReadStreamEventsBackwardCompleted readStreamEventsBackwardCompleted)
+	{
+		switch (readStreamEventsBackwardCompleted.Result)
+		{
+			case ReadStreamResult.Success:
+				try
+				{
+					_config =
+						PersistentSubscriptionConfig.FromSerializedForm(
+							readStreamEventsBackwardCompleted.Events[0].Event.Data);
+					foreach (var entry in _config.Entries)
+					{
+						if (!_consumerStrategyRegistry.ValidateStrategy(entry.NamedConsumerStrategy))
+						{
+							Log.Error(
+								"A persistent subscription exists with an invalid consumer strategy '{strategy}'. Ignoring it.",
+								entry.NamedConsumerStrategy);
+							continue;
 						}
 
-						continueWith();
-					} catch (Exception ex) {
-						Log.Error(ex, "There was an error loading configuration from storage.");
+						IPersistentSubscriptionEventSource eventSource;
+						if (entry.Stream == SystemStreams.AllStream)
+						{
+							IEventFilter filter = null;
+							if (entry.Filter != null)
+							{
+								var (success, reason) = EventFilter.TryParse(entry.Filter, out filter);
+								if (!success)
+								{
+									Log.Error(
+										"Could not load filtered persistent subscription to $all for group {group}. The filter could not be parsed: '{reason}",
+										entry.Group, reason);
+									continue;
+								}
+							}
+
+							eventSource = new PersistentSubscriptionAllStreamEventSource(filter);
+						}
+						else
+						{
+							eventSource = new PersistentSubscriptionSingleStreamEventSource(entry.Stream);
+						}
+
+						var result = TryCreateSubscriptionGroup(eventSource,
+							entry.Group,
+							entry.ResolveLinkTos,
+#pragma warning disable 612
+							eventSource.GetStreamPositionFor(entry.StartPosition ?? entry.StartFrom.ToString()),
+#pragma warning restore 612
+							entry.ExtraStatistics,
+							entry.MaxRetryCount,
+							entry.LiveBufferSize,
+							entry.HistoryBufferSize,
+							entry.ReadBatchSize,
+							ToCheckPointAfterTimeout(entry.CheckPointAfter),
+							entry.MinCheckPointCount,
+							entry.MaxCheckPointCount,
+							entry.MaxSubscriberCount,
+							entry.NamedConsumerStrategy,
+							ToMessageTimeout(entry.MessageTimeout));
+
+						if (!result)
+						{
+							var key = BuildSubscriptionGroupKey(eventSource.ToString(), entry.Group);
+							Log.Warning(
+								"A duplicate persistent subscription: {subscriptionKey} was found in the configuration. Ignoring it.",
+								key);
+						}
+
 					}
 
-					break;
-				case ReadStreamResult.NoStream:
-					_config = new PersistentSubscriptionConfig {Version = "2"};
 					continueWith();
-					break;
-				default:
-					throw new Exception(readStreamEventsBackwardCompleted.Result +
-					                    " is an unexpected result writing subscription configuration.");
-			}
+				}
+				catch (Exception ex)
+				{
+					Log.Error(ex, "There was an error loading configuration from storage.");
+				}
+
+				break;
+			case ReadStreamResult.NoStream:
+				_config = new PersistentSubscriptionConfig { Version = "2" };
+				continueWith();
+				break;
+			default:
+				throw new Exception(readStreamEventsBackwardCompleted.Result +
+				                    " is an unexpected result writing subscription configuration.");
 		}
+	}
 
-		private void SaveConfiguration(Action continueWith) {
-			Log.Debug("Saving persistent subscription configuration");
-			var data = _config.GetSerializedForm();
-			var ev = new Event(Guid.NewGuid(), "$PersistentConfig", true, data, new byte[0]);
-			var metadata = new StreamMetadata(maxCount: 2);
-			Lazy<StreamMetadata> streamMetadata = new Lazy<StreamMetadata>(() => metadata);
-			Event[] events = new Event[] {ev};
-			_ioDispatcher.ConfigureStreamAndWriteEvents(SystemStreams.PersistentSubscriptionConfig,
-				ExpectedVersion.Any, streamMetadata, events, SystemAccounts.System,
-				x => HandleSaveConfigurationCompleted(continueWith, x));
+	private void SaveConfiguration(Action continueWith)
+	{
+		Log.Debug("Saving persistent subscription configuration");
+		var data = _config.GetSerializedForm();
+		var ev = new Event(Guid.NewGuid(), "$PersistentConfig", true, data, new byte[0]);
+		var metadata = new StreamMetadata(maxCount: 2);
+		Lazy<StreamMetadata> streamMetadata = new Lazy<StreamMetadata>(() => metadata);
+		Event[] events = new Event[] { ev };
+		_ioDispatcher.ConfigureStreamAndWriteEvents(SystemStreams.PersistentSubscriptionConfig,
+			ExpectedVersion.Any, streamMetadata, events, SystemAccounts.System,
+			x => HandleSaveConfigurationCompleted(continueWith, x));
+	}
+
+	private void HandleSaveConfigurationCompleted(Action continueWith, ClientMessage.WriteEventsCompleted obj)
+	{
+		switch (obj.Result)
+		{
+			case OperationResult.Success:
+				continueWith();
+				break;
+			case OperationResult.CommitTimeout:
+			case OperationResult.PrepareTimeout:
+				Log.Information("Timeout while trying to save persistent subscription configuration. Retrying");
+				SaveConfiguration(continueWith);
+				break;
+			default:
+				throw new Exception(obj.Result +
+				                    " is an unexpected result writing persistent subscription configuration.");
 		}
+	}
 
-		private void HandleSaveConfigurationCompleted(Action continueWith, ClientMessage.WriteEventsCompleted obj) {
-			switch (obj.Result) {
-				case OperationResult.Success:
-					continueWith();
-					break;
-				case OperationResult.CommitTimeout:
-				case OperationResult.PrepareTimeout:
-					Log.Information("Timeout while trying to save persistent subscription configuration. Retrying");
-					SaveConfiguration(continueWith);
-					break;
-				default:
-					throw new Exception(obj.Result +
-					                    " is an unexpected result writing persistent subscription configuration.");
-			}
-		}
+	public void Handle(TelemetryMessage.Request message)
+	{
+		message.Envelope.ReplyWith(new TelemetryMessage.Response("persistentSubscriptions",
+			new JsonObject { ["count"] = _subscriptionsById?.Count ?? 0 }));
+	}
 
-		public void Handle(TelemetryMessage.Request message) {
-			message.Envelope.ReplyWith(new TelemetryMessage.Response("persistentSubscriptions", new JsonObject {
-				["count"] = _subscriptionsById?.Count ?? 0
-			}));
-		}
-
-		public void Handle(MonitoringMessage.GetPersistentSubscriptionStats message) {
-			if (!_started) {
-				message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
-					MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotReady, null)
-				);
-				return;
-			}
-
-			List<PersistentSubscription> subscribers;
-			if (!_subscriptionTopics.TryGetValue(message.EventStreamId, out subscribers) || subscribers == null) {
-				message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
-					MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotFound, null)
-				);
-				return;
-			}
-
-			var subscription = subscribers.FirstOrDefault(x => x.GroupName == message.GroupName);
-			if (subscription == null) {
-				message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
-					MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotFound, null)
-				);
-				return;
-			}
-
-			var stats = new List<MonitoringMessage.PersistentSubscriptionInfo>() {
-				subscription.GetStatistics()
-			};
+	public void Handle(MonitoringMessage.GetPersistentSubscriptionStats message)
+	{
+		if (!_started)
+		{
 			message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
-				MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success, stats)
+				MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotReady, null)
 			);
+			return;
 		}
 
-		public void Handle(MonitoringMessage.GetStreamPersistentSubscriptionStats message) {
-			if (!_started) {
-				message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
-					MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotReady, null)
-				);
-				return;
-			}
-
-			List<PersistentSubscription> subscribers;
-			if (!_subscriptionTopics.TryGetValue(message.EventStreamId, out subscribers)) {
-				message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
-					MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotFound, null)
-				);
-				return;
-			}
-
-			var stats = subscribers.Select(sub => sub.GetStatistics()).ToList();
+		List<PersistentSubscription> subscribers;
+		if (!_subscriptionTopics.TryGetValue(message.EventStreamId, out subscribers) || subscribers == null)
+		{
 			message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
-				MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success, stats)
+				MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotFound, null)
 			);
+			return;
 		}
 
-		public void Handle(MonitoringMessage.GetAllPersistentSubscriptionStats message) {
-			if (!_started) {
-				message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
-					MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotReady, null)
-				);
-				return;
-			}
-
-			var stats = (from subscription in _subscriptionTopics.Values
-				from sub in subscription
-				select sub.GetStatistics()).ToList();
+		var subscription = subscribers.FirstOrDefault(x => x.GroupName == message.GroupName);
+		if (subscription == null)
+		{
 			message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
-				MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success, stats)
+				MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotFound, null)
 			);
+			return;
 		}
 
-		public void Handle(SubscriptionMessage.PersistentSubscriptionTimerTick message) {
-			if (!_handleTick || _timerTickCorrelationId != message.CorrelationId) return;
-			try {
-				WakeSubscriptions();
-			} finally {
-				_timerTickCorrelationId = Guid.NewGuid();
-				_bus.Publish(TimerMessage.Schedule.Create(TimeSpan.FromMilliseconds(1000),
-					_bus,
-					new SubscriptionMessage.PersistentSubscriptionTimerTick(_timerTickCorrelationId)));
-			}
+		var stats = new List<MonitoringMessage.PersistentSubscriptionInfo>() { subscription.GetStatistics() };
+		message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
+			MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success, stats)
+		);
+	}
+
+	public void Handle(MonitoringMessage.GetStreamPersistentSubscriptionStats message)
+	{
+		if (!_started)
+		{
+			message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
+				MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotReady, null)
+			);
+			return;
 		}
 
-		private void WakeSubscriptions() {
-			var now = DateTime.UtcNow;
-
-			foreach (var subscription in _subscriptionsById.Values) {
-				subscription.NotifyClockTick(now);
-			}
+		List<PersistentSubscription> subscribers;
+		if (!_subscriptionTopics.TryGetValue(message.EventStreamId, out subscribers))
+		{
+			message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
+				MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotFound, null)
+			);
+			return;
 		}
 
+		var stats = subscribers.Select(sub => sub.GetStatistics()).ToList();
+		message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
+			MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success, stats)
+		);
+	}
 
-		private TimeSpan ToCheckPointAfterTimeout(int milliseconds) {
-			return milliseconds == 0 ? TimeSpan.MaxValue : TimeSpan.FromMilliseconds(milliseconds);
+	public void Handle(MonitoringMessage.GetAllPersistentSubscriptionStats message)
+	{
+		if (!_started)
+		{
+			message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
+				MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotReady, null)
+			);
+			return;
 		}
 
-		private TimeSpan ToMessageTimeout(int milliseconds) {
-			return milliseconds == 0 ? TimeSpan.Zero : TimeSpan.FromMilliseconds(milliseconds);
+		var stats = (from subscription in _subscriptionTopics.Values
+			from sub in subscription
+			select sub.GetStatistics()).ToList();
+		message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
+			MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success, stats)
+		);
+	}
+
+	public void Handle(SubscriptionMessage.PersistentSubscriptionTimerTick message)
+	{
+		if (!_handleTick || _timerTickCorrelationId != message.CorrelationId) return;
+		try
+		{
+			WakeSubscriptions();
 		}
+		finally
+		{
+			_timerTickCorrelationId = Guid.NewGuid();
+			_bus.Publish(TimerMessage.Schedule.Create(TimeSpan.FromMilliseconds(1000),
+				_bus,
+				new SubscriptionMessage.PersistentSubscriptionTimerTick(_timerTickCorrelationId)));
+		}
+	}
+
+	private void WakeSubscriptions()
+	{
+		var now = DateTime.UtcNow;
+
+		foreach (var subscription in _subscriptionsById.Values)
+		{
+			subscription.NotifyClockTick(now);
+		}
+	}
+
+
+	private TimeSpan ToCheckPointAfterTimeout(int milliseconds)
+	{
+		return milliseconds == 0 ? TimeSpan.MaxValue : TimeSpan.FromMilliseconds(milliseconds);
+	}
+
+	private TimeSpan ToMessageTimeout(int milliseconds)
+	{
+		return milliseconds == 0 ? TimeSpan.Zero : TimeSpan.FromMilliseconds(milliseconds);
 	}
 }

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -710,7 +710,8 @@ public class ManagedProjection : IDisposable
 				corrId, corrId, _readDispatcher.Envelope, ProjectionNamesBuilder.ProjectionsStreamPrefix + name, -1,
 				1,
 				resolveLinkTos: false, requireLeader: false, validationStreamVersion: null,
-				user: SystemAccounts.System),
+				user: SystemAccounts.System,
+				expires: DateTime.MaxValue),
 			new ReadStreamEventsBackwardHandlers.Optimistic(PersistedStateReadCompleted));
 	}
 

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -190,7 +190,8 @@ public class ProjectionManager
 					v => v.CorrelationId,
 					_inputQueue);
 		_getStats = TimerMessage.Schedule.Create(_interval, _inputQueue,
-			new ProjectionManagementMessage.Command.GetStatistics(new CallbackEnvelope(PushStatsToProjectionTracker), ProjectionMode.AllNonTransient, null, true));
+			new ProjectionManagementMessage.Command.GetStatistics(new CallbackEnvelope(PushStatsToProjectionTracker),
+				ProjectionMode.AllNonTransient, null, true));
 	}
 
 	private void PushStatsToProjectionTracker(Message message)
@@ -199,6 +200,7 @@ public class ProjectionManager
 		{
 			_projectionTracker.OnNewStats(stats.Projections);
 		}
+
 		_publisher.Publish(_getStats);
 	}
 
@@ -216,13 +218,12 @@ public class ProjectionManager
 
 		_started = true;
 		if (_runProjections >= ProjectionType.System)
-			StartExistingProjections(
-				() =>
-				{
-					_projectionsStarted = true;
-					_publisher.Publish(_getStats);
-					ScheduleExpire();
-				});
+			StartExistingProjections(() =>
+			{
+				_projectionsStarted = true;
+				_publisher.Publish(_getStats);
+				ScheduleExpire();
+			});
 		_publisher.Publish(new ProjectionSubsystemMessage.ComponentStarted(ServiceName, _instanceCorrelationId));
 	}
 
@@ -238,9 +239,11 @@ public class ProjectionManager
 		if (_instanceCorrelationId != message.InstanceCorrelationId)
 		{
 			_logger.Debug("PROJECTIONS: Projection Manager received stop request for incorrect correlation id." +
-						  "Current: {correlationId}. Requested: {requestedCorrelationId}", _instanceCorrelationId, message.InstanceCorrelationId);
+			              "Current: {correlationId}. Requested: {requestedCorrelationId}", _instanceCorrelationId,
+				message.InstanceCorrelationId);
 			return;
 		}
+
 		_logger.Debug("PROJECTIONS: Stopping Projections Manager. Correlation {correlation}", _instanceCorrelationId);
 		Stop();
 	}
@@ -291,8 +294,9 @@ public class ProjectionManager
 			else
 			{
 				var expectedVersion = _projectionsRegistrationExpectedVersion;
-				var pendingProjections = new Dictionary<string, PendingProjection> {
-					{message.Name, new PendingProjection(expectedVersion + 1, message)}
+				var pendingProjections = new Dictionary<string, PendingProjection>
+				{
+					{ message.Name, new PendingProjection(expectedVersion + 1, message) }
 				};
 				if (!ValidateProjections(pendingProjections.Values.ToArray(), message))
 					return;
@@ -314,6 +318,7 @@ public class ProjectionManager
 					"Transient projections in batches are not supported."));
 			return;
 		}
+
 		if (_isWritePending)
 		{
 			DelayMessage(message);
@@ -346,11 +351,11 @@ public class ProjectionManager
 		foreach (var projection in projections)
 		{
 			if (!ProjectionManagementMessage.RunAs.ValidateRunAs(
-					projection.Mode,
-					ReadWrite.Write,
-					null,
-					message,
-					replace: projection.EnableRunAs))
+				    projection.Mode,
+				    ReadWrite.Write,
+				    null,
+				    message,
+				    replace: projection.EnableRunAs))
 			{
 
 				_logger.Information("PROJECTIONS: Projections batch rejected due to invalid RunAs");
@@ -404,7 +409,7 @@ public class ProjectionManager
 		}
 
 		if (!ProjectionManagementMessage.RunAs.ValidateRunAs(projection.Mode, ReadWrite.Write, projection.RunAs,
-			message))
+			    message))
 			return;
 		try
 		{
@@ -419,10 +424,10 @@ public class ProjectionManager
 	private bool IsSystemProjection(string name)
 	{
 		return name == ProjectionNamesBuilder.StandardProjections.EventByCategoryStandardProjection ||
-			   name == ProjectionNamesBuilder.StandardProjections.EventByTypeStandardProjection ||
-			   name == ProjectionNamesBuilder.StandardProjections.StreamByCategoryStandardProjection ||
-			   name == ProjectionNamesBuilder.StandardProjections.StreamsStandardProjection ||
-			   name == ProjectionNamesBuilder.StandardProjections.EventByCorrIdStandardProjection;
+		       name == ProjectionNamesBuilder.StandardProjections.EventByTypeStandardProjection ||
+		       name == ProjectionNamesBuilder.StandardProjections.StreamByCategoryStandardProjection ||
+		       name == ProjectionNamesBuilder.StandardProjections.StreamsStandardProjection ||
+		       name == ProjectionNamesBuilder.StandardProjections.EventByCorrIdStandardProjection;
 	}
 
 	public void Handle(ProjectionManagementMessage.Command.GetQuery message)
@@ -435,7 +440,7 @@ public class ProjectionManager
 		else
 		{
 			if (!ProjectionManagementMessage.RunAs.ValidateRunAs(projection.Mode, ReadWrite.Read, projection.RunAs,
-				message))
+				    message))
 				return;
 			projection.Handle(message);
 		}
@@ -456,7 +461,7 @@ public class ProjectionManager
 		else
 		{
 			if (!ProjectionManagementMessage.RunAs.ValidateRunAs(projection.Mode, ReadWrite.Write, projection.RunAs,
-				message))
+				    message))
 				return;
 			projection.Handle(message); // update query text
 		}
@@ -474,7 +479,7 @@ public class ProjectionManager
 		else
 		{
 			if (!ProjectionManagementMessage.RunAs.ValidateRunAs(projection.Mode, ReadWrite.Write, projection.RunAs,
-				message))
+				    message))
 				return;
 			projection.Handle(message);
 		}
@@ -495,7 +500,7 @@ public class ProjectionManager
 		else
 		{
 			if (!ProjectionManagementMessage.RunAs.ValidateRunAs(projection.Mode, ReadWrite.Write, projection.RunAs,
-				message))
+				    message))
 				return;
 			projection.Handle(message);
 		}
@@ -513,7 +518,7 @@ public class ProjectionManager
 		else
 		{
 			if (!ProjectionManagementMessage.RunAs.ValidateRunAs(projection.Mode, ReadWrite.Write, projection.RunAs,
-				message))
+				    message))
 				return;
 			projection.Handle(message);
 		}
@@ -558,7 +563,7 @@ public class ProjectionManager
 		else
 		{
 			if (!ProjectionManagementMessage.RunAs.ValidateRunAs(projection.Mode, ReadWrite.Write, projection.RunAs,
-				message))
+				    message))
 				return;
 			projection.Handle(message);
 		}
@@ -581,14 +586,14 @@ public class ProjectionManager
 		else
 		{
 			var statuses = (from projectionNameValue in _projections
-							let projection = projectionNameValue.Value
-							where !projection.Deleted
-							where
-								message.Mode == null || message.Mode == projection.Mode
-													 || (message.Mode.GetValueOrDefault() == ProjectionMode.AllNonTransient
-														 && projection.Mode != ProjectionMode.Transient)
-							let status = projection.GetStatistics()
-							select status).ToArray();
+				let projection = projectionNameValue.Value
+				where !projection.Deleted
+				where
+					message.Mode == null || message.Mode == projection.Mode
+					                     || (message.Mode.GetValueOrDefault() == ProjectionMode.AllNonTransient
+					                         && projection.Mode != ProjectionMode.Transient)
+				let status = projection.GetStatistics()
+				select status).ToArray();
 			message.Envelope.ReplyWith(new ProjectionManagementMessage.Statistics(statuses));
 		}
 	}
@@ -625,7 +630,7 @@ public class ProjectionManager
 		else
 		{
 			if (!ProjectionManagementMessage.RunAs.ValidateRunAs(projection.Mode, ReadWrite.Read, projection.RunAs,
-				message))
+				    message))
 				return;
 			projection.Handle(message);
 		}
@@ -641,7 +646,7 @@ public class ProjectionManager
 		else
 		{
 			if (!ProjectionManagementMessage.RunAs.ValidateRunAs(projection.Mode, ReadWrite.Read, projection.RunAs,
-				message))
+				    message))
 				return;
 			try
 			{
@@ -783,23 +788,24 @@ public class ProjectionManager
 	}
 
 	private void DeleteProjection(
-		ProjectionManagementMessage.Internal.Deleted message, Action<long> completed, int retryCount = ProjectionCreationRetryCount)
+		ProjectionManagementMessage.Internal.Deleted message, Action<long> completed,
+		int retryCount = ProjectionCreationRetryCount)
 	{
 		var corrId = Guid.NewGuid();
 		var writeDelete = new ClientMessage.WriteEvents(
-				corrId,
-				corrId,
-				_writeDispatcher.Envelope,
-				true,
-				ProjectionNamesBuilder.ProjectionsRegistrationStream,
-				_projectionsRegistrationExpectedVersion,
-				new Event(
-					Guid.NewGuid(),
-					ProjectionEventTypes.ProjectionDeleted,
-					false,
-					Helper.UTF8NoBom.GetBytes(message.Name),
-					Empty.ByteArray),
-				SystemAccounts.System);
+			corrId,
+			corrId,
+			_writeDispatcher.Envelope,
+			true,
+			ProjectionNamesBuilder.ProjectionsRegistrationStream,
+			_projectionsRegistrationExpectedVersion,
+			new Event(
+				Guid.NewGuid(),
+				ProjectionEventTypes.ProjectionDeleted,
+				false,
+				Helper.UTF8NoBom.GetBytes(message.Name),
+				Empty.ByteArray),
+			SystemAccounts.System);
 
 		_isWritePending = true;
 		_writeDispatcher.Publish(
@@ -834,7 +840,8 @@ public class ProjectionManager
 		long from = 0)
 	{
 
-		_logger.Debug("PROJECTIONS: Reading Existing Projections from {stream}", ProjectionNamesBuilder.ProjectionsRegistrationStream);
+		_logger.Debug("PROJECTIONS: Reading Existing Projections from {stream}",
+			ProjectionNamesBuilder.ProjectionsRegistrationStream);
 		var corrId = Guid.NewGuid();
 		_readForwardDispatcher.Publish(
 			new ClientMessage.ReadStreamEventsForward(
@@ -848,7 +855,8 @@ public class ProjectionManager
 				requireLeader: false,
 				validationStreamVersion: null,
 				user: SystemAccounts.System,
-				replyOnExpired: false),
+				replyOnExpired: false,
+				expires: DateTime.MaxValue),
 			m => OnProjectionsListReadCompleted(m, registeredProjections, from, completedAction));
 	}
 
@@ -874,7 +882,7 @@ public class ProjectionManager
 
 					var projectionName = Helper.UTF8NoBom.GetString(evnt.Event.Data.Span);
 					if (string.IsNullOrEmpty(projectionName)
-						|| _projections.ContainsKey(projectionName))
+					    || _projections.ContainsKey(projectionName))
 					{
 						_logger.Warning(
 							"PROJECTIONS: The following projection: {projection} has a duplicate registration event.",
@@ -900,6 +908,7 @@ public class ProjectionManager
 						registeredProjections.Remove(projectionName);
 					}
 				}
+
 				_projectionsRegistrationExpectedVersion = msg.LastEventNumber;
 
 				if (!msg.IsEndOfStream)
@@ -917,6 +926,7 @@ public class ProjectionManager
 					msg.Result);
 				return;
 		}
+
 		completedAction(registeredProjections);
 	}
 
@@ -953,7 +963,7 @@ public class ProjectionManager
 		CreateSystemProjections(registeredProjections.Select(x => x.Key).ToList());
 
 		foreach (var projectionRegistration in registeredProjections.Where(x =>
-			x.Key != ProjectionEventTypes.ProjectionsInitialized))
+			         x.Key != ProjectionEventTypes.ProjectionsInitialized))
 		{
 			int queueIndex = GetNextWorkerIndex();
 			var managedProjection = CreateManagedProjectionInstance(
@@ -970,7 +980,7 @@ public class ProjectionManager
 	private bool IsProjectionEnabledToRunByMode(string projectionName)
 	{
 		return _runProjections >= ProjectionType.All
-			   || _runProjections == ProjectionType.System && projectionName.StartsWith("$");
+		       || _runProjections == ProjectionType.System && projectionName.StartsWith("$");
 	}
 
 	private void WriteProjectionsInitialized(Action action, Guid registrationEventId)
@@ -1024,35 +1034,35 @@ public class ProjectionManager
 		}
 
 		if (!existingSystemProjections.Contains(ProjectionNamesBuilder.StandardProjections
-			.StreamsStandardProjection))
+			    .StreamsStandardProjection))
 			systemProjections.Add(CreateSystemProjectionPost(
 				ProjectionNamesBuilder.StandardProjections.StreamsStandardProjection,
 				typeof(IndexStreams),
 				""));
 
 		if (!existingSystemProjections.Contains(ProjectionNamesBuilder.StandardProjections
-			.StreamByCategoryStandardProjection))
+			    .StreamByCategoryStandardProjection))
 			systemProjections.Add(CreateSystemProjectionPost(
 				ProjectionNamesBuilder.StandardProjections.StreamByCategoryStandardProjection,
 				typeof(CategorizeStreamByPath),
 				"first\r\n-"));
 
 		if (!existingSystemProjections.Contains(ProjectionNamesBuilder.StandardProjections
-			.EventByCategoryStandardProjection))
+			    .EventByCategoryStandardProjection))
 			systemProjections.Add(CreateSystemProjectionPost(
 				ProjectionNamesBuilder.StandardProjections.EventByCategoryStandardProjection,
 				typeof(CategorizeEventsByStreamPath),
 				"first\r\n-"));
 
 		if (!existingSystemProjections.Contains(ProjectionNamesBuilder.StandardProjections
-			.EventByTypeStandardProjection))
+			    .EventByTypeStandardProjection))
 			systemProjections.Add(CreateSystemProjectionPost(
 				ProjectionNamesBuilder.StandardProjections.EventByTypeStandardProjection,
 				typeof(IndexEventsByEventType),
 				""));
 
 		if (!existingSystemProjections.Contains(ProjectionNamesBuilder.StandardProjections
-			.EventByCorrIdStandardProjection))
+			    .EventByCorrIdStandardProjection))
 			systemProjections.Add(CreateSystemProjectionPost(
 				ProjectionNamesBuilder.StandardProjections.EventByCorrIdStandardProjection,
 				typeof(ByCorrelationId),
@@ -1157,8 +1167,8 @@ public class ProjectionManager
 			Enum.GetName(typeof(OperationResult), completed.Result));
 
 		if (completed.Result == OperationResult.ForwardTimeout ||
-			completed.Result == OperationResult.PrepareTimeout ||
-			completed.Result == OperationResult.CommitTimeout)
+		    completed.Result == OperationResult.PrepareTimeout ||
+		    completed.Result == OperationResult.CommitTimeout)
 		{
 			if (retryCount > 0)
 			{
@@ -1180,7 +1190,7 @@ public class ProjectionManager
 	}
 
 	private void StartNewlyRegisteredProjections
-		(IDictionary<string, PendingProjection> newProjections,
+	(IDictionary<string, PendingProjection> newProjections,
 		Action completedAction, IEnvelope replyEnvelope)
 	{
 
@@ -1230,7 +1240,8 @@ public class ProjectionManager
 				resolveLinkTos: false,
 				requireLeader: false,
 				validationStreamVersion: null,
-				user: SystemAccounts.System),
+				user: SystemAccounts.System,
+				expires: DateTime.MaxValue),
 			new ReadStreamEventsBackwardHandlers.Optimistic(onComplete));
 	}
 
@@ -1249,8 +1260,7 @@ public class ProjectionManager
 		try
 		{
 			int queueIndex = GetNextWorkerIndex();
-			initializer.
-				CreateAndInitializeNewProjection(this, Guid.NewGuid(), _workers[queueIndex],
+			initializer.CreateAndInitializeNewProjection(this, Guid.NewGuid(), _workers[queueIndex],
 				version: version);
 		}
 		catch (Exception ex)
@@ -1261,7 +1271,8 @@ public class ProjectionManager
 
 	private void OnProjectionsRegistrationCaughtUp()
 	{
-		_logger.Debug($"PROJECTIONS: Caught up with projections registration. Next expected version: {_projectionsRegistrationExpectedVersion}");
+		_logger.Debug(
+			$"PROJECTIONS: Caught up with projections registration. Next expected version: {_projectionsRegistrationExpectedVersion}");
 	}
 
 	private void WriteProjectionDeletedCompleted(ClientMessage.WriteEventsCompleted writeCompleted,
@@ -1284,8 +1295,10 @@ public class ProjectionManager
 			ProjectionNamesBuilder.ProjectionsRegistrationStream,
 			Enum.GetName(typeof(OperationResult), writeCompleted.Result));
 
-		if (writeCompleted.Result == OperationResult.CommitTimeout || writeCompleted.Result == OperationResult.ForwardTimeout
-																   || writeCompleted.Result == OperationResult.PrepareTimeout)
+		if (writeCompleted.Result == OperationResult.CommitTimeout || writeCompleted.Result ==
+		                                                           OperationResult.ForwardTimeout
+		                                                           || writeCompleted.Result ==
+		                                                           OperationResult.PrepareTimeout)
 		{
 			if (retryCount > 0)
 			{
@@ -1454,7 +1467,8 @@ public class ProjectionManager
 		public long ProjectionId { get; }
 
 		public PendingProjection(
-			long projectionId, ProjectionMode mode, SerializedRunAs runAs, string name, string handlerType, string query,
+			long projectionId, ProjectionMode mode, SerializedRunAs runAs, string name, string handlerType,
+			string query,
 			bool enabled, bool checkpointsEnabled, bool emitEnabled, bool enableRunAs,
 			bool trackEmittedStreams)
 		{
@@ -1471,17 +1485,20 @@ public class ProjectionManager
 			TrackEmittedStreams = trackEmittedStreams;
 		}
 
-		public PendingProjection(long projectionId, ProjectionManagementMessage.Command.PostBatch.ProjectionPost projection)
+		public PendingProjection(long projectionId,
+			ProjectionManagementMessage.Command.PostBatch.ProjectionPost projection)
 			: this(projectionId, projection.Mode, projection.RunAs, projection.Name, projection.HandlerType,
 				projection.Query, projection.Enabled, projection.CheckpointsEnabled,
 				projection.EmitEnabled, projection.EnableRunAs, projection.TrackEmittedStreams)
-		{ }
+		{
+		}
 
 		public PendingProjection(long projectionId, ProjectionManagementMessage.Command.Post projection)
 			: this(projectionId, projection.Mode, projection.RunAs, projection.Name, projection.HandlerType,
 				projection.Query, projection.Enabled, projection.CheckpointsEnabled,
 				projection.EmitEnabled, projection.EnableRunAs, projection.TrackEmittedStreams)
-		{ }
+		{
+		}
 
 		public NewProjectionInitializer CreateInitializer(IEnvelope replyEnvelope)
 		{

--- a/src/EventStore.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
@@ -1,3 +1,4 @@
+using System;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Projections.Core.Messages;
@@ -5,95 +6,78 @@ using EventStore.Projections.Core.Messaging;
 
 namespace EventStore.Projections.Core.Services.Processing;
 
-public class RequestResponseQueueForwarder : IHandle<ClientMessage.ReadEvent>,
-	IHandle<ClientMessage.ReadStreamEventsBackward>,
-	IHandle<ClientMessage.ReadStreamEventsForward>,
-	IHandle<ClientMessage.ReadAllEventsForward>,
-	IHandle<ClientMessage.WriteEvents>,
-	IHandle<ClientMessage.DeleteStream>,
-	IHandle<SystemMessage.SubSystemInitialized>,
-	IHandle<ProjectionCoreServiceMessage.SubComponentStarted>,
-	IHandle<ProjectionCoreServiceMessage.SubComponentStopped>
+public class RequestResponseQueueForwarder(IPublisher inputQueue, IPublisher externalRequestQueue)
+	: IHandle<ClientMessage.ReadEvent>,
+		IHandle<ClientMessage.ReadStreamEventsBackward>,
+		IHandle<ClientMessage.ReadStreamEventsForward>,
+		IHandle<ClientMessage.ReadAllEventsForward>,
+		IHandle<ClientMessage.WriteEvents>,
+		IHandle<ClientMessage.DeleteStream>,
+		IHandle<SystemMessage.SubSystemInitialized>,
+		IHandle<ProjectionCoreServiceMessage.SubComponentStarted>,
+		IHandle<ProjectionCoreServiceMessage.SubComponentStopped>
 {
-	private readonly IPublisher _externalRequestQueue;
-	private readonly IPublisher _inputQueue;
-
-	public RequestResponseQueueForwarder(IPublisher inputQueue, IPublisher externalRequestQueue)
-	{
-		_inputQueue = inputQueue;
-		_externalRequestQueue = externalRequestQueue;
-	}
-
-	public void Handle(ClientMessage.ReadEvent msg)
-	{
-		_externalRequestQueue.Publish(
+	public void Handle(ClientMessage.ReadEvent msg) =>
+		externalRequestQueue.Publish(
 			new ClientMessage.ReadEvent(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope),
+				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(inputQueue, msg.Envelope),
 				msg.EventStreamId, msg.EventNumber, msg.ResolveLinkTos, msg.RequireLeader, msg.User));
-	}
 
-	public void Handle(ClientMessage.WriteEvents msg)
-	{
-		_externalRequestQueue.Publish(
+	public void Handle(ClientMessage.WriteEvents msg) =>
+		externalRequestQueue.Publish(
 			new ClientMessage.WriteEvents(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope), true,
+				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(inputQueue, msg.Envelope), true,
 				msg.EventStreamId, msg.ExpectedVersion, msg.Events, msg.User));
-	}
 
-	public void Handle(ClientMessage.DeleteStream msg)
-	{
-		_externalRequestQueue.Publish(
+	public void Handle(ClientMessage.DeleteStream msg) =>
+		externalRequestQueue.Publish(
 			new ClientMessage.DeleteStream(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope), true,
+				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(inputQueue, msg.Envelope), true,
 				msg.EventStreamId, msg.ExpectedVersion, msg.HardDelete, msg.User));
-	}
 
-	public void Handle(ClientMessage.ReadStreamEventsBackward msg)
-	{
-		_externalRequestQueue.Publish(
+	// Historically, message forwarding here has discarded the original Expiration value,
+	// resetting it to the default (10 seconds from now). Ideally, we should propagate the
+	// original Expiration from the source message.
+	//
+	// For now, this fix takes a minimal-impact approach: we only preserve the Expiration
+	// when explicitly needed (i.e., DateTime.MaxValue), and only for the relevant messages.
+
+	public void Handle(ClientMessage.ReadStreamEventsBackward msg) =>
+		externalRequestQueue.Publish(
 			new ClientMessage.ReadStreamEventsBackward(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope),
+				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(inputQueue, msg.Envelope),
 				msg.EventStreamId, msg.FromEventNumber, msg.MaxCount, msg.ResolveLinkTos, msg.RequireLeader,
-				msg.ValidationStreamVersion, msg.User));
-	}
+				msg.ValidationStreamVersion, msg.User,
+				expires: msg.Expires == DateTime.MaxValue ? msg.Expires : null));
 
-	public void Handle(ClientMessage.ReadStreamEventsForward msg)
-	{
-		_externalRequestQueue.Publish(
+	public void Handle(ClientMessage.ReadStreamEventsForward msg) =>
+		externalRequestQueue.Publish(
 			new ClientMessage.ReadStreamEventsForward(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope),
+				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(inputQueue, msg.Envelope),
 				msg.EventStreamId, msg.FromEventNumber, msg.MaxCount, msg.ResolveLinkTos, msg.RequireLeader,
-				msg.ValidationStreamVersion, msg.User, replyOnExpired: false));
-	}
+				msg.ValidationStreamVersion, msg.User, replyOnExpired: false,
+				expires: msg.Expires == DateTime.MaxValue ? msg.Expires : null));
 
-	public void Handle(ClientMessage.ReadAllEventsForward msg)
-	{
-		_externalRequestQueue.Publish(
+	public void Handle(ClientMessage.ReadAllEventsForward msg) =>
+		externalRequestQueue.Publish(
 			new ClientMessage.ReadAllEventsForward(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope),
+				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(inputQueue, msg.Envelope),
 				msg.CommitPosition, msg.PreparePosition, msg.MaxCount, msg.ResolveLinkTos, msg.RequireLeader,
 				msg.ValidationTfLastCommitPosition, msg.User, replyOnExpired: false));
-	}
 
-	public void Handle(SystemMessage.SubSystemInitialized msg)
-	{
-		_externalRequestQueue.Publish(
+	public void Handle(SystemMessage.SubSystemInitialized msg) =>
+		externalRequestQueue.Publish(
 			new SystemMessage.SubSystemInitialized(msg.SubSystemName));
-	}
 
 	void IHandle<ProjectionCoreServiceMessage.SubComponentStarted>.Handle(
-		ProjectionCoreServiceMessage.SubComponentStarted message)
-	{
-		_externalRequestQueue.Publish(
+		ProjectionCoreServiceMessage.SubComponentStarted message) =>
+		externalRequestQueue.Publish(
 			new ProjectionCoreServiceMessage.SubComponentStarted(message.SubComponent, message.InstanceCorrelationId)
 		);
-	}
 
 	void IHandle<ProjectionCoreServiceMessage.SubComponentStopped>.Handle(
-		ProjectionCoreServiceMessage.SubComponentStopped message)
-	{
-		_externalRequestQueue.Publish(
+		ProjectionCoreServiceMessage.SubComponentStopped message) =>
+		externalRequestQueue.Publish(
 			new ProjectionCoreServiceMessage.SubComponentStopped(message.SubComponent, message.QueueId)
 		);
-	}
 }


### PR DESCRIPTION
Changed: Disable timeouts on critical reads to ensure startup stability

- Disable timeout on Projection Manager reads.
These reads are essential for subsystem initialization. If they time out, the subsystem fails to start properly.
- Set infinite timeout on Persistent Subscription startup config reads.
A timeout here would prevent Persistent Subscriptions from starting without manual recovery.