### PR TITLE
fix(storage): avoid undersized chunk read buffering

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkTrackerTests.cs
@@ -8,6 +8,7 @@ using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.XUnit.Tests.Metrics;
 using Xunit;
+using static EventStore.Core.TransactionLog.ITransactionFileTracker;
 
 namespace EventStore.Core.XUnit.Tests.TransactionLog.Chunks;
 
@@ -18,11 +19,14 @@ public class TFChunkTrackerTests : IDisposable
 
 	private readonly TFChunkTracker _sut;
 	private readonly TestMeterListener<long> _listener;
+	private readonly TestMeterListener<double> _doubleListener;
+	private readonly FakeClock _clock = new();
 
 	public TFChunkTrackerTests()
 	{
 		var meter = new Meter($"{typeof(TFChunkTrackerTests)}");
 		_listener = new TestMeterListener<long>(meter);
+		_doubleListener = new TestMeterListener<double>(meter);
 		var byteMetric = new CounterMetric(meter, "eventstore-io", unit: "bytes");
 		var eventMetric = new CounterMetric(meter, "eventstore-io", unit: "events");
 		var writerCheckpoint = new InMemoryCheckpoint(WriterCheckpoint);
@@ -30,6 +34,7 @@ public class TFChunkTrackerTests : IDisposable
 		var readTag = new KeyValuePair<string, object>("activity", "read");
 		_sut = new TFChunkTracker(
 			readDistribution: new LogicalChunkReadDistributionMetric(meter, "chunk-read-distribution", writerCheckpoint, ChunkSize),
+			readDurationMetric: new DurationMetric(meter, "eventstore-io-record-read-duration", _clock),
 			readBytes: new CounterSubMetric(byteMetric, [readTag]),
 			readEvents: new CounterSubMetric(eventMetric, [readTag]));
 	}
@@ -37,6 +42,7 @@ public class TFChunkTrackerTests : IDisposable
 	public void Dispose()
 	{
 		_listener.Dispose();
+		_doubleListener.Dispose();
 	}
 
 	[Fact]
@@ -46,7 +52,7 @@ public class TFChunkTrackerTests : IDisposable
 			data: new byte[5],
 			meta: new byte[5]);
 
-		_sut.OnRead(prepare);
+		_sut.OnRead(_clock.Now, prepare, Source.Unknown);
 		_listener.Observe();
 
 		AssertEventsRead(1);
@@ -57,7 +63,7 @@ public class TFChunkTrackerTests : IDisposable
 	public void disregard_system_log()
 	{
 		var system = CreateSystemRecord();
-		_sut.OnRead(system);
+		_sut.OnRead(_clock.Now, system, Source.Unknown);
 		_listener.Observe();
 
 		AssertEventsRead(0);
@@ -68,11 +74,42 @@ public class TFChunkTrackerTests : IDisposable
 	public void disregard_commit_log()
 	{
 		var system = CreateCommit();
-		_sut.OnRead(system);
+		_sut.OnRead(_clock.Now, system, Source.Unknown);
 		_listener.Observe();
 
 		AssertEventsRead(0);
 		AssertBytesRead(0);
+	}
+
+	[Theory]
+	[InlineData(Source.ChunkCache)]
+	[InlineData(Source.FileSystem)]
+	public void records_record_read_duration(Source source)
+	{
+		var prepare = CreatePrepare(
+			data: new byte[5],
+			meta: new byte[5]);
+
+		var start = _clock.Now;
+		_clock.AdvanceSeconds(3);
+
+		_sut.OnRead(start, prepare, source);
+		_doubleListener.Observe();
+
+		var actual = _doubleListener.RetrieveMeasurements("eventstore-io-record-read-duration-seconds");
+		Assert.Collection(
+			actual,
+			m =>
+			{
+				Assert.Equal(3, m.Value);
+				Assert.Collection(
+					m.Tags.ToArray(),
+					t =>
+					{
+						Assert.Equal("source", t.Key);
+						Assert.Equal(source, t.Value);
+					});
+			});
 	}
 
 	[Theory]
@@ -89,7 +126,10 @@ public class TFChunkTrackerTests : IDisposable
 	[InlineData(0, 4)]
 	public void records_read_distribution(long logPosition, long expectedChunk)
 	{
-		_sut.OnRead(CreatePrepare(data: new byte[5], meta: new byte[5], logPosition: logPosition));
+		_sut.OnRead(
+			_clock.Now,
+			CreatePrepare(data: new byte[5], meta: new byte[5], logPosition: logPosition),
+			Source.Unknown);
 
 		_listener.Observe();
 		var actual = _listener.RetrieveMeasurements("chunk-read-distribution");

--- a/src/EventStore.Core/Metrics/DurationMetric.cs
+++ b/src/EventStore.Core/Metrics/DurationMetric.cs
@@ -25,5 +25,15 @@ namespace EventStore.Core.Metrics {
 			_histogram.Record(elapsedSeconds, tag1, tag2);
 			return now;
 		}
+
+		public Instant Record(
+			Instant start,
+			KeyValuePair<string, object> tag1) {
+
+			var now = _clock.Now;
+			var elapsedSeconds = now.ElapsedSecondsSince(start);
+			_histogram.Record(elapsedSeconds, tag1);
+			return now;
+		}
 	}
 }

--- a/src/EventStore.Core/MetricsBootstrapper.cs
+++ b/src/EventStore.Core/MetricsBootstrapper.cs
@@ -88,6 +88,7 @@ public static class MetricsBootstrapper {
 		var queueBusyMetric = new AverageMetric(coreMeter, "eventstore-queue-busy", "seconds", label => new("queue", label));
 		var byteMetric = new CounterMetric(coreMeter, "eventstore-io", unit: "bytes");
 		var eventMetric = new CounterMetric(coreMeter, "eventstore-io", unit: "events");
+		var recordReadDurationMetric = new DurationMetric(coreMeter, "eventstore-io-record-read-duration");
 		var electionsCounterMetric = new CounterMetric(coreMeter, "eventstore-elections-count", unit: "");
 
 		// incoming grpc calls
@@ -130,6 +131,7 @@ public static class MetricsBootstrapper {
 					name: LogicalChunkReadDistributionName,
 					writer: dbConfig.WriterCheckpoint,
 					chunkSize: dbConfig.ChunkSize),
+				readDurationMetric: recordReadDurationMetric,
 				readBytes: new CounterSubMetric(byteMetric, [readTag]),
 				readEvents: new CounterSubMetric(eventMetric, [readTag]));
 		}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
@@ -11,7 +11,9 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
 
 internal sealed class ReaderWorkItem : Disposable
 {
-	private const int BufferSize = 512;
+	// Chunk reads sit on a hot path during scavenging, so a larger buffer avoids
+	// turning filesystem buffering overhead into the bottleneck.
+	private const int BufferSize = 8192;
 
 	// if item was taken from the pool, the field contains position within the array (>= 0)
 	private readonly int _positionInPool = -1;

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
@@ -30,12 +30,14 @@ internal sealed class ReaderWorkItem : Disposable
 		: this(CreateTransformedMemoryStream(sharedStream, chunkReadTransform), leaveOpen: true)
 	{
 		IsMemory = true;
+		Source = ITransactionFileTracker.Source.ChunkCache;
 	}
 
 	public ReaderWorkItem(IChunkHandle handle, IChunkReadTransform chunkReadTransform)
 		: this(CreateTransformedFileStream(handle, chunkReadTransform), leaveOpen: false)
 	{
 		IsMemory = false;
+		Source = ITransactionFileTracker.Source.FileSystem;
 	}
 
 	private static Stream CreateTransformedMemoryStream(Stream memStream, IChunkReadTransform chunkReadTransform)
@@ -51,6 +53,8 @@ internal sealed class ReaderWorkItem : Disposable
 	}
 
 	public bool IsMemory { get; }
+
+	public ITransactionFileTracker.Source Source { get; }
 
 	public int PositionInPool
 	{

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
@@ -8,6 +8,7 @@ using DotNext.Threading;
 using DotNext.IO;
 using EventStore.Common.Utils;
 using EventStore.Core.Exceptions;
+using EventStore.Core.Time;
 using EventStore.Core.TransactionLog.LogRecords;
 using Serilog;
 using static System.Threading.Timeout;
@@ -70,6 +71,7 @@ public partial class TFChunk
 		public async ValueTask<RecordReadResult> TryReadAt(long logicalPosition, bool couldBeScavenged,
 			CancellationToken token)
 		{
+			var start = Instant.Now;
 			var workItem = Chunk.GetReaderWorkItem();
 			try
 			{
@@ -81,7 +83,7 @@ public partial class TFChunk
 					return RecordReadResult.Failure;
 				}
 
-				var (record, length) = await TryReadForwardInternal(workItem, logicalPosition, token);
+				var (record, length) = await TryReadForwardInternal(start, workItem, logicalPosition, token);
 				return new RecordReadResult(record is not null, -1, record, length);
 			}
 			finally
@@ -95,13 +97,14 @@ public partial class TFChunk
 
 		public async ValueTask<RecordReadResult> TryReadClosestForward(long logicalPosition, CancellationToken token)
 		{
+			var start = Instant.Now;
 			var workItem = Chunk.GetReaderWorkItem();
 			try
 			{
 				if (logicalPosition >= Chunk.LogicalDataSize)
 					return RecordReadResult.Failure;
 
-				if (await TryReadForwardInternal(workItem, logicalPosition, token) is not ({ } record, var length))
+				if (await TryReadForwardInternal(start, workItem, logicalPosition, token) is not ({ } record, var length))
 					return RecordReadResult.Failure;
 
 				long nextLogicalPos = record.GetNextLogPosition(logicalPosition, length);
@@ -140,6 +143,7 @@ public partial class TFChunk
 
 		public async ValueTask<RecordReadResult> TryReadClosestBackward(long logicalPosition, CancellationToken token)
 		{
+			var start = Instant.Now;
 			var workItem = Chunk.GetReaderWorkItem();
 			try
 			{
@@ -147,7 +151,7 @@ public partial class TFChunk
 				if (logicalPosition > Chunk.LogicalDataSize)
 					return RecordReadResult.Failure;
 
-				if (await TryReadBackwardInternal(workItem, logicalPosition, token) is not ({ } record, var length))
+				if (await TryReadBackwardInternal(start, workItem, logicalPosition, token) is not ({ } record, var length))
 					return RecordReadResult.Failure;
 
 				long nextLogicalPos = record.GetPrevLogPosition(logicalPosition, length);
@@ -351,6 +355,7 @@ public partial class TFChunk
 		public async ValueTask<RecordReadResult> TryReadAt(long logicalPosition, bool couldBeScavenged,
 			CancellationToken token)
 		{
+			var start = Instant.Now;
 			var workItem = Chunk.GetReaderWorkItem();
 			try
 			{
@@ -368,7 +373,7 @@ public partial class TFChunk
 					return RecordReadResult.Failure;
 				}
 
-				var (record, length) = await TryReadForwardInternal(workItem, actualPosition, token);
+				var (record, length) = await TryReadForwardInternal(start, workItem, actualPosition, token);
 				return new(record is not null, -1, record, length);
 			}
 			finally
@@ -425,6 +430,7 @@ public partial class TFChunk
 			if (Chunk.ChunkFooter.MapCount is 0)
 				return RecordReadResult.Failure;
 
+			var start = Instant.Now;
 			var workItem = Chunk.GetReaderWorkItem();
 			try
 			{
@@ -432,7 +438,7 @@ public partial class TFChunk
 				if (actualPosition is -1 || actualPosition >= Chunk.PhysicalDataSize)
 					return RecordReadResult.Failure;
 
-				if (await TryReadForwardInternal(workItem, actualPosition, token) is not ({ } record, var length))
+				if (await TryReadForwardInternal(start, workItem, actualPosition, token) is not ({ } record, var length))
 					return RecordReadResult.Failure;
 
 				long nextLogicalPos =
@@ -490,6 +496,7 @@ public partial class TFChunk
 			if (Chunk.ChunkFooter.MapCount == 0)
 				return RecordReadResult.Failure;
 
+			var start = Instant.Now;
 			var workItem = Chunk.GetReaderWorkItem();
 			try
 			{
@@ -498,7 +505,7 @@ public partial class TFChunk
 				if (actualPosition is -1 || actualPosition > Chunk.PhysicalDataSize)
 					return RecordReadResult.Failure;
 
-				if (await TryReadBackwardInternal(workItem, actualPosition, token) is not ({ } record, var length))
+				if (await TryReadBackwardInternal(start, workItem, actualPosition, token) is not ({ } record, var length))
 					return RecordReadResult.Failure;
 
 				long nextLogicalPos = Chunk.ChunkHeader.GetLocalLogPosition(record.LogPosition);
@@ -672,7 +679,7 @@ public partial class TFChunk
 			}
 		}
 
-		protected async ValueTask<(ILogRecord, int)> TryReadForwardInternal(ReaderWorkItem workItem,
+		protected async ValueTask<(ILogRecord, int)> TryReadForwardInternal(Instant start, ReaderWorkItem workItem,
 			long actualPosition, CancellationToken token)
 		{
 			workItem.BaseStream.Position = GetRawPosition(actualPosition);
@@ -698,7 +705,7 @@ public partial class TFChunk
 				var reader = new SequenceReader(new(buffer.Memory[..length]));
 				record = LogRecord.ReadFrom(ref reader);
 
-				_tracker.OnRead(record);
+				_tracker.OnRead(start, record, workItem.Source);
 
 				int suffixLength =
 					BinaryPrimitives.ReadInt32LittleEndian(buffer.Span[^sizeof(int)..]);
@@ -739,7 +746,7 @@ public partial class TFChunk
 			return new(record, 0, length);
 		}
 
-		protected async ValueTask<(ILogRecord, int)> TryReadBackwardInternal(ReaderWorkItem workItem,
+		protected async ValueTask<(ILogRecord, int)> TryReadBackwardInternal(Instant start, ReaderWorkItem workItem,
 			long actualPosition, CancellationToken token)
 		{
 			// no space even for length prefix and suffix
@@ -808,7 +815,7 @@ public partial class TFChunk
 				buffer.Dispose();
 			}
 
-			_tracker.OnRead(record);
+			_tracker.OnRead(start, record, workItem.Source);
 
 			return (record, length);
 		}

--- a/src/EventStore.Core/TransactionLog/Chunks/TransactionFileTracker.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TransactionFileTracker.cs
@@ -1,26 +1,34 @@
 #nullable enable
+using System.Collections.Generic;
 using EventStore.Core.Metrics;
+using EventStore.Core.Time;
 using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Core.TransactionLog.Chunks;
 
 public class TFChunkTracker : ITransactionFileTracker {
 	private readonly LogicalChunkReadDistributionMetric _readDistribution;
+	private readonly DurationMetric _readDurationMetric;
 	private readonly CounterSubMetric _readBytes;
 	private readonly CounterSubMetric _readEvents;
 
 	public TFChunkTracker(
 		LogicalChunkReadDistributionMetric readDistribution,
+		DurationMetric readDurationMetric,
 		CounterSubMetric readBytes,
 		CounterSubMetric readEvents) {
 
+		_readDistribution = readDistribution;
+		_readDurationMetric = readDurationMetric;
 		_readBytes = readBytes;
 		_readEvents = readEvents;
-		_readDistribution = readDistribution;
 	}
 
-	public void OnRead(ILogRecord record) {
+	public void OnRead(Instant start, ILogRecord record, ITransactionFileTracker.Source source) {
 		_readDistribution.Record(record);
+		_readDurationMetric.Record(
+			start,
+			new KeyValuePair<string, object>("source", source));
 
 		if (record is not PrepareLogRecord prepare)
 			return;
@@ -30,7 +38,7 @@ public class TFChunkTracker : ITransactionFileTracker {
 	}
 
 	public class NoOp : ITransactionFileTracker {
-		public void OnRead(ILogRecord record) {
+		public void OnRead(Instant start, ILogRecord record, ITransactionFileTracker.Source source) {
 		}
 	}
 }

--- a/src/EventStore.Core/TransactionLog/ITransactionFileTracker.cs
+++ b/src/EventStore.Core/TransactionLog/ITransactionFileTracker.cs
@@ -1,7 +1,15 @@
+using EventStore.Core.Time;
 using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Core.TransactionLog;
 
 public interface ITransactionFileTracker {
-	void OnRead(ILogRecord record);
+	void OnRead(Instant start, ILogRecord record, Source source);
+
+	public enum Source {
+		Unknown,
+		Archive,
+		ChunkCache,
+		FileSystem,
+	}
 }


### PR DESCRIPTION
- chunk readers are spending their time in a hot path where the buffer size directly affects read throughput.
- the current local buffer is much smaller than the restored upstream setting, which makes scavenge-heavy read workloads pay extra overhead for no benefit.
- restoring the larger buffer keeps chunk reads closer to the expected throughput profile without changing read semantics.