### PR TITLE
feat(subscriptions): keep persistent stats manageable at scale

### DIFF
--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/GetAllPersistentSubscriptionStatsTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/GetAllPersistentSubscriptionStatsTests.cs
@@ -78,9 +78,10 @@ public class GetAllPersistentSubscriptionStatsTests<TLogFormat, TStreamId> {
 	}
 
 	[Test]
-	public async Task pages_by_stream_in_sorted_order() {
+	public async Task pages_by_subscription_in_stream_then_group_order() {
 		StartAsLeader();
 		await CreateSubscription("beta", "group-1");
+		await CreateSubscription("alpha", "group-2");
 		await CreateSubscription("alpha", "group-1");
 		await CreateSubscription("gamma", "group-1");
 
@@ -89,15 +90,16 @@ public class GetAllPersistentSubscriptionStatsTests<TLogFormat, TStreamId> {
 		Assert.AreEqual(
 			MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success,
 			response.Result);
-		Assert.That(response.Total, Is.EqualTo(3));
+		Assert.That(response.Total, Is.EqualTo(4));
 		Assert.That(response.RequestedOffset, Is.EqualTo(1));
 		Assert.That(response.RequestedCount, Is.EqualTo(1));
 		Assert.That(response.SubscriptionStats, Has.Count.EqualTo(1));
-		Assert.That(response.SubscriptionStats[0].EventSource, Is.EqualTo("beta"));
+		Assert.That(response.SubscriptionStats[0].EventSource, Is.EqualTo("alpha"));
+		Assert.That(response.SubscriptionStats[0].GroupName, Is.EqualTo("group-2"));
 	}
 
 	[Test]
-	public async Task counts_streams_when_returning_total_for_a_page() {
+	public async Task counts_subscription_records_when_returning_total_for_a_page() {
 		StartAsLeader();
 		await CreateSubscription("alpha", "group-1");
 		await CreateSubscription("alpha", "group-2");
@@ -108,10 +110,10 @@ public class GetAllPersistentSubscriptionStatsTests<TLogFormat, TStreamId> {
 		Assert.AreEqual(
 			MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success,
 			response.Result);
-		Assert.That(response.Total, Is.EqualTo(2));
-		Assert.That(response.SubscriptionStats, Has.Count.EqualTo(2));
-		Assert.That(response.SubscriptionStats, Has.All.Matches<MonitoringMessage.PersistentSubscriptionInfo>(
-			x => x.EventSource == "alpha"));
+		Assert.That(response.Total, Is.EqualTo(3));
+		Assert.That(response.SubscriptionStats, Has.Count.EqualTo(1));
+		Assert.That(response.SubscriptionStats[0].EventSource, Is.EqualTo("alpha"));
+		Assert.That(response.SubscriptionStats[0].GroupName, Is.EqualTo("group-1"));
 	}
 
 	private void StartAsLeader() {

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/GetAllPersistentSubscriptionStatsTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/GetAllPersistentSubscriptionStatsTests.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.LogAbstraction;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Metrics;
+using EventStore.Core.Services;
+using EventStore.Core.Services.PersistentSubscription;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
+using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.Tests;
+using EventStore.Core.Tests.TransactionLog;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+using StreamMetadata = EventStore.Core.Data.StreamMetadata;
+
+namespace EventStore.Core.Tests.Services.PersistentSubscription;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+public class GetAllPersistentSubscriptionStatsTests<TLogFormat, TStreamId> {
+	private PersistentSubscriptionService<TStreamId> _sut;
+	private FakeStorage _storage;
+
+	[SetUp]
+	public void SetUp() {
+		var bus = new SynchronousScheduler();
+		var ioDispatcher = new IODispatcher(bus, bus);
+		var trackers = new Trackers();
+
+		_storage = new FakeStorage();
+
+		bus.Subscribe<ClientMessage.ReadStreamEventsBackward>(_storage);
+		bus.Subscribe<ClientMessage.WriteEvents>(_storage);
+		bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(ioDispatcher.BackwardReader);
+		bus.Subscribe<ClientMessage.WriteEventsCompleted>(ioDispatcher.Writer);
+
+		_sut = new PersistentSubscriptionService<TStreamId>(
+			new QueuedHandlerThreadPool(bus, "test", new QueueStatsManager(), new QueueTrackers()),
+			new FakeReadIndex<TLogFormat, TStreamId>(_ => false, new MetaStreamLookup()),
+			ioDispatcher, bus,
+			new PersistentSubscriptionConsumerStrategyRegistry(bus, bus,
+				Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>()),
+			trackers.PersistentSubscriptionTracker);
+	}
+
+	[Test]
+	public async Task returns_not_ready_with_zero_total_before_starting() {
+		var response = await GetStats(offset: 0, count: 5);
+
+		Assert.AreEqual(
+			MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotReady,
+			response.Result);
+		Assert.That(response.Total, Is.Zero);
+		Assert.That(response.SubscriptionStats, Is.Null);
+	}
+
+	[Test]
+	public async Task returns_empty_page_when_no_subscriptions_exist() {
+		StartAsLeader();
+
+		var response = await GetStats(offset: 0, count: 5);
+
+		Assert.AreEqual(
+			MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success,
+			response.Result);
+		Assert.That(response.Total, Is.Zero);
+		Assert.That(response.RequestedOffset, Is.EqualTo(0));
+		Assert.That(response.RequestedCount, Is.EqualTo(5));
+		Assert.That(response.SubscriptionStats, Is.Empty);
+	}
+
+	[Test]
+	public async Task pages_by_stream_in_sorted_order() {
+		StartAsLeader();
+		await CreateSubscription("beta", "group-1");
+		await CreateSubscription("alpha", "group-1");
+		await CreateSubscription("gamma", "group-1");
+
+		var response = await GetStats(offset: 1, count: 1);
+
+		Assert.AreEqual(
+			MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success,
+			response.Result);
+		Assert.That(response.Total, Is.EqualTo(3));
+		Assert.That(response.RequestedOffset, Is.EqualTo(1));
+		Assert.That(response.RequestedCount, Is.EqualTo(1));
+		Assert.That(response.SubscriptionStats, Has.Count.EqualTo(1));
+		Assert.That(response.SubscriptionStats[0].EventSource, Is.EqualTo("beta"));
+	}
+
+	[Test]
+	public async Task counts_streams_when_returning_total_for_a_page() {
+		StartAsLeader();
+		await CreateSubscription("alpha", "group-1");
+		await CreateSubscription("alpha", "group-2");
+		await CreateSubscription("beta", "group-1");
+
+		var response = await GetStats(offset: 0, count: 1);
+
+		Assert.AreEqual(
+			MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success,
+			response.Result);
+		Assert.That(response.Total, Is.EqualTo(2));
+		Assert.That(response.SubscriptionStats, Has.Count.EqualTo(2));
+		Assert.That(response.SubscriptionStats, Has.All.Matches<MonitoringMessage.PersistentSubscriptionInfo>(
+			x => x.EventSource == "alpha"));
+	}
+
+	private void StartAsLeader() {
+		_sut.Start();
+		_sut.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+	}
+
+	private async Task CreateSubscription(string stream, string groupName) {
+		var envelope = new TcsEnvelope<ClientMessage.CreatePersistentSubscriptionToStreamCompleted>();
+		_sut.Handle(new ClientMessage.CreatePersistentSubscriptionToStream(
+			internalCorrId: Guid.NewGuid(),
+			correlationId: Guid.NewGuid(),
+			envelope: envelope,
+			eventStreamId: stream,
+			groupName: groupName,
+			resolveLinkTos: false,
+			startFrom: 0,
+			messageTimeoutMilliseconds: 10_000,
+			recordStatistics: false,
+			maxRetryCount: 10,
+			bufferSize: 10,
+			liveBufferSize: 10,
+			readbatchSize: 5,
+			checkPointAfterMilliseconds: 1_000,
+			minCheckPointCount: 10,
+			maxCheckPointCount: 100,
+			maxSubscriberCount: 10,
+			namedConsumerStrategy: SystemConsumerStrategies.RoundRobin,
+			user: ClaimsPrincipal.Current));
+
+		var response = await envelope.Task.WithTimeout();
+		Assert.AreEqual(
+			ClientMessage.CreatePersistentSubscriptionToStreamCompleted.CreatePersistentSubscriptionToStreamResult.Success,
+			response.Result,
+			response.Reason);
+	}
+
+	private async Task<MonitoringMessage.GetPersistentSubscriptionStatsCompleted> GetStats(int offset, int count) {
+		var envelope = new TcsEnvelope<MonitoringMessage.GetPersistentSubscriptionStatsCompleted>();
+		_sut.Handle(new MonitoringMessage.GetAllPersistentSubscriptionStats(envelope, offset, count));
+		return await envelope.Task.WithTimeout();
+	}
+
+	private sealed class FakeStorage :
+		IHandle<ClientMessage.ReadStreamEventsBackward>,
+		IHandle<ClientMessage.WriteEvents> {
+		private readonly Dictionary<string, List<Event>> _streams = new();
+
+		public void Handle(ClientMessage.ReadStreamEventsBackward msg) {
+			var result = ReadStreamResult.NoStream;
+			var resolvedEvents = new List<ResolvedEvent>();
+
+			if (_streams.TryGetValue(msg.EventStreamId, out var events)) {
+				result = ReadStreamResult.Success;
+
+				foreach (var ev in events) {
+					var prepareLogRecord = new PrepareLogRecord(
+						logPosition: 0,
+						correlationId: Guid.NewGuid(),
+						eventId: Guid.NewGuid(),
+						transactionPosition: 0,
+						transactionOffset: 0,
+						eventStreamId: msg.EventStreamId,
+						eventStreamIdSize: null,
+						expectedVersion: 0,
+						timeStamp: DateTime.UtcNow,
+						flags: PrepareFlags.Data,
+						eventType: ev.EventType,
+						eventTypeSize: null,
+						data: Array.Empty<byte>(),
+						metadata: Array.Empty<byte>());
+
+					var eventRecord = new EventRecord(0, prepareLogRecord, msg.EventStreamId, ev.EventType);
+					resolvedEvents.Add(ResolvedEvent.ForUnresolvedEvent(eventRecord));
+				}
+			}
+
+			msg.Envelope.ReplyWith(new ClientMessage.ReadStreamEventsBackwardCompleted(
+				correlationId: msg.CorrelationId,
+				eventStreamId: msg.EventStreamId,
+				fromEventNumber: 0,
+				maxCount: msg.MaxCount,
+				result: result,
+				events: resolvedEvents.ToArray(),
+				streamMetadata: new StreamMetadata(),
+				isCachePublic: false,
+				error: null,
+				nextEventNumber: -1,
+				lastEventNumber: 0,
+				isEndOfStream: true,
+				tfLastCommitPosition: 0));
+		}
+
+		public void Handle(ClientMessage.WriteEvents msg) {
+			if (!_streams.TryGetValue(msg.EventStreamId, out var events)) {
+				events = new List<Event>();
+				_streams.Add(msg.EventStreamId, events);
+			}
+
+			events.AddRange(msg.Events);
+
+			msg.Envelope.ReplyWith(new ClientMessage.WriteEventsCompleted(
+				correlationId: msg.CorrelationId,
+				firstEventNumber: 0,
+				lastEventNumber: 0,
+				preparePosition: 0,
+				commitPosition: 0));
+		}
+	}
+
+	private sealed class MetaStreamLookup : IMetastreamLookup<TStreamId> {
+		public bool IsMetaStream(TStreamId streamId) => throw new NotSupportedException();
+		public TStreamId MetaStreamOf(TStreamId streamId) => throw new NotSupportedException();
+		public TStreamId OriginalStreamOf(TStreamId streamId) => throw new NotSupportedException();
+	}
+}

--- a/src/EventStore.Core/Messages/MonitoringMessage.cs
+++ b/src/EventStore.Core/Messages/MonitoringMessage.cs
@@ -9,10 +9,21 @@ namespace EventStore.Core.Messages {
 		[DerivedMessage(CoreMessage.Monitoring)]
 		public partial class GetAllPersistentSubscriptionStats : Message {
 			public readonly IEnvelope Envelope;
+			public readonly int Offset;
+			public readonly int Count;
 
 			public GetAllPersistentSubscriptionStats(IEnvelope envelope) {
 				Ensure.NotNull(envelope, "envelope");
 				Envelope = envelope;
+				Offset = 0;
+				Count = int.MaxValue;
+			}
+
+			public GetAllPersistentSubscriptionStats(IEnvelope envelope, int offset, int count) {
+				Ensure.NotNull(envelope, "envelope");
+				Envelope = envelope;
+				Offset = offset;
+				Count = count;
 			}
 		}
 
@@ -58,12 +69,29 @@ namespace EventStore.Core.Messages {
 		public partial class GetPersistentSubscriptionStatsCompleted : Message {
 			public readonly OperationStatus Result;
 			public readonly List<PersistentSubscriptionInfo> SubscriptionStats;
+			public readonly int RequestedOffset;
+			public readonly int RequestedCount;
+			public readonly int Total;
 			public string ErrorString;
 
 			public GetPersistentSubscriptionStatsCompleted(OperationStatus result,
 				List<PersistentSubscriptionInfo> subscriptionStats, string errorString = "") {
 				Result = result;
 				SubscriptionStats = subscriptionStats;
+				RequestedOffset = 0;
+				RequestedCount = int.MaxValue;
+				Total = subscriptionStats?.Count ?? 0;
+				ErrorString = errorString;
+			}
+
+			public GetPersistentSubscriptionStatsCompleted(OperationStatus result,
+				List<PersistentSubscriptionInfo> subscriptionStats, int requestedOffset, int requestedCount,
+				int total, string errorString = "") {
+				Result = result;
+				SubscriptionStats = subscriptionStats;
+				RequestedOffset = requestedOffset;
+				RequestedCount = requestedCount;
+				Total = total;
 				ErrorString = errorString;
 			}
 

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -55,6 +55,7 @@ public class PersistentSubscriptionService<TStreamId> :
 {
 
 	private Dictionary<string, List<PersistentSubscription>> _subscriptionTopics;
+	private SortedDictionary<string, List<PersistentSubscription>> _sortedSubscriptionTopics;
 	private Dictionary<string, PersistentSubscription> _subscriptionsById;
 
 	private readonly IQueuedHandler _queuedHandler;
@@ -120,6 +121,7 @@ public class PersistentSubscriptionService<TStreamId> :
 	{
 		_handleTick = false;
 		_subscriptionTopics = new Dictionary<string, List<PersistentSubscription>>();
+		_sortedSubscriptionTopics = new SortedDictionary<string, List<PersistentSubscription>>(StringComparer.Ordinal);
 		_subscriptionsById = new Dictionary<string, PersistentSubscription>();
 	}
 
@@ -971,6 +973,7 @@ public class PersistentSubscriptionService<TStreamId> :
 		{
 			subscribers = new List<PersistentSubscription>();
 			_subscriptionTopics.Add(eventSource, subscribers);
+			_sortedSubscriptionTopics.Add(eventSource, subscribers);
 		}
 
 		// shut down any existing subscription
@@ -1011,6 +1014,11 @@ public class PersistentSubscriptionService<TStreamId> :
 				// delete
 				_subscriptionsById.Remove(key);
 				subscribers.RemoveAt(subscriptionIndex);
+				if (subscribers.Count == 0)
+				{
+					_subscriptionTopics.Remove(eventSource);
+					_sortedSubscriptionTopics.Remove(eventSource);
+				}
 			}
 		}
 		else
@@ -1420,7 +1428,7 @@ public class PersistentSubscriptionService<TStreamId> :
 	{
 		Log.Debug("Saving persistent subscription configuration");
 		var data = _config.GetSerializedForm();
-		var ev = new Event(Guid.NewGuid(), "$PersistentConfig", true, data, new byte[0]);
+		var ev = new Event(Guid.NewGuid(), SystemEventTypes.PersistentSubscriptionConfig, true, data, new byte[0]);
 		var metadata = new StreamMetadata(maxCount: 2);
 		Lazy<StreamMetadata> streamMetadata = new Lazy<StreamMetadata>(() => metadata);
 		Event[] events = new Event[] { ev };
@@ -1517,16 +1525,21 @@ public class PersistentSubscriptionService<TStreamId> :
 		if (!_started)
 		{
 			message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
-				MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotReady, null)
+				MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotReady, null,
+				message.Offset, message.Count, 0)
 			);
 			return;
 		}
 
-		var stats = (from subscription in _subscriptionTopics.Values
+		var total = _sortedSubscriptionTopics.Count;
+		var pageOffset = Math.Clamp(message.Offset, 0, total);
+		var pageLength = Math.Clamp(message.Count, 0, total - pageOffset);
+		var stats = (from subscription in _sortedSubscriptionTopics.Values.Skip(pageOffset).Take(pageLength)
 			from sub in subscription
 			select sub.GetStatistics()).ToList();
 		message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
-			MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success, stats)
+			MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success, stats,
+			message.Offset, message.Count, total)
 		);
 	}
 

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -1531,12 +1531,15 @@ public class PersistentSubscriptionService<TStreamId> :
 			return;
 		}
 
-		var total = _sortedSubscriptionTopics.Count;
+		var total = _subscriptionsById.Count;
 		var pageOffset = Math.Clamp(message.Offset, 0, total);
 		var pageLength = Math.Clamp(message.Count, 0, total - pageOffset);
-		var stats = (from subscription in _sortedSubscriptionTopics.Values.Skip(pageOffset).Take(pageLength)
-			from sub in subscription
-			select sub.GetStatistics()).ToList();
+		var stats = _sortedSubscriptionTopics
+			.SelectMany(topic => topic.Value.OrderBy(sub => sub.GroupName, StringComparer.Ordinal))
+			.Skip(pageOffset)
+			.Take(pageLength)
+			.Select(sub => sub.GetStatistics())
+			.ToList();
 		message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(
 			MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success, stats,
 			message.Offset, message.Count, total)

--- a/src/EventStore.Core/Services/SystemNames.cs
+++ b/src/EventStore.Core/Services/SystemNames.cs
@@ -80,6 +80,7 @@ namespace EventStore.Core.Services {
 		public const string Settings = "$settings";
 		public const string StreamCreated = "$stream";
 		public const string EpochInformation = "$epoch-information";
+		public const string PersistentSubscriptionConfig = "$PersistentConfig";
 
 		public const string V2__StreamCreated_InIndex = "StreamCreated";
 		public const string V1__StreamCreated__ = "$stream-created";

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
@@ -98,5 +98,14 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			var builder = new UriBuilder(hostUri.Scheme, hostUri.Host, hostUri.Port, hostUri.LocalPath + path);
 			return builder.Uri.AbsoluteUri;
 		}
+
+		protected static string MakeUrl(HttpEntityManager http, string path, string query) {
+			if (path.Length > 0 && path[0] == '/') path = path.Substring(1);
+			var hostUri = http.ResponseUrl;
+			var builder = new UriBuilder(hostUri.Scheme, hostUri.Host, hostUri.Port, hostUri.LocalPath + path) {
+				Query = query,
+			};
+			return builder.Uri.AbsoluteUri;
+		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -39,6 +39,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		}
 
 		protected override void SubscribeCore(IHttpService service) {
+			Register(service, "/subscriptions?offset={offset}&count={count}", HttpMethod.Get, GetAllSubscriptionInfo, Codec.NoCodecs, DefaultCodecs, new Operation(Operations.Subscriptions.Statistics));
 			Register(service, "/subscriptions", HttpMethod.Get, GetAllSubscriptionInfo, Codec.NoCodecs, DefaultCodecs, new Operation(Operations.Subscriptions.Statistics));
 			Register(service, "/subscriptions/restart", HttpMethod.Post, RestartPersistentSubscriptions, Codec.NoCodecs, DefaultCodecs, new Operation(Operations.Subscriptions.Restart));
 			Register(service, "/subscriptions/{stream}", HttpMethod.Get, GetSubscriptionInfoForStream, Codec.NoCodecs,
@@ -725,6 +726,37 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		private void GetAllSubscriptionInfo(HttpEntityManager http, UriTemplateMatch match) {
 			if (_httpForwarder.ForwardRequest(http))
 				return;
+
+			var offsetValue = match.BoundVariables["offset"];
+			var countValue = match.BoundVariables["count"];
+			if (offsetValue.IsEmptyString() && countValue.IsEmptyString()) {
+				GetSubscriptionInfoUnpaged(http);
+				return;
+			}
+
+			if (offsetValue.IsEmptyString() || !int.TryParse(offsetValue, out var offset) || offset < 0) {
+				SendBadRequest(http,
+					string.Format("Offset must be a non-negative integer 'offset' ='{0}'", offsetValue));
+				return;
+			}
+
+			if (countValue.IsEmptyString() || !int.TryParse(countValue, out var count) || count < 1) {
+				SendBadRequest(http,
+					string.Format("Count must be a positive integer 'count' ='{0}'", countValue));
+				return;
+			}
+
+			var envelope = new SendToHttpEnvelope(
+				_networkSendQueue, http,
+				(args, message) =>
+					http.ResponseCodec.To(ToPagedSummaryDto(http,
+						message as MonitoringMessage.GetPersistentSubscriptionStatsCompleted)),
+				(args, message) => StatsConfiguration(http, message));
+			var cmd = new MonitoringMessage.GetAllPersistentSubscriptionStats(envelope, offset, count);
+			Publish(cmd);
+		}
+
+		private void GetSubscriptionInfoUnpaged(HttpEntityManager http) {
 			var envelope = new SendToHttpEnvelope(
 				_networkSendQueue, http,
 				(args, message) =>
@@ -1016,6 +1048,43 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			}
 		}
 
+		private PagedSubscriptionInfo ToPagedSummaryDto(HttpEntityManager manager,
+			MonitoringMessage.GetPersistentSubscriptionStatsCompleted message) {
+			var subscriptions = ToSummaryDto(manager, message).ToArray();
+			var offset = message?.RequestedOffset ?? 0;
+			var count = message?.RequestedCount ?? 0;
+			var total = message?.Total ?? subscriptions.Length;
+
+			var links = new List<RelLink> {
+				new RelLink(MakeUrl(manager, "/subscriptions", CreatePagingQuery(offset, count)), "self"),
+				new RelLink(MakeUrl(manager, "/subscriptions", CreatePagingQuery(0, count)), "first"),
+			};
+
+			if (offset > 0) {
+				links.Add(new RelLink(
+					MakeUrl(manager, "/subscriptions",
+						CreatePagingQuery(Math.Max(0, offset - count), count)),
+					"previous"));
+			}
+
+			if (offset + count < total) {
+				links.Add(new RelLink(
+					MakeUrl(manager, "/subscriptions", CreatePagingQuery(offset + count, count)),
+					"next"));
+			}
+
+			return new PagedSubscriptionInfo {
+				Links = links,
+				Offset = offset,
+				Count = count,
+				Total = total,
+				Subscriptions = subscriptions,
+			};
+		}
+
+		private static string CreatePagingQuery(int offset, int count) =>
+			string.Format(CultureInfo.InvariantCulture, "offset={0}&count={1}", offset, count);
+
 		public class SubscriptionConfigData {
 			public bool ResolveLinktos { get; set; }
 			[Obsolete] public long StartFrom { get; set; }
@@ -1050,6 +1119,14 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				LiveBufferSize = 500;
 				ReadBatchSize = 20;
 			}
+		}
+
+		public class PagedSubscriptionInfo {
+			public List<RelLink> Links { get; set; }
+			public int Offset { get; set; }
+			public int Count { get; set; }
+			public int Total { get; set; }
+			public SubscriptionSummary[] Subscriptions { get; set; }
 		}
 
 		public class SubscriptionSummary {


### PR DESCRIPTION
- keep persistent subscription stats usable when the catalog grows beyond a single response.
- let operators and tooling move through the stats surface incrementally instead of pulling every stream group at once.
- preserve the existing unpaged endpoint shape so current clients can adopt paging without a breaking cutover.