### PR TITLE
fix(storage): keep atomic writes coherent under cancellation

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_with_a_cancelable_token.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_with_a_cancelable_token.cs
@@ -82,6 +82,19 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 		Assert.That(_observingHandle.SawCancelableReadOnlyToken, Is.False);
 	}
 
+	[Test]
+	public async Task completes_even_if_cancellation_arrives_during_complete_data_after_the_no_rollback_boundary()
+	{
+		using var cancellationTokenSource = new CancellationTokenSource();
+		_writeState.OnCompleteDataObserved = cancellationTokenSource.Cancel;
+
+		Assert.DoesNotThrowAsync(async () => await _chunk.Complete(cancellationTokenSource.Token));
+		Assert.That(_chunk.IsReadOnly, Is.True);
+		Assert.That(_writeState.CompleteDataCalls, Is.EqualTo(1));
+		Assert.That(_writeState.FooterWriteCalls, Is.EqualTo(1));
+		Assert.That(_observingHandle.SetReadOnlyCalls, Is.EqualTo(1));
+	}
+
 	private sealed class ObservingWriteState
 	{
 		public int StreamWriteCalls { get; private set; }
@@ -90,6 +103,8 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 		public bool SawCancelableStreamWriteToken { get; private set; }
 		public bool SawCancelableCompleteDataToken { get; private set; }
 		public bool SawCancelableFooterToken { get; private set; }
+		public Action OnCompleteDataObserved { get; set; }
+		public Action OnFooterWriteObserved { get; set; }
 
 		public void ObserveStreamWrite(CancellationToken token)
 		{
@@ -101,12 +116,14 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 		{
 			CompleteDataCalls++;
 			SawCancelableCompleteDataToken |= token.CanBeCanceled;
+			OnCompleteDataObserved?.Invoke();
 		}
 
 		public void ObserveFooterWrite(CancellationToken token)
 		{
 			FooterWriteCalls++;
 			SawCancelableFooterToken |= token.CanBeCanceled;
+			OnFooterWriteObserved?.Invoke();
 		}
 
 		public void Reset()
@@ -117,6 +134,8 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 			SawCancelableStreamWriteToken = false;
 			SawCancelableCompleteDataToken = false;
 			SawCancelableFooterToken = false;
+			OnCompleteDataObserved = null;
+			OnFooterWriteObserved = null;
 		}
 	}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_with_a_cancelable_token.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_with_a_cancelable_token.cs
@@ -3,8 +3,11 @@ using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Core.Transforms.Identity;
+using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Plugins.Transforms;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog;
@@ -14,6 +17,7 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 {
 	private TFChunk _chunk;
 	private ObservingChunkHandle _observingHandle;
+	private ObservingWriteState _writeState;
 	private long _nextLogPosition;
 
 	[SetUp]
@@ -21,7 +25,12 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 	{
 		Filename = Path.Combine(Path.GetTempPath(), $"{nameof(when_completing_a_tfchunk_with_a_cancelable_token)}-{Guid.NewGuid()}");
 
-		_chunk = await TFChunkHelper.CreateNewChunk(Filename);
+		_writeState = new ObservingWriteState();
+		_chunk = await TFChunk.CreateNew(Filename, 4096, 0, 0,
+			isScavenged: false, inMem: false, unbuffered: false,
+			writethrough: false, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
+			transformFactory: new ObservingChunkTransformFactory(_writeState),
+			token: CancellationToken.None);
 		var record = LogRecord.Commit(0, Guid.NewGuid(), 0, 0);
 		var writeResult = await _chunk.TryAppend(record, CancellationToken.None);
 		Assert.That(writeResult.Success, Is.True);
@@ -32,6 +41,7 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 		var originalHandle = (IChunkHandle)handleField.GetValue(_chunk)!;
 		_observingHandle = new ObservingChunkHandle(originalHandle);
 		handleField.SetValue(_chunk, _observingHandle);
+		_writeState.Reset();
 	}
 
 	[TearDown]
@@ -52,7 +62,8 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 		var writeResult = await _chunk.TryAppend(record, cancellationTokenSource.Token);
 
 		Assert.That(writeResult.Success, Is.True);
-		Assert.That(_observingHandle.SawCancelableWriteToken, Is.False);
+		Assert.That(_writeState.StreamWriteCalls, Is.GreaterThan(0));
+		Assert.That(_writeState.SawCancelableStreamWriteToken, Is.False);
 	}
 
 	[Test]
@@ -63,15 +74,123 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 		await _chunk.Complete(cancellationTokenSource.Token);
 
 		Assert.That(_chunk.IsReadOnly, Is.True);
+		Assert.That(_writeState.CompleteDataCalls, Is.EqualTo(1));
+		Assert.That(_writeState.FooterWriteCalls, Is.EqualTo(1));
+		Assert.That(_writeState.SawCancelableCompleteDataToken, Is.False);
+		Assert.That(_writeState.SawCancelableFooterToken, Is.False);
 		Assert.That(_observingHandle.SetReadOnlyCalls, Is.EqualTo(1));
-		Assert.That(_observingHandle.SawCancelableWriteToken, Is.False);
 		Assert.That(_observingHandle.SawCancelableReadOnlyToken, Is.False);
+	}
+
+	private sealed class ObservingWriteState
+	{
+		public int StreamWriteCalls { get; private set; }
+		public int CompleteDataCalls { get; private set; }
+		public int FooterWriteCalls { get; private set; }
+		public bool SawCancelableStreamWriteToken { get; private set; }
+		public bool SawCancelableCompleteDataToken { get; private set; }
+		public bool SawCancelableFooterToken { get; private set; }
+
+		public void ObserveStreamWrite(CancellationToken token)
+		{
+			StreamWriteCalls++;
+			SawCancelableStreamWriteToken |= token.CanBeCanceled;
+		}
+
+		public void ObserveCompleteData(CancellationToken token)
+		{
+			CompleteDataCalls++;
+			SawCancelableCompleteDataToken |= token.CanBeCanceled;
+		}
+
+		public void ObserveFooterWrite(CancellationToken token)
+		{
+			FooterWriteCalls++;
+			SawCancelableFooterToken |= token.CanBeCanceled;
+		}
+
+		public void Reset()
+		{
+			StreamWriteCalls = 0;
+			CompleteDataCalls = 0;
+			FooterWriteCalls = 0;
+			SawCancelableStreamWriteToken = false;
+			SawCancelableCompleteDataToken = false;
+			SawCancelableFooterToken = false;
+		}
+	}
+
+	private sealed class ObservingChunkTransformFactory(ObservingWriteState writeState) : IChunkTransformFactory
+	{
+		public TransformType Type => TransformType.Identity;
+		public int TransformDataPosition(int dataPosition) => dataPosition;
+		public void CreateTransformHeader(Span<byte> transformHeader) => transformHeader.Clear();
+
+		public ValueTask ReadTransformHeader(Stream stream, Memory<byte> transformHeader, CancellationToken token)
+			=> token.IsCancellationRequested ? ValueTask.FromCanceled(token) : ValueTask.CompletedTask;
+
+		public IChunkTransform CreateTransform(ReadOnlySpan<byte> transformHeader) =>
+			new ObservingChunkTransform(writeState);
+
+		public int TransformHeaderLength => 0;
+	}
+
+	private sealed class ObservingChunkTransform(ObservingWriteState writeState) : IChunkTransform
+	{
+		public IChunkReadTransform Read => IdentityChunkReadTransform.Instance;
+		public IChunkWriteTransform Write { get; } = new ObservingChunkWriteTransform(writeState);
+	}
+
+	private sealed class ObservingChunkWriteTransform(ObservingWriteState writeState) : IChunkWriteTransform
+	{
+		private ObservingChunkWriteStream _stream;
+
+		public ChunkDataWriteStream TransformData(ChunkDataWriteStream dataStream)
+		{
+			_stream = new ObservingChunkWriteStream(dataStream, writeState);
+			return _stream;
+		}
+
+		public ValueTask CompleteData(int footerSize, int alignmentSize, CancellationToken token)
+		{
+			writeState.ObserveCompleteData(token);
+			var chunkHeaderAndDataSize = (int)_stream.Position;
+			var alignedSize = GetAlignedSize(chunkHeaderAndDataSize + footerSize, alignmentSize);
+			var paddingSize = alignedSize - chunkHeaderAndDataSize - footerSize;
+
+			return paddingSize > 0
+				? _stream.WriteAsync(new byte[paddingSize], token)
+				: ValueTask.CompletedTask;
+		}
+
+		public async ValueTask<int> WriteFooter(ReadOnlyMemory<byte> footer, CancellationToken token)
+		{
+			writeState.ObserveFooterWrite(token);
+			await _stream.ChunkFileStream.WriteAsync(footer, token);
+			return (int)_stream.ChunkFileStream.Length;
+		}
+
+		private static int GetAlignedSize(int size, int alignmentSize)
+		{
+			if (size % alignmentSize == 0)
+				return size;
+			return (size / alignmentSize + 1) * alignmentSize;
+		}
+	}
+
+	private sealed class ObservingChunkWriteStream(ChunkDataWriteStream stream, ObservingWriteState writeState) :
+		ChunkDataWriteStream(stream.ChunkFileStream, stream.ChecksumAlgorithm)
+	{
+		public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken token = default)
+		{
+			writeState.ObserveStreamWrite(token);
+			return base.WriteAsync(buffer, token);
+		}
 	}
 
 	private sealed class ObservingChunkHandle(IChunkHandle inner) : IChunkHandle
 	{
 		public int SetReadOnlyCalls { get; private set; }
-		public bool SawCancelableWriteToken { get; private set; }
 		public bool SawCancelableReadOnlyToken { get; private set; }
 
 		public long Length
@@ -84,11 +203,8 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 
 		public void Flush() => inner.Flush();
 
-		public ValueTask WriteAsync(ReadOnlyMemory<byte> data, long offset, CancellationToken token)
-		{
-			SawCancelableWriteToken |= token.CanBeCanceled;
-			return inner.WriteAsync(data, offset, token);
-		}
+		public ValueTask WriteAsync(ReadOnlyMemory<byte> data, long offset, CancellationToken token) =>
+			inner.WriteAsync(data, offset, token);
 
 		public ValueTask<int> ReadAsync(Memory<byte> buffer, long offset, CancellationToken token) =>
 			inner.ReadAsync(buffer, offset, token);

--- a/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_with_a_cancelable_token.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_with_a_cancelable_token.cs
@@ -83,17 +83,16 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 	}
 
 	[Test]
-	public Task completes_even_if_cancellation_arrives_during_complete_data_after_the_no_rollback_boundary()
+	public async Task completes_even_if_cancellation_arrives_during_complete_data_after_the_no_rollback_boundary()
 	{
 		using var cancellationTokenSource = new CancellationTokenSource();
 		_writeState.OnCompleteDataObserved = cancellationTokenSource.Cancel;
 
-		Assert.DoesNotThrowAsync(async () => await _chunk.Complete(cancellationTokenSource.Token));
+		await _chunk.Complete(cancellationTokenSource.Token);
 		Assert.That(_chunk.IsReadOnly, Is.True);
 		Assert.That(_writeState.CompleteDataCalls, Is.EqualTo(1));
 		Assert.That(_writeState.FooterWriteCalls, Is.EqualTo(1));
 		Assert.That(_observingHandle.SetReadOnlyCalls, Is.EqualTo(1));
-		return Task.CompletedTask;
 	}
 
 	private sealed class ObservingWriteState

--- a/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_with_a_cancelable_token.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_with_a_cancelable_token.cs
@@ -14,16 +14,18 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 {
 	private TFChunk _chunk;
 	private ObservingChunkHandle _observingHandle;
+	private long _nextLogPosition;
 
-	[OneTimeSetUp]
-	public override async Task TestFixtureSetUp()
+	[SetUp]
+	public async Task SetUp()
 	{
-		await base.TestFixtureSetUp();
+		Filename = Path.Combine(Path.GetTempPath(), $"{nameof(when_completing_a_tfchunk_with_a_cancelable_token)}-{Guid.NewGuid()}");
 
 		_chunk = await TFChunkHelper.CreateNewChunk(Filename);
 		var record = LogRecord.Commit(0, Guid.NewGuid(), 0, 0);
 		var writeResult = await _chunk.TryAppend(record, CancellationToken.None);
 		Assert.That(writeResult.Success, Is.True);
+		_nextLogPosition = writeResult.NewPosition;
 
 		var handleField = typeof(TFChunk)
 			.GetField("_handle", BindingFlags.NonPublic | BindingFlags.Instance)!;
@@ -32,15 +34,29 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 		handleField.SetValue(_chunk, _observingHandle);
 	}
 
-	[OneTimeTearDown]
-	public override void TestFixtureTearDown()
+	[TearDown]
+	public void TearDown()
 	{
 		_chunk?.Dispose();
-		base.TestFixtureTearDown();
+		_chunk = null;
+		if (File.Exists(Filename))
+			File.Delete(Filename);
 	}
 
 	[Test]
-	public async Task completes_the_read_only_transition_without_forwarding_the_cancelable_token()
+	public async Task appending_does_not_forward_the_cancelable_token_to_writes()
+	{
+		using var cancellationTokenSource = new CancellationTokenSource();
+		var record = LogRecord.Commit(_nextLogPosition, Guid.NewGuid(), _nextLogPosition, 0);
+
+		var writeResult = await _chunk.TryAppend(record, cancellationTokenSource.Token);
+
+		Assert.That(writeResult.Success, Is.True);
+		Assert.That(_observingHandle.SawCancelableWriteToken, Is.False);
+	}
+
+	[Test]
+	public async Task completes_without_forwarding_the_cancelable_token_to_writes_or_read_only_transition()
 	{
 		using var cancellationTokenSource = new CancellationTokenSource();
 
@@ -48,13 +64,15 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 
 		Assert.That(_chunk.IsReadOnly, Is.True);
 		Assert.That(_observingHandle.SetReadOnlyCalls, Is.EqualTo(1));
-		Assert.That(_observingHandle.SawCancelableToken, Is.False);
+		Assert.That(_observingHandle.SawCancelableWriteToken, Is.False);
+		Assert.That(_observingHandle.SawCancelableReadOnlyToken, Is.False);
 	}
 
 	private sealed class ObservingChunkHandle(IChunkHandle inner) : IChunkHandle
 	{
 		public int SetReadOnlyCalls { get; private set; }
-		public bool SawCancelableToken { get; private set; }
+		public bool SawCancelableWriteToken { get; private set; }
+		public bool SawCancelableReadOnlyToken { get; private set; }
 
 		public long Length
 		{
@@ -66,8 +84,11 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 
 		public void Flush() => inner.Flush();
 
-		public ValueTask WriteAsync(ReadOnlyMemory<byte> data, long offset, CancellationToken token) =>
-			inner.WriteAsync(data, offset, token);
+		public ValueTask WriteAsync(ReadOnlyMemory<byte> data, long offset, CancellationToken token)
+		{
+			SawCancelableWriteToken |= token.CanBeCanceled;
+			return inner.WriteAsync(data, offset, token);
+		}
 
 		public ValueTask<int> ReadAsync(Memory<byte> buffer, long offset, CancellationToken token) =>
 			inner.ReadAsync(buffer, offset, token);
@@ -75,7 +96,7 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 		public ValueTask SetReadOnlyAsync(bool value, CancellationToken token)
 		{
 			SetReadOnlyCalls++;
-			SawCancelableToken |= token.CanBeCanceled;
+			SawCancelableReadOnlyToken |= token.CanBeCanceled;
 			return inner.SetReadOnlyAsync(value, token);
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_with_a_cancelable_token.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_with_a_cancelable_token.cs
@@ -83,7 +83,7 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 	}
 
 	[Test]
-	public async Task completes_even_if_cancellation_arrives_during_complete_data_after_the_no_rollback_boundary()
+	public Task completes_even_if_cancellation_arrives_during_complete_data_after_the_no_rollback_boundary()
 	{
 		using var cancellationTokenSource = new CancellationTokenSource();
 		_writeState.OnCompleteDataObserved = cancellationTokenSource.Cancel;
@@ -93,6 +93,7 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 		Assert.That(_writeState.CompleteDataCalls, Is.EqualTo(1));
 		Assert.That(_writeState.FooterWriteCalls, Is.EqualTo(1));
 		Assert.That(_observingHandle.SetReadOnlyCalls, Is.EqualTo(1));
+		return Task.CompletedTask;
 	}
 
 	private sealed class ObservingWriteState

--- a/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_writer_with_a_cancelable_token.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_writer_with_a_cancelable_token.cs
@@ -1,0 +1,107 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Transforms.Identity;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using EventStore.Plugins.Transforms;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog;
+
+[TestFixture]
+public class when_completing_a_tfchunk_writer_with_a_cancelable_token : SpecificationWithDirectory
+{
+	private TFChunkDb _db;
+	private TFChunkWriter _writer;
+	private TFChunk _chunk;
+
+	[SetUp]
+	public override async Task SetUp()
+	{
+		await base.SetUp();
+
+		_db = new TFChunkDb(TFChunkHelper.CreateDbConfig(
+			PathName,
+			new FileCheckpoint(GetFilePathFor("writer.chk"), "writer"),
+			new FileCheckpoint(GetFilePathFor("chaser.chk"), "chaser"),
+			chunkSize: 4096));
+		_writer = new TFChunkWriter(_db);
+	}
+
+	[TearDown]
+	public override async Task TearDown()
+	{
+		_chunk?.Dispose();
+		_chunk = null;
+		_db?.Config.WriterCheckpoint.Close(flush: false);
+		_db?.Config.ChaserCheckpoint.Close(flush: false);
+		await base.TearDown();
+	}
+
+	[Test]
+	public async Task complete_chunk_flushes_the_writer_checkpoint_even_if_cancellation_arrives_after_completion()
+	{
+		using var cancellationTokenSource = new CancellationTokenSource();
+		_chunk = await TFChunk.CreateNew(GetFilePathFor("chunk-000000.000000"), 4096, 0, 0,
+			isScavenged: false, inMem: false, unbuffered: false,
+			writethrough: false, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
+			transformFactory: new CancelDuringCompletionTransformFactory(cancellationTokenSource),
+			token: CancellationToken.None);
+		SetCurrentChunk(_writer, _chunk);
+
+		Assert.DoesNotThrowAsync(async () => await _writer.CompleteChunk(cancellationTokenSource.Token));
+		Assert.That(_chunk.IsReadOnly, Is.True);
+		Assert.That(_db.Config.WriterCheckpoint.Read(), Is.EqualTo(_chunk.ChunkHeader.ChunkEndPosition));
+	}
+
+	private static void SetCurrentChunk(TFChunkWriter writer, TFChunk chunk)
+	{
+		typeof(TFChunkWriter)
+			.GetField("_currentChunk", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.SetValue(writer, chunk);
+	}
+
+	private sealed class CancelDuringCompletionTransformFactory(CancellationTokenSource cancellationTokenSource)
+		: IChunkTransformFactory
+	{
+		public TransformType Type => TransformType.Identity;
+		public int TransformDataPosition(int dataPosition) => dataPosition;
+		public void CreateTransformHeader(Span<byte> transformHeader) => transformHeader.Clear();
+
+		public ValueTask ReadTransformHeader(Stream stream, Memory<byte> transformHeader, CancellationToken token)
+			=> token.IsCancellationRequested ? ValueTask.FromCanceled(token) : ValueTask.CompletedTask;
+
+		public IChunkTransform CreateTransform(ReadOnlySpan<byte> transformHeader) =>
+			new CancelDuringCompletionTransform(cancellationTokenSource);
+
+		public int TransformHeaderLength => 0;
+	}
+
+	private sealed class CancelDuringCompletionTransform(CancellationTokenSource cancellationTokenSource)
+		: IChunkTransform
+	{
+		public IChunkReadTransform Read => IdentityChunkReadTransform.Instance;
+		public IChunkWriteTransform Write { get; } = new CancelDuringCompletionWriteTransform(cancellationTokenSource);
+	}
+
+	private sealed class CancelDuringCompletionWriteTransform(CancellationTokenSource cancellationTokenSource)
+		: IChunkWriteTransform
+	{
+		private readonly IdentityChunkWriteTransform _inner = new();
+
+		public ChunkDataWriteStream TransformData(ChunkDataWriteStream dataStream) => _inner.TransformData(dataStream);
+
+		public ValueTask CompleteData(int footerSize, int alignmentSize, CancellationToken token) =>
+			_inner.CompleteData(footerSize, alignmentSize, token);
+
+		public ValueTask<int> WriteFooter(ReadOnlyMemory<byte> footer, CancellationToken token)
+		{
+			cancellationTokenSource.Cancel();
+			return _inner.WriteFooter(footer, token);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Transforms/TransformTests.cs
+++ b/src/EventStore.Core.Tests/Transforms/TransformTests.cs
@@ -33,6 +33,7 @@ public class TransformTests<TLogFormat, TStreamId> : SpecificationWithDirectoryP
 	[TestCase("bytedup", true)]
 	[TestCase("withheader", false)]
 	[TestCase("withheader", true)]
+	[Timeout(60000)]
 	public async Task transform_works(string transform, bool memDb)
 	{
 		MiniNode<TLogFormat, TStreamId> node = null;

--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -419,11 +419,10 @@ public class ClusterStorageWriterService<TStreamId> : StorageWriterService<TStre
 	private async ValueTask OnTransactionUnframed(IEnumerable<ILogRecord> records, CancellationToken token)
 	{
 		token.ThrowIfCancellationRequested();
-		token = CancellationToken.None;
 
 		Writer.OpenTransaction();
 		foreach (var record in records)
-			if (await Writer.WriteToTransaction(record, token) is null)
+			if (await Writer.WriteToTransaction(record, CancellationToken.None) is null)
 				ReplicationFail(
 					"Failed to write replicated log record at position: {0}. Writer's position: {1}.",
 					"Failed to write replicated log record at position: {recordPos}. Writer's position: {writerPos}.",

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -302,10 +302,8 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 
 		try
 		{
-			if (msg.CancellationToken.IsCancellationRequested || token.IsCancellationRequested)
+			if (msg.CancellationToken.IsCancellationRequested)
 				return;
-
-			token = CancellationToken.None;
 
 			var logPosition = Writer.Position;
 			var prepares = new List<IPrepareLogRecord<TStreamId>>();
@@ -858,13 +856,12 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 		}
 
 		token.ThrowIfCancellationRequested();
-		token = CancellationToken.None;
 
 		Writer.OpenTransaction();
 		var writerPos = Writer.Position;
 		foreach (var prepare in prepares)
 		{
-			long newWriterPos = await Writer.WriteToTransaction(prepare, token)
+			long newWriterPos = await Writer.WriteToTransaction(prepare, CancellationToken.None)
 			                    ?? throw new InvalidOperationException(
 				                    "The transaction does not fit in the current chunk.");
 			if (newWriterPos - writerPos != prepare.GetSizeWithLengthPrefixAndSuffix())

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -394,6 +394,8 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 				return;
 			}
 
+			token = CancellationToken.None;
+
 			bool softUndeleteMetastream = _systemStreams.IsMetaStream(streamId)
 			                              && await _indexWriter.IsSoftDeleted(_systemStreams.OriginalStreamOf(streamId),
 				                              token);

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -1101,6 +1101,8 @@ public partial class TFChunk : IDisposable
 
 	private async ValueTask<ChunkFooter> WriteFooter(IReadOnlyCollection<PosMap> mapping, CancellationToken token)
 	{
+		token.ThrowIfCancellationRequested();
+
 		var workItem = _writerWorkItem;
 		workItem.ResizeStream((int)workItem.WorkingStream.Position);
 
@@ -1131,7 +1133,7 @@ public partial class TFChunk : IDisposable
 
 			bufferFromPool = ArrayPool<byte>.Shared.Rent(Math.Max(mapSize, ChunkFooter.Size));
 			mapSize = WriteMapping(bufferFromPool, mapping);
-			await workItem.AppendData(bufferFromPool.AsMemory(0, mapSize), token);
+			await workItem.AppendData(bufferFromPool.AsMemory(0, mapSize), CancellationToken.None);
 		}
 
 		workItem.FlushToDisk();
@@ -1139,7 +1141,7 @@ public partial class TFChunk : IDisposable
 		await _transform.Write.CompleteData(
 			footerSize: ChunkFooter.Size,
 			alignmentSize: _chunkHeader.Version >= (byte)ChunkVersions.Aligned ? AlignmentSize : 1,
-			token);
+			CancellationToken.None);
 
 		await Flush(token);
 
@@ -1158,7 +1160,8 @@ public partial class TFChunk : IDisposable
 			footerWithHash = new ChunkFooter(true, true, _physicalDataSize, LogicalDataSize, mapSize, workItem.MD5);
 
 			footerWithHash.Format(bufferFromPool);
-			fileSize = await _transform.Write.WriteFooter(new(bufferFromPool, 0, ChunkFooter.Size), token);
+			fileSize = await _transform.Write.WriteFooter(new(bufferFromPool, 0, ChunkFooter.Size),
+				CancellationToken.None);
 		}
 		finally
 		{

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -1143,7 +1143,7 @@ public partial class TFChunk : IDisposable
 			alignmentSize: _chunkHeader.Version >= (byte)ChunkVersions.Aligned ? AlignmentSize : 1,
 			CancellationToken.None);
 
-		await Flush(token);
+		await Flush(CancellationToken.None);
 
 		int fileSize;
 		ChunkFooter footerWithHash;
@@ -1168,7 +1168,7 @@ public partial class TFChunk : IDisposable
 			ArrayPool<byte>.Shared.Return(bufferFromPool);
 		}
 
-		await Flush(token);
+		await Flush(CancellationToken.None);
 
 		_fileSize = fileSize;
 		return footerWithHash;

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/WriterWorkItem.cs
@@ -57,13 +57,13 @@ internal sealed class WriterWorkItem : Disposable
 			WorkingStream = memStream;
 	}
 
-	public ValueTask AppendData(ReadOnlyMemory<byte> buf, CancellationToken token)
+	public ValueTask AppendData(ReadOnlyMemory<byte> buf, CancellationToken _)
 	{
 		// MEMORY (in-memory write doesn't require async I/O)
 		_memStream?.Write(buf.Span);
 
 		// as we are always append-only, stream's position should be right here
-		return _fileStream?.WriteAsync(buf, token) ?? ValueTask.CompletedTask;
+		return _fileStream?.WriteAsync(buf, CancellationToken.None) ?? ValueTask.CompletedTask;
 	}
 
 	public void ResizeStream(int fileSize)

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
@@ -69,14 +69,13 @@ public class TFChunkWriter : ITransactionFileWriter
 	public async ValueTask<(bool, long)> Write(ILogRecord record, CancellationToken token)
 	{
 		token.ThrowIfCancellationRequested();
-		token = CancellationToken.None;
 
 		OpenTransaction();
 
-		if (await WriteToTransaction(record, token) is not { } result)
+		if (await WriteToTransaction(record, CancellationToken.None) is not { } result)
 		{
-			await CompleteChunkInTransaction(token);
-			await AddNewChunk(token: token);
+			await CompleteChunkInTransaction(CancellationToken.None);
+			await AddNewChunk(token: CancellationToken.None);
 			CommitTransaction();
 			await Flush(token);
 			return (false, _nextRecordPosition);
@@ -132,10 +131,9 @@ public class TFChunkWriter : ITransactionFileWriter
 	public async ValueTask CompleteChunk(CancellationToken token)
 	{
 		token.ThrowIfCancellationRequested();
-		token = CancellationToken.None;
 
 		OpenTransaction();
-		await CompleteChunkInTransaction(token);
+		await CompleteChunkInTransaction(CancellationToken.None);
 		CommitTransaction();
 		await Flush(token);
 	}
@@ -153,10 +151,9 @@ public class TFChunkWriter : ITransactionFileWriter
 	public async ValueTask CompleteReplicatedRawChunk(TFChunk.TFChunk rawChunk, CancellationToken token)
 	{
 		token.ThrowIfCancellationRequested();
-		token = CancellationToken.None;
 
 		OpenTransaction();
-		await CompleteReplicatedRawChunkInTransaction(rawChunk, token);
+		await CompleteReplicatedRawChunkInTransaction(rawChunk, CancellationToken.None);
 		CommitTransaction();
 		await Flush(token);
 	}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
@@ -77,7 +77,7 @@ public class TFChunkWriter : ITransactionFileWriter
 			await CompleteChunkInTransaction(CancellationToken.None);
 			await AddNewChunk(token: CancellationToken.None);
 			CommitTransaction();
-			await Flush(token);
+			await Flush(CancellationToken.None);
 			return (false, _nextRecordPosition);
 		}
 
@@ -135,7 +135,7 @@ public class TFChunkWriter : ITransactionFileWriter
 		OpenTransaction();
 		await CompleteChunkInTransaction(CancellationToken.None);
 		CommitTransaction();
-		await Flush(token);
+		await Flush(CancellationToken.None);
 	}
 
 	private async ValueTask CompleteReplicatedRawChunkInTransaction(TFChunk.TFChunk rawChunk,
@@ -155,7 +155,7 @@ public class TFChunkWriter : ITransactionFileWriter
 		OpenTransaction();
 		await CompleteReplicatedRawChunkInTransaction(rawChunk, CancellationToken.None);
 		CommitTransaction();
-		await Flush(token);
+		await Flush(CancellationToken.None);
 	}
 
 	private static void VerifyChunkNumberLimits(int chunkNumber)


### PR DESCRIPTION
- atomic write paths should not stop halfway through once the write has crossed the no-rollback boundary
- cancellation should still remain meaningful before durable completion, rather than corrupting chunk state after it
- shipping the write-side slice separately keeps row 230 reviewable while the reader-side cancellation work lands on its own path