### PR TITLE
feat(async): let queue shutdown compose with service teardown

### DIFF
--- a/src/EventStore.Core.Tests/Bus/FakeQueuedHandler.cs
+++ b/src/EventStore.Core.Tests/Bus/FakeQueuedHandler.cs
@@ -11,7 +11,7 @@ public class FakeQueuedHandler : IQueuedHandler
 	public void Handle(Message message) { }
 	public void Publish(Message message) { }
 	public Task Start() => Task.CompletedTask;
-	public void Stop() { }
+	public Task Stop() => Task.CompletedTask;
 	public void RequestStop() { }
 	public QueueStats GetStatistics() => null;
 }

--- a/src/EventStore.Core.Tests/Bus/Helpers/FakeQueuedHandler.cs
+++ b/src/EventStore.Core.Tests/Bus/Helpers/FakeQueuedHandler.cs
@@ -12,7 +12,7 @@ public class FakeQueuedHandler : IQueuedHandler
 	public List<Message> PublishedMessages { get; } = [];
 
 	public Task Start() => Task.CompletedTask;
-	public void Stop() { }
+	public Task Stop() => Task.CompletedTask;
 	public void RequestStop() { }
 	public QueueStats GetStatistics() => null;
 

--- a/src/EventStore.Core.Tests/Bus/Helpers/QueuedHandlerTestWithNoopConsumer.cs
+++ b/src/EventStore.Core.Tests/Bus/Helpers/QueuedHandlerTestWithNoopConsumer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
@@ -28,9 +29,9 @@ public abstract class QueuedHandlerTestWithNoopConsumer
 	}
 
 	[TearDown]
-	public virtual void TearDown()
+	public virtual async Task TearDown()
 	{
-		Queue.Stop();
+		await Queue.Stop();
 		Queue = null;
 		Consumer = null;
 	}

--- a/src/EventStore.Core.Tests/Bus/Helpers/QueuedHandlerTestWithWaitingConsumer.cs
+++ b/src/EventStore.Core.Tests/Bus/Helpers/QueuedHandlerTestWithWaitingConsumer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
@@ -28,9 +29,9 @@ public abstract class QueuedHandlerTestWithWaitingConsumer
 	}
 
 	[TearDown]
-	public virtual void TearDown()
+	public virtual async Task TearDown()
 	{
-		Queue.Stop();
+		await Queue.Stop();
 		Queue = null;
 		Consumer.Dispose();
 		Consumer = null;

--- a/src/EventStore.Core.Tests/Bus/when_publishing_to_queued_handler.cs
+++ b/src/EventStore.Core.Tests/Bus/when_publishing_to_queued_handler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests.Bus.Helpers;
@@ -23,11 +24,9 @@ public abstract class when_publishing_to_queued_handler : QueuedHandlerTestWithW
 		Queue.Start();
 	}
 
-	public override void TearDown()
+	public override async Task TearDown()
 	{
-		Consumer.Dispose();
-		Queue.Stop();
-		base.TearDown();
+		await base.TearDown();
 	}
 
 	[Test, Ignore("We do not check each message for null for performance reasons.")]

--- a/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
+++ b/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
@@ -118,7 +118,8 @@ public abstract class when_stopping_queued_handler : QueuedHandlerTestWithNoopCo
 			Assert.IsTrue(started.Wait(5000), "Consumer never started handling the message.");
 			await queue.Stop();
 			Assert.IsTrue(cancelled.Wait(5000), "Consumer never observed queue cancellation.");
-			Assert.That(startTask.IsCanceled, Is.True, "Queue lifecycle task should be cancelled after stop.");
+			Assert.That(startTask.IsCompletedSuccessfully, Is.True,
+				"Queue lifecycle task should complete successfully after a graceful stop.");
 		}
 		finally
 		{

--- a/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
+++ b/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
@@ -190,6 +190,7 @@ public abstract class when_stopping_queued_handler : QueuedHandlerTestWithNoopCo
 		}
 		finally
 		{
+			cancellationTokenSource.Cancel();
 			await queue.Stop();
 			started.Dispose();
 			cancelled.Dispose();

--- a/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
+++ b/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
@@ -20,51 +20,35 @@ public abstract class when_stopping_queued_handler : QueuedHandlerTestWithNoopCo
 
 
 	[Test]
-	public void gracefully_should_not_throw()
+	public async Task gracefully_should_not_throw()
 	{
-		Queue.Start();
-		Assert.DoesNotThrow(() => Queue.Stop());
+		_ = Queue.Start();
+		await Queue.Stop();
 	}
 
 	[Test]
-	public void gracefully_and_queue_is_not_busy_should_not_take_much_time()
+	public async Task gracefully_and_queue_is_not_busy_should_not_take_much_time()
 	{
-		Queue.Start();
-
-		var wait = new ManualResetEventSlim(false);
-
-		ThreadPool.QueueUserWorkItem(_ =>
-		{
-			Queue.Stop();
-			wait.Set();
-		});
-
-		Assert.IsTrue(wait.Wait(5000), "Could not stop queue in time.");
+		_ = Queue.Start();
+		await Queue.Stop().WaitAsync(TimeSpan.FromMilliseconds(5000));
 	}
 
 	[Test]
-	public void second_time_should_not_throw()
+	public async Task second_time_should_not_throw()
 	{
-		Queue.Start();
-		Queue.Stop();
-		Assert.DoesNotThrow(() => Queue.Stop());
+		_ = Queue.Start();
+		await Queue.Stop();
+		await Queue.Stop();
 	}
 
 	[Test]
-	public void second_time_should_not_take_much_time()
+	public async Task second_time_should_not_take_much_time()
 	{
-		Queue.Start();
-		Queue.Stop();
-
-		var wait = new ManualResetEventSlim(false);
-
-		ThreadPool.QueueUserWorkItem(_ =>
-		{
-			Queue.Stop();
-			wait.Set();
-		});
-
-		Assert.IsTrue(wait.Wait(1000), "Could not stop queue in time.");
+		_ = Queue.Start();
+		await Queue.Stop();
+		var secondStop = Queue.Stop();
+		await secondStop.WaitAsync(TimeSpan.FromMilliseconds(1000));
+		Assert.That(secondStop.IsCompletedSuccessfully, Is.True);
 	}
 
 	[Test]
@@ -86,14 +70,14 @@ public abstract class when_stopping_queued_handler : QueuedHandlerTestWithNoopCo
 			}));
 
 			handledEvent.WaitOne();
-			Assert.Throws<TimeoutException>(() => busyQueue.Stop());
+			Assert.ThrowsAsync<TimeoutException>(async () => await busyQueue.Stop());
 		}
 		finally
 		{
 			waitHandle.Set();
 			consumer.Wait();
 
-			busyQueue.Stop();
+			busyQueue.RequestStop();
 			waitHandle.Dispose();
 			handledEvent.Dispose();
 			consumer.Dispose();
@@ -101,7 +85,7 @@ public abstract class when_stopping_queued_handler : QueuedHandlerTestWithNoopCo
 	}
 
 	[Test]
-	public void while_processing_message_cancelled_by_queue_stop_should_not_timeout()
+	public async Task while_processing_message_cancelled_by_queue_stop_should_not_timeout()
 	{
 		var started = new ManualResetEventSlim(false);
 		var cancelled = new ManualResetEventSlim(false);
@@ -132,19 +116,13 @@ public abstract class when_stopping_queued_handler : QueuedHandlerTestWithNoopCo
 			queue.Publish(new TestMessage());
 
 			Assert.IsTrue(started.Wait(5000), "Consumer never started handling the message.");
-			Assert.DoesNotThrow(() => queue.Stop());
+			await queue.Stop();
 			Assert.IsTrue(cancelled.Wait(5000), "Consumer never observed queue cancellation.");
 			Assert.That(startTask.IsCanceled, Is.True, "Queue lifecycle task should be cancelled after stop.");
 		}
 		finally
 		{
-			try
-			{
-				queue.Stop();
-			}
-			catch (TimeoutException)
-			{
-			}
+			queue.RequestStop();
 
 			started.Dispose();
 			cancelled.Dispose();
@@ -152,7 +130,7 @@ public abstract class when_stopping_queued_handler : QueuedHandlerTestWithNoopCo
 	}
 
 	[Test]
-	public void while_processing_message_cancelled_by_message_token_should_continue_processing_queue()
+	public async Task while_processing_message_cancelled_by_message_token_should_continue_processing_queue()
 	{
 		var started = new ManualResetEventSlim(false);
 		var cancelled = new ManualResetEventSlim(false);
@@ -211,7 +189,7 @@ public abstract class when_stopping_queued_handler : QueuedHandlerTestWithNoopCo
 		}
 		finally
 		{
-			queue.Stop();
+			await queue.Stop();
 			started.Dispose();
 			cancelled.Dispose();
 			processedNext.Dispose();

--- a/src/EventStore.Core/Bus/IQueuedHandler.cs
+++ b/src/EventStore.Core/Bus/IQueuedHandler.cs
@@ -6,7 +6,7 @@ namespace EventStore.Core.Bus;
 public interface IQueuedHandler : IPublisher {
 	string Name { get; }
 	Task Start();
-	void Stop();
+	Task Stop();
 
 	void RequestStop();
 	

--- a/src/EventStore.Core/Bus/MultiQueuedHandler.cs
+++ b/src/EventStore.Core/Bus/MultiQueuedHandler.cs
@@ -38,14 +38,14 @@ public class MultiQueuedHandler : IPublisher {
 		return tasks;
 	}
 
-	public void Stop() {
+	public Task Stop() {
 		var stopTasks = new Task[_queues.Length];
 		var queues = _queues.Span;
 		for (int i = 0; i < queues.Length; ++i) {
-			stopTasks[i] = Task.Factory.StartNew(queues[i].Stop);
+			stopTasks[i] = Task.Run(queues[i].Stop);
 		}
 
-		Task.WaitAll(stopTasks);
+		return Task.WhenAll(stopTasks);
 	}
 
 	public void Publish(Message message) {

--- a/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
@@ -103,7 +103,7 @@ namespace EventStore.Core.Bus;
 		public void RequestStop() {
 			Cancel();
 			if (TryStopQueueStats()) {
-				_tcs.TrySetCanceled(_lifetimeToken);
+				_tcs.TrySetResult(null!);
 			}
 			_queueMonitor.Unregister(this);
 		}
@@ -165,7 +165,7 @@ namespace EventStore.Core.Bus;
 						} catch (OperationCanceledException ex) when (IsExpectedCancellation(ex, msg, _lifetimeToken)) {
 							_queueStats.ProcessingCancelled();
 							if (ex.CancellationToken == _lifetimeToken)
-								_tcs.TrySetCanceled(ex.CancellationToken);
+								_tcs.TrySetResult(null!);
 							break;
 						} catch (Exception ex) {
 							Log.Error(ex,
@@ -182,7 +182,7 @@ namespace EventStore.Core.Bus;
 					Interlocked.CompareExchange(ref _isRunning, 0, 1);
 					if (_lifetimeToken.IsCancellationRequested) {
 						TryStopQueueStats();
-						_tcs.TrySetCanceled(_lifetimeToken);
+						_tcs.TrySetResult(null!);
 					}
 
 					// try to reacquire lock if needed
@@ -191,7 +191,7 @@ namespace EventStore.Core.Bus;
 					          && Interlocked.CompareExchange(ref _isRunning, 1, 0) == 0;
 				}
 			} catch (OperationCanceledException e) when (e.CancellationToken == _lifetimeToken) {
-				_tcs.TrySetCanceled(e.CancellationToken);
+				_tcs.TrySetResult(null!);
 			} catch (Exception ex) {
 				_tcs.TrySetException(ex);
 				throw;

--- a/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
@@ -37,7 +37,6 @@ namespace EventStore.Core.Bus;
 
 		private CancellationTokenSource _lifetimeSource;
 		private readonly CancellationToken _lifetimeToken; // cached to avoid ObjectDisposedException
-		private readonly ManualResetEventSlim _stopped = new(true);
 		private readonly TimeSpan _threadStopWaitTimeout;
 
 		// monitoring
@@ -48,7 +47,7 @@ namespace EventStore.Core.Bus;
 		private int _isRunning;
 		private int _queueStatsState; //0 - never started, 1 - started, 2 - stopped
 
-		private readonly TaskCompletionSource<object> _tcs = new();
+		private readonly TaskCompletionSource<object> _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		public QueuedHandlerThreadPool(IAsyncHandle<Message> consumer,
 			string name,
@@ -89,30 +88,35 @@ namespace EventStore.Core.Bus;
 			}
 		}
 
-		public void Stop() {
-			Cancel();
-			WaitForStop();
-			TryStopQueueStats();
-			_queueMonitor.Unregister(this);
-		}
+		public async Task Stop() {
+			RequestStop();
 
-		public void WaitForStop() {
-			if (!_stopped.Wait(_threadStopWaitTimeout))
-				throw new TimeoutException(string.Format("Unable to stop thread '{0}'.", Name));
+			using var timeoutSource = new CancellationTokenSource(_threadStopWaitTimeout);
+			try {
+				await _tcs.Task.WaitAsync(timeoutSource.Token);
+			} catch (OperationCanceledException ex) when (ex.CancellationToken == timeoutSource.Token) {
+				throw new TimeoutException($"Unable to stop thread '{Name}'.");
+			} catch (OperationCanceledException) {
+			} catch (Exception) {
+			}
 		}
 
 		public void RequestStop() {
 			Cancel();
-			TryStopQueueStats();
+			if (TryStopQueueStats()) {
+				_tcs.TrySetCanceled(_lifetimeToken);
+			}
 			_queueMonitor.Unregister(this);
 		}
 
-		private void TryStopQueueStats() {
+		private bool TryStopQueueStats() {
 			if (Interlocked.CompareExchange(ref _isRunning, 1, 0) == 0) {
 				if (Interlocked.CompareExchange(ref _queueStatsState, 2, 1) == 1)
 					_queueStats.Stop();
-				Interlocked.CompareExchange(ref _isRunning, 0, 1);
+				return Interlocked.CompareExchange(ref _isRunning, 0, 1) == 1;
 			}
+
+			return false;
 		}
 
 		async void IThreadPoolWorkItem.Execute() {
@@ -122,7 +126,6 @@ namespace EventStore.Core.Bus;
 
 				bool proceed = true;
 				while (proceed) {
-					_stopped.Reset();
 					_queueStats.EnterBusy();
 					_tracker.EnterBusy();
 
@@ -180,9 +183,8 @@ namespace EventStore.Core.Bus;
 					Interlocked.CompareExchange(ref _isRunning, 0, 1);
 					if (_lifetimeToken.IsCancellationRequested) {
 						TryStopQueueStats();
+						_tcs.TrySetCanceled(_lifetimeToken);
 					}
-
-					_stopped.Set();
 
 					// try to reacquire lock if needed
 					proceed = !_lifetimeToken.IsCancellationRequested

--- a/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
@@ -97,7 +97,6 @@ namespace EventStore.Core.Bus;
 			} catch (OperationCanceledException ex) when (ex.CancellationToken == timeoutSource.Token) {
 				throw new TimeoutException($"Unable to stop thread '{Name}'.");
 			} catch (OperationCanceledException) {
-			} catch (Exception) {
 			}
 		}
 

--- a/src/EventStore.Core/Services/Storage/StorageReaderService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderService.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.LogAbstraction;
@@ -16,7 +18,7 @@ namespace EventStore.Core.Services.Storage {
 	}
 
 	public class StorageReaderService<TStreamId> : StorageReaderService, IHandle<SystemMessage.SystemInit>,
-		IHandle<SystemMessage.BecomeShuttingDown>,
+		IAsyncHandle<SystemMessage.BecomeShuttingDown>,
 		IHandle<SystemMessage.BecomeShutdown>,
 		IHandle<MonitoringMessage.InternalStatsRequest> {
 
@@ -90,9 +92,9 @@ namespace EventStore.Core.Services.Storage {
 			_bus.Publish(new SystemMessage.ServiceInitialized("StorageReader"));
 		}
 
-		void IHandle<SystemMessage.BecomeShuttingDown>.Handle(SystemMessage.BecomeShuttingDown message) {
+		async ValueTask IAsyncHandle<SystemMessage.BecomeShuttingDown>.HandleAsync(SystemMessage.BecomeShuttingDown message, CancellationToken token) {
 			try {
-				_workersMultiHandler.Stop();
+				await _workersMultiHandler.Stop();
 			} catch (Exception exc) {
 				Log.Error(exc, "Error while stopping readers multi handler.");
 			}

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -248,12 +248,13 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 		try
 		{
 			await _writerQueue.Stop();
-			Bus.Publish(new SystemMessage.ServiceShutdown("StorageWriter"));
 		}
 		catch (Exception exc)
 		{
 			Log.Error(exc, "Error when stopping StorageWriter queue.");
 		}
+
+		Bus.Publish(new SystemMessage.ServiceShutdown("StorageWriter"));
 	}
 
 	async ValueTask IAsyncHandle<SystemMessage.WriteEpoch>.HandleAsync(SystemMessage.WriteEpoch message,

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -237,10 +237,22 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 			{
 				await Writer.Flush(token);
 				BlockWriter = true;
-				_writerQueue.Stop().GetAwaiter().OnCompleted(() =>
-					Bus.Publish(new SystemMessage.ServiceShutdown("StorageWriter")));
+				_ = StopWriterQueueAndPublishShutdown();
 				break;
 			}
+		}
+	}
+
+	private async Task StopWriterQueueAndPublishShutdown()
+	{
+		try
+		{
+			await _writerQueue.Stop();
+			Bus.Publish(new SystemMessage.ServiceShutdown("StorageWriter"));
+		}
+		catch (Exception exc)
+		{
+			Log.Error(exc, "Error when stopping StorageWriter queue.");
 		}
 	}
 

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -236,9 +236,9 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 			case VNodeState.ShuttingDown:
 			{
 				await Writer.Flush(token);
-				_writerQueue.RequestStop();
 				BlockWriter = true;
-				Bus.Publish(new SystemMessage.ServiceShutdown("StorageWriter"));
+				_writerQueue.Stop().GetAwaiter().OnCompleted(() =>
+					Bus.Publish(new SystemMessage.ServiceShutdown("StorageWriter")));
 				break;
 			}
 		}

--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -585,7 +585,7 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 
 		try
 		{
-			_node.WorkersHandler.Stop();
+			await _node.WorkersHandler.Stop();
 			_mainQueue.RequestStop();
 		}
 		catch (Exception exc)

--- a/src/EventStore.Projections.Core.Javascript.Tests/Integration/ProjectionRuntimeScenario.cs
+++ b/src/EventStore.Projections.Core.Javascript.Tests/Integration/ProjectionRuntimeScenario.cs
@@ -56,8 +56,14 @@ public abstract class ProjectionRuntimeScenario : SubsystemScenario
 
 		async ValueTask StopAsync()
 		{
-			await subsystem.Stop();
-			await db.DisposeAsync();
+			try
+			{
+				await subsystem.Stop();
+			}
+			finally
+			{
+				await db.DisposeAsync();
+			}
 		}
 
 		return (StopAsync, subsystem.LeaderInputQueue);

--- a/src/EventStore.Projections.Core.Javascript.Tests/Integration/ProjectionRuntimeScenario.cs
+++ b/src/EventStore.Projections.Core.Javascript.Tests/Integration/ProjectionRuntimeScenario.cs
@@ -54,10 +54,12 @@ public abstract class ProjectionRuntimeScenario : SubsystemScenario
 		subsystem.ConfigureApplication(builder.Build().UseRouting(), EmptyConfiguration);
 		subsystem.Start();
 
-		return (() =>
+		async ValueTask StopAsync()
 		{
-			subsystem.Stop();
-			return db.DisposeAsync();
-		}, subsystem.LeaderInputQueue);
+			await subsystem.Stop();
+			await db.DisposeAsync();
+		}
+
+		return (StopAsync, subsystem.LeaderInputQueue);
 	}
 }

--- a/src/EventStore.Projections.Core.Javascript.Tests/Integration/SubsystemScenario.cs
+++ b/src/EventStore.Projections.Core.Javascript.Tests/Integration/SubsystemScenario.cs
@@ -65,7 +65,7 @@ public abstract class SubsystemScenario : IHandle<Message>, IAsyncLifetime
 		_miniStore.Complete();
 		await _complete;
 		await _stop();
-		_mainQueue.Stop();
+		await _mainQueue.Stop();
 	}
 
 	protected async Task<(long commitPosition, long nextRevision)> WriteEvents(string stream, long expectedRevision, params Event[] events)
@@ -400,4 +400,3 @@ public abstract class SubsystemScenario : IHandle<Message>, IAsyncLifetime
 		}
 	}
 }
-

--- a/src/EventStore.Projections.Core.Tests/ProjectionCoreWorkersNodeTests.cs
+++ b/src/EventStore.Projections.Core.Tests/ProjectionCoreWorkersNodeTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.Monitoring.Stats;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests;
+
+[TestFixture]
+public class ProjectionCoreWorkersNodeTests
+{
+	[Test]
+	public void stop_should_attempt_to_stop_output_queue_even_if_input_stop_fails()
+	{
+		var inputException = new InvalidOperationException("input");
+		var inputQueue = new FakeQueuedHandler(() => Task.FromException(inputException));
+		var outputQueue = new FakeQueuedHandler(() => Task.CompletedTask);
+		var sut = new CoreWorker(Guid.NewGuid(), inputQueue, outputQueue);
+
+		var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await sut.Stop());
+
+		Assert.That(ex, Is.SameAs(inputException));
+		Assert.That(inputQueue.StopCalls, Is.EqualTo(1));
+		Assert.That(outputQueue.StopCalls, Is.EqualTo(1));
+	}
+
+	[Test]
+	public void stop_should_aggregate_failures_from_both_queues()
+	{
+		var inputException = new InvalidOperationException("input");
+		var outputException = new InvalidOperationException("output");
+		var inputQueue = new FakeQueuedHandler(() => Task.FromException(inputException));
+		var outputQueue = new FakeQueuedHandler(() => Task.FromException(outputException));
+		var sut = new CoreWorker(Guid.NewGuid(), inputQueue, outputQueue);
+
+		var ex = Assert.ThrowsAsync<AggregateException>(async () => await sut.Stop());
+
+		Assert.That(ex!.InnerExceptions, Has.Count.EqualTo(2));
+		Assert.That(ex.InnerExceptions, Has.Some.SameAs(inputException));
+		Assert.That(ex.InnerExceptions, Has.Some.SameAs(outputException));
+		Assert.That(inputQueue.StopCalls, Is.EqualTo(1));
+		Assert.That(outputQueue.StopCalls, Is.EqualTo(1));
+	}
+
+	private sealed class FakeQueuedHandler : IQueuedHandler
+	{
+		private readonly Func<Task> _stop;
+
+		public FakeQueuedHandler(Func<Task> stop) => _stop = stop;
+
+		public int StopCalls { get; private set; }
+
+		public string Name => nameof(FakeQueuedHandler);
+		public Task Start() => Task.CompletedTask;
+		public void RequestStop() { }
+		public QueueStats GetStatistics() => null;
+		public void Publish(Message message) { }
+
+		public Task Stop()
+		{
+			StopCalls++;
+			return _stop();
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Services/TestFixtureWithProjectionCoreService.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/TestFixtureWithProjectionCoreService.cs
@@ -39,7 +39,7 @@ public class TestFixtureWithProjectionCoreService
 			throw new NotImplementedException();
 		}
 
-		public void Stop()
+		public Task Stop()
 		{
 			throw new NotImplementedException();
 		}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
@@ -42,7 +42,7 @@ public abstract class TestFixtureWithProjectionCoreAndManagementServices<TLogFor
 			throw new NotImplementedException();
 		}
 
-		public void Stop()
+		public Task Stop()
 		{
 			throw new NotImplementedException();
 		}

--- a/src/EventStore.Projections.Core/ProjectionCoreWorkersNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionCoreWorkersNode.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using EventStore.Common.Options;
 using EventStore.Core;
@@ -122,7 +123,39 @@ public class CoreWorker
 
 	public async Task Stop()
 	{
-		await CoreInputQueue.Stop();
-		await CoreOutputQueue.Stop();
+		var inputStop = TryStop(CoreInputQueue);
+		var outputStop = TryStop(CoreOutputQueue);
+
+		try
+		{
+			await Task.WhenAll(inputStop, outputStop);
+		}
+		catch
+		{
+			var exceptions = new List<Exception>();
+			if (inputStop.IsFaulted)
+				exceptions.AddRange(inputStop.Exception!.Flatten().InnerExceptions);
+			if (outputStop.IsFaulted)
+				exceptions.AddRange(outputStop.Exception!.Flatten().InnerExceptions);
+
+			if (exceptions.Count == 0)
+				throw;
+			if (exceptions.Count == 1)
+				ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
+
+			throw new AggregateException(exceptions);
+		}
+	}
+
+	private static Task TryStop(IQueuedHandler queue)
+	{
+		try
+		{
+			return queue.Stop();
+		}
+		catch (Exception ex)
+		{
+			return Task.FromException(ex);
+		}
 	}
 }

--- a/src/EventStore.Projections.Core/ProjectionCoreWorkersNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionCoreWorkersNode.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using EventStore.Common.Options;
 using EventStore.Core;
 using EventStore.Core.Bus;
@@ -119,9 +120,9 @@ public class CoreWorker
 		CoreOutputQueue.Start();
 	}
 
-	public void Stop()
+	public async Task Stop()
 	{
-		CoreInputQueue.Stop();
-		CoreOutputQueue.Stop();
+		await CoreInputQueue.Stop();
+		await CoreOutputQueue.Stop();
 	}
 }

--- a/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
@@ -433,9 +433,14 @@ public sealed class ProjectionsSubsystem : ISubsystem,
 	{
 		if (_subsystemStarted)
 		{
-			await (_leaderInputQueue?.Stop() ?? Task.CompletedTask);
-			foreach (var queue in _coreWorkers)
-				await queue.Value.Stop();
+			var stopTasks = new List<Task>();
+			if (_leaderInputQueue is not null)
+				stopTasks.Add(_leaderInputQueue.Stop());
+			if (_leaderOutputQueue is not null)
+				stopTasks.Add(_leaderOutputQueue.Stop());
+			stopTasks.AddRange(_coreWorkers.Values.Select(worker => worker.Stop()));
+
+			await Task.WhenAll(stopTasks);
 		}
 
 		_subsystemStarted = false;

--- a/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
@@ -429,19 +429,16 @@ public sealed class ProjectionsSubsystem : ISubsystem,
 		return _subsystemInitialized.Task;
 	}
 
-	public Task Stop()
+	public async Task Stop()
 	{
 		if (_subsystemStarted)
 		{
-			if (_leaderInputQueue != null)
-				_leaderInputQueue.Stop();
+			await (_leaderInputQueue?.Stop() ?? Task.CompletedTask);
 			foreach (var queue in _coreWorkers)
-				queue.Value.Stop();
+				await queue.Value.Stop();
 		}
 
 		_subsystemStarted = false;
-
-		return Task.CompletedTask;
 	}
 
 	public void Handle(CoreProjectionStatusMessage.Stopped message)


### PR DESCRIPTION
- queue shutdown needs to be awaitable so shutdown callers can compose teardown without blocking threads on queue joins
- storage and projection services need their shutdown signals to follow queue completion instead of racing ahead of worker exit
- the async phase needs a smaller queue lifecycle seam in place before the larger TFChunk async work can be migrated safely