### PR TITLE
fix(http): keep append limits aligned across transports

### DIFF
--- a/.github/workflows/build-container-ubuntu-lts.yml
+++ b/.github/workflows/build-container-ubuntu-lts.yml
@@ -44,6 +44,7 @@ jobs:
           - test-group-name: core-services
           - test-group-name: core-storage
           - test-group-name: core-hash-collisions
+          - test-group-name: core-transforms
           - test-group-name: core-rest
           - test-group-name: core-xunit
           - test-group-name: projections

--- a/.github/workflows/build-container-ubuntu-lts.yml
+++ b/.github/workflows/build-container-ubuntu-lts.yml
@@ -43,6 +43,7 @@ jobs:
           - test-group-name: core-http
           - test-group-name: core-services
           - test-group-name: core-storage
+          - test-group-name: core-hash-collisions
           - test-group-name: core-rest
           - test-group-name: core-xunit
           - test-group-name: projections

--- a/.github/workflows/build-container-ubuntu-lts.yml
+++ b/.github/workflows/build-container-ubuntu-lts.yml
@@ -42,6 +42,7 @@ jobs:
           - test-group-name: core-clientapi
           - test-group-name: core-http
           - test-group-name: core-services
+          - test-group-name: core-cluster-services
           - test-group-name: core-storage
           - test-group-name: core-hash-collisions
           - test-group-name: core-transforms

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -25,6 +25,10 @@ core_hash_collisions_projects=(
     EventStore.Core.Tests
 )
 
+core_transforms_projects=(
+    EventStore.Core.Tests
+)
+
 core_xunit_projects=(
     EventStore.Core.XUnit.Tests
 )
@@ -69,6 +73,9 @@ load_requested_projects() {
         core-hash-collisions)
             requested_projects=("${core_hash_collisions_projects[@]}")
             ;;
+        core-transforms)
+            requested_projects=("${core_transforms_projects[@]}")
+            ;;
         core-xunit)
             requested_projects=("${core_xunit_projects[@]}")
             ;;
@@ -98,6 +105,7 @@ validate_shard_coverage() {
             "${core_services_projects[@]}" \
             "${core_storage_projects[@]}" \
             "${core_hash_collisions_projects[@]}" \
+            "${core_transforms_projects[@]}" \
             "${core_xunit_projects[@]}" \
             "${core_http_projects[@]}" \
             "${projections_projects[@]}" \
@@ -189,10 +197,13 @@ project_filter() {
             printf '%s\n' "((FullyQualifiedName~EventStore.Core.Tests.Services&FullyQualifiedName!~EventStore.Core.Tests.Services.Storage&FullyQualifiedName!~EventStore.Core.Tests.Services.Transport.Http)|FullyQualifiedName~EventStore.Core.Tests.Integration|FullyQualifiedName~EventStore.Core.Tests.Cluster|FullyQualifiedName~EventStore.Core.Tests.Bus|FullyQualifiedName~EventStore.Core.Tests.Helpers|FullyQualifiedName~EventStore.Core.Tests.ClientOperations|FullyQualifiedName~EventStore.Core.Tests.Authentication|FullyQualifiedName~EventStore.Core.Tests.Authorization|FullyQualifiedName~EventStore.Core.Tests.Certificates|FullyQualifiedName~EventStore.Core.Tests.AwakeService|FullyQualifiedName~EventStore.Core.Tests.Replication|FullyQualifiedName~EventStore.Core.Tests.Settings|FullyQualifiedName~EventStore.Core.Tests.Synchronization|FullyQualifiedName~EventStore.Core.Tests.TcpApiTestPlugin)"
             ;;
         core-storage:EventStore.Core.Tests)
-            printf '%s\n' "((FullyQualifiedName~EventStore.Core.Tests.Services.Storage&FullyQualifiedName!~EventStore.Core.Tests.Services.Storage.HashCollisions)|FullyQualifiedName~EventStore.Core.Tests.Index|FullyQualifiedName~EventStore.Core.Tests.TransactionLog|FullyQualifiedName~EventStore.Core.Tests.Caching|FullyQualifiedName~EventStore.Core.Tests.DataStructures|FullyQualifiedName~EventStore.Core.Tests.Transforms)&FullyQualifiedName!~EventStore.Core.Tests.Hashes"
+            printf '%s\n' "((FullyQualifiedName~EventStore.Core.Tests.Services.Storage&FullyQualifiedName!~EventStore.Core.Tests.Services.Storage.HashCollisions)|FullyQualifiedName~EventStore.Core.Tests.Index|FullyQualifiedName~EventStore.Core.Tests.TransactionLog|FullyQualifiedName~EventStore.Core.Tests.Caching|FullyQualifiedName~EventStore.Core.Tests.DataStructures)&FullyQualifiedName!~EventStore.Core.Tests.Hashes&FullyQualifiedName!~EventStore.Core.Tests.Transforms"
             ;;
         core-hash-collisions:EventStore.Core.Tests)
             printf '%s\n' "(FullyQualifiedName~EventStore.Core.Tests.Services.Storage.HashCollisions|FullyQualifiedName~EventStore.Core.Tests.Hashes)"
+            ;;
+        core-transforms:EventStore.Core.Tests)
+            printf '%s\n' "FullyQualifiedName~EventStore.Core.Tests.Transforms"
             ;;
         core-rest:EventStore.Core.Tests)
             printf '%s\n' "FullyQualifiedName!~EventStore.Core.Tests.ClientAPI&FullyQualifiedName!~EventStore.Core.Tests.Http&FullyQualifiedName!~EventStore.Core.Tests.Services&FullyQualifiedName!~EventStore.Core.Tests.Integration&FullyQualifiedName!~EventStore.Core.Tests.Cluster&FullyQualifiedName!~EventStore.Core.Tests.Bus&FullyQualifiedName!~EventStore.Core.Tests.Helpers&FullyQualifiedName!~EventStore.Core.Tests.ClientOperations&FullyQualifiedName!~EventStore.Core.Tests.Authentication&FullyQualifiedName!~EventStore.Core.Tests.Authorization&FullyQualifiedName!~EventStore.Core.Tests.Certificates&FullyQualifiedName!~EventStore.Core.Tests.AwakeService&FullyQualifiedName!~EventStore.Core.Tests.Replication&FullyQualifiedName!~EventStore.Core.Tests.Settings&FullyQualifiedName!~EventStore.Core.Tests.Synchronization&FullyQualifiedName!~EventStore.Core.Tests.TcpApiTestPlugin&FullyQualifiedName!~EventStore.Core.Tests.Index&FullyQualifiedName!~EventStore.Core.Tests.TransactionLog&FullyQualifiedName!~EventStore.Core.Tests.Caching&FullyQualifiedName!~EventStore.Core.Tests.DataStructures&FullyQualifiedName!~EventStore.Core.Tests.Transforms&FullyQualifiedName!~EventStore.Core.Tests.Hashes"
@@ -218,6 +229,9 @@ project_timeout() {
             ;;
         core-hash-collisions:EventStore.Core.Tests)
             printf '%s\n' "30m"
+            ;;
+        core-transforms:EventStore.Core.Tests)
+            printf '%s\n' "20m"
             ;;
         core-http:EventStore.Core.Tests)
             printf '%s\n' "20m"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -21,6 +21,10 @@ core_storage_projects=(
     EventStore.Core.Tests
 )
 
+core_hash_collisions_projects=(
+    EventStore.Core.Tests
+)
+
 core_xunit_projects=(
     EventStore.Core.XUnit.Tests
 )
@@ -62,6 +66,9 @@ load_requested_projects() {
         core-storage)
             requested_projects=("${core_storage_projects[@]}")
             ;;
+        core-hash-collisions)
+            requested_projects=("${core_hash_collisions_projects[@]}")
+            ;;
         core-xunit)
             requested_projects=("${core_xunit_projects[@]}")
             ;;
@@ -90,6 +97,7 @@ validate_shard_coverage() {
             "${core_rest_projects[@]}" \
             "${core_services_projects[@]}" \
             "${core_storage_projects[@]}" \
+            "${core_hash_collisions_projects[@]}" \
             "${core_xunit_projects[@]}" \
             "${core_http_projects[@]}" \
             "${projections_projects[@]}" \
@@ -181,7 +189,10 @@ project_filter() {
             printf '%s\n' "((FullyQualifiedName~EventStore.Core.Tests.Services&FullyQualifiedName!~EventStore.Core.Tests.Services.Storage&FullyQualifiedName!~EventStore.Core.Tests.Services.Transport.Http)|FullyQualifiedName~EventStore.Core.Tests.Integration|FullyQualifiedName~EventStore.Core.Tests.Cluster|FullyQualifiedName~EventStore.Core.Tests.Bus|FullyQualifiedName~EventStore.Core.Tests.Helpers|FullyQualifiedName~EventStore.Core.Tests.ClientOperations|FullyQualifiedName~EventStore.Core.Tests.Authentication|FullyQualifiedName~EventStore.Core.Tests.Authorization|FullyQualifiedName~EventStore.Core.Tests.Certificates|FullyQualifiedName~EventStore.Core.Tests.AwakeService|FullyQualifiedName~EventStore.Core.Tests.Replication|FullyQualifiedName~EventStore.Core.Tests.Settings|FullyQualifiedName~EventStore.Core.Tests.Synchronization|FullyQualifiedName~EventStore.Core.Tests.TcpApiTestPlugin)"
             ;;
         core-storage:EventStore.Core.Tests)
-            printf '%s\n' "(FullyQualifiedName~EventStore.Core.Tests.Services.Storage|FullyQualifiedName~EventStore.Core.Tests.Index|FullyQualifiedName~EventStore.Core.Tests.TransactionLog|FullyQualifiedName~EventStore.Core.Tests.Caching|FullyQualifiedName~EventStore.Core.Tests.DataStructures|FullyQualifiedName~EventStore.Core.Tests.Transforms|FullyQualifiedName~EventStore.Core.Tests.Hashes)"
+            printf '%s\n' "((FullyQualifiedName~EventStore.Core.Tests.Services.Storage&FullyQualifiedName!~EventStore.Core.Tests.Services.Storage.HashCollisions)|FullyQualifiedName~EventStore.Core.Tests.Index|FullyQualifiedName~EventStore.Core.Tests.TransactionLog|FullyQualifiedName~EventStore.Core.Tests.Caching|FullyQualifiedName~EventStore.Core.Tests.DataStructures|FullyQualifiedName~EventStore.Core.Tests.Transforms)&FullyQualifiedName!~EventStore.Core.Tests.Hashes"
+            ;;
+        core-hash-collisions:EventStore.Core.Tests)
+            printf '%s\n' "(FullyQualifiedName~EventStore.Core.Tests.Services.Storage.HashCollisions|FullyQualifiedName~EventStore.Core.Tests.Hashes)"
             ;;
         core-rest:EventStore.Core.Tests)
             printf '%s\n' "FullyQualifiedName!~EventStore.Core.Tests.ClientAPI&FullyQualifiedName!~EventStore.Core.Tests.Http&FullyQualifiedName!~EventStore.Core.Tests.Services&FullyQualifiedName!~EventStore.Core.Tests.Integration&FullyQualifiedName!~EventStore.Core.Tests.Cluster&FullyQualifiedName!~EventStore.Core.Tests.Bus&FullyQualifiedName!~EventStore.Core.Tests.Helpers&FullyQualifiedName!~EventStore.Core.Tests.ClientOperations&FullyQualifiedName!~EventStore.Core.Tests.Authentication&FullyQualifiedName!~EventStore.Core.Tests.Authorization&FullyQualifiedName!~EventStore.Core.Tests.Certificates&FullyQualifiedName!~EventStore.Core.Tests.AwakeService&FullyQualifiedName!~EventStore.Core.Tests.Replication&FullyQualifiedName!~EventStore.Core.Tests.Settings&FullyQualifiedName!~EventStore.Core.Tests.Synchronization&FullyQualifiedName!~EventStore.Core.Tests.TcpApiTestPlugin&FullyQualifiedName!~EventStore.Core.Tests.Index&FullyQualifiedName!~EventStore.Core.Tests.TransactionLog&FullyQualifiedName!~EventStore.Core.Tests.Caching&FullyQualifiedName!~EventStore.Core.Tests.DataStructures&FullyQualifiedName!~EventStore.Core.Tests.Transforms&FullyQualifiedName!~EventStore.Core.Tests.Hashes"
@@ -204,6 +215,9 @@ project_timeout() {
             ;;
         core-storage:EventStore.Core.Tests)
             printf '%s\n' "20m"
+            ;;
+        core-hash-collisions:EventStore.Core.Tests)
+            printf '%s\n' "30m"
             ;;
         core-http:EventStore.Core.Tests)
             printf '%s\n' "20m"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -17,6 +17,10 @@ core_services_projects=(
     EventStore.Core.Tests
 )
 
+core_cluster_services_projects=(
+    EventStore.Core.Tests
+)
+
 core_storage_projects=(
     EventStore.Core.Tests
 )
@@ -67,6 +71,9 @@ load_requested_projects() {
         core-services)
             requested_projects=("${core_services_projects[@]}")
             ;;
+        core-cluster-services)
+            requested_projects=("${core_cluster_services_projects[@]}")
+            ;;
         core-storage)
             requested_projects=("${core_storage_projects[@]}")
             ;;
@@ -103,6 +110,7 @@ validate_shard_coverage() {
             "${core_clientapi_projects[@]}" \
             "${core_rest_projects[@]}" \
             "${core_services_projects[@]}" \
+            "${core_cluster_services_projects[@]}" \
             "${core_storage_projects[@]}" \
             "${core_hash_collisions_projects[@]}" \
             "${core_transforms_projects[@]}" \
@@ -194,7 +202,10 @@ project_filter() {
             printf '%s\n' "(FullyQualifiedName~EventStore.Core.Tests.Http|FullyQualifiedName~EventStore.Core.Tests.Services.Transport.Http)&FullyQualifiedName!~EventStore.Core.Tests.ClientAPI"
             ;;
         core-services:EventStore.Core.Tests)
-            printf '%s\n' "((FullyQualifiedName~EventStore.Core.Tests.Services&FullyQualifiedName!~EventStore.Core.Tests.Services.Storage&FullyQualifiedName!~EventStore.Core.Tests.Services.Transport.Http)|FullyQualifiedName~EventStore.Core.Tests.Integration|FullyQualifiedName~EventStore.Core.Tests.Cluster|FullyQualifiedName~EventStore.Core.Tests.Bus|FullyQualifiedName~EventStore.Core.Tests.Helpers|FullyQualifiedName~EventStore.Core.Tests.ClientOperations|FullyQualifiedName~EventStore.Core.Tests.Authentication|FullyQualifiedName~EventStore.Core.Tests.Authorization|FullyQualifiedName~EventStore.Core.Tests.Certificates|FullyQualifiedName~EventStore.Core.Tests.AwakeService|FullyQualifiedName~EventStore.Core.Tests.Replication|FullyQualifiedName~EventStore.Core.Tests.Settings|FullyQualifiedName~EventStore.Core.Tests.Synchronization|FullyQualifiedName~EventStore.Core.Tests.TcpApiTestPlugin)"
+            printf '%s\n' "((FullyQualifiedName~EventStore.Core.Tests.Services&FullyQualifiedName!~EventStore.Core.Tests.Services.Storage&FullyQualifiedName!~EventStore.Core.Tests.Services.Transport.Http&FullyQualifiedName!~EventStore.Core.Tests.Services.ElectionsService)|FullyQualifiedName~EventStore.Core.Tests.Bus|FullyQualifiedName~EventStore.Core.Tests.Helpers|FullyQualifiedName~EventStore.Core.Tests.ClientOperations|FullyQualifiedName~EventStore.Core.Tests.Authentication|FullyQualifiedName~EventStore.Core.Tests.Authorization|FullyQualifiedName~EventStore.Core.Tests.Certificates|FullyQualifiedName~EventStore.Core.Tests.AwakeService|FullyQualifiedName~EventStore.Core.Tests.Settings|FullyQualifiedName~EventStore.Core.Tests.TcpApiTestPlugin)"
+            ;;
+        core-cluster-services:EventStore.Core.Tests)
+            printf '%s\n' "(FullyQualifiedName~EventStore.Core.Tests.Integration|FullyQualifiedName~EventStore.Core.Tests.Cluster|FullyQualifiedName~EventStore.Core.Tests.Replication|FullyQualifiedName~EventStore.Core.Tests.Synchronization|FullyQualifiedName~EventStore.Core.Tests.Services.ElectionsService)"
             ;;
         core-storage:EventStore.Core.Tests)
             printf '%s\n' "((FullyQualifiedName~EventStore.Core.Tests.Services.Storage&FullyQualifiedName!~EventStore.Core.Tests.Services.Storage.HashCollisions)|FullyQualifiedName~EventStore.Core.Tests.Index|FullyQualifiedName~EventStore.Core.Tests.TransactionLog|FullyQualifiedName~EventStore.Core.Tests.Caching|FullyQualifiedName~EventStore.Core.Tests.DataStructures)&FullyQualifiedName!~EventStore.Core.Tests.Hashes&FullyQualifiedName!~EventStore.Core.Tests.Transforms"
@@ -222,7 +233,10 @@ project_timeout() {
             printf '%s\n' "15m"
             ;;
         core-services:EventStore.Core.Tests)
-            printf '%s\n' "20m"
+            printf '%s\n' "15m"
+            ;;
+        core-cluster-services:EventStore.Core.Tests)
+            printf '%s\n' "25m"
             ;;
         core-storage:EventStore.Core.Tests)
             printf '%s\n' "20m"

--- a/src/EventStore.Core.Tests/ClientAPI/SpecificationWithMiniNode.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/SpecificationWithMiniNode.cs
@@ -13,7 +13,7 @@ public abstract class SpecificationWithMiniNode<TLogFormat, TStreamId> : Specifi
 	protected MiniNode<TLogFormat, TStreamId> _node;
 	protected IEventStoreConnection _conn;
 	protected virtual TimeSpan Timeout { get; } = TimeSpan.FromMinutes(1);
-	protected virtual TimeSpan StartupTimeout => Timeout;
+	protected virtual TimeSpan StartupTimeout => TimeSpan.FromMinutes(5);
 
 	protected virtual Task Given() => Task.CompletedTask;
 
@@ -53,11 +53,11 @@ public abstract class SpecificationWithMiniNode<TLogFormat, TStreamId> : Specifi
 		{
 			_node = new MiniNode<TLogFormat, TStreamId>(PathName, chunkSize: _chunkSize);
 			await _node.Start(StartupTimeout);
-			await _node.WaitForTcpEndPoint().WithTimeout(TimeSpan.FromSeconds(60));
+			await _node.WaitForTcpEndPoint().WithTimeout(StartupTimeout);
 			_conn = await TestConnectionLifecycle.ReconnectUntilReady(
 				() => BuildConnection(_node),
 				connection => connection.ReadAllEventsForwardAsync(Position.Start, 1, false, DefaultData.AdminCredentials),
-				Timeout);
+				StartupTimeout);
 		}
 		catch (Exception ex)
 		{

--- a/src/EventStore.Core.Tests/ClientAPI/append_to_stream_with_hash_collision.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/append_to_stream_with_hash_collision.cs
@@ -14,8 +14,8 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions;
 [TestFixture(typeof(LogFormat.V3), typeof(uint), Ignore = "Hash collisions cannot occur in Log V3")]
 public class append_to_stream_with_hash_collision<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture
 {
-	private const int LongRunningTimeout = 600000;
-	private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(5);
+	private const int LongRunningTimeout = 1200000;
+	private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(10);
 	private MiniNode<TLogFormat, TStreamId> _node;
 
 	protected virtual IEventStoreConnection BuildConnection(MiniNode<TLogFormat, TStreamId> node)

--- a/src/EventStore.Core.Tests/ClientAPI/append_to_stream_with_hash_collision.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/append_to_stream_with_hash_collision.cs
@@ -15,6 +15,7 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions;
 public class append_to_stream_with_hash_collision<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture
 {
 	private const int LongRunningTimeout = 120000;
+	private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(5);
 	private MiniNode<TLogFormat, TStreamId> _node;
 
 	protected virtual IEventStoreConnection BuildConnection(MiniNode<TLogFormat, TStreamId> node)
@@ -33,7 +34,7 @@ public class append_to_stream_with_hash_collision<TLogFormat, TStreamId> : Speci
 			indexBitnessVersion: EventStore.Core.Index.PTableVersions.IndexV4,
 			hash32bit: true,
 			streamExistenceFilterSize: 0);
-		await _node.Start();
+		await _node.Start(StartupTimeout);
 	}
 
 	[OneTimeTearDown]
@@ -74,7 +75,7 @@ public class append_to_stream_with_hash_collision<TLogFormat, TStreamId> : Speci
 			indexBitnessVersion: EventStore.Core.Index.PTableVersions.IndexV4,
 			hash32bit: true,
 			streamExistenceFilterSize: 0);
-		await _node.Start();
+		await _node.Start(StartupTimeout);
 		using (var store = BuildConnection(_node))
 		{
 			await store.ConnectAsync();

--- a/src/EventStore.Core.Tests/ClientAPI/append_to_stream_with_hash_collision.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/append_to_stream_with_hash_collision.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions;
 [TestFixture(typeof(LogFormat.V3), typeof(uint), Ignore = "Hash collisions cannot occur in Log V3")]
 public class append_to_stream_with_hash_collision<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture
 {
-	private const int LongRunningTimeout = 120000;
+	private const int LongRunningTimeout = 600000;
 	private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(5);
 	private MiniNode<TLogFormat, TStreamId> _node;
 

--- a/src/EventStore.Core.Tests/ClientAPI/catchup_filtered_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/catchup_filtered_subscription.cs
@@ -92,7 +92,7 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 			subscriptionName: String.Empty
 		);
 
-		_conn.FilteredSubscribeToAllFrom(
+		var subscription = _conn.FilteredSubscribeToAllFrom(
 			Position.Start,
 			filter,
 			settings,
@@ -107,12 +107,19 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 				return Task.CompletedTask;
 			}, 1);
 
-		if (!checkpointReached.Wait(Timeout))
+		try
 		{
-			Assert.Fail("Checkpoint reached not called enough times within time limit.");
-		}
+			if (!checkpointReached.Wait(Timeout))
+			{
+				Assert.Fail("Checkpoint reached not called enough times within time limit.");
+			}
 
-		Assert.AreEqual(10, eventsSeen);
+			Assert.AreEqual(10, eventsSeen);
+		}
+		finally
+		{
+			StopSubscription(subscription);
+		}
 	}
 
 	[Test]
@@ -132,7 +139,7 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 			subscriptionName: String.Empty
 		);
 
-		_conn.FilteredSubscribeToAllFrom(
+		var subscription = _conn.FilteredSubscribeToAllFrom(
 			Position.Start,
 			filter,
 			settings,
@@ -155,12 +162,19 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 				_conn.AppendToStreamAsync("stream-a", ExpectedVersion.Any, _testEventsAfter.EvenEvents()).Wait();
 			});
 
-		if (!appeared.Wait(Timeout))
+		try
 		{
-			Assert.Fail("Checkpoint appeared not called enough times within time limit.");
-		}
+			if (!appeared.Wait(Timeout))
+			{
+				Assert.Fail("Checkpoint appeared not called enough times within time limit.");
+			}
 
-		Assert.AreEqual(20, eventsSeen);
+			Assert.AreEqual(20, eventsSeen);
+		}
+		finally
+		{
+			StopSubscription(subscription);
+		}
 	}
 
 	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
@@ -169,15 +183,21 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		var filter = Filter.StreamId.Prefix("stream-a");
 		var foundEvents = new ConcurrentBag<ResolvedEvent>();
 		var appeared = new CountdownEvent(20);
+		var subscription = Subscribe(filter, foundEvents, appeared);
 
-		Subscribe(filter, foundEvents, appeared);
-
-		if (!appeared.Wait(Timeout))
+		try
 		{
-			Assert.Fail("Appeared countdown event timed out.");
-		}
+			if (!appeared.Wait(Timeout))
+			{
+				Assert.Fail("Appeared countdown event timed out.");
+			}
 
-		Assert.True(foundEvents.All(e => e.Event.EventStreamId == "stream-a"));
+			Assert.True(foundEvents.All(e => e.Event.EventStreamId == "stream-a"));
+		}
+		finally
+		{
+			StopSubscription(subscription);
+		}
 	}
 
 	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
@@ -186,15 +206,21 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		var filter = Filter.EventType.Prefix("AE");
 		var foundEvents = new ConcurrentBag<ResolvedEvent>();
 		var appeared = new CountdownEvent(20);
+		var subscription = Subscribe(filter, foundEvents, appeared);
 
-		Subscribe(filter, foundEvents, appeared);
-
-		if (!appeared.Wait(Timeout))
+		try
 		{
-			Assert.Fail("Appeared countdown event timed out.");
-		}
+			if (!appeared.Wait(Timeout))
+			{
+				Assert.Fail("Appeared countdown event timed out.");
+			}
 
-		Assert.True(foundEvents.All(e => e.Event.EventType == "AEvent"));
+			Assert.True(foundEvents.All(e => e.Event.EventType == "AEvent"));
+		}
+		finally
+		{
+			StopSubscription(subscription);
+		}
 	}
 
 	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
@@ -203,15 +229,21 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		var filter = Filter.StreamId.Regex(new Regex(@"^.*eam-b.*$"));
 		var foundEvents = new ConcurrentBag<ResolvedEvent>();
 		var appeared = new CountdownEvent(20);
+		var subscription = Subscribe(filter, foundEvents, appeared);
 
-		Subscribe(filter, foundEvents, appeared);
-
-		if (!appeared.Wait(Timeout))
+		try
 		{
-			Assert.Fail("Appeared countdown event timed out.");
-		}
+			if (!appeared.Wait(Timeout))
+			{
+				Assert.Fail("Appeared countdown event timed out.");
+			}
 
-		Assert.True(foundEvents.All(e => e.Event.EventStreamId == "stream-b"));
+			Assert.True(foundEvents.All(e => e.Event.EventStreamId == "stream-b"));
+		}
+		finally
+		{
+			StopSubscription(subscription);
+		}
 	}
 
 	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
@@ -220,15 +252,21 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		var filter = Filter.EventType.Regex(new Regex(@"^.*BEv.*$"));
 		var foundEvents = new ConcurrentBag<ResolvedEvent>();
 		var appeared = new CountdownEvent(20);
+		var subscription = Subscribe(filter, foundEvents, appeared);
 
-		Subscribe(filter, foundEvents, appeared);
-
-		if (!appeared.Wait(Timeout))
+		try
 		{
-			Assert.Fail("Appeared countdown event timed out.");
-		}
+			if (!appeared.Wait(Timeout))
+			{
+				Assert.Fail("Appeared countdown event timed out.");
+			}
 
-		Assert.True(foundEvents.All(e => e.Event.EventType == "BEvent"));
+			Assert.True(foundEvents.All(e => e.Event.EventType == "BEvent"));
+		}
+		finally
+		{
+			StopSubscription(subscription);
+		}
 	}
 
 	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
@@ -237,20 +275,27 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		var filter = Filter.ExcludeSystemEvents;
 		var foundEvents = new ConcurrentBag<ResolvedEvent>();
 		var appeared = new CountdownEvent(20);
+		var subscription = Subscribe(filter, foundEvents, appeared);
 
-		Subscribe(filter, foundEvents, appeared);
-
-		if (!appeared.Wait(Timeout))
+		try
 		{
-			Assert.Fail("Appeared countdown event timed out.");
-		}
+			if (!appeared.Wait(Timeout))
+			{
+				Assert.Fail("Appeared countdown event timed out.");
+			}
 
-		Assert.True(foundEvents.All(e => !e.Event.EventType.StartsWith("$")));
+			Assert.True(foundEvents.All(e => !e.Event.EventType.StartsWith("$")));
+		}
+		finally
+		{
+			StopSubscription(subscription);
+		}
 	}
 
-	private void Subscribe(Filter filter, ConcurrentBag<ResolvedEvent> foundEvents, CountdownEvent appeared)
+	private EventStoreCatchUpSubscription Subscribe(Filter filter, ConcurrentBag<ResolvedEvent> foundEvents,
+		CountdownEvent appeared)
 	{
-		_conn.FilteredSubscribeToAllFrom(
+		return _conn.FilteredSubscribeToAllFrom(
 			Position.Start,
 			filter,
 			CatchUpSubscriptionFilteredSettings.Default,
@@ -283,5 +328,16 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		TestConnectionLifecycle.DisposeIfNeeded(_conn);
 		await _node.Shutdown();
 		await base.TearDown();
+	}
+
+	private static void StopSubscription(EventStoreCatchUpSubscription subscription)
+	{
+		try
+		{
+			subscription.Stop(ConnectionCloseTimeout);
+		}
+		catch
+		{
+		}
 	}
 }

--- a/src/EventStore.Core.Tests/ClientAPI/catchup_filtered_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/catchup_filtered_subscription.cs
@@ -107,9 +107,11 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 				return Task.CompletedTask;
 			}, 1);
 
+		var completed = false;
 		try
 		{
-			if (!checkpointReached.Wait(Timeout))
+			completed = checkpointReached.Wait(Timeout);
+			if (!completed)
 			{
 				Assert.Fail("Checkpoint reached not called enough times within time limit.");
 			}
@@ -118,7 +120,10 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 		finally
 		{
-			StopSubscription(subscription);
+			if (completed)
+			{
+				StopSubscription(subscription);
+			}
 		}
 	}
 
@@ -162,9 +167,11 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 				_conn.AppendToStreamAsync("stream-a", ExpectedVersion.Any, _testEventsAfter.EvenEvents()).Wait();
 			});
 
+		var completed = false;
 		try
 		{
-			if (!appeared.Wait(Timeout))
+			completed = appeared.Wait(Timeout);
+			if (!completed)
 			{
 				Assert.Fail("Checkpoint appeared not called enough times within time limit.");
 			}
@@ -173,7 +180,10 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 		finally
 		{
-			StopSubscription(subscription);
+			if (completed)
+			{
+				StopSubscription(subscription);
+			}
 		}
 	}
 
@@ -184,10 +194,12 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		var foundEvents = new ConcurrentBag<ResolvedEvent>();
 		var appeared = new CountdownEvent(20);
 		var subscription = Subscribe(filter, foundEvents, appeared);
+		var completed = false;
 
 		try
 		{
-			if (!appeared.Wait(Timeout))
+			completed = appeared.Wait(Timeout);
+			if (!completed)
 			{
 				Assert.Fail("Appeared countdown event timed out.");
 			}
@@ -196,7 +208,10 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 		finally
 		{
-			StopSubscription(subscription);
+			if (completed)
+			{
+				StopSubscription(subscription);
+			}
 		}
 	}
 
@@ -207,10 +222,12 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		var foundEvents = new ConcurrentBag<ResolvedEvent>();
 		var appeared = new CountdownEvent(20);
 		var subscription = Subscribe(filter, foundEvents, appeared);
+		var completed = false;
 
 		try
 		{
-			if (!appeared.Wait(Timeout))
+			completed = appeared.Wait(Timeout);
+			if (!completed)
 			{
 				Assert.Fail("Appeared countdown event timed out.");
 			}
@@ -219,7 +236,10 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 		finally
 		{
-			StopSubscription(subscription);
+			if (completed)
+			{
+				StopSubscription(subscription);
+			}
 		}
 	}
 
@@ -230,10 +250,12 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		var foundEvents = new ConcurrentBag<ResolvedEvent>();
 		var appeared = new CountdownEvent(20);
 		var subscription = Subscribe(filter, foundEvents, appeared);
+		var completed = false;
 
 		try
 		{
-			if (!appeared.Wait(Timeout))
+			completed = appeared.Wait(Timeout);
+			if (!completed)
 			{
 				Assert.Fail("Appeared countdown event timed out.");
 			}
@@ -242,7 +264,10 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 		finally
 		{
-			StopSubscription(subscription);
+			if (completed)
+			{
+				StopSubscription(subscription);
+			}
 		}
 	}
 
@@ -253,10 +278,12 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		var foundEvents = new ConcurrentBag<ResolvedEvent>();
 		var appeared = new CountdownEvent(20);
 		var subscription = Subscribe(filter, foundEvents, appeared);
+		var completed = false;
 
 		try
 		{
-			if (!appeared.Wait(Timeout))
+			completed = appeared.Wait(Timeout);
+			if (!completed)
 			{
 				Assert.Fail("Appeared countdown event timed out.");
 			}
@@ -265,7 +292,10 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 		finally
 		{
-			StopSubscription(subscription);
+			if (completed)
+			{
+				StopSubscription(subscription);
+			}
 		}
 	}
 
@@ -276,10 +306,12 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		var foundEvents = new ConcurrentBag<ResolvedEvent>();
 		var appeared = new CountdownEvent(20);
 		var subscription = Subscribe(filter, foundEvents, appeared);
+		var completed = false;
 
 		try
 		{
-			if (!appeared.Wait(Timeout))
+			completed = appeared.Wait(Timeout);
+			if (!completed)
 			{
 				Assert.Fail("Appeared countdown event timed out.");
 			}
@@ -288,7 +320,10 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 		finally
 		{
-			StopSubscription(subscription);
+			if (completed)
+			{
+				StopSubscription(subscription);
+			}
 		}
 	}
 

--- a/src/EventStore.Core.Tests/ClientAPI/catchup_filtered_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/catchup_filtered_subscription.cs
@@ -269,8 +269,9 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 	public void only_return_events_that_are_not_system_events()
 	{
 		var filter = Filter.ExcludeSystemEvents;
+		var expectedEvents = LogFormatHelper<TLogFormat, TStreamId>.IsV2 ? 40 : 44;
 		var foundEvents = new ConcurrentBag<ResolvedEvent>();
-		var appeared = new CountdownEvent(20);
+		var appeared = new CountdownEvent(expectedEvents);
 		var subscription = Subscribe(filter, foundEvents, appeared);
 		try
 		{
@@ -279,6 +280,7 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 				Assert.Fail("Appeared countdown event timed out.");
 			}
 
+			Assert.AreEqual(expectedEvents, foundEvents.Count);
 			Assert.True(foundEvents.All(e => !e.Event.EventType.StartsWith("$")));
 		}
 		finally

--- a/src/EventStore.Core.Tests/ClientAPI/catchup_filtered_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/catchup_filtered_subscription.cs
@@ -107,11 +107,9 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 				return Task.CompletedTask;
 			}, 1);
 
-		var completed = false;
 		try
 		{
-			completed = checkpointReached.Wait(Timeout);
-			if (!completed)
+			if (!checkpointReached.Wait(Timeout))
 			{
 				Assert.Fail("Checkpoint reached not called enough times within time limit.");
 			}
@@ -120,10 +118,7 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 		finally
 		{
-			if (completed)
-			{
-				StopSubscription(subscription);
-			}
+			StopSubscription(subscription);
 		}
 	}
 
@@ -167,11 +162,9 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 				_conn.AppendToStreamAsync("stream-a", ExpectedVersion.Any, _testEventsAfter.EvenEvents()).Wait();
 			});
 
-		var completed = false;
 		try
 		{
-			completed = appeared.Wait(Timeout);
-			if (!completed)
+			if (!appeared.Wait(Timeout))
 			{
 				Assert.Fail("Checkpoint appeared not called enough times within time limit.");
 			}
@@ -180,10 +173,7 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 		finally
 		{
-			if (completed)
-			{
-				StopSubscription(subscription);
-			}
+			StopSubscription(subscription);
 		}
 	}
 
@@ -194,12 +184,9 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		var foundEvents = new ConcurrentBag<ResolvedEvent>();
 		var appeared = new CountdownEvent(20);
 		var subscription = Subscribe(filter, foundEvents, appeared);
-		var completed = false;
-
 		try
 		{
-			completed = appeared.Wait(Timeout);
-			if (!completed)
+			if (!appeared.Wait(Timeout))
 			{
 				Assert.Fail("Appeared countdown event timed out.");
 			}
@@ -208,10 +195,7 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 		finally
 		{
-			if (completed)
-			{
-				StopSubscription(subscription);
-			}
+			StopSubscription(subscription);
 		}
 	}
 
@@ -222,12 +206,9 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		var foundEvents = new ConcurrentBag<ResolvedEvent>();
 		var appeared = new CountdownEvent(20);
 		var subscription = Subscribe(filter, foundEvents, appeared);
-		var completed = false;
-
 		try
 		{
-			completed = appeared.Wait(Timeout);
-			if (!completed)
+			if (!appeared.Wait(Timeout))
 			{
 				Assert.Fail("Appeared countdown event timed out.");
 			}
@@ -236,10 +217,7 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 		finally
 		{
-			if (completed)
-			{
-				StopSubscription(subscription);
-			}
+			StopSubscription(subscription);
 		}
 	}
 
@@ -250,12 +228,9 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		var foundEvents = new ConcurrentBag<ResolvedEvent>();
 		var appeared = new CountdownEvent(20);
 		var subscription = Subscribe(filter, foundEvents, appeared);
-		var completed = false;
-
 		try
 		{
-			completed = appeared.Wait(Timeout);
-			if (!completed)
+			if (!appeared.Wait(Timeout))
 			{
 				Assert.Fail("Appeared countdown event timed out.");
 			}
@@ -264,10 +239,7 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 		finally
 		{
-			if (completed)
-			{
-				StopSubscription(subscription);
-			}
+			StopSubscription(subscription);
 		}
 	}
 
@@ -278,12 +250,9 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		var foundEvents = new ConcurrentBag<ResolvedEvent>();
 		var appeared = new CountdownEvent(20);
 		var subscription = Subscribe(filter, foundEvents, appeared);
-		var completed = false;
-
 		try
 		{
-			completed = appeared.Wait(Timeout);
-			if (!completed)
+			if (!appeared.Wait(Timeout))
 			{
 				Assert.Fail("Appeared countdown event timed out.");
 			}
@@ -292,10 +261,7 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 		finally
 		{
-			if (completed)
-			{
-				StopSubscription(subscription);
-			}
+			StopSubscription(subscription);
 		}
 	}
 
@@ -306,12 +272,9 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		var foundEvents = new ConcurrentBag<ResolvedEvent>();
 		var appeared = new CountdownEvent(20);
 		var subscription = Subscribe(filter, foundEvents, appeared);
-		var completed = false;
-
 		try
 		{
-			completed = appeared.Wait(Timeout);
-			if (!completed)
+			if (!appeared.Wait(Timeout))
 			{
 				Assert.Fail("Appeared countdown event timed out.");
 			}
@@ -320,10 +283,7 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 		finally
 		{
-			if (completed)
-			{
-				StopSubscription(subscription);
-			}
+			StopSubscription(subscription);
 		}
 	}
 

--- a/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_filtered_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_filtered_should.cs
@@ -21,7 +21,7 @@ public class subscribe_to_all_filtered_should<TLogFormat, TStreamId> : Specifica
 {
 	private const int Timeout = 10000;
 	private const int LongRunningTimeout = 600000;
-	private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(5);
+	private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(10);
 	private static readonly TimeSpan ConnectionCloseTimeout = TimeSpan.FromSeconds(10);
 
 	private MiniNode<TLogFormat, TStreamId> _node;

--- a/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_should.cs
@@ -16,6 +16,7 @@ namespace EventStore.Core.Tests.ClientAPI;
 public class subscribe_to_all_should<TLogFormat, TStreamId> : SpecificationWithDirectory
 {
 	private const int Timeout = 10000;
+	private const int LongRunningTimeout = 120000;
 
 	private MiniNode<TLogFormat, TStreamId> _node;
 
@@ -76,7 +77,7 @@ public class subscribe_to_all_should<TLogFormat, TStreamId> : SpecificationWithD
 		}
 	}
 
-	[Test, Category("LongRunning")]
+	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
 	public async Task catch_deleted_events_as_well()
 	{
 		const string stream = "subscribe_to_all_should_catch_created_and_deleted_events_as_well";
@@ -86,16 +87,33 @@ public class subscribe_to_all_should<TLogFormat, TStreamId> : SpecificationWithD
 			var appeared = new CountdownEvent(1);
 			var dropped = new CountdownEvent(1);
 
-			using (await store.SubscribeToAllAsync(false, (s, x) =>
+			var completed = false;
+			var subscription = await store.SubscribeToAllAsync(false, (s, x) =>
 			{
 				appeared.Signal();
 				return Task.CompletedTask;
 			},
-				(s, r, e) => dropped.Signal()))
+				(s, r, e) => dropped.Signal());
+
+			try
 			{
-				var delete = await store.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true);
+				await store.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true);
 
 				Assert.IsTrue(appeared.Wait(Timeout), "Appeared countdown event didn't fire in time.");
+				completed = true;
+			}
+			finally
+			{
+				subscription.Unsubscribe();
+
+				if (completed)
+				{
+					Assert.IsTrue(dropped.Wait(Timeout), "Dropped countdown event timed out.");
+				}
+				else
+				{
+					dropped.Wait(Timeout);
+				}
 			}
 		}
 	}

--- a/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
@@ -44,6 +44,18 @@ namespace EventStore.Core.Tests.Http.Streams
 				return GetRequestResponse(request);
 			}
 
+			public Task<HttpResponseMessage> PostEvent(byte[] data)
+			{
+				var request = CreateRequest(TestStream, "", "POST", "application/json");
+				request.Headers.Add("ES-EventType", "SomeType");
+				request.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
+				request.Content = new ByteArrayContent(data)
+				{
+					Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+				};
+				return GetRequestResponse(request);
+			}
+
 			public Task TombstoneTestStream()
 			{
 				var deleteRequest = CreateRequest(TestStream, "", "DELETE", "application/json");
@@ -597,6 +609,74 @@ namespace EventStore.Core.Tests.Http.Streams
 			{
 				Assert.AreEqual(HttpStatusCode.Gone, _response.StatusCode);
 				// Assert.AreEqual(DeletedStreamDesc, _response.StatusDescription);
+			}
+		}
+
+		[Category("LongRunning")]
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class
+			should_reject_single_http_append_when_body_exceeds_configured_max_append_size<TLogFormat, TStreamId> :
+				ExpectedVersionSpecification<TLogFormat, TStreamId>
+		{
+			private HttpResponseMessage _response;
+			private List<JToken> _read;
+
+			protected override Task Given() => Task.CompletedTask;
+
+			protected override async Task When()
+			{
+				var payload = Encoding.UTF8.GetBytes("{\"payload\":\"" + new string('x', 2 * 1024 * 1024) + "\"}");
+				_response = await PostEvent(payload);
+				_read = await GetTestStream();
+			}
+
+			[Test]
+			public void should_return_request_entity_too_large()
+			{
+				Assert.AreEqual(HttpStatusCode.RequestEntityTooLarge, _response.StatusCode);
+			}
+
+			[Test]
+			public void should_not_append_to_stream()
+			{
+				Assert.AreEqual(0, _read.Count);
+			}
+		}
+
+		[Category("LongRunning")]
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class
+			should_reject_http_append_batch_when_total_body_exceeds_configured_max_append_size<TLogFormat, TStreamId> :
+				ExpectedVersionSpecification<TLogFormat, TStreamId>
+		{
+			private HttpResponseMessage _response;
+			private List<JToken> _read;
+
+			protected override Task Given() => Task.CompletedTask;
+
+			protected override async Task When()
+			{
+				_response = await MakeArrayEventsPost(
+					TestStream,
+					new[] {
+						new { EventId = Guid.NewGuid(), EventType = "event-type", Data = new string('x', 600_000) },
+						new { EventId = Guid.NewGuid(), EventType = "event-type", Data = new string('y', 600_000) },
+					});
+				_read = await GetTestStream();
+			}
+
+			[Test]
+			public void should_return_request_entity_too_large()
+			{
+				Assert.AreEqual(HttpStatusCode.RequestEntityTooLarge, _response.StatusCode);
+			}
+
+			[Test]
+			public void should_not_append_to_stream()
+			{
+				Assert.AreEqual(0, _read.Count);
 			}
 		}
 	}

--- a/src/EventStore.Core.Tests/Integration/when_a_single_node_is_restarted_multiple_times.cs
+++ b/src/EventStore.Core.Tests/Integration/when_a_single_node_is_restarted_multiple_times.cs
@@ -16,7 +16,7 @@ public class when_a_single_node_is_restarted_multiple_times<TLogFormat, TStreamI
 {
 	private List<Guid> _epochIds = new List<Guid>();
 	private const int _numberOfNodeStarts = 5;
-	private static readonly TimeSpan RestartTimeout = TimeSpan.FromSeconds(30);
+	private static readonly TimeSpan RestartTimeout = TimeSpan.FromMinutes(1);
 	private readonly AutoResetEvent _waitForStart = new AutoResetEvent(false);
 
 	protected override TimeSpan Timeout { get; } =

--- a/src/EventStore.Core.Tests/Integration/when_a_single_node_is_restarted_multiple_times.cs
+++ b/src/EventStore.Core.Tests/Integration/when_a_single_node_is_restarted_multiple_times.cs
@@ -4,7 +4,12 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Bus;
+using EventStore.Core.LogAbstraction;
 using EventStore.Core.Messages;
+using EventStore.Core.Services.Storage.EpochManager;
+using EventStore.Core.Tests;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework.Internal;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Integration;
@@ -17,40 +22,65 @@ public class when_a_single_node_is_restarted_multiple_times<TLogFormat, TStreamI
 	private List<Guid> _epochIds = new List<Guid>();
 	private const int _numberOfNodeStarts = 5;
 	private static readonly TimeSpan RestartTimeout = TimeSpan.FromMinutes(3);
-	private readonly AutoResetEvent _waitForStart = new AutoResetEvent(false);
+	private LogFormatAbstractor<TStreamId> _logFormat;
 
 	protected override TimeSpan Timeout { get; } =
 		TimeSpan.FromSeconds((RestartTimeout.TotalSeconds * _numberOfNodeStarts) + 120);
 
-	protected override void BeforeNodeStarts()
-	{
-		_node.Node.MainBus.Subscribe(new AdHocHandler<SystemMessage.EpochWritten>(Handle));
-		base.BeforeNodeStarts();
-	}
-
 	protected override async Task Given()
 	{
+		_epochIds.Add(await GetLastEpochId());
+
 		for (int i = 0; i < _numberOfNodeStarts - 1; i++)
 		{
-			Assert.That(
-				_waitForStart.WaitOne(RestartTimeout),
-				Is.True,
-				$"Timed out waiting for epoch write before restart {i + 1}");
 			await ShutdownNode();
 			await StartNode();
+			_epochIds.Add(await GetLastEpochId());
 		}
 
-		Assert.That(
-			_waitForStart.WaitOne(RestartTimeout),
-			Is.True,
-			"Timed out waiting for epoch write after final startup");
 		await base.Given();
 	}
 
-	private void Handle(SystemMessage.EpochWritten msg)
+	private async Task<Guid> GetLastEpochId()
 	{
-		_epochIds.Add(msg.Epoch.EpochId);
-		_waitForStart.Set();
+		_logFormat ??= LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory.Create(new() {
+			IndexDirectory = GetFilePathFor("epoch-index"),
+		});
+
+		await _node.Started.WaitAsync(RestartTimeout);
+		await _node.WaitForTcpEndPoint().WaitAsync(RestartTimeout);
+
+		var bus = new SynchronousScheduler(nameof(when_a_single_node_is_restarted_multiple_times<TLogFormat, TStreamId>));
+		await using var writer = new TFChunkWriter(_node.Db);
+		writer.Open();
+
+		var epochManager = new EpochManager<TStreamId>(
+			bus,
+			10,
+			_node.Db.Config.EpochCheckpoint,
+			writer,
+			initialReaderCount: 1,
+			maxReaderCount: 5,
+			readerFactory: () => new TFChunkReader(_node.Db, _node.Db.Config.WriterCheckpoint),
+			_logFormat.RecordFactory,
+			_logFormat.StreamNameIndex,
+			_logFormat.EventTypeIndex,
+			_logFormat.CreatePartitionManager(
+				reader: new TFChunkReader(_node.Db, _node.Db.Config.WriterCheckpoint),
+				writer: writer),
+			Guid.NewGuid());
+		await epochManager.Init(CancellationToken.None);
+
+		var epoch = epochManager.GetLastEpoch();
+		Assert.That(epoch, Is.Not.Null, "Expected startup to persist an epoch before restart assertions.");
+		return epoch.EpochId;
+	}
+
+	[OneTimeTearDown]
+	public override async Task TestFixtureTearDown()
+	{
+		_logFormat?.Dispose();
+		await base.TestFixtureTearDown();
 	}
 
 	[Test]

--- a/src/EventStore.Core.Tests/Integration/when_a_single_node_is_restarted_multiple_times.cs
+++ b/src/EventStore.Core.Tests/Integration/when_a_single_node_is_restarted_multiple_times.cs
@@ -16,7 +16,7 @@ public class when_a_single_node_is_restarted_multiple_times<TLogFormat, TStreamI
 {
 	private List<Guid> _epochIds = new List<Guid>();
 	private const int _numberOfNodeStarts = 5;
-	private static readonly TimeSpan RestartTimeout = TimeSpan.FromMinutes(1);
+	private static readonly TimeSpan RestartTimeout = TimeSpan.FromMinutes(3);
 	private readonly AutoResetEvent _waitForStart = new AutoResetEvent(false);
 
 	protected override TimeSpan Timeout { get; } =

--- a/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
+++ b/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
@@ -11,6 +11,7 @@ namespace EventStore.Core.Tests.Integration;
 [TestFixture(typeof(LogFormat.V3), typeof(uint))]
 public class when_restarting_one_node_at_a_time<TLogFormat, TStreamId> : specification_with_cluster<TLogFormat, TStreamId>
 {
+	private static readonly TimeSpan InitialStabilizationTimeout = TimeSpan.FromMinutes(5);
 	private static readonly TimeSpan RestartTimeout = TimeSpan.FromMinutes(3);
 	protected override TimeSpan GivenTimeout { get; } = TimeSpan.FromMinutes(10);
 
@@ -28,7 +29,7 @@ public class when_restarting_one_node_at_a_time<TLogFormat, TStreamId> : specifi
 					return states.Count(x => x == VNodeState.Leader) == 1 &&
 					       states.Count(x => x == VNodeState.Follower) == 2;
 				},
-				RestartTimeout,
+				i == 0 ? InitialStabilizationTimeout : RestartTimeout,
 				$"Cluster did not stabilize before restarting node {restartedNodeIndex}",
 				MiniNodeLogging.WriteLogs);
 

--- a/src/EventStore.Core.Tests/Transforms/TransformTests.cs
+++ b/src/EventStore.Core.Tests/Transforms/TransformTests.cs
@@ -24,6 +24,7 @@ public class TransformTests<TLogFormat, TStreamId> : SpecificationWithDirectoryP
 {
 	private const int NumEvents = 1000;
 	private const int BatchSize = 50;
+	private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(5);
 
 	[TestCase("identity", false)]
 	[TestCase("identity", true)]
@@ -33,7 +34,7 @@ public class TransformTests<TLogFormat, TStreamId> : SpecificationWithDirectoryP
 	[TestCase("bytedup", true)]
 	[TestCase("withheader", false)]
 	[TestCase("withheader", true)]
-	[Timeout(60000)]
+	[Timeout(600000)]
 	public async Task transform_works(string transform, bool memDb)
 	{
 		MiniNode<TLogFormat, TStreamId> node = null;
@@ -105,7 +106,7 @@ public class TransformTests<TLogFormat, TStreamId> : SpecificationWithDirectoryP
 			cachedChunkSize: (10_000 + ChunkHeader.Size + ChunkFooter.Size) * 2,
 			transform: dbTransform.Name,
 			newTransforms: [dbTransform]);
-		await node.Start();
+		await node.Start(StartupTimeout);
 
 		var connection = BuildConnection(node);
 		await connection.ConnectAsync();

--- a/src/EventStore.Core.XUnit.Tests/Data/EventSizeOnDiskTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Data/EventSizeOnDiskTests.cs
@@ -1,0 +1,32 @@
+using EventStore.Core.Data;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.CoreData;
+
+public class EventSizeOnDiskTests
+{
+	[Fact]
+	public void includes_data_metadata_and_event_type_bytes()
+	{
+		var size = Event.SizeOnDisk(
+			eventType: "type",
+			data: [1, 2, 3],
+			metadata: [4, 5]);
+
+		Assert.Equal(13, size);
+	}
+
+	[Theory]
+	[InlineData(null, null, 8)]
+	[InlineData(null, 2, 10)]
+	[InlineData(3, null, 11)]
+	public void treats_missing_payload_sections_as_zero(int? dataLength, int? metadataLength, int expectedSize)
+	{
+		var size = Event.SizeOnDisk(
+			eventType: "type",
+			data: dataLength is { } data ? new byte[data] : null,
+			metadata: metadataLength is { } metadata ? new byte[metadata] : null);
+
+		Assert.Equal(expectedSize, size);
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Data/EventSizeOnDiskTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Data/EventSizeOnDiskTests.cs
@@ -29,4 +29,15 @@ public class EventSizeOnDiskTests
 
 		Assert.Equal(expectedSize, size);
 	}
+
+	[Fact]
+	public void treats_missing_event_type_as_zero_bytes()
+	{
+		var size = Event.SizeOnDisk(
+			eventType: null,
+			data: [1, 2, 3],
+			metadata: [4, 5]);
+
+		Assert.Equal(5, size);
+	}
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1072,7 +1072,8 @@ public class ClusterVNode<TStreamId> :
 		var statController = new StatController(monitoringQueue, _workersHandler);
 		var metricsController = new MetricsController();
 		var atomController = new AtomController(_mainQueue, _workersHandler,
-			options.Application.DisableHttpCaching, TimeSpan.FromMilliseconds(options.Database.WriteTimeoutMs));
+			options.Application.DisableHttpCaching, options.Application.MaxAppendSize,
+			TimeSpan.FromMilliseconds(options.Database.WriteTimeoutMs));
 		var gossipController = new GossipController(_mainQueue, _workersHandler,
 			trackers.GossipTrackers.ProcessingRequestFromHttpClient);
 		var persistentSubscriptionController =

--- a/src/EventStore.Core/Data/Event.cs
+++ b/src/EventStore.Core/Data/Event.cs
@@ -17,7 +17,7 @@ namespace EventStore.Core.Data {
 		}
 
 		public static int SizeOnDisk(string eventType, byte[] data, byte[] metadata) =>
-			(data?.Length ?? 0) + (metadata?.Length ?? 0) + eventType.Length * 2;
+			(data?.Length ?? 0) + (metadata?.Length ?? 0) + (eventType?.Length ?? 0) * 2;
 
 		private static bool ExceedsMaximumSizeOnDisk(string eventType, byte[] data, byte[] metadata) =>
 			SizeOnDisk(eventType, data, metadata) > TFConsts.EffectiveMaxLogRecordSize;

--- a/src/EventStore.Core/Data/Event.cs
+++ b/src/EventStore.Core/Data/Event.cs
@@ -17,7 +17,7 @@ namespace EventStore.Core.Data {
 		}
 
 		public static int SizeOnDisk(string eventType, byte[] data, byte[] metadata) =>
-			data?.Length ?? 0 + metadata?.Length ?? 0 + eventType.Length * 2;
+			(data?.Length ?? 0) + (metadata?.Length ?? 0) + eventType.Length * 2;
 
 		private static bool ExceedsMaximumSizeOnDisk(string eventType, byte[] data, byte[] metadata) =>
 			SizeOnDisk(eventType, data, metadata) > TFConsts.EffectiveMaxLogRecordSize;

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
@@ -95,11 +95,13 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		};
 
 		private readonly IPublisher _networkSendQueue;
+		private readonly int _maxAppendSize;
 		private readonly TimeSpan _writeTimeout;
 
 		public AtomController(IPublisher publisher, IPublisher networkSendQueue,
-			bool disableHTTPCaching, TimeSpan writeTimeout) : base(publisher) {
+			bool disableHTTPCaching, int maxAppendSize, TimeSpan writeTimeout) : base(publisher) {
 			_networkSendQueue = networkSendQueue;
+			_maxAppendSize = maxAppendSize;
 			_writeTimeout = writeTimeout;
 
 			if (disableHTTPCaching) {
@@ -952,9 +954,12 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 						return;
 					}
 
+					var appendSize = 0;
 					foreach (var e in events) {
-						if (e.Data.Length + e.Metadata.Length > 4 * 1024 * 1024) {
-							SendTooBig(manager);
+						appendSize += Event.SizeOnDisk(e.EventType, e.Data, e.Metadata);
+						if (appendSize > _maxAppendSize) {
+							SendTooBig(manager, _maxAppendSize);
+							return;
 						}
 					}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
@@ -42,9 +42,9 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			return new RequestParams(done: true);
 		}
 
-		protected RequestParams SendTooBig(HttpEntityManager httpEntityManager) {
+		protected RequestParams SendTooBig(HttpEntityManager httpEntityManager, int maxAppendSize) {
 			httpEntityManager.ReplyStatus(HttpStatusCode.RequestEntityTooLarge,
-				"Too large events received. Limit is 4mb",
+				$"Too large events received. Limit is {maxAppendSize} bytes",
 				e => Log.Debug("Too large events received over HTTP"));
 			return new RequestParams(done: true);
 		}


### PR DESCRIPTION
- Keep HTTP append rejection aligned with the configured ceiling that gRPC clients already see.
- Avoid replying with a limit error and still continuing into the write path for oversized HTTP requests.
- Preserve predictable transport behavior when a batch exceeds the append budget as a whole.