### PR TITLE
fix(startup): disable server gc by default

### DIFF
--- a/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
+++ b/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
@@ -4,6 +4,7 @@
 		<OutputType>Exe</OutputType>
 		<ApplicationIcon>app2.ico</ApplicationIcon>
 		<GenerateSupportedRuntime>false</GenerateSupportedRuntime>
+		<ServerGarbageCollection>false</ServerGarbageCollection>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="SharpDotYaml.Extensions.Configuration" />

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -93,6 +93,10 @@ internal static class Program
 				GCSettings.IsServerGC,
 				GCSettings.LatencyMode);
 			Log.Information("{description,-25} {logsDirectory}", "LOGS:", logsDirectory);
+			var gcSettings = string.Join(
+				$"{Environment.NewLine}    ",
+				GC.GetConfigurationVariables().Select(kvp => $"{kvp.Key}: {kvp.Value}"));
+			Log.Information($"GC Configuration settings:{Environment.NewLine}    {{settings}}", gcSettings);
 			Log.Information(options.DumpOptions());
 
 			var level = options.Application.AllowUnknownOptions


### PR DESCRIPTION
- the hosting changes should not quietly change the process-wide GC mode for every deployment
- server GC can trade away page cache and overall memory headroom in ways operators may not want by default
- logging the effective GC configuration makes explicit overrides visible when users choose a different runtime profile