### PR TITLE
fix(config): reject incomplete archive configuration

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveOptionsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveOptionsTests.cs
@@ -1,0 +1,206 @@
+using System;
+using EventStore.Common.Exceptions;
+using EventStore.Core.Services.Archive;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.Archive;
+
+public class ArchiveOptionsTests
+{
+	[Fact]
+	public void disabled_archive_does_not_require_settings()
+	{
+		var sut = new ArchiveOptions();
+
+		sut.Validate();
+	}
+
+	[Fact]
+	public void enabled_archive_requires_storage_type()
+	{
+		var sut = new ArchiveOptions {
+			Enabled = true,
+			RetainAtLeast = new() {
+				Days = 7,
+				LogicalBytes = 1024,
+			},
+		};
+
+		var ex = Assert.Throws<InvalidConfigurationException>(sut.Validate);
+
+		Assert.Contains("StorageType", ex.Message);
+	}
+
+	[Fact]
+	public void filesystem_archive_requires_path()
+	{
+		var sut = new ArchiveOptions {
+			Enabled = true,
+			StorageType = StorageType.FileSystem,
+			RetainAtLeast = new() {
+				Days = 7,
+				LogicalBytes = 1024,
+			},
+		};
+
+		var ex = Assert.Throws<InvalidConfigurationException>(sut.Validate);
+
+		Assert.Contains("Archive configuration", ex.Message);
+		Assert.Contains("Path", ex.Message);
+	}
+
+	[Fact]
+	public void s3_archive_requires_bucket()
+	{
+		var sut = new ArchiveOptions {
+			Enabled = true,
+			StorageType = StorageType.S3,
+			S3 = new() {
+				Region = "us-east-1",
+			},
+			RetainAtLeast = new() {
+				Days = 7,
+				LogicalBytes = 1024,
+			},
+		};
+
+		var ex = Assert.Throws<InvalidConfigurationException>(sut.Validate);
+
+		Assert.Contains("Bucket", ex.Message);
+	}
+
+	[Fact]
+	public void s3_archive_requires_region()
+	{
+		var sut = new ArchiveOptions {
+			Enabled = true,
+			StorageType = StorageType.S3,
+			S3 = new() {
+				Bucket = "bucket",
+			},
+			RetainAtLeast = new() {
+				Days = 7,
+				LogicalBytes = 1024,
+			},
+		};
+
+		var ex = Assert.Throws<InvalidConfigurationException>(sut.Validate);
+
+		Assert.Contains("Region", ex.Message);
+	}
+
+	[Fact]
+	public void retention_requires_days()
+	{
+		var sut = new ArchiveOptions {
+			Enabled = true,
+			StorageType = StorageType.FileSystem,
+			FileSystem = new() {
+				Path = "/tmp/archive",
+			},
+			RetainAtLeast = new() {
+				LogicalBytes = 1024,
+			},
+		};
+
+		var ex = Assert.Throws<InvalidConfigurationException>(sut.Validate);
+
+		Assert.Contains("Days", ex.Message);
+	}
+
+	[Fact]
+	public void retention_requires_logical_bytes()
+	{
+		var sut = new ArchiveOptions {
+			Enabled = true,
+			StorageType = StorageType.FileSystem,
+			FileSystem = new() {
+				Path = "/tmp/archive",
+			},
+			RetainAtLeast = new() {
+				Days = 7,
+			},
+		};
+
+		var ex = Assert.Throws<InvalidConfigurationException>(sut.Validate);
+
+		Assert.Contains("LogicalBytes", ex.Message);
+	}
+
+	[Fact]
+	public void retention_rejects_negative_days()
+	{
+		var sut = new ArchiveOptions {
+			Enabled = true,
+			StorageType = StorageType.FileSystem,
+			FileSystem = new() {
+				Path = "/tmp/archive",
+			},
+			RetainAtLeast = new() {
+				Days = -1,
+				LogicalBytes = 1024,
+			},
+		};
+
+		var ex = Assert.Throws<InvalidConfigurationException>(sut.Validate);
+
+		Assert.Contains("Days", ex.Message);
+	}
+
+	[Fact]
+	public void retention_rejects_days_above_timespan_limit()
+	{
+		var sut = new ArchiveOptions {
+			Enabled = true,
+			StorageType = StorageType.FileSystem,
+			FileSystem = new() {
+				Path = "/tmp/archive",
+			},
+			RetainAtLeast = new() {
+				Days = TimeSpan.MaxValue.Days + 1L,
+				LogicalBytes = 1024,
+			},
+		};
+
+		var ex = Assert.Throws<InvalidConfigurationException>(sut.Validate);
+
+		Assert.Contains("Days", ex.Message);
+	}
+
+	[Fact]
+	public void retention_rejects_negative_logical_bytes()
+	{
+		var sut = new ArchiveOptions {
+			Enabled = true,
+			StorageType = StorageType.FileSystem,
+			FileSystem = new() {
+				Path = "/tmp/archive",
+			},
+			RetainAtLeast = new() {
+				Days = 7,
+				LogicalBytes = -1,
+			},
+		};
+
+		var ex = Assert.Throws<InvalidConfigurationException>(sut.Validate);
+
+		Assert.Contains("LogicalBytes", ex.Message);
+	}
+
+	[Fact]
+	public void unknown_storage_type_is_rejected()
+	{
+		var sut = new ArchiveOptions {
+			Enabled = true,
+			StorageType = (StorageType)999,
+			RetainAtLeast = new() {
+				Days = 7,
+				LogicalBytes = 1024,
+			},
+		};
+
+		var ex = Assert.Throws<InvalidConfigurationException>(sut.Validate);
+
+		Assert.Contains("Unknown StorageType", ex.Message);
+	}
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -276,6 +276,7 @@ public class ClusterVNode<TStreamId> :
 #endif
 
 		var archiveOptions = configuration.GetSection("EventStore:Archive").Get<ArchiveOptions>() ?? new();
+		archiveOptions.Validate();
 
 		var disableInternalTcpTls = options.Application.Insecure;
 		var disableExternalTcpTls = options.Application.Insecure;

--- a/src/EventStore.Core/Services/Archive/ArchiveOptions.cs
+++ b/src/EventStore.Core/Services/Archive/ArchiveOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using EventStore.Common.Exceptions;
 
 namespace EventStore.Core.Services.Archive;
 
@@ -9,6 +10,30 @@ public class ArchiveOptions
 	public FileSystemOptions FileSystem { get; init; } = new();
 	public S3Options S3 { get; init; } = new();
 	public RetentionOptions RetainAtLeast { get; init; } = new();
+
+	public void Validate() {
+		try {
+			if (!Enabled)
+				return;
+
+			switch (StorageType) {
+				case StorageType.Unspecified:
+					throw new InvalidConfigurationException("Please specify an Archive StorageType");
+				case StorageType.FileSystem:
+					FileSystem.Validate();
+					break;
+				case StorageType.S3:
+					S3.Validate();
+					break;
+				default:
+					throw new InvalidConfigurationException("Unknown StorageType");
+			}
+
+			RetainAtLeast.Validate();
+		} catch (InvalidConfigurationException ex) {
+			throw new InvalidConfigurationException($"Archive configuration: {ex.Message}", ex);
+		}
+	}
 }
 
 public enum StorageType
@@ -22,11 +47,28 @@ public class RetentionOptions
 {
 	public long Days { get; init; } = TimeSpan.MaxValue.Days;
 	public long LogicalBytes { get; init; } = long.MaxValue;
+
+	public void Validate() {
+		if (Days == TimeSpan.MaxValue.Days)
+			throw new InvalidConfigurationException("Please specify a value for Days to retain");
+		if (Days < 0 || Days > TimeSpan.MaxValue.Days)
+			throw new InvalidConfigurationException($"Days must be between 0 and {TimeSpan.MaxValue.Days}");
+
+		if (LogicalBytes == long.MaxValue)
+			throw new InvalidConfigurationException("Please specify a value for LogicalBytes to retain");
+		if (LogicalBytes < 0)
+			throw new InvalidConfigurationException("LogicalBytes must be greater than or equal to 0");
+	}
 }
 
 public class FileSystemOptions
 {
 	public string Path { get; init; } = "";
+
+	public void Validate() {
+		if (string.IsNullOrWhiteSpace(Path))
+			throw new InvalidConfigurationException("Please provide a Path for the FileSystem archive");
+	}
 }
 
 public class S3Options
@@ -34,4 +76,12 @@ public class S3Options
 	public string AwsCliProfileName { get; init; } = "default";
 	public string Bucket { get; init; } = "";
 	public string Region { get; init; } = "";
+
+	public void Validate() {
+		if (string.IsNullOrWhiteSpace(Bucket))
+			throw new InvalidConfigurationException("Please provide a Bucket for the S3 archive");
+
+		if (string.IsNullOrWhiteSpace(Region))
+			throw new InvalidConfigurationException("Please provide a Region for the S3 archive");
+	}
 }


### PR DESCRIPTION
- archive startup should fail with configuration-specific errors when required archive settings are missing instead of waiting for deeper archive components to fail later
- incomplete archive settings are easiest to diagnose at the binding boundary, where the configuration context is still clear
- retention settings and storage-specific fields should be validated consistently so archive-enabled nodes do not start from half-configured state