### PR TITLE
fix(startup): exit cleanly only for startup cancellation

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -198,13 +198,8 @@ internal static class Program
 			{
 				// add a small delay to allow the host to start up in case there's a premature shutdown
 				cts.CancelAfter(TimeSpan.FromSeconds(1));
-				exitCodeSource.SetResult(code);
+				exitCodeSource.TrySetResult(code);
 			});
-
-			Console.CancelKeyPress += delegate
-			{
-				Application.Exit(0, "Cancelled.");
-			};
 
 			using (var hostedService = new ClusterVNodeHostedService(options, certificateProvider, configuration))
 			{
@@ -261,6 +256,10 @@ internal static class Program
 						.ConfigureServices(services => services.AddSingleton<IHostedService>(hostedService))
 						.RunConsoleAsync(x => x.SuppressStatusMessages = true, cts.Token);
 
+					exitCodeSource.TrySetResult(0);
+				}
+				catch (OperationCanceledException) when (cts.IsCancellationRequested)
+				{
 					exitCodeSource.TrySetResult(0);
 				}
 				catch (Exception ex)


### PR DESCRIPTION
- startup cancellation should only look successful when shutdown is actually coming from the node's own startup cancellation path
- unrelated cancellation failures during startup should still surface as fatal startup errors instead of being treated as a clean exit
- late application exit signals should not turn shutdown into a secondary InvalidOperationException after the exit code task has already completed