### PR TITLE
fix(archiver): avoid re-archiving remote switched chunks

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiverServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiverServiceTests.cs
@@ -32,14 +32,15 @@ public class ArchiverServiceTests {
 		return (service, archive);
 	}
 
-	private static ChunkInfo GetChunkInfo(int chunkStartNumber, int chunkEndNumber, bool complete = true) {
+	private static ChunkInfo GetChunkInfo(int chunkStartNumber, int chunkEndNumber, bool complete = true, bool remote = false) {
 		return new ChunkInfo {
 			ChunkStartNumber = chunkStartNumber,
 			ChunkEndNumber = chunkEndNumber,
 			ChunkStartPosition = (long) chunkStartNumber * ChunkSize,
 			ChunkEndPosition = (long) (chunkEndNumber + 1) * ChunkSize,
 			IsCompleted = complete,
-			ChunkFileName = $"{chunkStartNumber}-{chunkEndNumber}"
+			ChunkFileName = $"{chunkStartNumber}-{chunkEndNumber}",
+			IsRemote = remote
 		};
 	}
 
@@ -131,6 +132,19 @@ public class ArchiverServiceTests {
 		await WaitFor(archive, numStores: 1);
 
 		Assert.Equal(["0-0.renamed"], archive.Chunks);
+	}
+
+	[Fact]
+	public async Task doesnt_archive_a_remote_switched_chunk() {
+		var (sut, archive) = CreateSut();
+
+		var chunkInfo = GetChunkInfo(0, 0, complete: true, remote: true);
+		sut.Handle(new ReplicationTrackingMessage.ReplicatedTo(0));
+		sut.Handle(new SystemMessage.ChunkSwitched(chunkInfo));
+
+		await WaitFor(archive, numStores: 0);
+
+		Assert.Equal([], archive.Chunks);
 	}
 
 	[Fact]

--- a/src/EventStore.Core/Data/ChunkInfo.cs
+++ b/src/EventStore.Core/Data/ChunkInfo.cs
@@ -8,4 +8,5 @@ public record ChunkInfo
 	public long ChunkStartPosition;
 	public long ChunkEndPosition;
 	public bool IsCompleted;
+	public bool IsRemote;
 }

--- a/src/EventStore.Core/Services/Archive/Archiver/ArchiverService.cs
+++ b/src/EventStore.Core/Services/Archive/Archiver/ArchiverService.cs
@@ -97,6 +97,9 @@ public class ArchiverService :
 
 	public void Handle(SystemMessage.ChunkSwitched message)
 	{
+		if (message.ChunkInfo.IsRemote)
+			return;
+
 		ScheduleChunkForArchiving(message.ChunkInfo, "changed");
 	}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -96,7 +96,8 @@ public partial class TFChunk : IDisposable
 			ChunkEndNumber = _chunkHeader.ChunkEndNumber,
 			ChunkStartPosition = _chunkHeader.ChunkStartPosition,
 			ChunkEndPosition = _chunkHeader.ChunkEndPosition,
-			IsCompleted = IsReadOnly
+			IsCompleted = IsReadOnly,
+			IsRemote = IsRemote
 		};
 	}
 


### PR DESCRIPTION
- a switched chunk that is already remote should not be queued for archiving again
- skipping that case keeps the archiver focused on local work it still needs to move and avoids unnecessary archive activity after chunk switches
- carrying the remote flag through chunk metadata makes the decision explicit at the point where the archiver receives the switch event