### PR TITLE
fix(docker): avoid leaking NuGet auth into restore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,17 +14,19 @@ WORKDIR /build/src
 COPY ./src/EventStore.sln ./src/*/*.csproj ./src/Directory.Build.* ./src/Directory.Packages.* ./src/NuGet.Config ./
 RUN for file in $(ls *.csproj); do mkdir -p ./${file%.*}/ && mv $file ./${file%.*}/; done
 
-# Configure NuGet authentication for GitHub Packages using Docker secrets
 RUN --mount=type=secret,id=nuget_auth_token \
+    NUGET_CONFIG=$(mktemp) && \
+    cp ./NuGet.Config "$NUGET_CONFIG" && \
     if [ -f /run/secrets/nuget_auth_token ]; then \
         NUGET_AUTH_TOKEN=$(cat /run/secrets/nuget_auth_token) && \
         dotnet nuget update source github \
+        --configfile "$NUGET_CONFIG" \
         --username docker \
         --password "$NUGET_AUTH_TOKEN" \
         --store-password-in-clear-text; \
-    fi
-
-RUN dotnet restore --runtime=${RUNTIME}
+    fi && \
+    dotnet restore --runtime=${RUNTIME} --configfile "$NUGET_CONFIG" && \
+    rm -f "$NUGET_CONFIG"
 COPY ./src .
 
 WORKDIR /build/.git

--- a/src/EventStore.Core.Tests/DataStructures/persistent_stream_bloom_filter.cs
+++ b/src/EventStore.Core.Tests/DataStructures/persistent_stream_bloom_filter.cs
@@ -19,6 +19,7 @@ public enum PersistenceStrategy
 [TestFixture(PersistenceStrategy.FileStream, PersistenceStrategy.FileStream)]
 public class persistent_stream_bloom_filter : SpecificationWithDirectoryPerTestFixture
 {
+	private const int LongRunningTimeout = 120000;
 	private readonly PersistenceStrategy _forCreate;
 	private readonly PersistenceStrategy _forOpen;
 
@@ -235,7 +236,7 @@ public class persistent_stream_bloom_filter : SpecificationWithDirectoryPerTestF
 		Assert.GreaterOrEqual(falsePositives, Math.Max(0, expectedFalsePositives - threeStandardDeviations));
 	}
 
-	[Test, Category("LongRunning")]
+	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
 	public void always_returns_true_when_an_item_was_added([Range(10_000, 100_000, 13337)] long size)
 	{
 		using var filter = GenSut(GetTempFilePath(), create: true, size, hasher: null);

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/rolling_manual_only_merges.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/rolling_manual_only_merges.cs
@@ -11,7 +11,7 @@ public class rolling_manual_only_merges : when_max_auto_merge_level_is_set
 	{
 	}
 
-	[Test]
+	[Test, Timeout(LongRunningTimeout)]
 	public void alternating_table_dumps_and_manual_merges_should_merge_correctly()
 	{
 		AddTables(1);

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_max_auto_merge_level_is_reduced.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_max_auto_merge_level_is_reduced.cs
@@ -10,7 +10,7 @@ public class when_max_auto_merge_level_is_reduced : when_max_auto_merge_level_is
 	{
 	}
 
-	[Test]
+	[Test, Timeout(LongRunningTimeout)]
 	public void should_merge_levels_above_max_level()
 	{
 		AddTables(201); //gives 1 level 0, 1 level 3 and 6 level 5s

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_max_auto_merge_level_is_set.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_max_auto_merge_level_is_set.cs
@@ -14,6 +14,7 @@ namespace EventStore.Core.Tests.Index.AutoMergeLevelTests;
 [TestFixture]
 public abstract class when_max_auto_merge_level_is_set : SpecificationWithDirectoryPerTestFixture
 {
+	protected const int LongRunningTimeout = 120000;
 	protected readonly int _maxAutoMergeLevel;
 	protected string _filename;
 	protected IndexMap _map;

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_tables_available_for_manual_merge.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_tables_available_for_manual_merge.cs
@@ -6,7 +6,7 @@ namespace EventStore.Core.Tests.Index.AutoMergeLevelTests;
 
 public class when_tables_available_for_manual_merge : when_max_auto_merge_level_is_set
 {
-	[Test, Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
 	public void should_merge_pending_tables_at_max_auto_merge_level()
 	{
 		AddTables(100);

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_tables_available_for_manual_merge.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_tables_available_for_manual_merge.cs
@@ -6,7 +6,7 @@ namespace EventStore.Core.Tests.Index.AutoMergeLevelTests;
 
 public class when_tables_available_for_manual_merge : when_max_auto_merge_level_is_set
 {
-	[Test]
+	[Test, Timeout(LongRunningTimeout)]
 	public void should_merge_pending_tables_at_max_auto_merge_level()
 	{
 		AddTables(100);

--- a/src/EventStore.Core.Tests/Index/IndexV1/ptable_midpoint_cache_should.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/ptable_midpoint_cache_should.cs
@@ -13,6 +13,7 @@ namespace EventStore.Core.Tests.Index.IndexV1;
 [TestFixture(PTableVersions.IndexV4, true)]
 public class ptable_midpoint_cache_should : SpecificationWithDirectory
 {
+	private const int LongRunningTimeout = 120000;
 	private static readonly ILogger Log = Serilog.Log.ForContext<ptable_midpoint_cache_should>();
 	protected byte _ptableVersion = PTableVersions.IndexV1;
 	private bool _skipIndexVerify;
@@ -99,7 +100,7 @@ public class ptable_midpoint_cache_should : SpecificationWithDirectory
 		construct_valid_cache_for_any_combination_of_params(4096);
 	}
 
-	[Test]
+	[Test, Timeout(LongRunningTimeout)]
 	public void construct_valid_cache_for_any_combination_of_params_small()
 	{
 		construct_valid_cache_for_any_combination_of_params(20);

--- a/src/EventStore.Core.Tests/Integration/when_a_single_node_is_restarted_multiple_times.cs
+++ b/src/EventStore.Core.Tests/Integration/when_a_single_node_is_restarted_multiple_times.cs
@@ -16,9 +16,10 @@ public class when_a_single_node_is_restarted_multiple_times<TLogFormat, TStreamI
 {
 	private List<Guid> _epochIds = new List<Guid>();
 	private const int _numberOfNodeStarts = 5;
+	private static readonly TimeSpan RestartTimeout = TimeSpan.FromSeconds(30);
 	private readonly AutoResetEvent _waitForStart = new AutoResetEvent(false);
 
-	protected override TimeSpan Timeout { get; } = TimeSpan.FromMinutes(1);
+	protected override TimeSpan Timeout { get; } = TimeSpan.FromMinutes(3);
 
 	protected override void BeforeNodeStarts()
 	{
@@ -30,12 +31,18 @@ public class when_a_single_node_is_restarted_multiple_times<TLogFormat, TStreamI
 	{
 		for (int i = 0; i < _numberOfNodeStarts - 1; i++)
 		{
-			_waitForStart.WaitOne(5000);
+			Assert.That(
+				_waitForStart.WaitOne(RestartTimeout),
+				Is.True,
+				$"Timed out waiting for epoch write before restart {i + 1}");
 			await ShutdownNode();
 			await StartNode();
 		}
 
-		_waitForStart.WaitOne(5000);
+		Assert.That(
+			_waitForStart.WaitOne(RestartTimeout),
+			Is.True,
+			"Timed out waiting for epoch write after final startup");
 		await base.Given();
 	}
 

--- a/src/EventStore.Core.Tests/Integration/when_a_single_node_is_restarted_multiple_times.cs
+++ b/src/EventStore.Core.Tests/Integration/when_a_single_node_is_restarted_multiple_times.cs
@@ -19,7 +19,8 @@ public class when_a_single_node_is_restarted_multiple_times<TLogFormat, TStreamI
 	private static readonly TimeSpan RestartTimeout = TimeSpan.FromSeconds(30);
 	private readonly AutoResetEvent _waitForStart = new AutoResetEvent(false);
 
-	protected override TimeSpan Timeout { get; } = TimeSpan.FromMinutes(3);
+	protected override TimeSpan Timeout { get; } =
+		TimeSpan.FromSeconds((RestartTimeout.TotalSeconds * _numberOfNodeStarts) + 120);
 
 	protected override void BeforeNodeStarts()
 	{

--- a/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
+++ b/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
@@ -23,20 +23,25 @@ public class when_restarting_one_node_at_a_time<TLogFormat, TStreamId> : specifi
 			var restartedNodeIndex = i % 3;
 
 			AssertEx.IsOrBecomesTrue(
-				() => _nodes.Count(x => x.NodeState == VNodeState.Leader) == 1 &&
-					  _nodes.Count(x => x.NodeState == VNodeState.Follower) == 2,
+				() => {
+					var states = _nodes.Select(x => x.NodeState).ToArray();
+					return states.Count(x => x == VNodeState.Leader) == 1 &&
+					       states.Count(x => x == VNodeState.Follower) == 2;
+				},
 				RestartTimeout,
 				$"Cluster did not stabilize before restarting node {restartedNodeIndex}",
 				MiniNodeLogging.WriteLogs);
 
 			await _nodes[restartedNodeIndex].Shutdown(keepDb: true);
 			AssertEx.IsOrBecomesTrue(
-				() => _nodes
-					.Where((_, index) => index != restartedNodeIndex)
-					.Count(x => x.NodeState == VNodeState.Leader) == 1 &&
-					  _nodes
-					.Where((_, index) => index != restartedNodeIndex)
-					.Count(x => x.NodeState == VNodeState.Follower) == 1,
+				() => {
+					var states = _nodes
+						.Where((_, index) => index != restartedNodeIndex)
+						.Select(x => x.NodeState)
+						.ToArray();
+					return states.Count(x => x == VNodeState.Leader) == 1 &&
+					       states.Count(x => x == VNodeState.Follower) == 1;
+				},
 				RestartTimeout,
 				$"Remaining cluster did not stabilize after shutting down node {restartedNodeIndex}",
 				MiniNodeLogging.WriteLogs);
@@ -49,8 +54,11 @@ public class when_restarting_one_node_at_a_time<TLogFormat, TStreamId> : specifi
 			await Task.WhenAll(_nodes.Select(x => x.Started))
 				.WithTimeout(RestartTimeout, MiniNodeLogging.WriteLogs);
 			AssertEx.IsOrBecomesTrue(
-				() => _nodes.Count(x => x.NodeState == VNodeState.Leader) == 1 &&
-					  _nodes.Count(x => x.NodeState == VNodeState.Follower) == 2,
+				() => {
+					var states = _nodes.Select(x => x.NodeState).ToArray();
+					return states.Count(x => x == VNodeState.Leader) == 1 &&
+					       states.Count(x => x == VNodeState.Follower) == 2;
+				},
 				RestartTimeout,
 				$"Cluster did not stabilize after restarting node {restartedNodeIndex}",
 				MiniNodeLogging.WriteLogs);

--- a/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
+++ b/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
@@ -11,8 +11,8 @@ namespace EventStore.Core.Tests.Integration;
 [TestFixture(typeof(LogFormat.V3), typeof(uint))]
 public class when_restarting_one_node_at_a_time<TLogFormat, TStreamId> : specification_with_cluster<TLogFormat, TStreamId>
 {
-	private static readonly TimeSpan RestartTimeout = TimeSpan.FromSeconds(120);
-	protected override TimeSpan GivenTimeout { get; } = TimeSpan.FromMinutes(5);
+	private static readonly TimeSpan RestartTimeout = TimeSpan.FromMinutes(3);
+	protected override TimeSpan GivenTimeout { get; } = TimeSpan.FromMinutes(10);
 
 	protected override async Task Given()
 	{
@@ -20,15 +20,31 @@ public class when_restarting_one_node_at_a_time<TLogFormat, TStreamId> : specifi
 
 		for (int i = 0; i < 9; i++)
 		{
-			await Task.Delay(2000); //flaky: temporary fix for getting stable cluster
+			var restartedNodeIndex = i % 3;
 
-			await _nodes[i % 3].Shutdown(keepDb: true);
-			await Task.Delay(2000);
+			AssertEx.IsOrBecomesTrue(
+				() => _nodes.Count(x => x.NodeState == VNodeState.Leader) == 1 &&
+					  _nodes.Count(x => x.NodeState == VNodeState.Follower) == 2,
+				RestartTimeout,
+				$"Cluster did not stabilize before restarting node {restartedNodeIndex}",
+				MiniNodeLogging.WriteLogs);
 
-			var node = CreateNode(i % 3, _nodeEndpoints[i % 3],
+			await _nodes[restartedNodeIndex].Shutdown(keepDb: true);
+			AssertEx.IsOrBecomesTrue(
+				() => _nodes
+					.Where((_, index) => index != restartedNodeIndex)
+					.Count(x => x.NodeState == VNodeState.Leader) == 1 &&
+					  _nodes
+					.Where((_, index) => index != restartedNodeIndex)
+					.Count(x => x.NodeState == VNodeState.Follower) == 1,
+				RestartTimeout,
+				$"Remaining cluster did not stabilize after shutting down node {restartedNodeIndex}",
+				MiniNodeLogging.WriteLogs);
+
+			var node = CreateNode(restartedNodeIndex, _nodeEndpoints[restartedNodeIndex],
 				new[] { _nodeEndpoints[(i + 1) % 3].HttpEndPoint, _nodeEndpoints[(i + 2) % 3].HttpEndPoint });
 			node.Start();
-			_nodes[i % 3] = node;
+			_nodes[restartedNodeIndex] = node;
 
 			await Task.WhenAll(_nodes.Select(x => x.Started))
 				.WithTimeout(RestartTimeout, MiniNodeLogging.WriteLogs);
@@ -36,7 +52,7 @@ public class when_restarting_one_node_at_a_time<TLogFormat, TStreamId> : specifi
 				() => _nodes.Count(x => x.NodeState == VNodeState.Leader) == 1 &&
 					  _nodes.Count(x => x.NodeState == VNodeState.Follower) == 2,
 				RestartTimeout,
-				$"Cluster did not stabilize after restarting node {i % 3}",
+				$"Cluster did not stabilize after restarting node {restartedNodeIndex}",
 				MiniNodeLogging.WriteLogs);
 		}
 	}

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_database.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_database.cs
@@ -13,7 +13,9 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation;
 [TestFixture(typeof(LogFormat.V3), typeof(uint))]
 public class when_truncating_database<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture
 {
-	[Test, Category("LongRunning")]
+	private const int LongRunningTimeout = 120000;
+
+	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
 	public async Task everything_should_go_fine()
 	{
 		var miniNode = new MiniNode<TLogFormat, TStreamId>(PathName, inMemDb: false);
@@ -68,7 +70,7 @@ public class when_truncating_database<TLogFormat, TStreamId> : SpecificationWith
 		await miniNode.Shutdown();
 	}
 
-	[Test, Category("LongRunning"), Category("Network")]
+	[Test, Category("LongRunning"), Category("Network"), Timeout(LongRunningTimeout)]
 	public async Task with_truncate_position_in_completed_chunk_everything_should_go_fine()
 	{
 		const int chunkSize = 1024 * 1024;


### PR DESCRIPTION
- keep GitHub Packages credentials scoped to the restore step instead of rewriting the checked-in NuGet config used by later Docker layers
- reduce the chance of clear-text package credentials lingering in the build context or derived image layers after restore finishes