### PR TITLE
fix(storage): avoid shutdown failures during queue cancellation

### DIFF
--- a/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
+++ b/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
@@ -127,12 +127,13 @@ public abstract class when_stopping_queued_handler : QueuedHandlerTestWithNoopCo
 
 		try
 		{
-			queue.Start();
+			var startTask = queue.Start();
 			queue.Publish(new TestMessage());
 
 			Assert.IsTrue(started.Wait(5000), "Consumer never started handling the message.");
 			Assert.DoesNotThrow(() => queue.Stop());
 			Assert.IsTrue(cancelled.Wait(5000), "Consumer never observed queue cancellation.");
+			Assert.That(startTask.IsCanceled, Is.True, "Queue lifecycle task should be cancelled after stop.");
 		}
 		finally
 		{

--- a/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
+++ b/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests.Bus.Helpers;
@@ -95,6 +96,56 @@ public abstract class when_stopping_queued_handler : QueuedHandlerTestWithNoopCo
 			waitHandle.Dispose();
 			handledEvent.Dispose();
 			consumer.Dispose();
+		}
+	}
+
+	[Test]
+	public void while_processing_message_cancelled_by_queue_stop_should_not_timeout()
+	{
+		var started = new ManualResetEventSlim(false);
+		var cancelled = new ManualResetEventSlim(false);
+		var queue = new QueuedHandlerThreadPool(
+			new AdHocHandler<Message>(async (_, token) =>
+			{
+				started.Set();
+
+				try
+				{
+					await Task.Delay(Timeout.Infinite, token);
+				}
+				catch (OperationCanceledException ex) when (ex.CancellationToken == token)
+				{
+					cancelled.Set();
+					throw;
+				}
+			}),
+			"cancelled_test_queue",
+			new QueueStatsManager(),
+			new(),
+			watchSlowMsg: false,
+			threadStopWaitTimeout: TimeSpan.FromMilliseconds(500));
+
+		try
+		{
+			queue.Start();
+			queue.Publish(new TestMessage());
+
+			Assert.IsTrue(started.Wait(5000), "Consumer never started handling the message.");
+			Assert.DoesNotThrow(() => queue.Stop());
+			Assert.IsTrue(cancelled.Wait(5000), "Consumer never observed queue cancellation.");
+		}
+		finally
+		{
+			try
+			{
+				queue.Stop();
+			}
+			catch (TimeoutException)
+			{
+			}
+
+			started.Dispose();
+			cancelled.Dispose();
 		}
 	}
 }

--- a/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
@@ -161,6 +161,7 @@ namespace EventStore.Core.Bus;
 
 							_queueStats.ProcessingEnded(1);
 						} catch (OperationCanceledException ex) when (ex.CancellationToken == _lifetimeToken) {
+							_tcs.TrySetCanceled(ex.CancellationToken);
 							break;
 						} catch (Exception ex) {
 							Log.Error(ex,

--- a/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
@@ -91,10 +91,14 @@ namespace EventStore.Core.Bus;
 
 		public void Stop() {
 			Cancel();
-			if (!_stopped.Wait(_threadStopWaitTimeout))
-				throw new TimeoutException(string.Format("Unable to stop thread '{0}'.", Name));
+			WaitForStop();
 			TryStopQueueStats();
 			_queueMonitor.Unregister(this);
+		}
+
+		public void WaitForStop() {
+			if (!_stopped.Wait(_threadStopWaitTimeout))
+				throw new TimeoutException(string.Format("Unable to stop thread '{0}'.", Name));
 		}
 
 		public void RequestStop() {
@@ -156,6 +160,8 @@ namespace EventStore.Core.Bus;
 							}
 
 							_queueStats.ProcessingEnded(1);
+						} catch (OperationCanceledException ex) when (ex.CancellationToken == _lifetimeToken) {
+							break;
 						} catch (Exception ex) {
 							Log.Error(ex,
 								"Error while processing message {message} in queued handler '{queue}'.", msg,

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -60,7 +60,7 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 	protected readonly IEpochManager EpochManager;
 	protected readonly IPublisher Bus;
 	private readonly ISubscriber _subscribeToBus;
-	protected readonly IQueuedHandler StorageWriterQueue;
+	private readonly QueuedHandlerThreadPool _writerQueue;
 	private readonly InMemoryBus _writerBus;
 
 	private readonly Clock _clock = Clock.Instance;
@@ -143,7 +143,7 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 		Writer = writer;
 
 		_writerBus = new InMemoryBus("StorageWriterBus", watchSlowMsg: false);
-		StorageWriterQueue = new QueuedHandlerThreadPool(new AdHocHandler<Message>(CommonHandle),
+		_writerQueue = new QueuedHandlerThreadPool(new AdHocHandler<Message>(CommonHandle),
 			"StorageWriterQueue",
 			queueStatsManager,
 			queueTrackers,
@@ -165,7 +165,7 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 	public void Start()
 	{
 		Writer.Open();
-		_tasks.Add(StorageWriterQueue.Start());
+		_tasks.Add(_writerQueue.Start());
 	}
 
 	protected void SubscribeToMessage<T>() where T : Message
@@ -179,13 +179,12 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 		if (message is StorageMessage.IFlushableMessage)
 			Interlocked.Increment(ref FlushMessagesInQueue);
 
-		StorageWriterQueue.Publish(message);
+		_writerQueue.Publish(message);
 
 		if (message is SystemMessage.BecomeShuttingDown)
-			// we need to handle this message on main thread to stop StorageWriterQueue
 		{
-			StorageWriterQueue.Stop();
-			BlockWriter = true;
+			// Waiting here keeps the queue from trying to stop itself while it drains shutdown work.
+			_writerQueue.WaitForStop();
 			Bus.Publish(new SystemMessage.ServiceShutdown("StorageWriter"));
 		}
 	}
@@ -244,6 +243,8 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 			case VNodeState.ShuttingDown:
 			{
 				await Writer.Flush(token);
+				_writerQueue.RequestStop();
+				BlockWriter = true;
 				break;
 			}
 		}

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -180,13 +180,6 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 			Interlocked.Increment(ref FlushMessagesInQueue);
 
 		_writerQueue.Publish(message);
-
-		if (message is SystemMessage.BecomeShuttingDown)
-		{
-			// Waiting here keeps the queue from trying to stop itself while it drains shutdown work.
-			_writerQueue.WaitForStop();
-			Bus.Publish(new SystemMessage.ServiceShutdown("StorageWriter"));
-		}
 	}
 
 	private async ValueTask CommonHandle(Message message, CancellationToken token)
@@ -245,6 +238,7 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 				await Writer.Flush(token);
 				_writerQueue.RequestStop();
 				BlockWriter = true;
+				Bus.Publish(new SystemMessage.ServiceShutdown("StorageWriter"));
 				break;
 			}
 		}


### PR DESCRIPTION
- Prevents expected shutdown cancellation from being treated like a storage-writer fault.
- Keeps queue-drain shutdown from timing out when a handler observes the queue lifetime token mid-dispatch.
- Locks in the shutdown expectation with a focused regression test so future queue changes do not reopen the failure mode.