### PR TITLE
fix(http): keep transport cancellation state out of message payloads

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Http/message_codec_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/message_codec_should.cs
@@ -1,0 +1,33 @@
+using EventStore.Core.Messages;
+using EventStore.Transport.Http.Codecs;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Transport.Http;
+
+[TestFixture]
+public class message_codec_should {
+	[OneTimeSetUp]
+	public void SetUp() {
+		HttpMessage.TextMessage.LabelStatic = "Http";
+	}
+
+	[Test]
+	public void round_trip_json_without_serializing_cancellation_token() {
+		var encoded = Codec.Json.To(new HttpMessage.TextMessage("Hello World!"));
+		var decoded = Codec.Json.From<HttpMessage.TextMessage>(encoded);
+
+		StringAssert.DoesNotContain("cancellationToken", encoded);
+		Assert.AreEqual("Hello World!", decoded.Text);
+		Assert.AreEqual("Http", decoded.Label);
+	}
+
+	[Test]
+	public void round_trip_xml_without_serializing_cancellation_token() {
+		var encoded = Codec.Xml.To(new HttpMessage.TextMessage("Hello World!"));
+		var decoded = Codec.Xml.From<HttpMessage.TextMessage>(encoded);
+
+		StringAssert.DoesNotContain("CancellationToken", encoded);
+		Assert.AreEqual("Hello World!", decoded.Text);
+		Assert.AreEqual("Http", decoded.Label);
+	}
+}

--- a/src/EventStore.Core/Messaging/Message.cs
+++ b/src/EventStore.Core/Messaging/Message.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using Newtonsoft.Json;
 
 namespace EventStore.Core.Messaging;
 
@@ -24,5 +25,6 @@ public abstract partial class Message {
 		CancellationToken = cancellationToken;
 	}
 
+	[JsonIgnore]
 	public CancellationToken CancellationToken { get; }
 }


### PR DESCRIPTION
- Keeps HTTP message payloads focused on wire-visible data instead of leaking transport-only cancellation state.
- Preserves JSON and XML response compatibility for message-backed HTTP endpoints while closing the row 250 serialization gap.