### PR TITLE
fix(streams): prevent invalid filtered all checkpoints

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.CombinationTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.CombinationTests.cs
@@ -580,6 +580,7 @@ public partial class EnumeratorTests
 						// not always straightforward to calculate how many checkpoints we will receive.
 						numResponsesExpected++;
 
+						Assert.True(checkpoint.CheckpointPosition < Position.End);
 						var checkpointPos = checkpoint.CheckpointPosition.ToInt64();
 						var checkpointTfPos = new TFPos(checkpointPos.commitPosition, checkpointPos.preparePosition);
 
@@ -609,7 +610,9 @@ public partial class EnumeratorTests
 			// then expect a final checkpoint
 			if (shouldCheckpoint)
 			{
-				Assert.True(await sub.GetNext() is Checkpoint);
+				var response = await sub.GetNext();
+				Assert.IsInstanceOf<Checkpoint>(response);
+				Assert.True(((Checkpoint)response).CheckpointPosition < Position.End);
 				numEventsSinceLastCheckpoint = 0;
 			}
 

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.Tests.cs
@@ -62,7 +62,22 @@ public partial class EnumeratorTests
 
 			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
 			Assert.AreEqual(_eventIds[0], ((Event)await sub.GetNext()).Id);
-			Assert.True(await sub.GetNext() is Checkpoint);
+			var response = await sub.GetNext();
+			Assert.IsInstanceOf<Checkpoint>(response);
+			Assert.True(((Checkpoint)response).CheckpointPosition < Position.End);
+			Assert.True(await sub.GetNext() is CaughtUp);
+		}
+
+		[Test]
+		public async Task should_receive_a_valid_checkpoint_when_no_events_match_from_start()
+		{
+			await using var sub = CreateAllSubscriptionFiltered(
+				_publisher, null, EventFilter.EventType.Prefixes(false, "match-nothing"));
+
+			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
+			var response = await sub.GetNext();
+			Assert.IsInstanceOf<Checkpoint>(response);
+			Assert.True(((Checkpoint)response).CheckpointPosition < Position.End);
 			Assert.True(await sub.GetNext() is CaughtUp);
 		}
 	}
@@ -118,7 +133,24 @@ public partial class EnumeratorTests
 
 			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
 			Assert.AreEqual(_eventIds[0], ((Event)await sub.GetNext()).Id);
-			Assert.True(await sub.GetNext() is Checkpoint);
+			var response = await sub.GetNext();
+			Assert.IsInstanceOf<Checkpoint>(response);
+			Assert.True(((Checkpoint)response).CheckpointPosition < Position.End);
+			Assert.True(await sub.GetNext() is CaughtUp);
+		}
+
+		[Test]
+		public async Task should_receive_a_valid_checkpoint_when_no_events_match_after_the_start_position()
+		{
+			await using var sub = CreateAllSubscriptionFiltered(
+				_publisher,
+				new Position((ulong)_subscribeFrom.CommitPosition, (ulong)_subscribeFrom.PreparePosition),
+				EventFilter.EventType.Prefixes(false, "match-nothing"));
+
+			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
+			var response = await sub.GetNext();
+			Assert.IsInstanceOf<Checkpoint>(response);
+			Assert.True(((Checkpoint)response).CheckpointPosition < Position.End);
 			Assert.True(await sub.GetNext() is CaughtUp);
 		}
 	}

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
@@ -140,7 +140,7 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 
 			private static TFPos ConvertCheckpoint(Position? checkpoint, TFPos lastLivePos) {
 				if (!checkpoint.HasValue)
-					return new TFPos(-1, -1);
+					return TFPos.HeadOfTf;
 
 				if (checkpoint == Position.End)
 					return lastLivePos;
@@ -298,6 +298,9 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 									_subscriptionId, _eventFilter, completed.ConsideredEventsCount, _checkpointInterval, checkpointIntervalCounter);
 
 								if (completed.IsEndOfStream) {
+									if (checkpoint < completed.CurrentPos)
+										checkpoint = completed.CurrentPos;
+
 									// issue a checkpoint when going live to make sure that at least
 									// one checkpoint is issued within the checkpoint interval
 									await SendCheckpointToSubscription(checkpoint, ct);
@@ -342,6 +345,9 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 			}
 
 			private async Task SendCheckpointToSubscription(TFPos checkpoint, CancellationToken ct) {
+				if (checkpoint == TFPos.HeadOfTf)
+					return;
+
 				var checkpointPos = Position.FromInt64(checkpoint.CommitPosition, checkpoint.PreparePosition);
 				await _channel.Writer.WriteAsync(new ReadResponse.CheckpointReceived(
 					commitPosition: checkpointPos.CommitPosition,


### PR DESCRIPTION
## Summary
- prevent filtered $all subscriptions from emitting invalid checkpoints when catching up to live with no matching events
- promote the final catch-up checkpoint to the latest valid scanned position before sending it
- add regression coverage for no-match cases and checkpoint validity assertions

## Testing
- not run locally: dotnet test src/EventStore.Core.Tests/EventStore.Core.Tests.csproj --filter FullyQualifiedName~subscribe_filtered_all_from_start
- not run locally: dotnet test src/EventStore.Core.Tests/EventStore.Core.Tests.csproj --filter FullyQualifiedName~subscribe_filtered_all_from_position
- reason: this environment is missing the net8.0 targeting pack and fails with NETSDK1127
