### PR TITLE
fix(storage): avoid stale cached raw chunk reads

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
@@ -1,5 +1,8 @@
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Core.Tests.Transforms.WithHeader;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog;
@@ -98,6 +101,38 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
 			Assert.IsTrue(result.IsEOF);
 			Assert.AreEqual(4096, result.BytesRead); //does not includes header and footer space
+		}
+
+		chunk.MarkForDeletion();
+		chunk.WaitForDestroy(5000);
+	}
+
+	[Test]
+	public async Task a_raw_read_on_completed_transformed_chunk_falls_back_from_stale_cache()
+	{
+		var chunk = await TFChunk.CreateNew(
+			GetFilePathFor("file1"),
+			2000,
+			0,
+			0,
+			isScavenged: false,
+			inMem: false,
+			unbuffered: false,
+			writethrough: false,
+			reduceFileCachePressure: false,
+			tracker: new TFChunkTracker.NoOp(),
+			transformFactory: new WithHeaderChunkTransformFactory(),
+			token: CancellationToken.None);
+		await chunk.Complete(CancellationToken.None);
+
+		using (var reader = chunk.AcquireRawReader())
+		{
+			Assert.IsFalse(reader.IsMemory);
+
+			var buffer = new byte[1024];
+			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
+			Assert.IsFalse(result.IsEOF);
+			Assert.Greater(result.BytesRead, 0);
 		}
 
 		chunk.MarkForDeletion();

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -1567,6 +1567,12 @@ public partial class TFChunk : IDisposable
 			return false;
 		}
 
+		if (raw && IsReadOnly && !_cachedDataTransformed)
+		{
+			reader = null;
+			return false;
+		}
+
 		if (_cachedData is 0)
 			throw new Exception("Unexpected error: a cached chunk had no cached data");
 


### PR DESCRIPTION
- completed transformed chunks need raw reads to reflect the completed on-disk shape, not an older in-memory cache snapshot captured before completion.
- falling back away from that stale cache keeps raw bulk reads aligned with the read-only chunk state instead of returning an outdated memory-backed view.
- this closes a narrow cache-state bug without changing this repo's existing support for raw reads on active chunks.