### PR TITLE
fix(messages): keep invalid empty-stream metadata writes out of storage

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Messages/ClientMessageTests/WriteEventsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Messages/ClientMessageTests/WriteEventsTests.cs
@@ -1,0 +1,45 @@
+using System;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Messages.ClientMessageTests;
+
+public class WriteEventsTests
+{
+	private static ClientMessage.WriteEvents CreateSut(
+		string eventStreamId = "normal",
+		long expectedVersion = default) =>
+		new(
+			internalCorrId: Guid.NewGuid(),
+			correlationId: Guid.NewGuid(),
+			envelope: new NoopEnvelope(),
+			requireLeader: false,
+			eventStreamId: eventStreamId,
+			expectedVersion: expectedVersion,
+			events: [],
+			user: default);
+
+	[Theory]
+	[InlineData("normal")]
+	[InlineData("  not normal  ")]
+	[InlineData("$$normal")]
+	public void accepts_valid_stream_ids(string streamId)
+	{
+		CreateSut(eventStreamId: streamId);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("$$")]
+	public void rejects_invalid_stream_ids(string streamId)
+	{
+		var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
+		{
+			CreateSut(eventStreamId: streamId);
+		});
+
+		Assert.Equal("eventStreamId", ex.ParamName);
+	}
+}

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -202,7 +202,8 @@ public static partial class ClientMessage
 			IReadOnlyDictionary<string, string> tokens = null, CancellationToken cancellationToken = default)
 			: base(internalCorrId, correlationId, envelope, requireLeader, user, tokens)
 		{
-			Ensure.NotNullOrEmpty(eventStreamId, "eventStreamId");
+			if (SystemStreams.IsInvalidStream(eventStreamId))
+				throw new ArgumentOutOfRangeException(nameof(eventStreamId));
 			if (expectedVersion < Data.ExpectedVersion.StreamExists ||
 			    expectedVersion == Data.ExpectedVersion.Invalid)
 				throw new ArgumentOutOfRangeException(nameof(expectedVersion));

--- a/src/EventStore.Core/Services/SystemNames.cs
+++ b/src/EventStore.Core/Services/SystemNames.cs
@@ -35,6 +35,9 @@ namespace EventStore.Core.Services {
 
 		public static bool IsSystemStream(string streamId) => streamId is ['$', ..];
 
+		public static bool IsInvalidStream(string streamId) =>
+			string.IsNullOrEmpty(streamId) || streamId == "$$";
+
 		public static string MetastreamOf(string streamId) {
 			return "$$" + streamId;
 		}


### PR DESCRIPTION
- metadata for the empty stream is invalid, but the current write-message boundary still lets that request turn into a `83204` write
- rejecting that shape earlier keeps a bad request from reaching the storage path and avoids a node failure mode it should never have to process
- keeping the validation at the message boundary makes the rule explicit and easy to regression test