### PR TITLE
Provide estimated available memory in Linux from MemAvailable

### DIFF
--- a/src/EventStore.SystemRuntime/Diagnostics/RuntimeStats.cs
+++ b/src/EventStore.SystemRuntime/Diagnostics/RuntimeStats.cs
@@ -55,7 +55,7 @@ public static class RuntimeStats
 
 		static async ValueTask<long> GetFreeMemoryLinux()
 		{
-			var output = await ExecuteShellCommandAsync("grep MemFree /proc/meminfo"); // old code uses MemAvailable
+			var output = await ExecuteShellCommandAsync("grep MemAvailable /proc/meminfo");
 			var parts = output.Split(' ', StringSplitOptions.RemoveEmptyEntries);
 			var value = ToInt64(parts[1]) * 1024; // Convert KB to bytes
 			return value;


### PR DESCRIPTION
Changed : Provide estimated available memory in Linux from MemAvailable rather than the amount of physical RAM left unused by the system MemFree.