### PR TITLE
fix(metrics): align histogram bucket selection

### DIFF
--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -245,8 +245,7 @@ public class ClusterVNodeStartup<TStreamId> : IStartup, IHandle<SystemMessage.Sy
 							]
 						};
 					else if (i.Name.StartsWith("eventstore-") &&
-					         i.Name.EndsWith("-latency") &&
-					         i.Unit == "seconds")
+					         i.Name.EndsWith("-latency-seconds"))
 						return new ExplicitBucketHistogramConfiguration
 						{
 							Boundaries =
@@ -261,7 +260,8 @@ public class ClusterVNodeStartup<TStreamId> : IStartup, IHandle<SystemMessage.Sy
 								5, // 5000 ms
 							]
 						};
-					else if (i.Name.StartsWith("eventstore-") && i.Unit == "seconds")
+					else if (i.Name.StartsWith("eventstore-") &&
+					         i.Name.EndsWith("-seconds"))
 						return new ExplicitBucketHistogramConfiguration
 						{
 							Boundaries =


### PR DESCRIPTION
- the metrics view logic should match the histogram names that are actually exported, not the pre-unit names used at definition time
- mismatched suffix checks make the dashboard-oriented bucket overrides miss the intended metrics
- aligning the selection logic keeps the exported histograms consistent with the dashboard expectations