### PR TITLE
fix(storage): fill missing scavenged chunk midpoints

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
@@ -42,6 +42,9 @@ public class Scenario
 // sort of similar to ScavengeTestScenario
 public class Scenario<TLogFormat, TStreamId> : Scenario
 {
+	private const int ForceImmediatePTableConversion = 1;
+	private const int KeepIndexInMemoryWhenSkippingIndexCheck = 1_000_000;
+
 	private static EqualityComparer<TStreamId> StreamIdComparer { get; } =
 		EqualityComparer<TStreamId>.Default;
 
@@ -52,6 +55,7 @@ public class Scenario<TLogFormat, TStreamId> : Scenario
 	private ITFChunkScavengerLog _logger;
 
 	private int _threads = 1;
+	private bool _skipIndexCheck;
 	private bool _mergeChunks;
 	private bool _syncOnly;
 	private string _dbPath;
@@ -105,6 +109,12 @@ public class Scenario<TLogFormat, TStreamId> : Scenario
 	public Scenario<TLogFormat, TStreamId> WithThreads(int threads)
 	{
 		_threads = threads;
+		return this;
+	}
+
+	public Scenario<TLogFormat, TStreamId> SkipIndexCheck()
+	{
+		_skipIndexCheck = true;
 		return this;
 	}
 
@@ -320,7 +330,9 @@ public class Scenario<TLogFormat, TStreamId> : Scenario
 			ptableVersion: PTableVersions.IndexV4,
 			maxAutoMergeIndexLevel: int.MaxValue,
 			pTableMaxReaderCount: ESConsts.PTableInitialReaderCount,
-			maxSizeForMemory: 1, // convert everything to ptables immediately
+			maxSizeForMemory: _skipIndexCheck
+				? KeepIndexInMemoryWhenSkippingIndexCheck
+				: ForceImmediatePTableConversion,
 			maxTablesPerLevel: 2,
 			inMem: false);
 		logFormat.StreamNamesProvider.SetTableIndex(tableIndex);
@@ -657,7 +669,9 @@ public class Scenario<TLogFormat, TStreamId> : Scenario
 			if (keptRecords != null)
 			{
 				await CheckRecords(keptRecords, dbResult, cancellationTokenSource.Token);
-				await CheckIndex(keptIndexEntries, readIndex, collidingStreams, hasher, cancellationTokenSource.Token);
+				if (!_skipIndexCheck)
+					await CheckIndex(keptIndexEntries, readIndex, collidingStreams, hasher,
+						cancellationTokenSource.Token);
 			}
 
 			_assertState?.Invoke(scavengeState);

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/ScavengedChunkReadingTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/ScavengedChunkReadingTests.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Core.Tests;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using EventStore.Core.XUnit.Tests.Scavenge.Sqlite;
+using Xunit;
+using static EventStore.Core.XUnit.Tests.Scavenge.StreamMetadatas;
+
+namespace EventStore.Core.XUnit.Tests.Scavenge;
+
+public class ScavengedChunkReadingTests : SqliteDbPerTest<ScavengedChunkReadingTests>
+{
+	[Fact]
+	public async Task missing_midpoint()
+	{
+		var t = 0;
+		await new Scenario<LogFormat.V2, string>()
+			.WithDbPath(Fixture.Directory)
+			.SkipIndexCheck()
+			.WithDb(x => x
+				.Chunk([
+					Rec.Write(t++, "ab-1"),
+					Rec.Write(t++, "ab-1"),
+					..Enumerable.Range(0, 2738).Select(_ => Rec.Write(t++, "cd-1")),
+				])
+				.Chunk(
+					Rec.Write(t++, "$$ab-1", "$metadata", metadata: SoftDelete),
+					ScavengePointRec(t++)))
+			.WithState(x => x.WithConnectionPool(Fixture.DbConnectionPool))
+			.RunAsync(x => [
+				x.Recs[0][1..],
+				x.Recs[1],
+			]);
+	}
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
@@ -269,14 +269,20 @@ public partial class TFChunk
 					midpoints = new Midpoint[1 + (mapCount + segmentSize - 1) / segmentSize];
 				}
 
-				for (int x = 0, i = 0, xN = mapCount - 1; x < xN; x += segmentSize, i++)
+				var i = 0;
+				for (int x = 0, xN = mapCount - 1; x < xN; x += segmentSize, i++)
 				{
 					midpoints[i] = new Midpoint(x, await ReadPosMap(workItem, x, buffer.Memory, token));
 				}
 
-				// add the very last item as the last midpoint (possibly it is done twice)
-				midpoints[^1] = new Midpoint(mapCount - 1,
+				var lastMidpoint = new Midpoint(mapCount - 1,
 					await ReadPosMap(workItem, mapCount - 1, buffer.Memory, token));
+				while (i < midpoints.Length)
+				{
+					midpoints[i] = lastMidpoint;
+					i++;
+				}
+
 				return midpoints;
 			}
 			catch (FileBeingDeletedException)


### PR DESCRIPTION
- scavenged chunks should keep a complete midpoint table even when the midpoint spacing leaves trailing slots at the end
- missing tail midpoints make read bounds wider than necessary and leave the chunk reader with an avoidable hole in its cached search data
- the added regression test keeps this bug pinned to the scavenged-chunk case that previously produced the missing midpoint