### PR TITLE
fix(storage): keep custom chunk sizes consistent

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterNodeOptionsTests/when_building/with_single_node_and_custom_settings.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterNodeOptionsTests/when_building/with_single_node_and_custom_settings.cs
@@ -123,19 +123,21 @@ public class
 	with_custom_number_of_cached_chunks<TLogFormat, TStreamId> : SingleNodeScenario<TLogFormat, TStreamId>
 {
 	private readonly int _cachedChunks = 10;
+	private readonly int _chunkSize = 268435;
 
 	protected override ClusterVNodeOptions WithOptions(ClusterVNodeOptions options) => options with
 	{
 		Database = options.Database with
 		{
-			CachedChunks = _cachedChunks
+			CachedChunks = _cachedChunks,
+			ChunkSize = _chunkSize
 		}
 	};
 
 	[Test]
 	public void should_set_max_chunk_size_to_the_size_of_the_number_of_cached_chunks()
 	{
-		var chunkSizeResult = _cachedChunks * (long)(TFConsts.ChunkSize + ChunkHeader.Size + ChunkFooter.Size);
+		var chunkSizeResult = _cachedChunks * ((long)_chunkSize + ChunkHeader.Size + ChunkFooter.Size);
 		Assert.AreEqual(chunkSizeResult, _node.Db.Config.MaxChunksCacheSize);
 	}
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -417,7 +417,7 @@ public class ClusterVNode<TStreamId> :
 			}
 
 			var cache = options.Database.CachedChunks >= 0
-				? options.Database.CachedChunks * (long)(TFConsts.ChunkSize + ChunkHeader.Size + ChunkFooter.Size)
+				? options.Database.CachedChunks * ((long)options.Database.ChunkSize + ChunkHeader.Size + ChunkFooter.Size)
 				: options.Database.ChunksCacheSize;
 
 			// Calculate automatic configuration changes
@@ -1323,14 +1323,14 @@ public class ClusterVNode<TStreamId> :
 
 			var accumulator = new Accumulator<TStreamId>(
 				logger: logger,
-				chunkSize: TFConsts.ChunkSize,
+				chunkSize: options.Database.ChunkSize,
 				metastreamLookup: logFormat.Metastreams,
 				chunkReader: new ChunkReaderForAccumulator<TStreamId>(
 					Db.Manager,
 					logFormat.Metastreams,
 					logFormat.StreamIdConverter,
 					Db.Config.ReplicationCheckpoint,
-					TFConsts.ChunkSize),
+					options.Database.ChunkSize),
 				index: new IndexReaderForAccumulator<TStreamId>(readIndex),
 				cancellationCheckPeriod: cancellationCheckPeriod,
 				throttle: throttle);
@@ -1341,7 +1341,7 @@ public class ClusterVNode<TStreamId> :
 					readIndex,
 					() => new TFReaderLease(readerPool),
 					state.LookupUniqueHashUser),
-				chunkSize: TFConsts.ChunkSize,
+				chunkSize: options.Database.ChunkSize,
 				cancellationCheckPeriod: cancellationCheckPeriod,
 				buffer: calculatorBuffer,
 				throttle: throttle);


### PR DESCRIPTION
- custom chunk sizing should flow through cache sizing and scavenging instead of silently reverting to the built-in default
- inconsistent chunk sizing can distort cache limits and chunk traversal when operators tune storage settings
- the configuration path now stays aligned with the chunk size the node is actually started with