### PR TITLE
fix(storage): keep cancelled reads from looking like storage failures

### DIFF
--- a/src/EventStore.Core.Tests/Services/Storage/when_cancelling_storage_reader_worker.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/when_cancelling_storage_reader_worker.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Tests.Services.Storage;
 public class when_cancelling_storage_reader_worker
 {
 	[Test]
-	public async Task read_event_cancellation_from_message_token_is_rethrown_without_reply()
+	public void read_event_cancellation_from_message_token_is_rethrown_without_reply()
 	{
 		var readIndex = new BlockingReadIndex();
 		var worker = CreateWorker(readIndex);
@@ -76,7 +76,7 @@ public class when_cancelling_storage_reader_worker
 	}
 
 	[Test]
-	public async Task effective_stream_acl_cancellation_from_queue_token_is_rethrown_without_reply()
+	public void effective_stream_acl_cancellation_from_queue_token_is_rethrown_without_reply()
 	{
 		var readIndex = new BlockingReadIndex();
 		var worker = CreateWorker(readIndex);

--- a/src/EventStore.Core.Tests/Services/Storage/when_cancelling_storage_reader_worker.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/when_cancelling_storage_reader_worker.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.LogAbstraction;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.Storage;
+using EventStore.Core.Services.Storage.InMemory;
+using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.TransactionLog.Checkpoint;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Storage;
+
+[TestFixture]
+public class when_cancelling_storage_reader_worker
+{
+	[Test]
+	public async Task read_event_cancellation_from_message_token_is_rethrown_without_reply()
+	{
+		var readIndex = new BlockingReadIndex();
+		var worker = CreateWorker(readIndex);
+		var reply = default(Message);
+		using var messageCancellation = new CancellationTokenSource();
+		var message = new ClientMessage.ReadEvent(
+			Guid.NewGuid(),
+			Guid.NewGuid(),
+			new CallbackEnvelope(m => reply = m),
+			"stream",
+			0,
+			resolveLinkTos: false,
+			requireLeader: false,
+			user: new ClaimsPrincipal(),
+			cancellationToken: messageCancellation.Token);
+
+		var task = ((IAsyncHandle<ClientMessage.ReadEvent>)worker)
+			.HandleAsync(message, CancellationToken.None)
+			.AsTask();
+
+		Assert.That(readIndex.ReadEventStarted.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+		messageCancellation.Cancel();
+
+		var ex = Assert.CatchAsync<OperationCanceledException>(async () => await task);
+		Assert.That(ex?.CancellationToken, Is.EqualTo(messageCancellation.Token));
+		Assert.That(reply, Is.Null);
+	}
+
+	[Test]
+	public async Task effective_stream_acl_cancellation_from_message_token_replies_with_operation_cancelled()
+	{
+		var readIndex = new BlockingReadIndex();
+		var worker = CreateWorker(readIndex);
+		var reply = default(Message);
+		using var messageCancellation = new CancellationTokenSource();
+		var message = new StorageMessage.EffectiveStreamAclRequest(
+			"stream",
+			new CallbackEnvelope(m => reply = m),
+			messageCancellation.Token);
+
+		var task = ((IAsyncHandle<StorageMessage.EffectiveStreamAclRequest>)worker)
+			.HandleAsync(message, CancellationToken.None)
+			.AsTask();
+
+		Assert.That(readIndex.EffectiveAclStarted.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+		messageCancellation.Cancel();
+		await task;
+
+		Assert.That(reply, Is.TypeOf<StorageMessage.OperationCancelledMessage>());
+		Assert.That(reply?.CancellationToken, Is.EqualTo(messageCancellation.Token));
+	}
+
+	[Test]
+	public async Task effective_stream_acl_cancellation_from_queue_token_is_rethrown_without_reply()
+	{
+		var readIndex = new BlockingReadIndex();
+		var worker = CreateWorker(readIndex);
+		var reply = default(Message);
+		using var queueCancellation = new CancellationTokenSource();
+		using var messageCancellation = new CancellationTokenSource();
+		var message = new StorageMessage.EffectiveStreamAclRequest(
+			"stream",
+			new CallbackEnvelope(m => reply = m),
+			messageCancellation.Token);
+
+		var task = ((IAsyncHandle<StorageMessage.EffectiveStreamAclRequest>)worker)
+			.HandleAsync(message, queueCancellation.Token)
+			.AsTask();
+
+		Assert.That(readIndex.EffectiveAclStarted.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+		queueCancellation.Cancel();
+
+		var ex = Assert.CatchAsync<OperationCanceledException>(async () => await task);
+		Assert.That(ex?.CancellationToken, Is.EqualTo(queueCancellation.Token));
+		Assert.That(reply, Is.Null);
+	}
+
+	private static StorageReaderWorker<string> CreateWorker(BlockingReadIndex readIndex) =>
+		new(
+			new NoopPublisher(),
+			readIndex,
+			new StubSystemStreamLookup(),
+			new StubCheckpoint(),
+			new StubInMemoryStreamReader(),
+			queueId: 0);
+
+	private sealed class BlockingReadIndex : IReadIndex<string>
+	{
+		public ManualResetEventSlim ReadEventStarted { get; } = new(false);
+		public ManualResetEventSlim EffectiveAclStarted { get; } = new(false);
+
+		public long LastIndexedPosition => 0;
+		public IIndexWriter<string> IndexWriter => throw new NotSupportedException();
+
+		public ValueTask<IndexReadEventResult> ReadEvent(string streamName, string streamId, long eventNumber,
+			CancellationToken token) =>
+			AwaitCancellation<IndexReadEventResult>(ReadEventStarted, token);
+
+		public ValueTask<StorageMessage.EffectiveAcl> GetEffectiveAcl(string streamId, CancellationToken token) =>
+			AwaitCancellation<StorageMessage.EffectiveAcl>(EffectiveAclStarted, token);
+
+		public string GetStreamId(string streamName) => streamName;
+
+		public ReadIndexStats GetStatistics() => throw new NotSupportedException();
+		public ValueTask<IndexReadStreamResult> ReadStreamEventsBackward(string streamName, string streamId,
+			long fromEventNumber, int maxCount, CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<IndexReadStreamResult> ReadStreamEventsForward(string streamName, string streamId,
+			long fromEventNumber, int maxCount, CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<IndexReadEventInfoResult> ReadEventInfo_KeepDuplicates(string streamId, long eventNumber,
+			CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<IndexReadEventInfoResult> ReadEventInfoForward_KnownCollisions(string streamId,
+			long fromEventNumber, int maxCount, long beforePosition, CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<IndexReadEventInfoResult> ReadEventInfoForward_NoCollisions(ulong stream,
+			long fromEventNumber, int maxCount, long beforePosition, CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<IndexReadEventInfoResult> ReadEventInfoBackward_KnownCollisions(string streamId,
+			long fromEventNumber, int maxCount, long beforePosition, CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<IndexReadEventInfoResult> ReadEventInfoBackward_NoCollisions(ulong stream,
+			Func<ulong, string> getStreamId, long fromEventNumber, int maxCount, long beforePosition,
+			CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<bool> IsStreamDeleted(string streamId, CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<long> GetStreamLastEventNumber(string streamId, CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<long> GetStreamLastEventNumber_KnownCollisions(string streamId, long beforePosition,
+			CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<long> GetStreamLastEventNumber_NoCollisions(ulong stream, Func<ulong, string> getStreamId,
+			long beforePosition, CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<StreamMetadata> GetStreamMetadata(string streamId, CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<string> GetEventStreamIdByTransactionId(long transactionId, CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<string> GetStreamName(string streamId, CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<IndexReadAllResult> ReadAllEventsForward(TFPos pos, int maxCount, CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<IndexReadAllResult> ReadAllEventsBackward(TFPos pos, int maxCount, CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<IndexReadAllResult> ReadAllEventsForwardFiltered(TFPos pos, int maxCount, int maxSearchWindow,
+			IEventFilter eventFilter, CancellationToken token) =>
+			throw new NotSupportedException();
+		public ValueTask<IndexReadAllResult> ReadAllEventsBackwardFiltered(TFPos pos, int maxCount, int maxSearchWindow,
+			IEventFilter eventFilter, CancellationToken token) =>
+			throw new NotSupportedException();
+		public void Close() => throw new NotSupportedException();
+		public void Dispose()
+		{
+			ReadEventStarted.Dispose();
+			EffectiveAclStarted.Dispose();
+		}
+
+		private static async ValueTask<T> AwaitCancellation<T>(ManualResetEventSlim started, CancellationToken token)
+		{
+			started.Set();
+			await Task.Delay(Timeout.InfiniteTimeSpan, token);
+			throw new InvalidOperationException("Expected cancellation before completion.");
+		}
+	}
+
+	private sealed class StubSystemStreamLookup : ISystemStreamLookup<string>
+	{
+		public string AllStream => "$all";
+		public string SettingsStream => "$settings";
+
+		public bool IsMetaStream(string streamId) => false;
+		public string MetaStreamOf(string streamId) => "$$" + streamId;
+		public string OriginalStreamOf(string streamId) => streamId;
+		public ValueTask<bool> IsSystemStream(string streamId, CancellationToken token) => new(false);
+	}
+
+	private sealed class StubCheckpoint : IReadOnlyCheckpoint
+	{
+		public string Name => "stub";
+		public event Action<long> Flushed
+		{
+			add { }
+			remove { }
+		}
+
+		public long Read() => 0;
+		public long ReadNonFlushed() => 0;
+	}
+
+	private sealed class StubInMemoryStreamReader : IInMemoryStreamReader
+	{
+		public ClientMessage.ReadStreamEventsForwardCompleted ReadForwards(ClientMessage.ReadStreamEventsForward msg) =>
+			throw new NotSupportedException();
+
+		public ClientMessage.ReadStreamEventsBackwardCompleted ReadBackwards(ClientMessage.ReadStreamEventsBackward msg) =>
+			throw new NotSupportedException();
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Storage/when_cancelling_storage_reader_worker.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/when_cancelling_storage_reader_worker.cs
@@ -22,7 +22,7 @@ public class when_cancelling_storage_reader_worker
 	[Test]
 	public void read_event_cancellation_from_message_token_is_rethrown_without_reply()
 	{
-		var readIndex = new BlockingReadIndex();
+		using var readIndex = new BlockingReadIndex();
 		var worker = CreateWorker(readIndex);
 		var reply = default(Message);
 		using var messageCancellation = new CancellationTokenSource();
@@ -53,7 +53,7 @@ public class when_cancelling_storage_reader_worker
 	[Test]
 	public async Task effective_stream_acl_cancellation_from_message_token_replies_with_operation_cancelled()
 	{
-		var readIndex = new BlockingReadIndex();
+		using var readIndex = new BlockingReadIndex();
 		var worker = CreateWorker(readIndex);
 		var reply = default(Message);
 		using var messageCancellation = new CancellationTokenSource();
@@ -78,7 +78,7 @@ public class when_cancelling_storage_reader_worker
 	[Test]
 	public void effective_stream_acl_cancellation_from_queue_token_is_rethrown_without_reply()
 	{
-		var readIndex = new BlockingReadIndex();
+		using var readIndex = new BlockingReadIndex();
 		var worker = CreateWorker(readIndex);
 		var reply = default(Message);
 		using var queueCancellation = new CancellationTokenSource();
@@ -110,7 +110,7 @@ public class when_cancelling_storage_reader_worker
 			new StubInMemoryStreamReader(),
 			queueId: 0);
 
-	private sealed class BlockingReadIndex : IReadIndex<string>
+	private sealed class BlockingReadIndex : IReadIndex<string>, IDisposable
 	{
 		public ManualResetEventSlim ReadEventStarted { get; } = new(false);
 		public ManualResetEventSlim EffectiveAclStarted { get; } = new(false);

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
@@ -88,13 +88,20 @@ public class StorageReaderWorker<TStreamId> :
 			return;
 		}
 
-		ClientMessage.ReadEventCompleted ev;
-		using (token.LinkTo(msg.CancellationToken))
+		var cts = token.LinkTo(msg.CancellationToken);
+		try
 		{
-			ev = await ReadEvent(msg, token);
+			var ev = await ReadEvent(msg, token);
+			msg.Envelope.ReplyWith(ev);
 		}
-
-		msg.Envelope.ReplyWith(ev);
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts?.Token)
+		{
+			throw new OperationCanceledException(null, ex, cts.CancellationOrigin);
+		}
+		finally
+		{
+			cts?.Dispose();
+		}
 	}
 
 	async ValueTask IAsyncHandle<ClientMessage.ReadStreamEventsForward>.HandleAsync(
@@ -121,11 +128,20 @@ public class StorageReaderWorker<TStreamId> :
 		}
 
 		ClientMessage.ReadStreamEventsForwardCompleted res;
-		using (token.LinkTo(msg.CancellationToken))
+		var cts = token.LinkTo(msg.CancellationToken);
+		try
 		{
 			res = SystemStreams.IsInMemoryStream(msg.EventStreamId)
 				? _inMemReader.ReadForwards(msg)
 				: await ReadStreamEventsForward(msg, token);
+		}
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts?.Token)
+		{
+			throw new OperationCanceledException(null, ex, cts.CancellationOrigin);
+		}
+		finally
+		{
+			cts?.Dispose();
 		}
 
 		switch (res.Result)
@@ -171,12 +187,23 @@ public class StorageReaderWorker<TStreamId> :
 			return;
 		}
 
-		using var cts = token.LinkTo(msg.CancellationToken);
-		var res = SystemStreams.IsInMemoryStream(msg.EventStreamId)
-			? _inMemReader.ReadBackwards(msg)
-			: await ReadStreamEventsBackward(msg, token);
+		var cts = token.LinkTo(msg.CancellationToken);
+		try
+		{
+			var res = SystemStreams.IsInMemoryStream(msg.EventStreamId)
+				? _inMemReader.ReadBackwards(msg)
+				: await ReadStreamEventsBackward(msg, token);
 
-		msg.Envelope.ReplyWith(res);
+			msg.Envelope.ReplyWith(res);
+		}
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts?.Token)
+		{
+			throw new OperationCanceledException(null, ex, cts.CancellationOrigin);
+		}
+		finally
+		{
+			cts?.Dispose();
+		}
 	}
 
 	async ValueTask IAsyncHandle<ClientMessage.ReadAllEventsForward>.HandleAsync(ClientMessage.ReadAllEventsForward msg,
@@ -381,6 +408,10 @@ public class StorageReaderWorker<TStreamId> :
 		{
 			reply = new StorageMessage.OperationCancelledMessage(msg.CancellationToken);
 		}
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts?.Token)
+		{
+			throw new OperationCanceledException(null, ex, cts.CancellationOrigin);
+		}
 		finally
 		{
 			cts?.Dispose();
@@ -413,7 +444,7 @@ public class StorageReaderWorker<TStreamId> :
 			return new ClientMessage.ReadEventCompleted(msg.CorrelationId, msg.EventStreamId, result.Result,
 				record.Value, result.Metadata, false, null);
 		}
-		catch (Exception exc)
+		catch (Exception exc) when (exc is not OperationCanceledException oce || oce.CancellationToken != token)
 		{
 			Log.Error(exc, "Error during processing ReadEvent request.");
 			return NoData(msg, ReadEventResult.Error, exc.Message);
@@ -451,7 +482,7 @@ public class StorageReaderWorker<TStreamId> :
 				(ReadStreamResult)result.Result, resolvedPairs, result.Metadata, false, string.Empty,
 				result.NextEventNumber, result.LastEventNumber, result.IsEndOfStream, lastIndexPosition);
 		}
-		catch (Exception exc)
+		catch (Exception exc) when (exc is not OperationCanceledException oce || oce.CancellationToken != token)
 		{
 			Log.Error(exc, "Error during processing ReadStreamEventsForward request.");
 			return NoData(msg, ReadStreamResult.Error, lastIndexPosition, error: exc.Message);
@@ -489,7 +520,7 @@ public class StorageReaderWorker<TStreamId> :
 				(ReadStreamResult)result.Result, resolvedPairs, result.Metadata, false, string.Empty,
 				result.NextEventNumber, result.LastEventNumber, result.IsEndOfStream, lastIndexedPosition);
 		}
-		catch (Exception exc)
+		catch (Exception exc) when (exc is not OperationCanceledException oce || oce.CancellationToken != token)
 		{
 			Log.Error(exc, "Error during processing ReadStreamEventsBackward request.");
 			return NoData(msg, ReadStreamResult.Error, lastIndexedPosition, error: exc.Message);
@@ -535,7 +566,7 @@ public class StorageReaderWorker<TStreamId> :
 				"Error during processing ReadAllEventsBackward request. The read appears to be at an invalid position.");
 			return NoData(msg, ReadAllResult.InvalidPosition, pos, lastIndexedPosition, exc.Message);
 		}
-		catch (Exception exc)
+		catch (Exception exc) when (exc is not OperationCanceledException oce || oce.CancellationToken != token)
 		{
 			Log.Error(exc, "Error during processing ReadAllEventsForward request.");
 			return NoData(msg, ReadAllResult.Error, pos, lastIndexedPosition, exc.Message);
@@ -581,7 +612,7 @@ public class StorageReaderWorker<TStreamId> :
 				"Error during processing ReadAllEventsBackward request. The read appears to be at an invalid position.");
 			return NoData(msg, ReadAllResult.InvalidPosition, pos, lastIndexedPosition, exc.Message);
 		}
-		catch (Exception exc)
+		catch (Exception exc) when (exc is not OperationCanceledException oce || oce.CancellationToken != token)
 		{
 			Log.Error(exc, "Error during processing ReadAllEventsBackward request.");
 			return NoData(msg, ReadAllResult.Error, pos, lastIndexedPosition, exc.Message);
@@ -634,7 +665,7 @@ public class StorageReaderWorker<TStreamId> :
 			return NoDataForFilteredCommand(msg, FilteredReadAllResult.InvalidPosition, pos, lastIndexedPosition,
 				exc.Message);
 		}
-		catch (Exception exc)
+		catch (Exception exc) when (exc is not OperationCanceledException oce || oce.CancellationToken != token)
 		{
 			Log.Error(exc, "Error during processing ReadAllEventsForwardFiltered request.");
 			return NoDataForFilteredCommand(msg, FilteredReadAllResult.Error, pos, lastIndexedPosition,
@@ -687,7 +718,7 @@ public class StorageReaderWorker<TStreamId> :
 			return NoDataForFilteredCommand(msg, FilteredReadAllResult.InvalidPosition, pos, lastIndexedPosition,
 				exc.Message);
 		}
-		catch (Exception exc)
+		catch (Exception exc) when (exc is not OperationCanceledException oce || oce.CancellationToken != token)
 		{
 			Log.Error(exc, "Error during processing ReadAllEventsBackwardFiltered request.");
 			return NoDataForFilteredCommand(msg, FilteredReadAllResult.Error, pos, lastIndexedPosition,
@@ -827,7 +858,7 @@ public class StorageReaderWorker<TStreamId> :
 				Log.Warning($"Invalid link event payload [{linkPayload}]: {eventRecord}");
 				return ResolvedEvent.ForUnresolvedEvent(eventRecord, commitPosition);
 			}
-			catch (Exception exc)
+			catch (Exception exc) when (exc is not OperationCanceledException oce || oce.CancellationToken != token)
 			{
 				Log.Error(exc, "Error while resolving link for event record: {eventRecord}",
 					eventRecord.ToString());
@@ -947,6 +978,10 @@ public class StorageReaderWorker<TStreamId> :
 		catch (OperationCanceledException e) when (e.CausedBy(cts, message.CancellationToken))
 		{
 			reply = new StorageMessage.OperationCancelledMessage(message.CancellationToken);
+		}
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts?.Token)
+		{
+			throw new OperationCanceledException(null, ex, cts.CancellationOrigin);
 		}
 		finally
 		{


### PR DESCRIPTION
- Keep intentional read cancellation from surfacing as storage-reader failure noise when the caller or queue has already decided the work should stop.
- Preserve the original cancellation source so shutdown and request cancellation remain attributable to the right token while row 230 is being reconciled in focused slices.