### PR TITLE
fix(shutdown): avoid waiting on services that never started

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -229,7 +229,7 @@ internal static class Program
 							.Configure<KestrelServerOptions>(configuration.GetSection("Kestrel"))
 							.Configure<HostOptions>(x =>
 							{
-								x.ShutdownTimeout = TimeSpan.FromSeconds(5);
+								x.ShutdownTimeout = ClusterVNode.ShutdownTimeout + TimeSpan.FromSeconds(1);
 #if DEBUG
 								x.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.StopHost;
 #endif

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_leader_replication_service_faults.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_leader_replication_service_faults.cs
@@ -23,7 +23,9 @@ public class when_leader_replication_service_faults : SpecificationWithDirectory
 		var publisher = new SynchronousScheduler("publisher");
 		var shutdowns = new ConcurrentQueue<SystemMessage.ServiceShutdown>();
 		var initializations = new ConcurrentQueue<SystemMessage.ServiceInitialized>();
-		var writerCheckpoint = new ThrowingCheckpoint(Checkpoint.Writer);
+		var writerCheckpoint = new FaultingCheckpoint(Checkpoint.Writer) {
+			ThrowOnFlushedSubscription = true
+		};
 		var dbConfig = CreateDbConfig(writerCheckpoint);
 		var leaderId = Guid.NewGuid();
 
@@ -57,8 +59,6 @@ public class when_leader_replication_service_faults : SpecificationWithDirectory
 			service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			AssertEx.IsOrBecomesTrue(() => initializations.Count == 1, TimeSpan.FromSeconds(5));
-
-			writerCheckpoint.ThrowOnRead = true;
 
 			AssertEx.IsOrBecomesTrue(() => service.Task.IsFaulted, TimeSpan.FromSeconds(5));
 			AssertEx.IsOrBecomesTrue(() => shutdowns.Count == 1, TimeSpan.FromSeconds(5));
@@ -95,19 +95,17 @@ public class when_leader_replication_service_faults : SpecificationWithDirectory
 			inMemDb: true);
 	}
 
-	private sealed class ThrowingCheckpoint(string name, long initialValue = 0) : ICheckpoint
+	private sealed class FaultingCheckpoint(string name, long initialValue = 0) : ICheckpoint
 	{
 		private long _last = initialValue;
 		private long _lastFlushed = initialValue;
+		private Action<long> _flushed;
 
-		public bool ThrowOnRead { get; set; }
+		public bool ThrowOnFlushedSubscription { get; set; }
 		public string Name => name;
 
 		public long Read()
 		{
-			if (ThrowOnRead)
-				throw new InvalidOperationException("writer checkpoint read failed");
-
 			return _lastFlushed;
 		}
 
@@ -124,10 +122,23 @@ public class when_leader_replication_service_faults : SpecificationWithDirectory
 				return;
 
 			_lastFlushed = _last;
-			Flushed?.Invoke(_lastFlushed);
+			_flushed?.Invoke(_lastFlushed);
 		}
 
-		public event Action<long> Flushed;
+		public event Action<long> Flushed
+		{
+			add
+			{
+				if (ThrowOnFlushedSubscription)
+					throw new InvalidOperationException("writer checkpoint subscription failed");
+
+				_flushed += value;
+			}
+			remove
+			{
+				_flushed -= value;
+			}
+		}
 
 		public void Close(bool flush)
 		{

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_leader_replication_service_faults.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_leader_replication_service_faults.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.Monitoring.Stats;
+using EventStore.Core.Services.Replication;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Core.Tests.Services.ElectionsService;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Replication.LeaderReplication;
+
+[TestFixture]
+public class when_leader_replication_service_faults : SpecificationWithDirectory
+{
+	[Test]
+	public async Task publishes_service_shutdown_after_service_initialized()
+	{
+		var publisher = new SynchronousScheduler("publisher");
+		var shutdowns = new ConcurrentQueue<SystemMessage.ServiceShutdown>();
+		var initializations = new ConcurrentQueue<SystemMessage.ServiceInitialized>();
+		var writerCheckpoint = new ThrowingCheckpoint(Checkpoint.Writer);
+		var dbConfig = CreateDbConfig(writerCheckpoint);
+		var leaderId = Guid.NewGuid();
+
+		publisher.Subscribe(new AdHocHandler<SystemMessage.ServiceInitialized>(message =>
+		{
+			if (message.ServiceName == "Leader Replication Service")
+				initializations.Enqueue(message);
+		}));
+		publisher.Subscribe(new AdHocHandler<SystemMessage.ServiceShutdown>(message =>
+		{
+			if (message.ServiceName == "Leader Replication Service")
+				shutdowns.Enqueue(message);
+		}));
+
+		var db = new TFChunkDb(dbConfig);
+		try
+		{
+			await db.Open();
+
+			var service = new LeaderReplicationService(
+				publisher,
+				leaderId,
+				db,
+				new SynchronousScheduler("tcpSend"),
+				new FakeEpochManager(),
+				clusterSize: 3,
+				unsafeAllowSurplusNodes: false,
+				new QueueStatsManager());
+
+			service.Handle(new SystemMessage.SystemStart());
+			service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+
+			AssertEx.IsOrBecomesTrue(() => initializations.Count == 1, TimeSpan.FromSeconds(5));
+
+			writerCheckpoint.ThrowOnRead = true;
+
+			AssertEx.IsOrBecomesTrue(() => service.Task.IsFaulted, TimeSpan.FromSeconds(5));
+			AssertEx.IsOrBecomesTrue(() => shutdowns.Count == 1, TimeSpan.FromSeconds(5));
+		}
+		finally
+		{
+			await db.DisposeAsync();
+		}
+	}
+
+	private TFChunkDbConfig CreateDbConfig(ICheckpoint writerCheckpoint)
+	{
+		ICheckpoint chaserCheckpoint = new InMemoryCheckpoint(Checkpoint.Chaser);
+		ICheckpoint epochCheckpoint = new InMemoryCheckpoint(Checkpoint.Epoch, initValue: -1);
+		ICheckpoint proposalCheckpoint = new InMemoryCheckpoint(Checkpoint.Proposal, initValue: -1);
+		ICheckpoint truncateCheckpoint = new InMemoryCheckpoint(Checkpoint.Truncate, initValue: -1);
+		ICheckpoint replicationCheckpoint = new InMemoryCheckpoint(-1);
+		ICheckpoint indexCheckpoint = new InMemoryCheckpoint(-1);
+		ICheckpoint streamExistenceFilterCheckpoint = new InMemoryCheckpoint(-1);
+
+		return new TFChunkDbConfig(
+			PathName,
+			new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
+			chunkSize: 1000,
+			maxChunksCacheSize: 10000,
+			writerCheckpoint,
+			chaserCheckpoint,
+			epochCheckpoint,
+			proposalCheckpoint,
+			truncateCheckpoint,
+			replicationCheckpoint,
+			indexCheckpoint,
+			streamExistenceFilterCheckpoint,
+			inMemDb: true);
+	}
+
+	private sealed class ThrowingCheckpoint(string name, long initialValue = 0) : ICheckpoint
+	{
+		private long _last = initialValue;
+		private long _lastFlushed = initialValue;
+
+		public bool ThrowOnRead { get; set; }
+		public string Name => name;
+
+		public long Read()
+		{
+			if (ThrowOnRead)
+				throw new InvalidOperationException("writer checkpoint read failed");
+
+			return _lastFlushed;
+		}
+
+		public long ReadNonFlushed() => _last;
+
+		public void Write(long checkpoint)
+		{
+			_last = checkpoint;
+		}
+
+		public void Flush()
+		{
+			if (_last == _lastFlushed)
+				return;
+
+			_lastFlushed = _last;
+			Flushed?.Invoke(_lastFlushed);
+		}
+
+		public event Action<long> Flushed;
+
+		public void Close(bool flush)
+		{
+			if (flush)
+				Flush();
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Transport/Http/http_service_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/http_service_should.cs
@@ -89,10 +89,18 @@ public class kestrel_http_service_should
 		sut.Handle(new SystemMessage.SystemInit());
 		inputBus.PublishedMessages.Clear();
 
-		sut.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), exitProcess: false, shutdownHttp: false));
+		try
+		{
+			sut.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), exitProcess: false, shutdownHttp: false));
 
-		Assert.That(inputBus.PublishedMessages.OfType<SystemMessage.ServiceShutdown>(), Has.Exactly(1).Items);
-		Assert.That(sut.IsListening, Is.True);
+			var shutdownMessage = inputBus.PublishedMessages.OfType<SystemMessage.ServiceShutdown>().Single();
+			Assert.That(shutdownMessage.ServiceName, Is.EqualTo("HttpServer [127.0.0.1:2113]"));
+			Assert.That(sut.IsListening, Is.True);
+		}
+		finally
+		{
+			sut.Shutdown();
+		}
 	}
 
 	[Test]
@@ -115,7 +123,8 @@ public class kestrel_http_service_should
 
 		sut.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), exitProcess: false, shutdownHttp: true));
 
-		Assert.That(inputBus.PublishedMessages.OfType<SystemMessage.ServiceShutdown>(), Has.Exactly(1).Items);
+		var shutdownMessage = inputBus.PublishedMessages.OfType<SystemMessage.ServiceShutdown>().Single();
+		Assert.That(shutdownMessage.ServiceName, Is.EqualTo("HttpServer [127.0.0.1:2113]"));
 		Assert.That(sut.IsListening, Is.False);
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Transport/Http/http_service_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/http_service_should.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using EventStore.Core.Messages;
+using EventStore.Core.Services.Transport.Http;
+using EventStore.Core.Tests.Bus.Helpers;
 using EventStore.Core.Tests.Helpers;
 using NUnit.Framework;
 using HttpStatusCode = System.Net.HttpStatusCode;
@@ -61,6 +65,56 @@ public class http_service_should : SpecificationWithDirectory
 
 		Assert.AreEqual(HttpStatusCode.NotFound, result.StatusCode);
 		Assert.IsEmpty(await result.Content.ReadAsStringAsync());
+	}
+}
+
+[TestFixture]
+public class kestrel_http_service_should
+{
+	[Test]
+	public void not_publish_service_shutdown_when_http_shutdown_is_disabled()
+	{
+		var inputBus = new FakeQueuedHandler();
+		var sut = new KestrelHttpService(
+			ServiceAccessibility.Public,
+			inputBus,
+			new TrieUriRouter(),
+			multiQueuedHandler: null,
+			logHttpRequests: false,
+			advertiseAsHost: "127.0.0.1",
+			advertiseAsPort: 2113,
+			disableAuthorization: false,
+			new IPEndPoint(IPAddress.Loopback, 2113));
+
+		sut.Handle(new SystemMessage.SystemInit());
+		inputBus.PublishedMessages.Clear();
+
+		sut.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), exitProcess: false, shutdownHttp: false));
+
+		Assert.That(inputBus.PublishedMessages.OfType<SystemMessage.ServiceShutdown>(), Is.Empty);
+	}
+
+	[Test]
+	public void publish_service_shutdown_when_http_shutdown_is_enabled()
+	{
+		var inputBus = new FakeQueuedHandler();
+		var sut = new KestrelHttpService(
+			ServiceAccessibility.Public,
+			inputBus,
+			new TrieUriRouter(),
+			multiQueuedHandler: null,
+			logHttpRequests: false,
+			advertiseAsHost: "127.0.0.1",
+			advertiseAsPort: 2113,
+			disableAuthorization: false,
+			new IPEndPoint(IPAddress.Loopback, 2113));
+
+		sut.Handle(new SystemMessage.SystemInit());
+		inputBus.PublishedMessages.Clear();
+
+		sut.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), exitProcess: false, shutdownHttp: true));
+
+		Assert.That(inputBus.PublishedMessages.OfType<SystemMessage.ServiceShutdown>(), Has.Exactly(1).Items);
 	}
 }
 

--- a/src/EventStore.Core.Tests/Services/Transport/Http/http_service_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/http_service_should.cs
@@ -72,7 +72,7 @@ public class http_service_should : SpecificationWithDirectory
 public class kestrel_http_service_should
 {
 	[Test]
-	public void not_publish_service_shutdown_when_http_shutdown_is_disabled()
+	public void publish_service_shutdown_without_stopping_http_when_http_shutdown_is_disabled()
 	{
 		var inputBus = new FakeQueuedHandler();
 		var sut = new KestrelHttpService(
@@ -91,7 +91,8 @@ public class kestrel_http_service_should
 
 		sut.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), exitProcess: false, shutdownHttp: false));
 
-		Assert.That(inputBus.PublishedMessages.OfType<SystemMessage.ServiceShutdown>(), Is.Empty);
+		Assert.That(inputBus.PublishedMessages.OfType<SystemMessage.ServiceShutdown>(), Has.Exactly(1).Items);
+		Assert.That(sut.IsListening, Is.True);
 	}
 
 	[Test]
@@ -115,6 +116,7 @@ public class kestrel_http_service_should
 		sut.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), exitProcess: false, shutdownHttp: true));
 
 		Assert.That(inputBus.PublishedMessages.OfType<SystemMessage.ServiceShutdown>(), Has.Exactly(1).Items);
+		Assert.That(sut.IsListening, Is.False);
 	}
 }
 

--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterNodeOptionsTests/when_shutting_down_an_isolated_cluster_member.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterNodeOptionsTests/when_shutting_down_an_isolated_cluster_member.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Authentication;
 using EventStore.Core.Authentication.InternalAuthentication;
@@ -28,7 +29,16 @@ public class when_shutting_down_an_isolated_cluster_member<TLogFormat, TStreamId
 		var shutdownComplete = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 		var startedServices = new HashSet<string>();
 		var shutdownServices = new HashSet<string>();
+		var shutdownSignals = 0;
 		var logFormatFactory = LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory;
+
+		static string[] Snapshot(HashSet<string> services)
+		{
+			lock (services)
+			{
+				return services.OrderBy(x => x).ToArray();
+			}
+		}
 
 		var options = new ClusterVNodeOptions()
 			.ReduceMemoryUsageForTests()
@@ -64,7 +74,10 @@ public class when_shutting_down_an_isolated_cluster_member<TLogFormat, TStreamId
 		}));
 
 		node.MainBus.Subscribe(new AdHocHandler<SystemMessage.BecomeShutdown>(_ =>
-			shutdownComplete.TrySetResult(true)));
+		{
+			Interlocked.Increment(ref shutdownSignals);
+			shutdownComplete.TrySetResult(true);
+		}));
 
 		node.MainBus.Subscribe(new AdHocHandler<SystemMessage.ServiceShutdown>(message =>
 		{
@@ -85,11 +98,24 @@ public class when_shutting_down_an_isolated_cluster_member<TLogFormat, TStreamId
 			catch (TimeoutException)
 			{
 				await shutdownComplete.Task.WithTimeout(TimeSpan.FromSeconds(10));
+				var startedServicesSnapshot = Snapshot(startedServices);
+				var shutdownServicesSnapshot = Snapshot(shutdownServices);
 				Assert.Fail(
-					$"Shutdown timed out. Started: [{string.Join(", ", startedServices.OrderBy(x => x))}] Shutdown: [{string.Join(", ", shutdownServices.OrderBy(x => x))}]");
+					$"Shutdown timed out. Started: [{string.Join(", ", startedServicesSnapshot)}] Shutdown: [{string.Join(", ", shutdownServicesSnapshot)}]");
 			}
 
 			await shutdownComplete.Task.WithTimeout(TimeSpan.FromSeconds(5));
+
+			var completedStartedServices = Snapshot(startedServices);
+			if (completedStartedServices.Contains("Leader Replication Service"))
+			{
+				AssertEx.IsOrBecomesTrue(
+					() => Snapshot(shutdownServices).Contains("Leader Replication Service"),
+					TimeSpan.FromSeconds(1),
+					"Timed out waiting for the leader replication service to report shutdown");
+			}
+
+			Assert.That(Volatile.Read(ref shutdownSignals), Is.EqualTo(1));
 		}
 		finally
 		{

--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterNodeOptionsTests/when_shutting_down_an_isolated_cluster_member.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterNodeOptionsTests/when_shutting_down_an_isolated_cluster_member.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using EventStore.Core.Authentication;
+using EventStore.Core.Authentication.InternalAuthentication;
+using EventStore.Core.Authorization;
+using EventStore.Core.Authorization.AuthorizationPolicies;
+using EventStore.Core.Bus;
+using EventStore.Core.Certificates;
+using EventStore.Core.LogAbstraction;
+using EventStore.Core.Messages;
+using EventStore.Core.Tests;
+using EventStore.Core.Tests.Services.Transport.Tcp;
+using NUnit.Framework;
+
+namespace EventStore.Core.XUnit.Tests.Configuration.ClusterNodeOptionsTests;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+public class when_shutting_down_an_isolated_cluster_member<TLogFormat, TStreamId> : SpecificationWithDirectory
+{
+	[Test]
+	public async Task completes_without_waiting_for_services_that_never_initialized()
+	{
+		var coreServicesStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var shutdownComplete = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var startedServices = new HashSet<string>();
+		var shutdownServices = new HashSet<string>();
+		var logFormatFactory = LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory;
+
+		var options = new ClusterVNodeOptions()
+			.ReduceMemoryUsageForTests()
+			.InCluster(3)
+			.RunInMemory()
+			.Secure(new X509Certificate2Collection(ssl_connections.GetRootCertificate()),
+				ssl_connections.GetServerCertificate());
+
+		var node = new ClusterVNode<TStreamId>(options, logFormatFactory,
+			new AuthenticationProviderFactory(c =>
+				new InternalAuthenticationProviderFactory(c, options.DefaultUser)),
+			new AuthorizationProviderFactory(c => new InternalAuthorizationProviderFactory(
+				new StaticAuthorizationPolicyRegistry([new LegacyPolicySelectorFactory(
+					options.Application.AllowAnonymousEndpointAccess,
+					options.Application.AllowAnonymousStreamAccess,
+					options.Application.OverrideAnonymousEndpointAccessForGossip).Create(c.MainQueue)]))),
+			certificateProvider: new OptionsCertificateProvider());
+
+		node.MainBus.Subscribe(new AdHocHandler<SystemMessage.ServiceInitialized>(message =>
+		{
+			lock (startedServices)
+			{
+				if (!startedServices.Add(message.ServiceName))
+					return;
+
+				if (startedServices.Contains("StorageChaser")
+				    && startedServices.Contains("StorageReader")
+				    && startedServices.Contains("StorageWriter"))
+				{
+					coreServicesStarted.TrySetResult(true);
+				}
+			}
+		}));
+
+		node.MainBus.Subscribe(new AdHocHandler<SystemMessage.BecomeShutdown>(_ =>
+			shutdownComplete.TrySetResult(true)));
+
+		node.MainBus.Subscribe(new AdHocHandler<SystemMessage.ServiceShutdown>(message =>
+		{
+			lock (shutdownServices)
+			{
+				shutdownServices.Add(message.ServiceName);
+			}
+		}));
+
+		try
+		{
+			await node.StartAsync(waitUntilReady: false);
+			await coreServicesStarted.Task.WithTimeout(TimeSpan.FromSeconds(30));
+			try
+			{
+				await node.StopAsync(TimeSpan.FromSeconds(2));
+			}
+			catch (TimeoutException)
+			{
+				await shutdownComplete.Task.WithTimeout(TimeSpan.FromSeconds(10));
+				Assert.Fail(
+					$"Shutdown timed out. Started: [{string.Join(", ", startedServices.OrderBy(x => x))}] Shutdown: [{string.Join(", ", shutdownServices.OrderBy(x => x))}]");
+			}
+
+			await shutdownComplete.Task.WithTimeout(TimeSpan.FromSeconds(5));
+		}
+		finally
+		{
+			if (!shutdownComplete.Task.IsCompleted)
+				await shutdownComplete.Task.WithTimeout(TimeSpan.FromSeconds(10));
+		}
+	}
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -84,6 +84,7 @@ namespace EventStore.Core;
 public abstract class ClusterVNode
 {
 	protected static readonly ILogger Log = Serilog.Log.ForContext<ClusterVNode>();
+	public static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(6);
 
 	public static ClusterVNode<TStreamId> Create<TStreamId>(
 		ClusterVNodeOptions options,
@@ -137,8 +138,6 @@ public class ClusterVNode<TStreamId> :
 	IHandle<SystemMessage.SystemStart>,
 	IHandle<ClientMessage.ReloadConfig>
 {
-	private static readonly TimeSpan DefaultShutdownTimeout = TimeSpan.FromSeconds(5);
-
 	private readonly ClusterVNodeOptions _options;
 
 	public override TFChunkDb Db { get; }
@@ -1664,23 +1663,23 @@ public class ClusterVNode<TStreamId> :
 					"Truncate checkpoint is present. Truncate: {truncatePosition} (0x{truncatePosition:X}), Writer: {writerCheckpoint} (0x{writerCheckpoint:X}), Chaser: {chaserCheckpoint} (0x{chaserCheckpoint:X}), Epoch: {epochCheckpoint} (0x{epochCheckpoint:X})",
 					truncPos, truncPos, writerCheckpoint, writerCheckpoint, chaserCheckpoint, chaserCheckpoint,
 					epochCheckpoint, epochCheckpoint);
-				var truncator = new TFChunkDbTruncator(Db.Config,
-					type => Db.TransformManager.GetFactoryForExistingChunk(type));
-				using (var task = truncator.TruncateDb(truncPos, CancellationToken.None).AsTask()) {
-					task.Wait(DefaultShutdownTimeout);
-				}
+					var truncator = new TFChunkDbTruncator(Db.Config,
+						type => Db.TransformManager.GetFactoryForExistingChunk(type));
+					using (var task = truncator.TruncateDb(truncPos, CancellationToken.None).AsTask()) {
+						task.Wait(ShutdownTimeout);
+					}
 
 				// The truncator has moved the checkpoints but it is possible that other components in the startup have
 				// already read the old values. If we ensure all checkpoint reads are performed after the truncation
 				// then we can remove this extra restart
 				Log.Information("Truncation successful. Shutting down.");
 				var shutdownGuid = Guid.NewGuid();
-				using (var task = HandleAsync(
-					       new SystemMessage.BecomeShuttingDown(shutdownGuid, exitProcess: true, shutdownHttp: true),
-					       CancellationToken.None).AsTask())
-				{
-					task.Wait(DefaultShutdownTimeout);
-				}
+					using (var task = HandleAsync(
+						       new SystemMessage.BecomeShuttingDown(shutdownGuid, exitProcess: true, shutdownHttp: true),
+						       CancellationToken.None).AsTask())
+					{
+						task.Wait(ShutdownTimeout);
+					}
 
 				Handle(new SystemMessage.BecomeShutdown(shutdownGuid));
 				Application.Exit(0, "Shutting down after successful truncation.");
@@ -1943,15 +1942,17 @@ public class ClusterVNode<TStreamId> :
 
 		try
 		{
-			await _shutdownSource.Task.WaitAsync(timeout ?? DefaultShutdownTimeout, cancellationToken);
+			await _shutdownSource.Task.WaitAsync(timeout ?? ShutdownTimeout, cancellationToken);
 		}
 		catch (Exception)
 		{
 			Log.Error("Graceful shutdown not complete. Forcing shutdown now.");
 			throw;
 		}
-
-		_switchChunksLock?.Dispose();
+		finally
+		{
+			_switchChunksLock?.Dispose();
+		}
 	}
 
 	public async ValueTask HandleAsync(SystemMessage.BecomeShuttingDown message, CancellationToken token)

--- a/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
@@ -492,13 +492,23 @@ public class LeaderReplicationService : IMonitoredQueue,
 
 	private async void MainLoop()
 	{
+		Exception error = null;
+		var initialized = false;
+		var queueStatsStarted = false;
+		var queueRegistered = false;
+		var writerCheckpointSubscribed = false;
+
 		try
 		{
 			_publisher.Publish(new SystemMessage.ServiceInitialized(Name));
+			initialized = true;
 			_queueStats.Start();
+			queueStatsStarted = true;
 			QueueMonitor.Default.Register(this);
+			queueRegistered = true;
 
 			_db.Config.WriterCheckpoint.Flushed += OnWriterFlushed;
+			writerCheckpointSubscribed = true;
 
 			while (!_stopToken.IsCancellationRequested)
 			{
@@ -544,20 +554,42 @@ public class LeaderReplicationService : IMonitoredQueue,
 			{
 				subscription.Dispose();
 			}
-
-			_db.Config.WriterCheckpoint.Flushed -= OnWriterFlushed;
-
-			_publisher.Publish(new SystemMessage.ServiceShutdown(Name));
-			_tcs.TrySetResult();
 		}
 		catch (Exception e)
 		{
-			_tcs.TrySetException(e);
+			error = e;
 		}
 		finally
 		{
-			_queueStats.Stop();
-			QueueMonitor.Default.Unregister(this);
+			try
+			{
+				if (writerCheckpointSubscribed)
+					_db.Config.WriterCheckpoint.Flushed -= OnWriterFlushed;
+
+				if (initialized)
+					_publisher.Publish(new SystemMessage.ServiceShutdown(Name));
+			}
+			catch (Exception cleanupException) when (error is null)
+			{
+				error = cleanupException;
+			}
+			catch (Exception cleanupException)
+			{
+				Log.Error(cleanupException, "Error while shutting down leader replication service.");
+			}
+			finally
+			{
+				if (queueStatsStarted)
+					_queueStats.Stop();
+
+				if (queueRegistered)
+					QueueMonitor.Default.Unregister(this);
+			}
+
+			if (error is null)
+				_tcs.TrySetResult();
+			else
+				_tcs.TrySetException(error);
 		}
 	}
 

--- a/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
@@ -563,33 +563,60 @@ public class LeaderReplicationService : IMonitoredQueue,
 		{
 			try
 			{
-				if (writerCheckpointSubscribed)
-					_db.Config.WriterCheckpoint.Flushed -= OnWriterFlushed;
+				try
+				{
+					if (writerCheckpointSubscribed)
+						_db.Config.WriterCheckpoint.Flushed -= OnWriterFlushed;
 
-				if (initialized)
-					_publisher.Publish(new SystemMessage.ServiceShutdown(Name));
-			}
-			catch (Exception cleanupException) when (error is null)
-			{
-				error = cleanupException;
-			}
-			catch (Exception cleanupException)
-			{
-				Log.Error(cleanupException, "Error while shutting down leader replication service.");
+					if (initialized)
+						_publisher.Publish(new SystemMessage.ServiceShutdown(Name));
+				}
+				catch (Exception cleanupException) when (error is null)
+				{
+					error = cleanupException;
+				}
+				catch (Exception cleanupException)
+				{
+					Log.Error(cleanupException, "Error while shutting down leader replication service.");
+				}
+				finally
+				{
+					try
+					{
+						if (queueStatsStarted)
+							_queueStats.Stop();
+					}
+					catch (Exception cleanupException) when (error is null)
+					{
+						error = cleanupException;
+					}
+					catch (Exception cleanupException)
+					{
+						Log.Error(cleanupException, "Error stopping queue stats for leader replication service.");
+					}
+
+					try
+					{
+						if (queueRegistered)
+							QueueMonitor.Default.Unregister(this);
+					}
+					catch (Exception cleanupException) when (error is null)
+					{
+						error = cleanupException;
+					}
+					catch (Exception cleanupException)
+					{
+						Log.Error(cleanupException, "Error unregistering queue monitor for leader replication service.");
+					}
+				}
 			}
 			finally
 			{
-				if (queueStatsStarted)
-					_queueStats.Stop();
-
-				if (queueRegistered)
-					QueueMonitor.Default.Unregister(this);
+				if (error is null)
+					_tcs.TrySetResult();
+				else
+					_tcs.TrySetException(error);
 			}
-
-			if (error is null)
-				_tcs.TrySetResult();
-			else
-				_tcs.TrySetException(error);
 		}
 	}
 

--- a/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
@@ -494,6 +494,7 @@ public class LeaderReplicationService : IMonitoredQueue,
 	{
 		try
 		{
+			_publisher.Publish(new SystemMessage.ServiceInitialized(Name));
 			_queueStats.Start();
 			QueueMonitor.Default.Register(this);
 

--- a/src/EventStore.Core/Services/Replication/ReplicationTrackingService.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicationTrackingService.cs
@@ -72,6 +72,7 @@ namespace EventStore.Core.Services.Replication {
 		private void TrackReplication() {
 
 			try {
+				_publisher.Publish(new SystemMessage.ServiceInitialized(nameof(ReplicationTrackingService)));
 				while (!_stop) {
 					_replicationChange.Reset();
 					if (_state == VNodeState.Leader || _state == VNodeState.PreLeader) {

--- a/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
+++ b/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
@@ -113,6 +113,7 @@ public class IndexCommitterService<TStreamId> : IndexCommitterService, IIndexCom
 
 	async void IThreadPoolWorkItem.Execute()
 	{
+		_publisher.Publish(new SystemMessage.ServiceInitialized(Name));
 		try
 		{
 			_queueStats.Start();

--- a/src/EventStore.Core/Services/Storage/StorageChaser.cs
+++ b/src/EventStore.Core/Services/Storage/StorageChaser.cs
@@ -111,7 +111,7 @@ public class StorageChaser<TStreamId> : StorageChaser, IMonitoredQueue,
 			// with no concurrency issues with writer, as writer before jumping
 			// into leader mode and accepting writes will wait till chaser caught up.
 			await _indexCommitterService.Init(_chaser.Checkpoint.Read(), _stopToken);
-			_leaderBus.Publish(new SystemMessage.ServiceInitialized("StorageChaser"));
+			_leaderBus.Publish(new SystemMessage.ServiceInitialized(nameof(StorageChaser)));
 
 			while (!_stopToken.IsCancellationRequested)
 			{
@@ -144,7 +144,7 @@ public class StorageChaser<TStreamId> : StorageChaser, IMonitoredQueue,
 
 		_writerCheckpoint.Flushed -= OnWriterFlushed;
 		_chaser.Close();
-		_leaderBus.Publish(new SystemMessage.ServiceShutdown(Name));
+		_leaderBus.Publish(new SystemMessage.ServiceShutdown(nameof(StorageChaser)));
 	}
 
 	private void OnWriterFlushed(long obj) =>

--- a/src/EventStore.Core/Services/Transport/Http/KestrelHttpService.cs
+++ b/src/EventStore.Core/Services/Transport/Http/KestrelHttpService.cs
@@ -32,12 +32,13 @@ namespace EventStore.Core.Services.Transport.Http {
 		private readonly ServiceAccessibility _accessibility;
 		private readonly IPublisher _inputBus;
 		public IUriRouter UriRouter { get; }
-		public bool LogHttpRequests { get; }
+			public bool LogHttpRequests { get; }
 
-		public string AdvertiseAsHost { get; }
-		public int AdvertiseAsPort { get; }
+			public string AdvertiseAsHost { get; }
+			public int AdvertiseAsPort { get; }
+			private string ServiceName => $"HttpServer [{String.Join(", ", EndPoints)}]";
 
-		private bool _isListening;
+			private bool _isListening;
 
 		public KestrelHttpService(ServiceAccessibility accessibility, IPublisher inputBus, IUriRouter uriRouter,
 			MultiQueuedHandler multiQueuedHandler, bool logHttpRequests, string advertiseAsHost,
@@ -58,18 +59,18 @@ namespace EventStore.Core.Services.Transport.Http {
 			EndPoints = endPoints;
 		}
 
-		public void Handle(SystemMessage.SystemInit message) {
+			public void Handle(SystemMessage.SystemInit message) {
 
-			_isListening = true;
-		}
+				_isListening = true;
+				_inputBus.Publish(new SystemMessage.ServiceInitialized(ServiceName));
+			}
 
 		public void Handle(SystemMessage.BecomeShuttingDown message) {
-			if (message.ShutdownHttp)
-				Shutdown();
-			_inputBus.Publish(
-				new SystemMessage.ServiceShutdown(
-					$"HttpServer [{String.Join(", ", EndPoints)}]"));
-		}
+				if (message.ShutdownHttp)
+					Shutdown();
+				_inputBus.Publish(
+					new SystemMessage.ServiceShutdown(ServiceName));
+			}
 
 		public void Shutdown() {
 			_isListening = false;

--- a/src/EventStore.Core/Services/Transport/Http/KestrelHttpService.cs
+++ b/src/EventStore.Core/Services/Transport/Http/KestrelHttpService.cs
@@ -65,10 +65,12 @@ namespace EventStore.Core.Services.Transport.Http {
 		}
 
 		public void Handle(SystemMessage.BecomeShuttingDown message) {
-			if (!message.ShutdownHttp || !_isListening)
+			if (!_isListening)
 				return;
 
-			Shutdown();
+			if (message.ShutdownHttp)
+				Shutdown();
+
 			_inputBus.Publish(new SystemMessage.ServiceShutdown(ServiceName));
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/KestrelHttpService.cs
+++ b/src/EventStore.Core/Services/Transport/Http/KestrelHttpService.cs
@@ -32,13 +32,13 @@ namespace EventStore.Core.Services.Transport.Http {
 		private readonly ServiceAccessibility _accessibility;
 		private readonly IPublisher _inputBus;
 		public IUriRouter UriRouter { get; }
-			public bool LogHttpRequests { get; }
+		public bool LogHttpRequests { get; }
 
-			public string AdvertiseAsHost { get; }
-			public int AdvertiseAsPort { get; }
-			private string ServiceName => $"HttpServer [{String.Join(", ", EndPoints)}]";
+		public string AdvertiseAsHost { get; }
+		public int AdvertiseAsPort { get; }
+		private string ServiceName => $"HttpServer [{string.Join(", ", EndPoints)}]";
 
-			private bool _isListening;
+		private bool _isListening;
 
 		public KestrelHttpService(ServiceAccessibility accessibility, IPublisher inputBus, IUriRouter uriRouter,
 			MultiQueuedHandler multiQueuedHandler, bool logHttpRequests, string advertiseAsHost,
@@ -59,18 +59,18 @@ namespace EventStore.Core.Services.Transport.Http {
 			EndPoints = endPoints;
 		}
 
-			public void Handle(SystemMessage.SystemInit message) {
-
-				_isListening = true;
-				_inputBus.Publish(new SystemMessage.ServiceInitialized(ServiceName));
-			}
+		public void Handle(SystemMessage.SystemInit message) {
+			_isListening = true;
+			_inputBus.Publish(new SystemMessage.ServiceInitialized(ServiceName));
+		}
 
 		public void Handle(SystemMessage.BecomeShuttingDown message) {
-				if (message.ShutdownHttp)
-					Shutdown();
-				_inputBus.Publish(
-					new SystemMessage.ServiceShutdown(ServiceName));
-			}
+			if (!message.ShutdownHttp || !_isListening)
+				return;
+
+			Shutdown();
+			_inputBus.Publish(new SystemMessage.ServiceShutdown(ServiceName));
+		}
 
 		public void Shutdown() {
 			_isListening = false;

--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -66,6 +66,7 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 	private int _subSystemInitsToExpect;
 	private readonly Dictionary<string, ServiceState> _initializedServices = [];
 	private bool _publishedSystemStart;
+	private bool _finalizingShutdown;
 
 	private bool _exitProcessOnShutdown;
 
@@ -127,7 +128,6 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 			.InState(VNodeState.Initializing)
 			.When<SystemMessage.SystemInit>().Do(Handle)
 			.When<SystemMessage.SystemStart>().Do(Handle)
-			.When<SystemMessage.ServiceInitialized>().Do(Handle)
 			.When<SystemMessage.BecomeReadOnlyLeaderless>().Do(Handle)
 			.When<SystemMessage.BecomeDiscoverLeader>().Do(Handle)
 			.When<ClientMessage.ScavengeDatabase>().Ignore()
@@ -243,6 +243,8 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 			.When<ClientMessage.TransactionCommitCompleted>().ForwardTo(_outputBus)
 			.When<ClientMessage.DeleteStreamCompleted>().ForwardTo(_outputBus)
 			.When<SystemMessage.BecomeShuttingDown>().Do(Handle)
+			.InAllStatesExcept(VNodeState.ShuttingDown, VNodeState.Shutdown)
+			.When<SystemMessage.ServiceInitialized>().Do(Handle)
 			.InAllStatesExcept(VNodeState.Initializing, VNodeState.ShuttingDown, VNodeState.Shutdown,
 				VNodeState.ReadOnlyLeaderless, VNodeState.PreReadOnlyReplica, VNodeState.ReadOnlyReplica)
 			.When<ElectionMessage.ElectionsDone>().Do(Handle)
@@ -336,8 +338,10 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 			.InState(VNodeState.ShuttingDown)
 			.When<SystemMessage.BecomeShutdown>().Do(Handle)
 			.When<SystemMessage.ShutdownTimeout>().Do(Handle)
-			.InStates(VNodeState.ShuttingDown, VNodeState.Shutdown)
 			.When<SystemMessage.ServiceShutdown>().Do(Handle)
+			.WhenOther().ForwardTo(_outputBus)
+			.InState(VNodeState.Shutdown)
+			.When<SystemMessage.ServiceShutdown>().Ignore()
 			.WhenOther().ForwardTo(_outputBus)
 			.InState(VNodeState.DiscoverLeader)
 			.When<GossipMessage.GossipUpdated>().Do(HandleAsDiscoverLeader)
@@ -559,6 +563,7 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 		_leader = null;
 		_stateCorrelationId = message.CorrelationId;
 		_exitProcessOnShutdown = message.ExitProcess;
+		_finalizingShutdown = false;
 		State = VNodeState.ShuttingDown;
 		_mainQueue.Publish(TimerMessage.Schedule.Create(ShutdownTimeout, _publishEnvelope,
 			new SystemMessage.ShutdownTimeout()));
@@ -1473,8 +1478,20 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 		Log.Information("========== [{httpEndPoint}] Service '{service}' has shut down.", _nodeInfo.HttpEndPoint,
 			message.ServiceName);
 
-		_initializedServices[message.ServiceName] = ServiceState.Shutdown;
-		if (_initializedServices.Count > 0 && _initializedServices.All(kvp => kvp.Value is ServiceState.Shutdown))
+		if (_initializedServices.ContainsKey(message.ServiceName))
+		{
+			_initializedServices[message.ServiceName] = ServiceState.Shutdown;
+		}
+		else
+		{
+			Log.Debug(
+				"========== [{httpEndPoint}] Ignoring shutdown for untracked service '{service}'.",
+				_nodeInfo.HttpEndPoint, message.ServiceName);
+		}
+
+		if (_initializedServices.Count > 0
+		    && _initializedServices.All(kvp => kvp.Value is ServiceState.Shutdown)
+		    && TryFinalizeShutdown())
 		{
 			Log.Information("========== [{httpEndPoint}] All Services Shutdown.", _nodeInfo.HttpEndPoint);
 			await Shutdown(token);
@@ -1500,7 +1517,9 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 			Log.Error("========== [{httpEndPoint}] Shutdown Timeout. Gave up waiting for services: [{services}]",
 				_nodeInfo.HttpEndPoint, pendingServices);
 		}
-		await Shutdown(token);
+		if (TryFinalizeShutdown())
+			await Shutdown(token);
+
 		await _outputBus.DispatchAsync(message, token);
 	}
 
@@ -1516,6 +1535,15 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 		=> HasInitialized("StorageChaser")
 		   && HasInitialized("StorageReader")
 		   && HasInitialized("StorageWriter");
+
+	private bool TryFinalizeShutdown()
+	{
+		if (_finalizingShutdown)
+			return false;
+
+		_finalizingShutdown = true;
+		return true;
+	}
 
 	private bool HasInitialized(string serviceName)
 		=> _initializedServices.TryGetValue(serviceName, out var state) && state is ServiceState.Initialized;

--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -19,11 +20,11 @@ namespace EventStore.Core.Services.VNode;
 
 public abstract class ClusterVNodeController {
 	protected static readonly ILogger Log = Serilog.Log.ForContext<ClusterVNodeController>();
+	public static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(5);
 }
 
 public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 {
-	public static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(5);
 	public static readonly TimeSpan LeaderReconnectionDelay = TimeSpan.FromMilliseconds(500);
 	private static readonly TimeSpan LeaderSubscriptionRetryDelay = TimeSpan.FromMilliseconds(500);
 	private static readonly TimeSpan LeaderSubscriptionTimeout = TimeSpan.FromMilliseconds(1000);
@@ -63,19 +64,16 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 	private readonly Action _startSubsystems;
 
 	private int _subSystemInitsToExpect;
-
-	private int _serviceInitsToExpect = 1 /* StorageChaser */
-	                                    + 1 /* StorageReader */
-	                                    + 1 /* StorageWriter */;
-
-	private int _serviceShutdownsToExpect = 1 /* StorageChaser */
-	                                        + 1 /* StorageReader */
-	                                        + 1 /* StorageWriter */
-	                                        + 1 /* IndexCommitterService */
-	                                        + 1 /* LeaderReplicationService */
-	                                        + 1 /* HttpService */;
+	private readonly Dictionary<string, ServiceState> _initializedServices = [];
+	private bool _publishedSystemStart;
 
 	private bool _exitProcessOnShutdown;
+
+	private enum ServiceState
+	{
+		Initialized,
+		Shutdown
+	}
 
 	public ClusterVNodeController(
 		QueueStatsManager statsManager,
@@ -100,15 +98,6 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 		_subsystemCount = options.Subsystems.Count;
 		_subSystemInitsToExpect = _subsystemCount;
 		_clusterSize = options.Cluster.ClusterSize;
-		if (_clusterSize == 1)
-		{
-			_serviceShutdownsToExpect = 1 /* StorageChaser */
-			                            + 1 /* StorageReader */
-			                            + 1 /* StorageWriter */
-			                            + 1 /* IndexCommitterService */
-			                            + 1 /* HttpService */;
-		}
-
 
 		_forwardingProxy = forwardingProxy;
 		_forwardingTimeout = TimeSpan.FromMilliseconds(options.Database.PrepareTimeoutMs +
@@ -636,10 +625,15 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 	{
 		Log.Information("========== [{httpEndPoint}] Service '{service}' initialized.", _nodeInfo.HttpEndPoint,
 			message.ServiceName);
-		_serviceInitsToExpect -= 1;
+
+		_initializedServices[message.ServiceName] = ServiceState.Initialized;
 		await _outputBus.DispatchAsync(message, token);
-		if (_serviceInitsToExpect == 0)
+
+		if (!_publishedSystemStart && CoreServicesInitialized())
+		{
 			_mainQueue.Publish(new SystemMessage.SystemStart());
+			_publishedSystemStart = true;
+		}
 	}
 
 	private async ValueTask Handle(AuthenticationMessage.AuthenticationProviderInitialized message,
@@ -1479,8 +1473,8 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 		Log.Information("========== [{httpEndPoint}] Service '{service}' has shut down.", _nodeInfo.HttpEndPoint,
 			message.ServiceName);
 
-		_serviceShutdownsToExpect -= 1;
-		if (_serviceShutdownsToExpect is 0)
+		_initializedServices[message.ServiceName] = ServiceState.Shutdown;
+		if (_initializedServices.Count > 0 && _initializedServices.All(kvp => kvp.Value is ServiceState.Shutdown))
 		{
 			Log.Information("========== [{httpEndPoint}] All Services Shutdown.", _nodeInfo.HttpEndPoint);
 			await Shutdown(token);
@@ -1493,7 +1487,19 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 	{
 		Debug.Assert(State is VNodeState.ShuttingDown);
 
-		Log.Error("========== [{httpEndPoint}] Shutdown Timeout.", _nodeInfo.HttpEndPoint);
+		var pendingServices = string.Join(", ", _initializedServices
+			.Where(kvp => kvp.Value is not ServiceState.Shutdown)
+			.Select(kvp => kvp.Key));
+
+		if (string.IsNullOrEmpty(pendingServices))
+		{
+			Log.Error("========== [{httpEndPoint}] Shutdown Timeout.", _nodeInfo.HttpEndPoint);
+		}
+		else
+		{
+			Log.Error("========== [{httpEndPoint}] Shutdown Timeout. Gave up waiting for services: [{services}]",
+				_nodeInfo.HttpEndPoint, pendingServices);
+		}
 		await Shutdown(token);
 		await _outputBus.DispatchAsync(message, token);
 	}
@@ -1505,6 +1511,14 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 		await _db.Close(token);
 		await _fsm.HandleAsync(new SystemMessage.BecomeShutdown(_stateCorrelationId), token);
 	}
+
+	private bool CoreServicesInitialized()
+		=> HasInitialized("StorageChaser")
+		   && HasInitialized("StorageReader")
+		   && HasInitialized("StorageWriter");
+
+	private bool HasInitialized(string serviceName)
+		=> _initializedServices.TryGetValue(serviceName, out var state) && state is ServiceState.Initialized;
 
 	private static bool IsAliveLeader(MemberInfo member)
 		=> member is { IsAlive: true, State: VNodeState.Leader };


### PR DESCRIPTION
- isolated cluster members can time out on shutdown because the controller waits for services that never initialized
- tracking only the services that actually started keeps graceful shutdown tied to real runtime state instead of a stale hard-coded count
- the timeout cushion and extra diagnostics make shutdown failures point to the actual holdout service when something really is stuck