### PR TITLE
fix(startup): avoid unwritable database directories

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeDbPathTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeDbPathTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using EventStore.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Configuration;
+
+public class ClusterVNodeDbPathTests
+{
+	public static TheoryData<Type> WriteFailureExceptions => [
+		typeof(UnauthorizedAccessException),
+		typeof(IOException)
+	];
+
+	[Theory]
+	[MemberData(nameof(WriteFailureExceptions))]
+	public void falls_back_when_default_database_directory_cannot_be_written(Type exceptionType)
+	{
+		var rootPath = CreateTemporaryDirectory();
+
+		try
+		{
+			var defaultDataDirectory = Path.Combine(rootPath, "default-db");
+			var fallbackDefaultDataDirectory = Path.Combine(rootPath, "fallback-db");
+			var probedPaths = new List<string>();
+
+			var actual = InvokeEnsureWritableDbPath(
+				defaultDataDirectory,
+				defaultDataDirectory,
+				fallbackDefaultDataDirectory,
+				dbPath => {
+					probedPaths.Add(dbPath);
+
+					if (dbPath == defaultDataDirectory)
+						throw CreateWriteFailure(exceptionType);
+				});
+
+			actual.Should().Be(fallbackDefaultDataDirectory);
+			Directory.Exists(fallbackDefaultDataDirectory).Should().BeTrue();
+			probedPaths.Should().Equal(defaultDataDirectory, fallbackDefaultDataDirectory);
+		}
+		finally
+		{
+			DeleteTemporaryDirectory(rootPath);
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(WriteFailureExceptions))]
+	public void rethrows_when_custom_database_directory_cannot_be_written(Type exceptionType)
+	{
+		var rootPath = CreateTemporaryDirectory();
+
+		try
+		{
+			var customDataDirectory = Path.Combine(rootPath, "custom-db");
+			var defaultDataDirectory = Path.Combine(rootPath, "default-db");
+			var fallbackDefaultDataDirectory = Path.Combine(rootPath, "fallback-db");
+			var probedPaths = new List<string>();
+
+			var act = () => InvokeEnsureWritableDbPath(
+				customDataDirectory,
+				defaultDataDirectory,
+				fallbackDefaultDataDirectory,
+				dbPath => {
+					probedPaths.Add(dbPath);
+					throw CreateWriteFailure(exceptionType);
+				});
+
+			Assert.Throws(exceptionType, act);
+			probedPaths.Should().Equal(customDataDirectory);
+			Directory.Exists(fallbackDefaultDataDirectory).Should().BeFalse();
+		}
+		finally
+		{
+			DeleteTemporaryDirectory(rootPath);
+		}
+	}
+
+	private static Exception CreateWriteFailure(Type exceptionType) =>
+		exceptionType == typeof(UnauthorizedAccessException)
+			? new UnauthorizedAccessException("write denied")
+			: exceptionType == typeof(IOException)
+				? new IOException("write denied")
+				: throw new ArgumentOutOfRangeException(nameof(exceptionType), exceptionType, "Unsupported write failure.");
+
+	private static string InvokeEnsureWritableDbPath(
+		string dbPath,
+		string defaultDataDirectory,
+		string fallbackDefaultDataDirectory,
+		Action<string> probeWriteAccess)
+	{
+		var method = typeof(ClusterVNode<string>).GetMethod(
+			"EnsureWritableDbPath",
+			BindingFlags.NonPublic | BindingFlags.Static,
+			null,
+			[
+				typeof(string),
+				typeof(string),
+				typeof(string),
+				typeof(Action<string>)
+			],
+			null);
+
+		if (method is null)
+			throw new InvalidOperationException("Could not find ClusterVNode<TStreamId>.EnsureWritableDbPath.");
+
+		try
+		{
+			return (string)method.Invoke(
+				obj: null,
+				[
+					dbPath,
+					defaultDataDirectory,
+					fallbackDefaultDataDirectory,
+					probeWriteAccess
+				])!;
+		}
+		catch (TargetInvocationException ex) when (ex.InnerException is not null)
+		{
+			ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+			throw new UnreachableException();
+		}
+	}
+
+	private static string CreateTemporaryDirectory()
+	{
+		var path = Path.Combine(Path.GetTempPath(), $"ESX-{nameof(ClusterVNodeDbPathTests)}-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(path);
+		return path;
+	}
+
+	private static void DeleteTemporaryDirectory(string path)
+	{
+		if (Directory.Exists(path))
+			Directory.Delete(path, recursive: true);
+	}
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -367,36 +367,14 @@ public class ClusterVNode<TStreamId> :
 			}
 			else
 			{
-				try
-				{
-					if (!Directory.Exists(dbPath)) // mono crashes without this check
-						Directory.CreateDirectory(dbPath);
-				}
-				catch (UnauthorizedAccessException)
-				{
-					if (dbPath == Locations.DefaultDataDirectory)
-					{
-						Log.Information(
-							"Access to path {dbPath} denied. The Event Store database will be created in {fallbackDefaultDataDirectory}",
-							dbPath, Locations.FallbackDefaultDataDirectory);
-						dbPath = Locations.FallbackDefaultDataDirectory;
-						Log.Information("Defaulting DB Path to {dbPath}", dbPath);
-
-						if (!Directory.Exists(dbPath)) // mono crashes without this check
-							Directory.CreateDirectory(dbPath);
-					}
-					else
-					{
-						throw;
-					}
-				}
+				dbPath = EnsureWritableDbPath(
+					dbPath,
+					Locations.DefaultDataDirectory,
+					Locations.FallbackDefaultDataDirectory);
 
 				var indexPath = options.Database.Index ?? Path.Combine(dbPath, ESConsts.DefaultIndexDirectoryName);
 				var streamExistencePath = Path.Combine(indexPath, ESConsts.StreamExistenceFilterDirectoryName);
-				if (!Directory.Exists(streamExistencePath))
-				{
-					Directory.CreateDirectory(streamExistencePath);
-				}
+				Directory.CreateDirectory(streamExistencePath);
 
 				var writerCheckFilename = Path.Combine(dbPath, Checkpoint.Writer + ".chk");
 				var chaserCheckFilename = Path.Combine(dbPath, Checkpoint.Chaser + ".chk");
@@ -1756,6 +1734,63 @@ public class ClusterVNode<TStreamId> :
 		var periodicLogging = new PeriodicallyLoggingService(_mainQueue, VersionInfo.Version, Log);
 		_mainBus.Subscribe<SystemMessage.SystemStart>(periodicLogging);
 		_mainBus.Subscribe<MonitoringMessage.CheckEsVersion>(periodicLogging);
+	}
+
+	private static string EnsureWritableDbPath(
+		string dbPath,
+		string defaultDataDirectory,
+		string fallbackDefaultDataDirectory)
+		=> EnsureWritableDbPath(
+			dbPath,
+			defaultDataDirectory,
+			fallbackDefaultDataDirectory,
+			ProbeWriteAccess);
+
+	private static string EnsureWritableDbPath(
+		string dbPath,
+		string defaultDataDirectory,
+		string fallbackDefaultDataDirectory,
+		Action<string> probeWriteAccess)
+	{
+		try
+		{
+			Directory.CreateDirectory(dbPath);
+			probeWriteAccess(dbPath);
+
+			return dbPath;
+		}
+		catch (Exception ex) when (dbPath == defaultDataDirectory && (ex is UnauthorizedAccessException || ex is IOException))
+		{
+			return FallBackToDefaultDbPath(fallbackDefaultDataDirectory, probeWriteAccess, dbPath);
+		}
+	}
+
+	private static string FallBackToDefaultDbPath(
+		string fallbackDefaultDataDirectory,
+		Action<string> probeWriteAccess,
+		string dbPath)
+	{
+		Log.Information(
+			"Access to path {dbPath} denied. The Event Store database will be created in {fallbackDefaultDataDirectory}",
+			dbPath,
+			fallbackDefaultDataDirectory);
+		Log.Information("Defaulting DB Path to {dbPath}", fallbackDefaultDataDirectory);
+
+		Directory.CreateDirectory(fallbackDefaultDataDirectory);
+		probeWriteAccess(fallbackDefaultDataDirectory);
+		return fallbackDefaultDataDirectory;
+	}
+
+	private static void ProbeWriteAccess(string dbPath)
+	{
+		var writeProbePath = Path.Combine(dbPath, $"write-access-{Guid.NewGuid():N}.tmp");
+		using var writeProbe = new FileStream(
+			writeProbePath,
+			FileMode.CreateNew,
+			FileAccess.Write,
+			FileShare.None,
+			bufferSize: 1,
+			FileOptions.DeleteOnClose);
 	}
 
 	static int GetPTableMaxReaderCount(int readerThreadsCount)


### PR DESCRIPTION
- startup should not continue with a database path that exists but cannot accept writes
- default installations need a safe fallback when the standard data directory is denied
- custom database paths should still fail fast so configuration problems stay visible