### PR TITLE
fix(storage): keep cancellation boundaries coherent

### DIFF
--- a/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
+++ b/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
@@ -149,6 +149,58 @@ public abstract class when_stopping_queued_handler : QueuedHandlerTestWithNoopCo
 			cancelled.Dispose();
 		}
 	}
+
+	[Test]
+	public void while_processing_message_cancelled_by_message_token_should_continue_processing_queue()
+	{
+		var started = new ManualResetEventSlim(false);
+		var processedNext = new ManualResetEventSlim(false);
+		using var cancellationTokenSource = new CancellationTokenSource();
+		var queue = new QueuedHandlerThreadPool(
+			new AdHocHandler<Message>(async (message, token) =>
+			{
+				if (message is CancelledMessage)
+				{
+					started.Set();
+					await Task.Delay(Timeout.Infinite, message.CancellationToken);
+					return;
+				}
+
+				processedNext.Set();
+			}),
+			"message_cancelled_test_queue",
+			new QueueStatsManager(),
+			new(),
+			watchSlowMsg: false,
+			threadStopWaitTimeout: TimeSpan.FromMilliseconds(500));
+
+		try
+		{
+			var startTask = queue.Start();
+			queue.Publish(new CancelledMessage(cancellationTokenSource.Token));
+
+			Assert.IsTrue(started.Wait(5000), "Consumer never started handling the cancelled message.");
+
+			cancellationTokenSource.Cancel();
+			queue.Publish(new TestMessage());
+
+			Assert.IsTrue(processedNext.Wait(5000), "Queue never resumed processing after message cancellation.");
+			Assert.That(startTask.IsCompleted, Is.False, "Message cancellation should not complete the queue lifecycle task.");
+		}
+		finally
+		{
+			queue.Stop();
+			started.Dispose();
+			processedNext.Dispose();
+		}
+	}
+}
+
+file sealed class CancelledMessage : Message
+{
+	public CancelledMessage(CancellationToken cancellationToken) : base(cancellationToken)
+	{
+	}
 }
 
 [TestFixture]

--- a/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
+++ b/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Bus;
@@ -194,6 +195,39 @@ public abstract class when_stopping_queued_handler : QueuedHandlerTestWithNoopCo
 			processedNext.Dispose();
 		}
 	}
+
+	[Test]
+	public void default_message_token_should_not_match_unrelated_cancellation()
+	{
+		using var lifetimeSource = new CancellationTokenSource();
+		var lifetimeToken = lifetimeSource.Token;
+		var result = IsExpectedCancellation(new OperationCanceledException(), new TestMessage(), lifetimeToken);
+
+		Assert.That(result, Is.False);
+	}
+
+	[Test]
+	public void explicit_message_token_should_match_its_own_cancellation()
+	{
+		using var cancellationTokenSource = new CancellationTokenSource();
+		using var lifetimeSource = new CancellationTokenSource();
+		var result = IsExpectedCancellation(
+			new OperationCanceledException(cancellationTokenSource.Token),
+			new CancelledMessage(cancellationTokenSource.Token),
+			lifetimeSource.Token);
+
+		Assert.That(result, Is.True);
+	}
+
+	private static bool IsExpectedCancellation(
+		OperationCanceledException exception,
+		Message message,
+		CancellationToken lifetimeToken) =>
+		(bool)typeof(QueuedHandlerThreadPool)
+			.GetMethod(
+				"IsExpectedCancellation",
+				BindingFlags.NonPublic | BindingFlags.Static)!
+			.Invoke(null, [exception, message, lifetimeToken])!;
 }
 
 file sealed class CancelledMessage : Message

--- a/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
+++ b/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
@@ -155,6 +155,7 @@ public abstract class when_stopping_queued_handler : QueuedHandlerTestWithNoopCo
 	public void while_processing_message_cancelled_by_message_token_should_continue_processing_queue()
 	{
 		var started = new ManualResetEventSlim(false);
+		var cancelled = new ManualResetEventSlim(false);
 		var processedNext = new ManualResetEventSlim(false);
 		using var cancellationTokenSource = new CancellationTokenSource();
 		var queue = new QueuedHandlerThreadPool(
@@ -163,7 +164,16 @@ public abstract class when_stopping_queued_handler : QueuedHandlerTestWithNoopCo
 				if (message is CancelledMessage)
 				{
 					started.Set();
-					await Task.Delay(Timeout.Infinite, message.CancellationToken);
+					try
+					{
+						await Task.Delay(Timeout.Infinite, message.CancellationToken);
+					}
+					catch (OperationCanceledException ex) when (ex.CancellationToken == message.CancellationToken)
+					{
+						cancelled.Set();
+						throw;
+					}
+
 					return;
 				}
 
@@ -183,15 +193,27 @@ public abstract class when_stopping_queued_handler : QueuedHandlerTestWithNoopCo
 			Assert.IsTrue(started.Wait(5000), "Consumer never started handling the cancelled message.");
 
 			cancellationTokenSource.Cancel();
+			Assert.IsTrue(cancelled.Wait(5000), "Consumer never observed message cancellation.");
+			Assert.IsTrue(SpinWait.SpinUntil(() =>
+			{
+				var stats = queue.GetStatistics();
+				return stats.CurrentIdleTime is not null
+				       && stats.InProgressMessageType is null
+				       && stats.TotalItemsProcessed == 0;
+			}, 5000), "Queue stats never cleared the cancelled message state.");
+
 			queue.Publish(new TestMessage());
 
 			Assert.IsTrue(processedNext.Wait(5000), "Queue never resumed processing after message cancellation.");
+			Assert.IsTrue(SpinWait.SpinUntil(() => queue.GetStatistics().TotalItemsProcessed == 1, 5000),
+				"Queue stats never counted the next completed message.");
 			Assert.That(startTask.IsCompleted, Is.False, "Message cancellation should not complete the queue lifecycle task.");
 		}
 		finally
 		{
 			queue.Stop();
 			started.Dispose();
+			cancelled.Dispose();
 			processedNext.Dispose();
 		}
 	}

--- a/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_with_a_cancelable_token.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_with_a_cancelable_token.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog;
+
+[TestFixture]
+public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWithFilePerTestFixture
+{
+	private TFChunk _chunk;
+	private ObservingChunkHandle _observingHandle;
+
+	[OneTimeSetUp]
+	public override async Task TestFixtureSetUp()
+	{
+		await base.TestFixtureSetUp();
+
+		_chunk = await TFChunkHelper.CreateNewChunk(Filename);
+		var record = LogRecord.Commit(0, Guid.NewGuid(), 0, 0);
+		var writeResult = await _chunk.TryAppend(record, CancellationToken.None);
+		Assert.That(writeResult.Success, Is.True);
+
+		var handleField = typeof(TFChunk)
+			.GetField("_handle", BindingFlags.NonPublic | BindingFlags.Instance)!;
+		var originalHandle = (IChunkHandle)handleField.GetValue(_chunk)!;
+		_observingHandle = new ObservingChunkHandle(originalHandle);
+		handleField.SetValue(_chunk, _observingHandle);
+	}
+
+	[OneTimeTearDown]
+	public override void TestFixtureTearDown()
+	{
+		_chunk?.Dispose();
+		base.TestFixtureTearDown();
+	}
+
+	[Test]
+	public async Task completes_the_read_only_transition_without_forwarding_the_cancelable_token()
+	{
+		using var cancellationTokenSource = new CancellationTokenSource();
+
+		await _chunk.Complete(cancellationTokenSource.Token);
+
+		Assert.That(_chunk.IsReadOnly, Is.True);
+		Assert.That(_observingHandle.SetReadOnlyCalls, Is.EqualTo(1));
+		Assert.That(_observingHandle.SawCancelableToken, Is.False);
+	}
+
+	private sealed class ObservingChunkHandle(IChunkHandle inner) : IChunkHandle
+	{
+		public int SetReadOnlyCalls { get; private set; }
+		public bool SawCancelableToken { get; private set; }
+
+		public long Length
+		{
+			get => inner.Length;
+			set => inner.Length = value;
+		}
+
+		public FileAccess Access => inner.Access;
+
+		public void Flush() => inner.Flush();
+
+		public ValueTask WriteAsync(ReadOnlyMemory<byte> data, long offset, CancellationToken token) =>
+			inner.WriteAsync(data, offset, token);
+
+		public ValueTask<int> ReadAsync(Memory<byte> buffer, long offset, CancellationToken token) =>
+			inner.ReadAsync(buffer, offset, token);
+
+		public ValueTask SetReadOnlyAsync(bool value, CancellationToken token)
+		{
+			SetReadOnlyCalls++;
+			SawCancelableToken |= token.CanBeCanceled;
+			return inner.SetReadOnlyAsync(value, token);
+		}
+
+		public Stream CreateStream() => inner.CreateStream();
+
+		public void Dispose() => inner.Dispose();
+	}
+}

--- a/src/EventStore.Core/Bus/QueueStatsCollector.cs
+++ b/src/EventStore.Core/Bus/QueueStatsCollector.cs
@@ -93,6 +93,10 @@ namespace EventStore.Core.Bus {
 			_inProgressMsgType = null;
 		}
 
+		public void ProcessingCancelled() {
+			_inProgressMsgType = null;
+		}
+
 		public void EnterIdle() {
 #if DEBUG
 			Debug.Assert(_started,

--- a/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
@@ -161,6 +161,7 @@ namespace EventStore.Core.Bus;
 
 							_queueStats.ProcessingEnded(1);
 						} catch (OperationCanceledException ex) when (IsExpectedCancellation(ex, msg, _lifetimeToken)) {
+							_queueStats.ProcessingCancelled();
 							if (ex.CancellationToken == _lifetimeToken)
 								_tcs.TrySetCanceled(ex.CancellationToken);
 							break;

--- a/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
@@ -160,8 +160,7 @@ namespace EventStore.Core.Bus;
 							}
 
 							_queueStats.ProcessingEnded(1);
-						} catch (OperationCanceledException ex) when (
-							ex.CancellationToken == _lifetimeToken || ex.CancellationToken == msg.CancellationToken) {
+						} catch (OperationCanceledException ex) when (IsExpectedCancellation(ex, msg, _lifetimeToken)) {
 							if (ex.CancellationToken == _lifetimeToken)
 								_tcs.TrySetCanceled(ex.CancellationToken);
 							break;
@@ -196,6 +195,14 @@ namespace EventStore.Core.Bus;
 				throw;
 			}
 		}
+
+		private static bool IsExpectedCancellation(
+			OperationCanceledException exception,
+			Message message,
+			CancellationToken lifetimeToken) =>
+			exception.CancellationToken == lifetimeToken
+			|| message.CancellationToken.CanBeCanceled
+			&& exception.CancellationToken == message.CancellationToken;
 
 		public void Publish(Message message) {
 			//Ensure.NotNull(message, "message");

--- a/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
@@ -202,8 +202,8 @@ namespace EventStore.Core.Bus;
 			Message message,
 			CancellationToken lifetimeToken) =>
 			exception.CancellationToken == lifetimeToken
-			|| message.CancellationToken.CanBeCanceled
-			&& exception.CancellationToken == message.CancellationToken;
+			|| (message.CancellationToken.CanBeCanceled
+			    && exception.CancellationToken == message.CancellationToken);
 
 		public void Publish(Message message) {
 			//Ensure.NotNull(message, "message");

--- a/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
@@ -160,8 +160,10 @@ namespace EventStore.Core.Bus;
 							}
 
 							_queueStats.ProcessingEnded(1);
-						} catch (OperationCanceledException ex) when (ex.CancellationToken == _lifetimeToken) {
-							_tcs.TrySetCanceled(ex.CancellationToken);
+						} catch (OperationCanceledException ex) when (
+							ex.CancellationToken == _lifetimeToken || ex.CancellationToken == msg.CancellationToken) {
+							if (ex.CancellationToken == _lifetimeToken)
+								_tcs.TrySetCanceled(ex.CancellationToken);
 							break;
 						} catch (Exception ex) {
 							Log.Error(ex,

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -63,7 +63,9 @@ public static partial class ClientMessage
 
 		protected WriteRequestMessage(Guid internalCorrId,
 			Guid correlationId, IEnvelope envelope, bool requireLeader,
-			ClaimsPrincipal user, IReadOnlyDictionary<string, string> tokens)
+			ClaimsPrincipal user, IReadOnlyDictionary<string, string> tokens,
+			CancellationToken cancellationToken)
+			: base(cancellationToken)
 		{
 			Ensure.NotEmptyGuid(internalCorrId, "internalCorrId");
 			Ensure.NotEmptyGuid(correlationId, "correlationId");
@@ -89,11 +91,11 @@ public static partial class ClientMessage
 		public readonly ClaimsPrincipal User;
 
 		public readonly DateTime Expires;
-		public readonly CancellationToken CancellationToken;
 
 		protected ReadRequestMessage(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
 			ClaimsPrincipal user, DateTime? expires,
 			CancellationToken cancellationToken = default)
+			: base(cancellationToken)
 		{
 			Ensure.NotEmptyGuid(internalCorrId, "internalCorrId");
 			Ensure.NotEmptyGuid(correlationId, "correlationId");
@@ -105,7 +107,6 @@ public static partial class ClientMessage
 
 			User = user;
 			Expires = expires ?? DateTime.UtcNow.AddMilliseconds(ESConsts.ReadRequestTimeout);
-			CancellationToken = cancellationToken;
 		}
 
 		public override string ToString() =>
@@ -195,12 +196,11 @@ public static partial class ClientMessage
 		public readonly string EventStreamId;
 		public readonly long ExpectedVersion;
 		public readonly Event[] Events;
-		public readonly CancellationToken CancellationToken;
 
 		public WriteEvents(Guid internalCorrId, Guid correlationId, IEnvelope envelope, bool requireLeader,
 			string eventStreamId, long expectedVersion, Event[] events, ClaimsPrincipal user,
 			IReadOnlyDictionary<string, string> tokens = null, CancellationToken cancellationToken = default)
-			: base(internalCorrId, correlationId, envelope, requireLeader, user, tokens)
+			: base(internalCorrId, correlationId, envelope, requireLeader, user, tokens, cancellationToken)
 		{
 			if (SystemStreams.IsInvalidStream(eventStreamId))
 				throw new ArgumentOutOfRangeException(nameof(eventStreamId));
@@ -212,7 +212,6 @@ public static partial class ClientMessage
 			EventStreamId = eventStreamId;
 			ExpectedVersion = expectedVersion;
 			Events = events;
-			CancellationToken = cancellationToken;
 		}
 
 		public WriteEvents(Guid internalCorrId, Guid correlationId, IEnvelope envelope, bool requireLeader,
@@ -313,7 +312,7 @@ public static partial class ClientMessage
 		public TransactionStart(Guid internalCorrId, Guid correlationId, IEnvelope envelope, bool requireLeader,
 			string eventStreamId, long expectedVersion, ClaimsPrincipal user,
 			IReadOnlyDictionary<string, string> tokens = null)
-			: base(internalCorrId, correlationId, envelope, requireLeader, user, tokens)
+			: base(internalCorrId, correlationId, envelope, requireLeader, user, tokens, CancellationToken.None)
 		{
 			Ensure.NotNullOrEmpty(eventStreamId, "eventStreamId");
 			if (expectedVersion < Data.ExpectedVersion.Any)
@@ -355,7 +354,7 @@ public static partial class ClientMessage
 
 		public TransactionWrite(Guid internalCorrId, Guid correlationId, IEnvelope envelope, bool requireLeader,
 			long transactionId, Event[] events, ClaimsPrincipal user, IReadOnlyDictionary<string, string> tokens = null)
-			: base(internalCorrId, correlationId, envelope, requireLeader, user, tokens)
+			: base(internalCorrId, correlationId, envelope, requireLeader, user, tokens, CancellationToken.None)
 		{
 			Ensure.Nonnegative(transactionId, "transactionId");
 			Ensure.NotNull(events, "events");
@@ -395,7 +394,7 @@ public static partial class ClientMessage
 
 		public TransactionCommit(Guid internalCorrId, Guid correlationId, IEnvelope envelope, bool requireLeader,
 			long transactionId, ClaimsPrincipal user, IReadOnlyDictionary<string, string> tokens = null)
-			: base(internalCorrId, correlationId, envelope, requireLeader, user, tokens)
+			: base(internalCorrId, correlationId, envelope, requireLeader, user, tokens, CancellationToken.None)
 		{
 			Ensure.Nonnegative(transactionId, "transactionId");
 			TransactionId = transactionId;
@@ -472,12 +471,11 @@ public static partial class ClientMessage
 		public readonly string EventStreamId;
 		public readonly long ExpectedVersion;
 		public readonly bool HardDelete;
-		public readonly CancellationToken CancellationToken;
 
 		public DeleteStream(Guid internalCorrId, Guid correlationId, IEnvelope envelope, bool requireLeader,
 			string eventStreamId, long expectedVersion, bool hardDelete, ClaimsPrincipal user,
 			IReadOnlyDictionary<string, string> tokens = null, CancellationToken cancellationToken = default)
-			: base(internalCorrId, correlationId, envelope, requireLeader, user, tokens)
+			: base(internalCorrId, correlationId, envelope, requireLeader, user, tokens, cancellationToken)
 		{
 			Ensure.NotNullOrEmpty(eventStreamId, "eventStreamId");
 			EventStreamId = eventStreamId;
@@ -488,7 +486,6 @@ public static partial class ClientMessage
 				_ => expectedVersion
 			};
 			HardDelete = hardDelete;
-			CancellationToken = cancellationToken;
 		}
 	}
 

--- a/src/EventStore.Core/Messages/StorageMessage.cs
+++ b/src/EventStore.Core/Messages/StorageMessage.cs
@@ -30,16 +30,14 @@ namespace EventStore.Core.Messages {
 
 			public string EventStreamId { get; private set; }
 			public long ExpectedVersion { get; private set; }
-			public CancellationToken CancellationToken { get; }
 			public readonly Event[] Events;
 
 			public WritePrepares(Guid correlationId, IEnvelope envelope, string eventStreamId, long expectedVersion,
-				Event[] events, CancellationToken cancellationToken) {
+				Event[] events, CancellationToken cancellationToken) : base(cancellationToken) {
 				CorrelationId = correlationId;
 				Envelope = envelope;
 				EventStreamId = eventStreamId;
 				ExpectedVersion = expectedVersion;
-				CancellationToken = cancellationToken;
 				Events = events;
 			}
 
@@ -60,11 +58,10 @@ namespace EventStore.Core.Messages {
 			public IEnvelope Envelope { get; private set; }
 			public string EventStreamId { get; private set; }
 			public long ExpectedVersion { get; private set; }
-			public CancellationToken CancellationToken { get; }
 			public readonly bool HardDelete;
 
 			public WriteDelete(Guid correlationId, IEnvelope envelope, string eventStreamId, long expectedVersion,
-				bool hardDelete, CancellationToken cancellationToken = default) {
+				bool hardDelete, CancellationToken cancellationToken = default) : base(cancellationToken) {
 				Ensure.NotEmptyGuid(correlationId, "correlationId");
 				Ensure.NotNull(envelope, "envelope");
 				Ensure.NotNull(eventStreamId, "eventStreamId");
@@ -73,7 +70,6 @@ namespace EventStore.Core.Messages {
 				Envelope = envelope;
 				EventStreamId = eventStreamId;
 				ExpectedVersion = expectedVersion;
-				CancellationToken = cancellationToken;
 				HardDelete = hardDelete;
 			}
 		}
@@ -358,12 +354,11 @@ namespace EventStore.Core.Messages {
 		public partial class EffectiveStreamAclRequest : Message {
 			public readonly string StreamId;
 			public readonly IEnvelope Envelope;
-			public readonly CancellationToken CancellationToken;
 
-			public EffectiveStreamAclRequest(string streamId, IEnvelope envelope, CancellationToken cancellationToken) {
+			public EffectiveStreamAclRequest(string streamId, IEnvelope envelope, CancellationToken cancellationToken)
+				: base(cancellationToken) {
 				StreamId = streamId;
 				Envelope = envelope;
-				CancellationToken = cancellationToken;
 			}
 		}
 
@@ -418,10 +413,7 @@ namespace EventStore.Core.Messages {
 
 		[DerivedMessage(CoreMessage.Storage)]
 		public partial class OperationCancelledMessage : Message {
-			public CancellationToken CancellationToken { get; }
-
-			public OperationCancelledMessage(CancellationToken cancellationToken) {
-				CancellationToken = cancellationToken;
+			public OperationCancelledMessage(CancellationToken cancellationToken) : base(cancellationToken) {
 			}
 		}
 
@@ -429,10 +421,9 @@ namespace EventStore.Core.Messages {
 		public partial class StreamIdFromTransactionIdRequest : Message {
 			public readonly long TransactionId;
 			public readonly IEnvelope Envelope;
-			public readonly CancellationToken CancellationToken;
 
-			public StreamIdFromTransactionIdRequest(in long transactionId, IEnvelope envelope, CancellationToken cancellationToken) {
-				CancellationToken = cancellationToken;
+			public StreamIdFromTransactionIdRequest(in long transactionId, IEnvelope envelope,
+				CancellationToken cancellationToken) : base(cancellationToken) {
 				TransactionId = transactionId;
 				Envelope = envelope;
 			}

--- a/src/EventStore.Core/Messaging/Message.cs
+++ b/src/EventStore.Core/Messaging/Message.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace EventStore.Core.Messaging;
 
@@ -18,4 +19,10 @@ public class DerivedMessageAttribute : Attribute {
 }
 
 [BaseMessage]
-public abstract partial class Message;
+public abstract partial class Message {
+	protected Message(CancellationToken cancellationToken = default) {
+		CancellationToken = cancellationToken;
+	}
+
+	public CancellationToken CancellationToken { get; }
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -1059,6 +1059,8 @@ public partial class TFChunk : IDisposable
 
 		_chunkFooter = await WriteFooter(mapping, token); // WriteFooter always calls Flush
 
+		await (_handle?.SetReadOnlyAsync(true, CancellationToken.None) ?? ValueTask.CompletedTask);
+
 		if (!_inMem)
 			CreateReaderStreams();
 
@@ -1066,8 +1068,6 @@ public partial class TFChunk : IDisposable
 
 		_writerWorkItem?.Dispose();
 		_writerWorkItem = null;
-
-		await (_handle?.SetReadOnlyAsync(true, token) ?? ValueTask.CompletedTask);
 	}
 
 	public async ValueTask CompleteRaw(CancellationToken token)
@@ -1080,14 +1080,6 @@ public partial class TFChunk : IDisposable
 		await Flush(token);
 
 		if (!_inMem)
-			CreateReaderStreams();
-
-		IsReadOnly = true;
-
-		_writerWorkItem?.Dispose();
-		_writerWorkItem = null;
-
-		if (!_inMem)
 		{
 			await _handle.SetReadOnlyAsync(true, token);
 			await using var stream = _handle.CreateStream();
@@ -1097,6 +1089,14 @@ public partial class TFChunk : IDisposable
 		{
 			_chunkFooter = await ReadFooter(_sharedMemStream, token);
 		}
+
+		if (!_inMem)
+			CreateReaderStreams();
+
+		IsReadOnly = true;
+
+		_writerWorkItem?.Dispose();
+		_writerWorkItem = null;
 	}
 
 	private async ValueTask<ChunkFooter> WriteFooter(IReadOnlyCollection<PosMap> mapping, CancellationToken token)


### PR DESCRIPTION
- request-scoped cancellation should stop abandoned work without making queued handlers look unhealthy
- chunk completion should stay coherent once storage crosses a no-rollback boundary
- carrying row 230 in smaller slices keeps the remaining cancellation work reviewable instead of mixing unrelated plumbing