### PR TITLE
fix(http): keep cross-origin stats requests predictable

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Http/http_service_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/http_service_should.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.Transport.Http;
@@ -65,6 +66,23 @@ public class http_service_should : SpecificationWithDirectory
 
 		Assert.AreEqual(HttpStatusCode.NotFound, result.StatusCode);
 		Assert.IsEmpty(await result.Content.ReadAsStringAsync());
+	}
+
+	[Test]
+	[Category("Network")]
+	public async Task apply_cors_headers_to_cross_origin_stats_requests()
+	{
+		await using var node = new MiniNode<LogFormat.V2, string>(PathName);
+		await node.Start();
+
+		var request = new HttpRequestMessage(HttpMethod.Get, "/stats/replication");
+		request.Headers.Add("Origin", "https://example.com");
+
+		var result = await node.HttpClient.SendAsync(request);
+
+		Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
+		Assert.That(result.Headers.TryGetValues("Access-Control-Allow-Origin", out var values), Is.True);
+		Assert.That(values, Is.EquivalentTo(new[] { "*" }));
 	}
 }
 

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -10,6 +10,7 @@ using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Services.Transport.Grpc;
 using EventStore.Core.Services.Transport.Grpc.Cluster;
 using EventStore.Core.Services.Transport.Http;
+using EventStore.Transport.Http;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Plugins;
 using EventStore.Plugins.Authentication;
@@ -130,6 +131,7 @@ public class ClusterVNodeStartup<TStreamId> : IStartup, IHandle<SystemMessage.Sy
 		_mainBus.Subscribe(internalDispatcher);
 
 		app = app.Map("/health", _statusCheck.Configure)
+			.UseCors("default")
 			// AuthenticationMiddleware uses _httpAuthenticationProviders and assigns
 			// the resulting ClaimsPrinciple to HttpContext.User
 			.UseMiddleware<AuthenticationMiddleware>()
@@ -290,6 +292,11 @@ public class ClusterVNodeStartup<TStreamId> : IStartup, IHandle<SystemMessage.Sy
 			.AddServiceOptions<Streams<TStreamId>>(options =>
 				options.MaxReceiveMessageSize = TFConsts.EffectiveMaxLogRecordSize)
 			.Services;
+
+		services.AddCors(o => o.AddPolicy(
+			"default",
+			b => b.AllowAnyOrigin().WithMethods(HttpMethod.Options, HttpMethod.Get).AllowAnyHeader())
+		);
 
 		services = _configureNodeServices(services);
 


### PR DESCRIPTION
- Keeps cross-origin stats requests from failing in the HTTP pipeline when browser-based tooling reaches the node from another origin.
- Gives the read-only HTTP surface a default CORS policy so operational endpoints remain usable without widening write access.