### PR TITLE
Improve error handling in ClusterVNode and refactor TFChunkDb processing

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1664,6 +1664,15 @@ public class ClusterVNode<TStreamId> :
 		}
 
 		void StartNode(IApplicationBuilder app) {
+			try {
+				StartNodeCore(app);
+			} catch (AggregateException aggEx) when (aggEx.InnerException is { } innerEx) {
+				// We only really care that *something* is wrong - throw the first inner exception.
+				throw innerEx;
+			}
+		}
+
+		void StartNodeCore(IApplicationBuilder app) {
 		// TRUNCATE IF NECESSARY
 			var truncPos = Db.Config.TruncateCheckpoint.Read();
 			if (truncPos != -1)


### PR DESCRIPTION
Changed: Added error handling in StartNode method to throw the first inner exception from AggregateException.

Signed-off-by: Yordis Prieto <yordis.prieto@gmail.com>
