### PR TITLE
Fix config reload

### DIFF
--- a/src/EventStore.Common/Configuration/SectionProvider.cs
+++ b/src/EventStore.Common/Configuration/SectionProvider.cs
@@ -1,23 +1,55 @@
+using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
 
 namespace EventStore.Common.Configuration;
 
-public class SectionProvider : ConfigurationProvider
+public sealed class SectionProvider : ConfigurationProvider, IDisposable
 {
-	private readonly IConfiguration _configuration;
+	private readonly IConfigurationRoot _configuration;
+	public IEnumerable<IConfigurationProvider> Providers => _configuration.Providers;
 	private readonly string _sectionName;
+	private readonly IDisposable _registration;
 
-	public SectionProvider(string sectionName, IConfiguration configuration)
+	public SectionProvider(string sectionName, IConfigurationRoot configuration)
 	{
 		_configuration = configuration;
 		_sectionName = sectionName;
+		_registration = ChangeToken.OnChange(
+			configuration.GetReloadToken,
+			Load);
 	}
+
+	public bool TryGetProviderFor(string key, out IConfigurationProvider provider)
+	{
+		var prefix = _sectionName + ":";
+		if (key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+		{
+			key = key[prefix.Length..];
+			foreach (var candidate in Providers)
+			{
+				if (!candidate.TryGet(key, out _)) continue;
+				provider = candidate;
+				return true;
+			}
+		}
+
+		provider = null;
+		return false;
+	}
+
+	public void Dispose() => _registration.Dispose();
 
 	public override void Load()
 	{
+		var data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 		foreach (var kvp in _configuration.AsEnumerable())
 		{
-			Data[_sectionName + ":" + kvp.Key] = kvp.Value;
+			data[_sectionName + ":" + kvp.Key] = kvp.Value;
 		}
+
+		Data = data;
+		OnReload();
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
@@ -124,9 +124,9 @@ public class ClusterVNodeOptionsTests
 		var result = options.CheckForEnvironmentOnlyOptions();
 
 		result.Should().BeEquivalentTo(
-			"Provided by: Command Line. " +
+			"\"DefaultAdminPassword\" Provided by: Command Line. " +
 			"The Admin user password can only be set using Environment Variables" + Environment.NewLine +
-			"Provided by: Command Line. " +
+			"\"DefaultOpsPassword\" Provided by: Command Line. " +
 			"The Ops user password can only be set using Environment Variables" + Environment.NewLine);
 	}
 

--- a/src/EventStore.Core/Configuration/ConfigurationRootExtensions.cs
+++ b/src/EventStore.Core/Configuration/ConfigurationRootExtensions.cs
@@ -35,13 +35,13 @@ public static class ConfigurationRootExtensions {
 				from key in provider.GetChildKeys()
 				from property in environmentOptionsOnly
 				where string.Equals(property.Name, key, StringComparison.CurrentCultureIgnoreCase)
-				select property.GetCustomAttribute<EnvironmentOnlyAttribute>()?.Message;
+				select (key, property.GetCustomAttribute<EnvironmentOnlyAttribute>()?.Message);
 
 			errorBuilder.Append(
 				errorDescriptions
 					.Aggregate(
 						new StringBuilder(),
-						(sb, err) => sb.AppendLine($"Provided by: {ClusterVNodeOptions.GetSourceDisplayName(provider.GetType())}. {err}")
+						(sb, pair) => sb.AppendLine($"\"{pair.key}\" Provided by: {ClusterVNodeOptions.GetSourceDisplayName(EventStoreConfigurationKeys.Prefix + ":" + pair.key, provider)}. {pair.Message}")
 					)
 			);
 		}


### PR DESCRIPTION
Changed: Detect updates in wrapped sections.
Changed: Identify the wrapped provider in pretty-printed config sources.