### PR TITLE
fix(metrics): avoid zero disk io stats on linux

### DIFF
--- a/src/EventStore.SystemRuntime.Tests/ProcessStatsTests.cs
+++ b/src/EventStore.SystemRuntime.Tests/ProcessStatsTests.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics;
+
+namespace EventStore.SystemRuntime.Tests;
+
+public class ProcessStatsTests
+{
+	[Fact]
+	public void linux_parser_keeps_reading_after_write_ops()
+	{
+		var lines = new[]
+		{
+			"rchar: 1",
+			"write_bytes: 22",
+			"syscw: 44",
+			"read_bytes: 11",
+			"syscr: 33",
+		};
+
+		var result = ProcessStats.ParseLinuxDiskIo(lines);
+
+		Assert.Equal(new DiskIoData(
+			readBytes: 11,
+			writtenBytes: 22,
+			readOps: 33,
+			writeOps: 44), result);
+	}
+
+	[Fact]
+	public void get_disk_io_returns_without_throwing()
+	{
+		var result = ProcessStats.GetDiskIo(Process.GetCurrentProcess());
+
+		Assert.IsType<DiskIoData>(result);
+	}
+}

--- a/src/EventStore.SystemRuntime.Tests/ProcessStatsTests.cs
+++ b/src/EventStore.SystemRuntime.Tests/ProcessStatsTests.cs
@@ -26,10 +26,34 @@ public class ProcessStatsTests
 	}
 
 	[Fact]
+	public void linux_parser_treats_zero_values_as_parsed()
+	{
+		var result = ProcessStats.ParseLinuxDiskIo(ThrowAfter(
+			"write_bytes: 0",
+			"syscw: 0",
+			"read_bytes: 0",
+			"syscr: 0"));
+
+		Assert.Equal(new DiskIoData(
+			readBytes: 0,
+			writtenBytes: 0,
+			readOps: 0,
+			writeOps: 0), result);
+	}
+
+	[Fact]
 	public void get_disk_io_returns_without_throwing()
 	{
 		var result = ProcessStats.GetDiskIo(Process.GetCurrentProcess());
 
 		Assert.IsType<DiskIoData>(result);
+	}
+
+	private static IEnumerable<string> ThrowAfter(params string[] lines)
+	{
+		foreach (var line in lines)
+			yield return line;
+
+		throw new InvalidOperationException("Parser read past the point where all counters were already present.");
 	}
 }

--- a/src/EventStore.SystemRuntime/AssemblyInfo.cs
+++ b/src/EventStore.SystemRuntime/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("EventStore.SystemRuntime.Tests")]

--- a/src/EventStore.SystemRuntime/Diagnostics/ProcessStats.cs
+++ b/src/EventStore.SystemRuntime/Diagnostics/ProcessStats.cs
@@ -9,6 +9,17 @@ namespace System.Diagnostics;
 [PublicAPI]
 public static class ProcessStats
 {
+	[Flags]
+	private enum LinuxIoField
+	{
+		None = 0,
+		ReadBytes = 1,
+		WrittenBytes = 2,
+		ReadOps = 4,
+		WriteOps = 8,
+		All = ReadBytes | WrittenBytes | ReadOps | WriteOps,
+	}
+
 	public static DiskIoData GetDiskIo(Process process)
 	{
 		return RuntimeInformation.OsPlatform switch
@@ -47,22 +58,32 @@ public static class ProcessStats
 	internal static DiskIoData ParseLinuxDiskIo(IEnumerable<string> lines)
 	{
 		var result = new DiskIoData();
+		var seenFields = LinuxIoField.None;
 
 		foreach (var line in lines)
 		{
 			if (TryExtractIoValue(line, "read_bytes", out var readBytes))
+			{
 				result = result with { ReadBytes = readBytes };
+				seenFields |= LinuxIoField.ReadBytes;
+			}
 			else if (TryExtractIoValue(line, "write_bytes", out var writeBytes))
+			{
 				result = result with { WrittenBytes = writeBytes };
+				seenFields |= LinuxIoField.WrittenBytes;
+			}
 			else if (TryExtractIoValue(line, "syscr", out var readOps))
+			{
 				result = result with { ReadOps = readOps };
+				seenFields |= LinuxIoField.ReadOps;
+			}
 			else if (TryExtractIoValue(line, "syscw", out var writeOps))
+			{
 				result = result with { WriteOps = writeOps };
+				seenFields |= LinuxIoField.WriteOps;
+			}
 
-			if (result.ReadBytes is not 0 &&
-				result.WrittenBytes is not 0 &&
-				result.ReadOps is not 0 &&
-				result.WriteOps is not 0)
+			if (seenFields == LinuxIoField.All)
 				break;
 		}
 

--- a/src/EventStore.SystemRuntime/Diagnostics/ProcessStats.cs
+++ b/src/EventStore.SystemRuntime/Diagnostics/ProcessStats.cs
@@ -26,41 +26,11 @@ public static class ProcessStats
 
 			try
 			{
-				var result = new DiskIoData();
-
-				foreach (var line in File.ReadLines(procIoFile))
-				{
-					if (TryExtractIoValue(line, "read_bytes", out var readBytes))
-						result = result with { ReadBytes = readBytes };
-					else if (TryExtractIoValue(line, "write_bytes", out var writeBytes))
-						result = result with { WrittenBytes = writeBytes };
-					else if (TryExtractIoValue(line, "syscr", out var readOps))
-						result = result with { ReadOps = readOps };
-					else if (TryExtractIoValue(line, "syscw", out var writeOps))
-					{
-						result = result with { WriteOps = writeOps };
-						break;
-					}
-				}
-
-				return result;
+				return ParseLinuxDiskIo(File.ReadLines(procIoFile));
 			}
 			catch (Exception ex)
 			{
 				throw new ApplicationException("Failed to get Linux process I/O info", ex);
-			}
-
-			static bool TryExtractIoValue(string line, string key, out ulong value)
-			{
-				if (line.StartsWith(key))
-				{
-					var rawValue = line[(key.Length + 1)..].Trim(); // handle the `:` character
-					value = Convert.ToUInt64(rawValue);
-					return true;
-				}
-
-				value = 0;
-				return false;
 			}
 		}
 
@@ -73,6 +43,44 @@ public static class ProcessStats
 
 	public static DiskIoData GetDiskIo() =>
 		GetDiskIo(Process.GetCurrentProcess());
+
+	internal static DiskIoData ParseLinuxDiskIo(IEnumerable<string> lines)
+	{
+		var result = new DiskIoData();
+
+		foreach (var line in lines)
+		{
+			if (TryExtractIoValue(line, "read_bytes", out var readBytes))
+				result = result with { ReadBytes = readBytes };
+			else if (TryExtractIoValue(line, "write_bytes", out var writeBytes))
+				result = result with { WrittenBytes = writeBytes };
+			else if (TryExtractIoValue(line, "syscr", out var readOps))
+				result = result with { ReadOps = readOps };
+			else if (TryExtractIoValue(line, "syscw", out var writeOps))
+				result = result with { WriteOps = writeOps };
+
+			if (result.ReadBytes is not 0 &&
+				result.WrittenBytes is not 0 &&
+				result.ReadOps is not 0 &&
+				result.WriteOps is not 0)
+				break;
+		}
+
+		return result;
+	}
+
+	private static bool TryExtractIoValue(string line, string key, out ulong value)
+	{
+		if (line.StartsWith(key))
+		{
+			var rawValue = line[(key.Length + 1)..].Trim(); // handle the `:` character
+			value = Convert.ToUInt64(rawValue);
+			return true;
+		}
+
+		value = 0;
+		return false;
+	}
 }
 
 /// <summary>


### PR DESCRIPTION
- Linux disk I/O stats should not depend on  listing the counters in one specific order
- stopping at the first write-ops line can hide the read counters and report misleading zero values to operators
- keeping the parser aligned with the full counter set makes runtime diagnostics more trustworthy on Linux