### PR TITLE
fix(startup): avoid fatal logs after truncation

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -204,6 +204,7 @@ public class ClusterVNode<TStreamId> :
 	private readonly EventStoreClusterClientCache _eventStoreClusterClientCache;
 
 	private int _stopCalled;
+	private int _systemInitPublished;
 	private int _reloadingConfig;
 	private PosixSignalRegistration _reloadConfigSignalRegistration;
 
@@ -1707,6 +1708,7 @@ public class ClusterVNode<TStreamId> :
 			AddTask(redactionQueue.Start());
 
 			dynamicCacheManager.Start();
+			PublishSystemInitIfNeeded();
 		}
 
 		_startup = new ClusterVNodeStartup<TStreamId>(
@@ -1907,6 +1909,15 @@ public class ClusterVNode<TStreamId> :
 
 	public override void Start()
 	{
+		if (!IsShutdown)
+			PublishSystemInitIfNeeded();
+	}
+
+	private void PublishSystemInitIfNeeded()
+	{
+		if (Interlocked.CompareExchange(ref _systemInitPublished, 1, 0) != 0)
+			return;
+
 		_mainQueue.Publish(new SystemMessage.SystemInit());
 	}
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -185,6 +185,7 @@ public class ClusterVNode<TStreamId> :
 	private readonly IAuthorizationProvider _authorizationProvider;
 	private readonly IReadIndex<TStreamId> _readIndex;
 	private readonly SemaphoreSlimLock _switchChunksLock = new();
+	private readonly object _systemInitGate = new();
 
 	private readonly InMemoryBus[] _workerBuses;
 	private readonly MultiQueuedHandler _workersHandler;
@@ -1915,13 +1916,17 @@ public class ClusterVNode<TStreamId> :
 
 	private void PublishSystemInitIfNeeded()
 	{
-		if (Volatile.Read(ref _shutdownStarted) != 0 || IsShutdown)
-			return;
+		lock (_systemInitGate)
+		{
+			if (_shutdownStarted != 0 || IsShutdown)
+				return;
 
-		if (Interlocked.CompareExchange(ref _systemInitPublished, 1, 0) != 0)
-			return;
+			if (_systemInitPublished != 0)
+				return;
 
-		_mainQueue.Publish(new SystemMessage.SystemInit());
+			_systemInitPublished = 1;
+			_mainQueue.Publish(new SystemMessage.SystemInit());
+		}
 	}
 
 	public override async Task StopAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
@@ -1949,7 +1954,9 @@ public class ClusterVNode<TStreamId> :
 
 	public async ValueTask HandleAsync(SystemMessage.BecomeShuttingDown message, CancellationToken token)
 	{
-		Interlocked.Exchange(ref _shutdownStarted, 1);
+		lock (_systemInitGate)
+			_shutdownStarted = 1;
+
 		Log.Information("========== [{httpEndPoint}] Is shutting down subsystems", NodeInfo.HttpEndPoint);
 
 		_reloadConfigSignalRegistration?.Dispose();

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -205,6 +205,7 @@ public class ClusterVNode<TStreamId> :
 
 	private int _stopCalled;
 	private int _systemInitPublished;
+	private int _shutdownStarted;
 	private int _reloadingConfig;
 	private PosixSignalRegistration _reloadConfigSignalRegistration;
 
@@ -1909,12 +1910,14 @@ public class ClusterVNode<TStreamId> :
 
 	public override void Start()
 	{
-		if (!IsShutdown)
-			PublishSystemInitIfNeeded();
+		PublishSystemInitIfNeeded();
 	}
 
 	private void PublishSystemInitIfNeeded()
 	{
+		if (Volatile.Read(ref _shutdownStarted) != 0 || IsShutdown)
+			return;
+
 		if (Interlocked.CompareExchange(ref _systemInitPublished, 1, 0) != 0)
 			return;
 
@@ -1946,6 +1949,7 @@ public class ClusterVNode<TStreamId> :
 
 	public async ValueTask HandleAsync(SystemMessage.BecomeShuttingDown message, CancellationToken token)
 	{
+		Interlocked.Exchange(ref _shutdownStarted, 1);
 		Log.Information("========== [{httpEndPoint}] Is shutting down subsystems", NodeInfo.HttpEndPoint);
 
 		_reloadConfigSignalRegistration?.Dispose();


### PR DESCRIPTION
- successful truncation is a clean restart path and should not look like a fatal storage failure
- late system initialization can wake background services after shutdown has already begun, which produces misleading fatal noise during restart
- aligning initialization with the real startup lifecycle keeps truncation-driven restarts predictable for operators