### PR TITLE
fix(config): reject unsafe hard-delete archivers

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsValidatorTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsValidatorTests.cs
@@ -40,4 +40,27 @@ public class ClusterVNodeOptionsValidatorTests
 			Assert.Throws<InvalidConfigurationException>(When);
 		}
 	}
+
+	[Fact]
+	public void archiver_not_compatible_with_unsafe_ignore_hard_delete()
+	{
+		var options = new ClusterVNodeOptions
+		{
+			Cluster = new()
+			{
+				Archiver = true,
+				ClusterSize = 3,
+				ReadOnlyReplica = true,
+			},
+			Database = new()
+			{
+				UnsafeIgnoreHardDelete = true,
+			}
+		};
+
+		Assert.Throws<InvalidConfigurationException>(() =>
+		{
+			ClusterVNodeOptionsValidator.Validate(options);
+		});
+	}
 }

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
@@ -94,6 +94,11 @@ public static class ClusterVNodeOptionsValidator {
 			throw new InvalidConfigurationException(
 				"Only Read Only Replica nodes can be Archivers.");
 		}
+
+		if (options.Cluster.Archiver && options.Database.UnsafeIgnoreHardDelete) {
+			throw new InvalidConfigurationException(
+				"The Archiving feature is not compatible with UnsafeIgnoreHardDelete.");
+		}
 	}
 
 	public static bool ValidateForStartup(ClusterVNodeOptions options) {


### PR DESCRIPTION
- archiving currently keeps hard-delete tombstones around, so pairing it with UnsafeIgnoreHardDelete creates an unsafe configuration rather than a valid cleanup path.
- rejecting that combination at startup makes the incompatibility explicit before it can shape archive state in a misleading way.
- this keeps archiver behavior aligned with the guarantees the current archive/scavenge pipeline can actually uphold.