### PR TITLE
feat(chunks): keep local file access explicit while async IO settles

### DIFF
--- a/src/EventStore.Core.Tests/ClientAPI/append_to_stream_with_hash_collision.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/append_to_stream_with_hash_collision.cs
@@ -14,6 +14,7 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions;
 [TestFixture(typeof(LogFormat.V3), typeof(uint), Ignore = "Hash collisions cannot occur in Log V3")]
 public class append_to_stream_with_hash_collision<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture
 {
+	private const int LongRunningTimeout = 120000;
 	private MiniNode<TLogFormat, TStreamId> _node;
 
 	protected virtual IEventStoreConnection BuildConnection(MiniNode<TLogFormat, TStreamId> node)
@@ -42,7 +43,7 @@ public class append_to_stream_with_hash_collision<TLogFormat, TStreamId> : Speci
 		await base.TestFixtureTearDown();
 	}
 
-	[Test]
+	[Test, Timeout(LongRunningTimeout)]
 	public async Task should_throw_wrong_expected_version()
 	{
 		const string stream1 = "account--696193173";

--- a/src/EventStore.Core.Tests/Services/RedactionService/SwitchChunkFailureTests.cs
+++ b/src/EventStore.Core.Tests/Services/RedactionService/SwitchChunkFailureTests.cs
@@ -152,7 +152,7 @@ public class SwitchChunkFailureTests<TLogFormat, TStreamId> : SwitchChunkTests<T
 		newChunk = $"{nameof(cannot_switch_with_chunk_having_mismatched_range)}-chunk-0-2.tmp";
 		var chunkHeader = new ChunkHeader(1, 1, 1024, 0, 2, true, Guid.NewGuid(), TransformType.Identity);
 		var chunk = await TFChunk.CreateWithHeader(Path.Combine(PathName, newChunk), chunkHeader, 1024, false, false,
-			false, false,
+			false, false, false,
 			new TFChunkTracker.NoOp(), new IdentityChunkTransformFactory(), ReadOnlyMemory<byte>.Empty,
 			CancellationToken.None);
 		chunk.Dispose();

--- a/src/EventStore.Core.Tests/Services/Replication/LogReplication/LogReplicationWithExistingDbFixture.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LogReplication/LogReplicationWithExistingDbFixture.cs
@@ -55,6 +55,7 @@ public abstract class
 			unbuffered: db.Config.Unbuffered,
 			writethrough: db.Config.WriteThrough,
 			reduceFileCachePressure: db.Config.ReduceFileCachePressure,
+			asyncIO: db.Config.AsyncIO,
 			tracker: new TFChunkTracker.NoOp(),
 			transformFactory: new IdentityChunkTransformFactory(),
 			transformHeader: ReadOnlyMemory<byte>.Empty,

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
@@ -18,7 +18,7 @@ public class ScavengedChunk : SpecificationWithFile
 	{
 		var map = new List<PosMap>();
 		var chunk = await TFChunk.CreateNew(Filename, 1024 * 1024, 0, 0, true, false, false, false,
-			false,
+			false, false,
 			new TFChunkTracker.NoOp(),
 			new IdentityChunkTransformFactory(),
 			CancellationToken.None);

--- a/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
@@ -79,7 +79,7 @@ public static class TFChunkHelper
 	{
 		return TFChunk.CreateNew(fileName, chunkSize, 0, 0,
 			isScavenged: isScavenged, inMem: false, unbuffered: false,
-			writethrough: false, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
+			writethrough: false, reduceFileCachePressure: false, asyncIO: false, tracker: new TFChunkTracker.NoOp(),
 			transformFactory: new IdentityChunkTransformFactory(),
 			token);
 	}

--- a/src/EventStore.Core.Tests/TransactionLog/when_accessing_tfchunk_stream_synchronously.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_accessing_tfchunk_stream_synchronously.cs
@@ -15,6 +15,7 @@ using Serilog.Events;
 namespace EventStore.Core.Tests.TransactionLog;
 
 [TestFixture]
+[NonParallelizable]
 public class when_accessing_tfchunk_stream_synchronously : SpecificationWithFile
 {
 	private ILogger _originalLogger;

--- a/src/EventStore.Core.Tests/TransactionLog/when_accessing_tfchunk_stream_synchronously.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_accessing_tfchunk_stream_synchronously.cs
@@ -1,0 +1,170 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Transforms.Identity;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using NUnit.Framework;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace EventStore.Core.Tests.TransactionLog;
+
+[TestFixture]
+public class when_accessing_tfchunk_stream_synchronously : SpecificationWithFile
+{
+	private ILogger _originalLogger;
+	private TFChunk _chunk;
+	private CollectingSink _sink;
+
+	[SetUp]
+	public override async Task SetUp()
+	{
+		await base.SetUp();
+
+		_originalLogger = Log.Logger;
+		_sink = new CollectingSink();
+		Log.Logger = new LoggerConfiguration()
+			.MinimumLevel.Debug()
+			.WriteTo.Sink(_sink)
+			.CreateLogger();
+	}
+
+	[TearDown]
+	public override void TearDown()
+	{
+		Log.Logger = _originalLogger;
+		_chunk?.Dispose();
+		base.TearDown();
+	}
+
+	[Test]
+	public async Task default_local_chunk_io_does_not_warn_on_synchronous_reads()
+	{
+		await CreateChunk(asyncIO: false);
+
+		using var stream = GetHandle().CreateStream();
+		Assert.That(stream.CanTimeout, Is.False);
+		ReadSingleByte(stream);
+
+		Assert.That(LoggedWarnings(), Is.Empty);
+	}
+
+	[Test]
+	public async Task experimental_async_local_chunk_io_uses_timeout_capable_stream()
+	{
+		await CreateChunk(asyncIO: true);
+
+		using var stream = GetHandle().CreateStream();
+
+		Assert.That(stream.CanTimeout, Is.True);
+	}
+
+	[Test]
+	public void generic_chunk_handles_warn_on_synchronous_reads()
+	{
+		var handle = new TestChunkHandle();
+
+		using var stream = ((IChunkHandle)handle).CreateStream();
+		ReadSingleByte(stream);
+
+		Assert.That(LoggedWarnings(), Has.Some.Contains("Synchronous reads should be uncommon."));
+	}
+
+	private async Task CreateChunk(bool asyncIO)
+	{
+		_chunk = await TFChunk.CreateNew(
+			filename: Filename,
+			chunkDataSize: 4096,
+			chunkStartNumber: 0,
+			chunkEndNumber: 0,
+			isScavenged: false,
+			inMem: false,
+			unbuffered: false,
+			writethrough: false,
+			reduceFileCachePressure: false,
+			asyncIO: asyncIO,
+			tracker: new EventStore.Core.TransactionLog.Chunks.TFChunkTracker.NoOp(),
+			transformFactory: new IdentityChunkTransformFactory(),
+			token: CancellationToken.None);
+	}
+
+	private IChunkHandle GetHandle()
+	{
+		var handleField = typeof(TFChunk).GetField("_handle", BindingFlags.NonPublic | BindingFlags.Instance)!;
+		return (IChunkHandle)handleField.GetValue(_chunk)!;
+	}
+
+	private static void ReadSingleByte(Stream stream)
+	{
+		var buffer = new byte[1];
+		var bytesRead = stream.Read(buffer, 0, buffer.Length);
+
+		Assert.That(bytesRead, Is.EqualTo(1));
+	}
+
+	private string[] LoggedWarnings()
+	{
+		return _sink.Events
+			.Where(x => x.Level == LogEventLevel.Warning)
+			.Select(x => x.RenderMessage())
+			.ToArray();
+	}
+
+	private sealed class TestChunkHandle : IChunkHandle
+	{
+		public long Length { get; set; } = 1;
+		public string Name => "test-handle";
+		public FileAccess Access => FileAccess.Read;
+
+		public void Flush()
+		{
+		}
+
+		public ValueTask WriteAsync(ReadOnlyMemory<byte> data, long offset, CancellationToken token) =>
+			ValueTask.CompletedTask;
+
+		public ValueTask<int> ReadAsync(Memory<byte> buffer, long offset, CancellationToken token)
+		{
+			if (!buffer.IsEmpty)
+				buffer.Span[0] = 0x42;
+
+			return new(1);
+		}
+
+		public ValueTask SetReadOnlyAsync(bool value, CancellationToken token) => ValueTask.CompletedTask;
+
+		public void Dispose()
+		{
+		}
+	}
+
+	private sealed class CollectingSink : ILogEventSink
+	{
+		private readonly object _lock = new();
+		public LogEvent[] Events
+		{
+			get
+			{
+				lock (_lock)
+				{
+					return _events.ToArray();
+				}
+			}
+		}
+
+		private readonly System.Collections.Generic.List<LogEvent> _events = [];
+
+		public void Emit(LogEvent logEvent)
+		{
+			lock (_lock)
+			{
+				_events.Add(logEvent);
+			}
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/TransactionLog/when_accessing_tfchunk_stream_synchronously.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_accessing_tfchunk_stream_synchronously.cs
@@ -66,14 +66,15 @@ public class when_accessing_tfchunk_stream_synchronously : SpecificationWithFile
 	}
 
 	[Test]
-	public void generic_chunk_handles_warn_on_synchronous_reads()
+	public void generic_chunk_handles_warn_once_on_repeated_synchronous_reads()
 	{
 		var handle = new TestChunkHandle();
 
 		using var stream = ((IChunkHandle)handle).CreateStream();
 		ReadSingleByte(stream);
+		ReadSingleByte(stream);
 
-		Assert.That(LoggedWarnings(), Has.Some.Contains("Synchronous reads should be uncommon."));
+		Assert.That(LoggedWarnings().Count(x => x.Contains("Synchronous reads should be uncommon.")), Is.EqualTo(1));
 	}
 
 	private async Task CreateChunk(bool asyncIO)

--- a/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_with_a_cancelable_token.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_with_a_cancelable_token.cs
@@ -28,7 +28,7 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 		_writeState = new ObservingWriteState();
 		_chunk = await TFChunk.CreateNew(Filename, 4096, 0, 0,
 			isScavenged: false, inMem: false, unbuffered: false,
-			writethrough: false, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
+			writethrough: false, reduceFileCachePressure: false, asyncIO: false, tracker: new TFChunkTracker.NoOp(),
 			transformFactory: new ObservingChunkTransformFactory(_writeState),
 			token: CancellationToken.None);
 		var record = LogRecord.Commit(0, Guid.NewGuid(), 0, 0);
@@ -219,6 +219,8 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 		}
 
 		public FileAccess Access => inner.Access;
+
+		public string Name => inner.Name;
 
 		public void Flush() => inner.Flush();
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_writer_with_a_cancelable_token.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_writer_with_a_cancelable_token.cs
@@ -48,7 +48,7 @@ public class when_completing_a_tfchunk_writer_with_a_cancelable_token : Specific
 		using var cancellationTokenSource = new CancellationTokenSource();
 		_chunk = await TFChunk.CreateNew(GetFilePathFor("chunk-000000.000000"), 4096, 0, 0,
 			isScavenged: false, inMem: false, unbuffered: false,
-			writethrough: false, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
+			writethrough: false, reduceFileCachePressure: false, asyncIO: false, tracker: new TFChunkTracker.NoOp(),
 			transformFactory: new CancelDuringCompletionTransformFactory(cancellationTokenSource),
 			token: CancellationToken.None);
 		SetCurrentChunk(_writer, _chunk);

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
@@ -120,6 +120,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 			unbuffered: false,
 			writethrough: false,
 			reduceFileCachePressure: false,
+			asyncIO: false,
 			tracker: new TFChunkTracker.NoOp(),
 			transformFactory: new WithHeaderChunkTransformFactory(),
 			token: CancellationToken.None);

--- a/src/EventStore.Core.Tests/TransactionLog/when_verifying_a_remote_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_verifying_a_remote_tfchunk.cs
@@ -78,6 +78,8 @@ public class when_verifying_a_remote_tfchunk : SpecificationWithFilePerTestFixtu
 
 		public FileAccess Access => FileAccess.Read;
 
+		public string Name => "throwing-remote-handle";
+
 		public void Flush() {
 		}
 

--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
@@ -260,6 +260,18 @@ public class ClusterVNodeOptionsTests
 	}
 
 	[Fact]
+	public void can_set_async_io_from_env_vars()
+	{
+		var config = new ConfigurationBuilder()
+			.AddEventStoreEnvironmentVariables(("EVENTSTORE_ASYNC_IO", "true"))
+			.Build();
+
+		var options = ClusterVNodeOptions.FromConfiguration(config);
+
+		options.Experimental.AsyncIO.Should().BeTrue();
+	}
+
+	[Fact]
 	public void can_set_cluster_size_from_config_file()
 	{
 		var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Configuration", "test.eventstore.conf");

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
@@ -873,6 +873,7 @@ public class Scenario<TLogFormat, TStreamId> : Scenario
 				unbuffered: false,
 				writethrough: false,
 				reduceFileCachePressure: false,
+				asyncIO: false,
 				tracker: new TFChunkTracker.NoOp(),
 				transformFactory: transformFactory,
 				transformHeader: transformHeader,

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -456,7 +456,8 @@ public class ClusterVNode<TStreamId> :
 				unbuffered: false,
 				options.Database.WriteThrough,
 				options.Database.ReduceFileCachePressure,
-				options.Database.MaxTruncation);
+				options.Database.MaxTruncation,
+				options.Experimental.AsyncIO);
 		}
 
 		var writerCheckpoint = Db.Config.WriterCheckpoint.Read();

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -42,6 +42,7 @@ public partial record ClusterVNodeOptions
 	[OptionGroup] public CertificateStoreOptions CertificateStore { get; init; } = new();
 	[OptionGroup] public ClusterOptions Cluster { get; init; } = new();
 	[OptionGroup] public DatabaseOptions Database { get; init; } = new();
+	[OptionGroup] public ExperimentalOptions Experimental { get; init; } = new();
 	[OptionGroup] public GrpcOptions Grpc { get; init; } = new();
 	[OptionGroup] public InterfaceOptions Interface { get; init; } = new();
 	[OptionGroup] public ProjectionOptions Projection { get; init; } = new();
@@ -82,6 +83,7 @@ public partial record ClusterVNodeOptions
 			CertificateStore = configuration.BindOptions<CertificateStoreOptions>(),
 			Cluster = configuration.BindOptions<ClusterOptions>(),
 			Database = configuration.BindOptions<DatabaseOptions>(),
+			Experimental = configuration.BindOptions<ExperimentalOptions>(),
 			Grpc = configuration.BindOptions<GrpcOptions>(),
 			Interface = configuration.BindOptions<InterfaceOptions>(),
 			Projection = configuration.BindOptions<ProjectionOptions>(),
@@ -207,6 +209,13 @@ public partial record ClusterVNodeOptions
 		public int LogFileRetentionCount { get; init; } = 31;
 
 		[Description("Disable log to disk.")] public bool DisableLogFile { get; init; } = false;
+	}
+
+	[Description("Experimental Options")]
+	public record ExperimentalOptions
+	{
+		[Description("Use asynchronous local chunk reads and writes. Disabled by default while local async I/O remains experimental.")]
+		public bool AsyncIO { get; init; } = false;
 	}
 
 	[Description("Authentication/Authorization Options")]

--- a/src/EventStore.Core/Services/RedactionService.cs
+++ b/src/EventStore.Core/Services/RedactionService.cs
@@ -310,6 +310,7 @@ public class RedactionService<TStreamId> :
 				verifyHash: true,
 				unbufferedRead: _db.Config.Unbuffered,
 				reduceFileCachePressure: true,
+				asyncIO: _db.Config.AsyncIO,
 				tracker: new TFChunkTracker.NoOp(),
 				getTransformFactory: _db.TransformManager.GetFactoryForExistingChunk,
 				token: token);

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkFileHandle.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkFileHandle.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNext;
+using DotNext.IO;
 using Microsoft.Win32.SafeHandles;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
@@ -11,6 +12,8 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
 internal sealed class ChunkFileHandle : Disposable, IChunkHandle
 {
 	private readonly SafeFileHandle _handle;
+	private readonly string _path;
+	private readonly bool _asynchronous;
 
 	public ChunkFileHandle(string path, FileStreamOptions options)
 	{
@@ -19,6 +22,8 @@ internal sealed class ChunkFileHandle : Disposable, IChunkHandle
 
 		_handle = File.OpenHandle(path, options.Mode, options.Access, options.Share, options.Options,
 			options.PreallocationSize);
+		_path = path;
+		_asynchronous = options.Options.HasFlag(FileOptions.Asynchronous);
 		Access = options.Access;
 
 		SetReadOnly(_handle, options.Access.HasFlag(FileAccess.Write) is false);
@@ -27,10 +32,41 @@ internal sealed class ChunkFileHandle : Disposable, IChunkHandle
 	public void Flush() => RandomAccess.FlushToDisk(_handle);
 
 	public ValueTask WriteAsync(ReadOnlyMemory<byte> data, long offset, CancellationToken token)
-		=> RandomAccess.WriteAsync(_handle, data, offset, token);
+	{
+		if (_asynchronous)
+			return RandomAccess.WriteAsync(_handle, data, offset, token);
+
+		if (token.IsCancellationRequested)
+			return ValueTask.FromCanceled(token);
+
+		try
+		{
+			Write(data.Span, offset);
+			return ValueTask.CompletedTask;
+		}
+		catch (Exception ex)
+		{
+			return ValueTask.FromException(ex);
+		}
+	}
 
 	public ValueTask<int> ReadAsync(Memory<byte> buffer, long offset, CancellationToken token)
-		=> RandomAccess.ReadAsync(_handle, buffer, offset, token);
+	{
+		if (_asynchronous)
+			return RandomAccess.ReadAsync(_handle, buffer, offset, token);
+
+		if (token.IsCancellationRequested)
+			return ValueTask.FromCanceled<int>(token);
+
+		try
+		{
+			return new(Read(buffer.Span, offset));
+		}
+		catch (Exception ex)
+		{
+			return ValueTask.FromException<int>(ex);
+		}
+	}
 
 	public long Length
 	{
@@ -38,7 +74,11 @@ internal sealed class ChunkFileHandle : Disposable, IChunkHandle
 		set => RandomAccess.SetLength(_handle, value);
 	}
 
+	public string Name => _path;
+
 	public FileAccess Access { get; }
+
+	internal bool Asynchronous => _asynchronous;
 
 	public ValueTask SetReadOnlyAsync(bool value, CancellationToken token)
 	{
@@ -63,6 +103,12 @@ internal sealed class ChunkFileHandle : Disposable, IChunkHandle
 		return task;
 	}
 
+	internal void Write(ReadOnlySpan<byte> data, long offset) => RandomAccess.Write(_handle, data, offset);
+
+	internal int Read(Span<byte> buffer, long offset) => RandomAccess.Read(_handle, buffer, offset);
+
+	internal Stream CreateSynchronousStream() => new SynchronousStream(this);
+
 	private static void SetReadOnly(SafeFileHandle handle, bool value)
 	{
 		var flags = value
@@ -84,6 +130,40 @@ internal sealed class ChunkFileHandle : Disposable, IChunkHandle
 		{
 			File.SetAttributes(handle, flags);
 		}
+	}
+
+	private sealed class SynchronousStream(ChunkFileHandle handle) : RandomAccessStream
+	{
+		public override void Flush() => handle.Flush();
+
+		public override void SetLength(long value) => handle.Length = value;
+
+		public override bool CanRead => handle.Access.HasFlag(FileAccess.Read);
+
+		public override bool CanSeek => true;
+
+		public override bool CanWrite => handle.Access.HasFlag(FileAccess.Write);
+
+		public override bool CanTimeout => false;
+
+		public override long Length => handle.Length;
+
+		protected override void Write(ReadOnlySpan<byte> buffer, long offset)
+		{
+			if (buffer.IsEmpty)
+				return;
+
+			handle.Write(buffer, offset);
+		}
+
+		protected override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, long offset, CancellationToken token) =>
+			handle.WriteAsync(buffer, offset, token);
+
+		protected override int Read(Span<byte> buffer, long offset)
+			=> buffer.IsEmpty ? 0 : handle.Read(buffer, offset);
+
+		protected override ValueTask<int> ReadAsync(Memory<byte> buffer, long offset, CancellationToken token) =>
+			handle.ReadAsync(buffer, offset, token);
 	}
 
 	protected override void Dispose(bool disposing)

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkFileHandle.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkFileHandle.cs
@@ -9,6 +9,12 @@ using Microsoft.Win32.SafeHandles;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
 
+/// <summary>
+/// Wraps local chunk file access and makes the sync-vs-async file I/O choice explicit.
+/// When opened without <see cref="FileOptions.Asynchronous"/>, cancellation is only observed
+/// before the synchronous filesystem call starts; callers that need cooperative mid-operation
+/// cancellation should prefer asynchronous handles.
+/// </summary>
 internal sealed class ChunkFileHandle : Disposable, IChunkHandle
 {
 	private readonly SafeFileHandle _handle;
@@ -31,6 +37,11 @@ internal sealed class ChunkFileHandle : Disposable, IChunkHandle
 
 	public void Flush() => RandomAccess.FlushToDisk(_handle);
 
+	/// <summary>
+	/// Writes to the chunk handle at the requested offset.
+	/// For synchronous handles, <paramref name="token"/> is checked before the write begins but
+	/// cannot interrupt a blocking local filesystem write once it has started.
+	/// </summary>
 	public ValueTask WriteAsync(ReadOnlyMemory<byte> data, long offset, CancellationToken token)
 	{
 		if (_asynchronous)
@@ -50,6 +61,11 @@ internal sealed class ChunkFileHandle : Disposable, IChunkHandle
 		}
 	}
 
+	/// <summary>
+	/// Reads from the chunk handle at the requested offset.
+	/// For synchronous handles, <paramref name="token"/> is checked before the read begins but
+	/// cannot interrupt a blocking local filesystem read once it has started.
+	/// </summary>
 	public ValueTask<int> ReadAsync(Memory<byte> buffer, long offset, CancellationToken token)
 	{
 		if (_asynchronous)

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkHandle.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkHandle.cs
@@ -51,6 +51,8 @@ public interface IChunkHandle : IFlushable, IDisposable
 	private sealed class UnbufferedStream(IChunkHandle handle) : RandomAccessStream
 	{
 		private int _readTimeout, _writeTimeout;
+		private int _readWarningLogged;
+		private int _writeWarningLogged;
 		private CancellationTokenSource _timeoutSource;
 
 		public override void Flush() => handle.Flush();
@@ -87,7 +89,7 @@ public interface IChunkHandle : IFlushable, IDisposable
 			if (buffer.IsEmpty)
 				return;
 
-			Log.Warning("Synchronous writes should be uncommon. Handle: {Handle}", handle.Name);
+			LogSynchronousWriteOnce();
 
 			// Do sync over async without any optimizations to make it just works.
 			// In practice, no one should call synchronous write
@@ -125,7 +127,7 @@ public interface IChunkHandle : IFlushable, IDisposable
 			}
 			else
 			{
-				Log.Warning("Synchronous reads should be uncommon. Handle: {Handle}", handle.Name);
+				LogSynchronousReadOnce();
 
 				// Do sync over async without any optimizations to make it just works.
 				// In practice, no one should call synchronous write
@@ -157,6 +159,22 @@ public interface IChunkHandle : IFlushable, IDisposable
 
 		protected override ValueTask<int> ReadAsync(Memory<byte> buffer, long offset, CancellationToken token)
 			=> handle.ReadAsync(buffer, offset, token);
+
+		private void LogSynchronousReadOnce()
+		{
+			if (Interlocked.Exchange(ref _readWarningLogged, 1) != 0)
+				return;
+
+			Log.Warning("Synchronous reads should be uncommon. Handle: {Handle}", handle.Name);
+		}
+
+		private void LogSynchronousWriteOnce()
+		{
+			if (Interlocked.Exchange(ref _writeWarningLogged, 1) != 0)
+				return;
+
+			Log.Warning("Synchronous writes should be uncommon. Handle: {Handle}", handle.Name);
+		}
 
 		private CancellationToken GetTimeoutToken(int timeout)
 		{

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkHandle.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkHandle.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using DotNext;
 using DotNext.Buffers;
 using DotNext.IO;
+using Serilog;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
 
@@ -27,6 +28,8 @@ public interface IChunkHandle : IFlushable, IDisposable
 		set;
 	}
 
+	string Name { get; }
+
 	/// <summary>
 	/// Gets access mode for this handle.
 	/// </summary>
@@ -41,7 +44,9 @@ public interface IChunkHandle : IFlushable, IDisposable
 	Stream CreateStream() => CreateStream(this, 60_000);
 
 	protected static Stream CreateStream(IChunkHandle handle, int synchronousTimeout)
-		=> new UnbufferedStream(handle) { ReadTimeout = synchronousTimeout, WriteTimeout = synchronousTimeout };
+		=> handle is ChunkFileHandle { Asynchronous: false } chunkFileHandle
+			? chunkFileHandle.CreateSynchronousStream()
+			: new UnbufferedStream(handle) { ReadTimeout = synchronousTimeout, WriteTimeout = synchronousTimeout };
 
 	private sealed class UnbufferedStream(IChunkHandle handle) : RandomAccessStream
 	{
@@ -82,6 +87,8 @@ public interface IChunkHandle : IFlushable, IDisposable
 			if (buffer.IsEmpty)
 				return;
 
+			Log.Warning("Synchronous writes should be uncommon. Handle: {Handle}", handle.Name);
+
 			// Do sync over async without any optimizations to make it just works.
 			// In practice, no one should call synchronous write
 			var bufferCopy = buffer.Copy();
@@ -118,6 +125,8 @@ public interface IChunkHandle : IFlushable, IDisposable
 			}
 			else
 			{
+				Log.Warning("Synchronous reads should be uncommon. Handle: {Handle}", handle.Name);
+
 				// Do sync over async without any optimizations to make it just works.
 				// In practice, no one should call synchronous write
 				var bufferCopy = Memory.AllocateExactly<byte>(buffer.Length);
@@ -127,6 +136,7 @@ public interface IChunkHandle : IFlushable, IDisposable
 				{
 					task.Wait();
 					bytesRead = task.Result;
+					bufferCopy.Span.Slice(0, bytesRead).CopyTo(buffer);
 				}
 				catch (AggregateException e) when (e.InnerExceptions is [OperationCanceledException canceledEx] &&
 				                                   canceledEx.CancellationToken == timeoutToken)
@@ -140,7 +150,6 @@ public interface IChunkHandle : IFlushable, IDisposable
 					bufferCopy.Dispose();
 				}
 
-				bufferCopy.Span.Slice(0, bytesRead).CopyTo(buffer);
 			}
 
 			return bytesRead;

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -184,6 +184,7 @@ public partial class TFChunk : IDisposable
 
 	// https://learn.microsoft.com/en-US/troubleshoot/windows-server/application-management/operating-system-performance-degrades
 	private readonly bool _reduceFileCachePressure;
+	private readonly bool _asyncIO;
 
 	private IChunkReadSide _readSide;
 
@@ -195,7 +196,8 @@ public partial class TFChunk : IDisposable
 		bool inMem,
 		bool unbuffered,
 		bool writethrough,
-		bool reduceFileCachePressure)
+		bool reduceFileCachePressure,
+		bool asyncIO)
 	{
 		Ensure.NotNullOrEmpty(filename, "filename");
 		Ensure.Nonnegative(midpointsDepth, "midpointsDepth");
@@ -206,6 +208,7 @@ public partial class TFChunk : IDisposable
 		_unbuffered = unbuffered;
 		_writeThrough = writethrough;
 		_reduceFileCachePressure = reduceFileCachePressure;
+		_asyncIO = asyncIO;
 		_memStreams = new();
 		_fileStreams = new();
 
@@ -223,11 +226,11 @@ public partial class TFChunk : IDisposable
 	// local or remote
 	public static async ValueTask<TFChunk> FromCompletedFile(string filename, bool verifyHash, bool unbufferedRead,
 		ITransactionFileTracker tracker, Func<TransformType, IChunkTransformFactory> getTransformFactory,
-		bool reduceFileCachePressure = false, CancellationToken token = default)
+		bool reduceFileCachePressure = false, bool asyncIO = false, CancellationToken token = default)
 	{
 
 		var chunk = new TFChunk(filename,
-			TFConsts.MidpointsDepth, false, unbufferedRead, false, reduceFileCachePressure);
+			TFConsts.MidpointsDepth, false, unbufferedRead, false, reduceFileCachePressure, asyncIO);
 		try
 		{
 			await chunk.InitCompleted(verifyHash, tracker, getTransformFactory, token);
@@ -244,6 +247,7 @@ public partial class TFChunk : IDisposable
 	// always local
 	public static async ValueTask<TFChunk> FromOngoingFile(string filename, int writePosition, bool unbuffered,
 		bool writethrough, bool reduceFileCachePressure, ITransactionFileTracker tracker,
+		bool asyncIO,
 		Func<TransformType, IChunkTransformFactory> getTransformFactory,
 		CancellationToken token)
 	{
@@ -252,7 +256,8 @@ public partial class TFChunk : IDisposable
 			false,
 			unbuffered,
 			writethrough,
-			reduceFileCachePressure);
+			reduceFileCachePressure,
+			asyncIO);
 		try
 		{
 			await chunk.InitOngoing(writePosition, tracker, getTransformFactory, token);
@@ -276,6 +281,7 @@ public partial class TFChunk : IDisposable
 		bool unbuffered,
 		bool writethrough,
 		bool reduceFileCachePressure,
+		bool asyncIO,
 		ITransactionFileTracker tracker,
 		IChunkTransformFactory transformFactory,
 		CancellationToken token)
@@ -300,7 +306,7 @@ public partial class TFChunk : IDisposable
 		transformFactory.CreateTransformHeader(transformHeader);
 
 		return await CreateWithHeader(filename, chunkHeader, fileSize, inMem, unbuffered, writethrough,
-			reduceFileCachePressure, tracker, transformFactory, transformHeader, token);
+			reduceFileCachePressure, asyncIO, tracker, transformFactory, transformHeader, token);
 	}
 
 	// local only
@@ -311,6 +317,7 @@ public partial class TFChunk : IDisposable
 		bool unbuffered,
 		bool writethrough,
 		bool reduceFileCachePressure,
+		bool asyncIO,
 		ITransactionFileTracker tracker,
 		IChunkTransformFactory transformFactory,
 		ReadOnlyMemory<byte> transformHeader,
@@ -321,7 +328,8 @@ public partial class TFChunk : IDisposable
 			inMem,
 			unbuffered,
 			writethrough,
-			reduceFileCachePressure);
+			reduceFileCachePressure,
+			asyncIO);
 		try
 		{
 			await chunk.InitNew(header, fileSize, tracker, transformFactory, transformHeader, token);
@@ -346,9 +354,7 @@ public partial class TFChunk : IDisposable
 			Mode = FileMode.Open,
 			Access = FileAccess.Read,
 			Share = FileShare.ReadWrite,
-			Options = _reduceFileCachePressure
-				? FileOptions.Asynchronous
-				: FileOptions.RandomAccess | FileOptions.Asynchronous
+			Options = ReadOnlyHandleOptions
 		};
 		_handle = new ChunkFileHandle(_filename, options);
 		_fileSize = (int)_handle.Length;
@@ -525,19 +531,25 @@ public partial class TFChunk : IDisposable
 		return StreamSource.AsSharedStream(new(memoryView), compatWithAsync: true);
 	}
 
+	private FileOptions ReadOnlyHandleOptions =>
+		ComposeHandleOptions(_reduceFileCachePressure ? FileOptions.None : FileOptions.RandomAccess);
+
 	private FileOptions WritableHandleOptions
 	{
 		get
 		{
-			var options = _reduceFileCachePressure
-				? FileOptions.Asynchronous
-				: FileOptions.RandomAccess | FileOptions.Asynchronous;
+			var options = ComposeHandleOptions(_reduceFileCachePressure ? FileOptions.None : FileOptions.RandomAccess);
 			if (_writeThrough)
 				options |= FileOptions.WriteThrough;
 
 			return options;
 		}
 	}
+
+	private FileOptions TempFileOptions => ComposeHandleOptions(FileOptions.SequentialScan);
+
+	private FileOptions ComposeHandleOptions(FileOptions baseOptions) =>
+		_asyncIO ? baseOptions | FileOptions.Asynchronous : baseOptions;
 
 	private async ValueTask CreateWriterWorkItemForNewChunk(ChunkHeader chunkHeader, int fileSize,
 		ReadOnlyMemory<byte> transformHeader, CancellationToken token)
@@ -553,7 +565,7 @@ public partial class TFChunk : IDisposable
 			Mode = FileMode.CreateNew,
 			Access = FileAccess.ReadWrite,
 			Share = FileShare.Read,
-			Options = FileOptions.SequentialScan | FileOptions.Asynchronous,
+			Options = TempFileOptions,
 			PreallocationSize = fileSize, // avoid fragmentation of file
 			BufferSize = WriterWorkItem.BufferSize,
 		};

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -110,6 +110,7 @@ public class TFChunkDb : IAsyncDisposable
 							unbufferedRead: Config.Unbuffered,
 							tracker: _tracker,
 							reduceFileCachePressure: Config.ReduceFileCachePressure,
+							asyncIO: Config.AsyncIO,
 							getTransformFactory: TransformManager.GetFactoryForExistingChunk,
 							token: token);
 					else
@@ -119,6 +120,7 @@ public class TFChunkDb : IAsyncDisposable
 							writethrough: Config.WriteThrough,
 							reduceFileCachePressure: Config.ReduceFileCachePressure,
 							tracker: _tracker,
+							asyncIO: Config.AsyncIO,
 							getTransformFactory: TransformManager.GetFactoryForExistingChunk,
 							token);
 						// chunk is full with data, we should complete it right here
@@ -131,6 +133,7 @@ public class TFChunkDb : IAsyncDisposable
 					chunk = await TFChunk.TFChunk.FromCompletedFile(chunkInfo.ChunkFileName, verifyHash: false,
 						unbufferedRead: Config.Unbuffered,
 						reduceFileCachePressure: Config.ReduceFileCachePressure,
+						asyncIO: Config.AsyncIO,
 						tracker: _tracker,
 						getTransformFactory: TransformManager.GetFactoryForExistingChunk,
 						token: token);
@@ -177,6 +180,7 @@ public class TFChunkDb : IAsyncDisposable
 				var lastChunk = await TFChunk.TFChunk.FromCompletedFile(chunkFileName, verifyHash: false,
 					unbufferedRead: Config.Unbuffered,
 					reduceFileCachePressure: Config.ReduceFileCachePressure,
+					asyncIO: Config.AsyncIO,
 					tracker: _tracker,
 					getTransformFactory: TransformManager.GetFactoryForExistingChunk,
 					token: token);
@@ -209,6 +213,7 @@ public class TFChunkDb : IAsyncDisposable
 					writethrough: Config.WriteThrough,
 					reduceFileCachePressure: Config.ReduceFileCachePressure,
 					tracker: _tracker,
+					asyncIO: Config.AsyncIO,
 					getTransformFactory: type => TransformManager.GetFactoryForExistingChunk(type),
 					token);
 				await Manager.AddChunk(lastChunk, token);

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
@@ -21,6 +21,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		public readonly bool WriteThrough;
 		public readonly bool ReduceFileCachePressure;
 		public readonly long MaxTruncation;
+		public readonly bool AsyncIO;
 
 		public TFChunkDbConfig(string path,
 			IVersionedFileNamingStrategy fileNamingStrategy,
@@ -38,7 +39,8 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			bool unbuffered = false,
 			bool writethrough = false,
 			bool reduceFileCachePressure = false,
-			long maxTruncation = 256 * 1024 * 1024) {
+			long maxTruncation = 256 * 1024 * 1024,
+			bool asyncIO = false) {
 			Ensure.NotNullOrEmpty(path, "path");
 			Ensure.NotNull(fileNamingStrategy, "fileNamingStrategy");
 			Ensure.Positive(chunkSize, "chunkSize");
@@ -69,6 +71,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			WriteThrough = writethrough;
 			ReduceFileCachePressure = reduceFileCachePressure;
 			MaxTruncation = maxTruncation;
+			AsyncIO = asyncIO;
 		}
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -142,6 +142,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 			_config.Unbuffered,
 			_config.WriteThrough,
 			_config.ReduceFileCachePressure,
+			_config.AsyncIO,
 			_tracker,
 			// temporary chunks are used for replicating raw (scavenged) chunks.
 			// since the raw data being replicated is already transformed, we use
@@ -170,6 +171,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 				unbuffered: _config.Unbuffered,
 				writethrough: _config.WriteThrough,
 				reduceFileCachePressure: _config.ReduceFileCachePressure,
+				asyncIO: _config.AsyncIO,
 				tracker: _tracker,
 				transformFactory: _transformManager.GetFactoryForNewChunk(),
 				token);
@@ -211,6 +213,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 				unbuffered: _config.Unbuffered,
 				writethrough: _config.WriteThrough,
 				reduceFileCachePressure: _config.ReduceFileCachePressure,
+				asyncIO: _config.AsyncIO,
 				tracker: _tracker,
 				transformFactory: _transformManager.GetFactoryForExistingChunk(chunkHeader.TransformType),
 				transformHeader: transformHeader,
@@ -321,7 +324,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 
 			newChunk = await TFChunk.TFChunk.FromCompletedFile(newFileName, verifyHash, _config.Unbuffered,
 				_tracker, type => _transformManager.GetFactoryForExistingChunk(type),
-				_config.ReduceFileCachePressure, token: token);
+				_config.ReduceFileCachePressure, _config.AsyncIO, token: token);
 		}
 
 		bool triggerCaching;

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -229,6 +229,7 @@ public class TFChunkScavenger<TStreamId> : TFChunkScavenger
 				unbuffered: _db.Config.Unbuffered,
 				writethrough: _db.Config.WriteThrough,
 				reduceFileCachePressure: _db.Config.ReduceFileCachePressure,
+				asyncIO: _db.Config.AsyncIO,
 				tracker: new TFChunkTracker.NoOp(),
 				transformFactory: _db.TransformManager.GetFactoryForNewChunk(),
 				ct);
@@ -498,6 +499,7 @@ public class TFChunkScavenger<TStreamId> : TFChunkScavenger
 				unbuffered: db.Config.Unbuffered,
 				writethrough: db.Config.WriteThrough,
 				reduceFileCachePressure: db.Config.ReduceFileCachePressure,
+				asyncIO: db.Config.AsyncIO,
 				tracker: new TFChunkTracker.NoOp(),
 				transformFactory: db.TransformManager.GetFactoryForNewChunk(),
 				ct);

--- a/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkWriterForExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkWriterForExecutor.cs
@@ -56,6 +56,7 @@ public class ChunkWriterForExecutor<TStreamId> : IChunkWriterForExecutor<TStream
 			unbuffered: dbConfig.Unbuffered,
 			writethrough: dbConfig.WriteThrough,
 			reduceFileCachePressure: dbConfig.ReduceFileCachePressure,
+			asyncIO: dbConfig.AsyncIO,
 			tracker: new TFChunkTracker.NoOp(),
 			transformFactory: transformManager.GetFactoryForNewChunk(),
 			token);


### PR DESCRIPTION
- keep chunk file access explicit while local async file IO is still experimental
- surface synchronous compatibility reads so slow paths stop hiding behind chunk stream adapters
- let chunk, scavenging, and redaction flows share one storage access mode instead of assuming async everywhere