### PR TITLE
fix(projections): stop oversized state from slipping through

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -84,7 +84,8 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable
 					TimeSpan.FromMinutes(options.Projection.ProjectionsQueryExpiry),
 					options.Projection.FaultOutOfOrderProjections,
 					options.Projection.ProjectionCompilationTimeout,
-					options.Projection.ProjectionExecutionTimeout)))
+					options.Projection.ProjectionExecutionTimeout,
+					options.Projection.MaxProjectionStateSize)))
 			: options;
 
 		if (!_options.Database.MemDb)

--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterNodeOptionsTests/when_building/with_default_settings.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterNodeOptionsTests/when_building/with_default_settings.cs
@@ -6,6 +6,7 @@ using EventStore.Core.Authentication.DelegatedAuthentication;
 using EventStore.Core.Services.Monitoring;
 using EventStore.Core.Tests;
 using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.Util;
 using NUnit.Framework;
 
 namespace EventStore.Core.XUnit.Tests.Configuration.ClusterNodeOptionsTests.when_building;
@@ -66,6 +67,8 @@ public class with_default_node_as_single_node<TLogFormat, TStreamId> : SingleNod
 		Assert.AreEqual(2000, _options.Database.PrepareTimeoutMs, "PrepareTimeout");
 		Assert.AreEqual(2000, _options.Database.CommitTimeoutMs, "CommitTimeout");
 		Assert.AreEqual(2000, _options.Database.WriteTimeoutMs, "WriteTimeout");
+		Assert.AreEqual(Opts.MaxProjectionStateSizeDefault, _options.Projection.MaxProjectionStateSize,
+			"MaxProjectionStateSize");
 
 		Assert.AreEqual(700, _options.Interface.ReplicationHeartbeatInterval, "ReplicationHeartbeatInterval");
 

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -624,6 +624,9 @@ public partial record ClusterVNodeOptions
 			 "The maximum execution time in milliseconds for executing a handler in a user projection. It can be overridden for a specific projection by setting ProjectionExecutionTimeout config for that projection"),
 		 Unit("ms")]
 		public int ProjectionExecutionTimeout { get; set; } = DefaultProjectionExecutionTimeout;
+
+		[Description("The maximum size, in bytes, of a projection's state and result. A projection faults when its state grows beyond this limit.")]
+		public int MaxProjectionStateSize { get; set; } = Opts.MaxProjectionStateSizeDefault;
 	}
 
 	public record UnknownOptions(IReadOnlyList<(string, string)> Options)

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -15,6 +15,8 @@ namespace EventStore.Core.Util {
 
 		public const int ProjectionsQueryExpiryDefault = 5;
 
+		public const int MaxProjectionStateSizeDefault = int.MaxValue;
+
 		public const byte IndexBitnessVersionDefault = Index.PTableVersions.IndexV4;
 
 		public static readonly string AuthenticationTypeDefault = "internal";

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/FakeCoreProjection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/FakeCoreProjection.cs
@@ -22,6 +22,9 @@ public class FakeCoreProjection : ICoreProjection,
 	public readonly List<CoreProjectionProcessingMessage.PrerecordedEventsLoaded> _prerecordedEventsLoadedMessages =
 		new List<CoreProjectionProcessingMessage.PrerecordedEventsLoaded>();
 
+	public readonly List<CoreProjectionProcessingMessage.Failed> _failedMessages =
+		new List<CoreProjectionProcessingMessage.Failed>();
+
 	public void Handle(CoreProjectionProcessingMessage.CheckpointCompleted message)
 	{
 		_checkpointCompletedMessages.Add(message);
@@ -39,7 +42,7 @@ public class FakeCoreProjection : ICoreProjection,
 
 	public void Handle(CoreProjectionProcessingMessage.Failed message)
 	{
-		throw new System.NotImplementedException();
+		_failedMessages.Add(message);
 	}
 
 	public void Handle(CoreProjectionProcessingMessage.PrerecordedEventsLoaded message)

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
@@ -33,6 +33,7 @@ public abstract class TestFixtureWithCoreProjectionCheckpointManager<TLogFormat,
 	protected CoreProjectionCheckpointReader _checkpointReader;
 	protected string _projectionName;
 	protected ProjectionVersion _projectionVersion;
+	protected int _maxProjectionStateSize = int.MaxValue;
 
 	[SetUp]
 	public void setup()
@@ -64,7 +65,7 @@ public abstract class TestFixtureWithCoreProjectionCheckpointManager<TLogFormat,
 			_bus, _projectionCorrelationId, _projectionVersion, null, _ioDispatcher, _config, _projectionName,
 			new StreamPositionTagger(0, "stream"), _namingBuilder, _checkpointsEnabled, _producesResults,
 			_definesFold,
-			_checkpointWriter);
+			_checkpointWriter, _maxProjectionStateSize);
 	}
 
 	protected new virtual void Given()

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_projection_state_is_too_large.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_projection_state_is_too_large.cs
@@ -51,7 +51,7 @@ public class when_projection_state_is_too_large<TLogFormat, TStreamId> :
 			newState = new PartitionState(
 				$"{{ \"state\": \"{new string('*', _maxProjectionStateSize)}\"}}",
 				"",
-				firstEventCheckpointTag);
+				secondEventCheckpointTag);
 			_manager.StateUpdated("", oldState, newState);
 			_manager.EventProcessed(secondEventCheckpointTag, 77.7f);
 		}

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_projection_state_is_too_large.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_projection_state_is_too_large.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using EventStore.Core.Tests;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Processing.Checkpointing;
+using EventStore.Projections.Core.Services.Processing.Partitioning;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_manager;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+public class when_projection_state_is_too_large<TLogFormat, TStreamId> :
+	TestFixtureWithCoreProjectionCheckpointManager<TLogFormat, TStreamId>
+{
+	private Exception _exception;
+
+	protected override void Given()
+	{
+		AllWritesSucceed();
+		base.Given();
+		_checkpointHandledThreshold = 2;
+		_maxProjectionStateSize = 1024 * 1024;
+	}
+
+	protected override void When()
+	{
+		base.When();
+		_exception = null;
+
+		try
+		{
+			_checkpointReader.BeginLoadState();
+			var checkpointLoaded =
+				_consumer.HandledMessages.OfType<CoreProjectionProcessingMessage.CheckpointLoaded>().First();
+			_checkpointWriter.StartFrom(checkpointLoaded.CheckpointTag, checkpointLoaded.CheckpointEventNumber);
+			_manager.BeginLoadPrerecordedEvents(checkpointLoaded.CheckpointTag);
+
+			var initialCheckpointTag = CheckpointTag.FromStreamPosition(0, "stream", 10);
+			_manager.Start(initialCheckpointTag, null);
+			var oldState = new PartitionState("", "", initialCheckpointTag);
+
+			var firstEventCheckpointTag = CheckpointTag.FromStreamPosition(0, "stream", 11);
+			var newState = new PartitionState("{ \"state\": \"foo\"}", "", firstEventCheckpointTag);
+			_manager.StateUpdated("", oldState, newState);
+			_manager.EventProcessed(firstEventCheckpointTag, 55.5f);
+
+			var secondEventCheckpointTag = CheckpointTag.FromStreamPosition(0, "stream", 12);
+			oldState = newState;
+			newState = new PartitionState(
+				$"{{ \"state\": \"{new string('*', _maxProjectionStateSize)}\"}}",
+				"",
+				firstEventCheckpointTag);
+			_manager.StateUpdated("", oldState, newState);
+			_manager.EventProcessed(secondEventCheckpointTag, 77.7f);
+		}
+		catch (Exception ex)
+		{
+			_exception = ex;
+		}
+	}
+
+	[Test]
+	public void messages_are_handled()
+	{
+		Assert.IsNull(_exception);
+	}
+
+	[Test]
+	public void publishes_projection_failed_message()
+	{
+		var failedMessages = _consumer.HandledMessages.OfType<CoreProjectionProcessingMessage.Failed>().ToArray();
+
+		Assert.AreEqual(1, failedMessages.Length);
+		StringAssert.Contains("exceeds the configured MaxProjectionStateSize", failedMessages[0].Reason);
+	}
+
+	[Test]
+	public void the_second_event_is_not_processed()
+	{
+		var stats = new ProjectionStatistics();
+		_manager.GetStatistics(stats);
+
+		Assert.AreEqual(1, stats.EventsProcessedAfterRestart);
+		Assert.AreEqual(55.5f, stats.Progress);
+		Assert.AreEqual(CheckpointTag.FromStreamPosition(0, "stream", 11).ToString(), stats.Position);
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_projection_state_is_too_large.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_projection_state_is_too_large.cs
@@ -21,7 +21,7 @@ public class when_projection_state_is_too_large<TLogFormat, TStreamId> :
 		AllWritesSucceed();
 		base.Given();
 		_checkpointHandledThreshold = 2;
-		_maxProjectionStateSize = 1024 * 1024;
+		_maxProjectionStateSize = 1024;
 	}
 
 	protected override void When()
@@ -48,8 +48,9 @@ public class when_projection_state_is_too_large<TLogFormat, TStreamId> :
 
 			var secondEventCheckpointTag = CheckpointTag.FromStreamPosition(0, "stream", 12);
 			oldState = newState;
+			var unicodePayloadThatExceedsUtf8ByteLimit = new string('é', 600);
 			newState = new PartitionState(
-				$"{{ \"state\": \"{new string('*', _maxProjectionStateSize)}\"}}",
+				$"{{ \"state\": \"{unicodePayloadThatExceedsUtf8ByteLimit}\"}}",
 				"",
 				secondEventCheckpointTag);
 			_manager.StateUpdated("", oldState, newState);

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/multi_phase/specification_with_multi_phase_core_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/multi_phase/specification_with_multi_phase_core_projection.cs
@@ -37,7 +37,7 @@ abstract class specification_with_multi_phase_core_projection<TLogFormat, TStrea
 		public FakeProjectionProcessingStrategy(
 			string name, ProjectionVersion projectionVersion, ILogger logger, FakeProjectionProcessingPhase phase1,
 			FakeProjectionProcessingPhase phase2)
-			: base(name, projectionVersion, logger)
+			: base(name, projectionVersion, logger, int.MaxValue)
 		{
 			_phase1 = phase1;
 			_phase2 = phase2;

--- a/src/EventStore.Projections.Core.Tests/Services/partition_state/partition_state.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/partition_state/partition_state.cs
@@ -1,4 +1,5 @@
 using System;
+using EventStore.Common.Utils;
 using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Services.Processing.Checkpointing;
 using EventStore.Projections.Core.Services.Processing.Partitioning;
@@ -30,6 +31,19 @@ public static class partition_state
 		public void can_be_created()
 		{
 			new PartitionState("state", "result", CheckpointTag.FromPosition(0, 100, 50));
+		}
+
+		[Test]
+		public void size_is_measured_in_utf8_bytes()
+		{
+			var state = @"{""state"":""é""}";
+			var result = @"{""result"":""界""}";
+
+			var partitionState = new PartitionState(state, result, CheckpointTag.FromPosition(0, 100, 50));
+
+			Assert.AreEqual(
+				Helper.UTF8NoBom.GetByteCount(state) + Helper.UTF8NoBom.GetByteCount(result),
+				partitionState.Size);
 		}
 	}
 

--- a/src/EventStore.Projections.Core/ProjectionsStandardComponents.cs
+++ b/src/EventStore.Projections.Core/ProjectionsStandardComponents.cs
@@ -12,7 +12,10 @@ public class ProjectionsStandardComponents
 		IPublisher leaderOutputQueue,
 		ISubscriber leaderInputBus,
 		IPublisher leaderInputQueue,
-		bool faultOutOfOrderProjections, int projectionCompilationTimeout, int projectionExecutionTimeout)
+		bool faultOutOfOrderProjections,
+		int projectionCompilationTimeout,
+		int projectionExecutionTimeout,
+		int maxProjectionStateSize = int.MaxValue)
 	{
 		ProjectionWorkerThreadCount = projectionWorkerThreadCount;
 		RunProjections = runProjections;
@@ -23,6 +26,7 @@ public class ProjectionsStandardComponents
 		FaultOutOfOrderProjections = faultOutOfOrderProjections;
 		ProjectionCompilationTimeout = projectionCompilationTimeout;
 		ProjectionExecutionTimeout = projectionExecutionTimeout;
+		MaxProjectionStateSize = maxProjectionStateSize;
 	}
 
 	public int ProjectionWorkerThreadCount { get; }
@@ -40,4 +44,6 @@ public class ProjectionsStandardComponents
 	public int ProjectionCompilationTimeout { get; }
 
 	public int ProjectionExecutionTimeout { get; }
+
+	public int MaxProjectionStateSize { get; }
 }

--- a/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
@@ -30,7 +30,8 @@ public record ProjectionSubsystemOptions(
 	TimeSpan ProjectionQueryExpiry,
 	bool FaultOutOfOrderProjections,
 	int CompilationTimeout,
-	int ExecutionTimeout);
+	int ExecutionTimeout,
+	int MaxProjectionStateSize = int.MaxValue);
 
 public sealed class ProjectionsSubsystem : ISubsystem,
 	IHandle<SystemMessage.SystemCoreReady>,
@@ -68,6 +69,7 @@ public sealed class ProjectionsSubsystem : ISubsystem,
 
 	private readonly int _compilationTimeout;
 	private readonly int _executionTimeout;
+	private readonly int _maxProjectionStateSize;
 
 	private readonly int _componentCount;
 	private readonly int _dispatcherCount;
@@ -114,6 +116,7 @@ public sealed class ProjectionsSubsystem : ISubsystem,
 		_subsystemInitialized = new();
 		_executionTimeout = projectionSubsystemOptions.ExecutionTimeout;
 		_compilationTimeout = projectionSubsystemOptions.CompilationTimeout;
+		_maxProjectionStateSize = projectionSubsystemOptions.MaxProjectionStateSize;
 	}
 
 	public IPublisher LeaderOutputQueue => _leaderOutputQueue;
@@ -161,7 +164,8 @@ public sealed class ProjectionsSubsystem : ISubsystem,
 			leaderInputQueue: _leaderInputQueue,
 			_faultOutOfOrderProjections,
 			_compilationTimeout,
-			_executionTimeout);
+			_executionTimeout,
+			_maxProjectionStateSize);
 
 		CreateAwakerService(standardComponents);
 		_coreWorkers = ProjectionCoreWorkersNode.CreateCoreWorkers(standardComponents, projectionsStandardComponents);

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
@@ -16,6 +16,7 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 	protected readonly ProjectionNamesBuilder _namingBuilder;
 	protected readonly ProjectionConfig _projectionConfig;
 	protected readonly ILogger _logger;
+	protected readonly int _maxProjectionStateSize;
 
 	private readonly bool _usePersistentCheckpoints;
 
@@ -39,7 +40,6 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 	protected bool _stopped;
 
 	private PartitionState _currentProjectionState;
-	private bool _largeStateWarningLogged = false;
 
 	protected CoreProjectionCheckpointManager(
 		IPublisher publisher,
@@ -48,7 +48,8 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		string name,
 		PositionTagger positionTagger,
 		ProjectionNamesBuilder namingBuilder,
-		bool usePersistentCheckpoints)
+		bool usePersistentCheckpoints,
+		int maxProjectionStateSize)
 	{
 		if (publisher == null)
 			throw new ArgumentNullException("publisher");
@@ -62,6 +63,8 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 			throw new ArgumentNullException("namingBuilder");
 		if (name == "")
 			throw new ArgumentException("name");
+		if (maxProjectionStateSize <= 0)
+			throw new ArgumentException(nameof(maxProjectionStateSize));
 
 		_lastProcessedEventPosition = new PositionTracker(positionTagger);
 		_zeroTag = positionTagger.MakeZeroCheckpointTag();
@@ -74,6 +77,7 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		_usePersistentCheckpoints = usePersistentCheckpoints;
 		_requestedCheckpointState = new PartitionState("", null, _zeroTag);
 		_currentProjectionState = new PartitionState("", null, _zeroTag);
+		_maxProjectionStateSize = maxProjectionStateSize;
 	}
 
 	protected abstract ProjectionCheckpoint CreateProjectionCheckpoint(CheckpointTag checkpointPosition);
@@ -192,7 +196,8 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		if (partition == "" && newState.State == null) // ignore non-root partitions and non-changed states
 			throw new NotSupportedException("Internal check");
 
-		CheckStateSize(newState, partition);
+		if (!CheckStateSize(newState, partition))
+			return;
 
 		if (_usePersistentCheckpoints && partition != "")
 			CapturePartitionStateUpdated(partition, oldState, newState);
@@ -201,24 +206,18 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 			_currentProjectionState = newState;
 	}
 
-	private void CheckStateSize(PartitionState result, string partition)
+	private bool CheckStateSize(PartitionState result, string partition)
 	{
-		if (!_largeStateWarningLogged && result.Size >= 8_000_000 && !partition.Equals(""))
+		if (result.Size > _maxProjectionStateSize)
 		{
-			Log.Warning(
-				"State size for the Projection {projectionName} for Partition {partitionName} is greater than 8 MB. State size for a projection must be less than 16 MB. Current state size for Partition {partitionName} is {stateSize} MB.",
-				_namingBuilder.EffectiveProjectionName, partition, partition,
-				result.Size / Math.Pow(10, 6));
-			_largeStateWarningLogged = true;
+			var partitionMessage = partition == string.Empty ? string.Empty : $" in partition '{partition}'";
+			Failed(
+				$"The state size of projection '{_namingBuilder.EffectiveProjectionName}'{partitionMessage} is {result.Size:N0} bytes " +
+				$"which exceeds the configured MaxProjectionStateSize of {_maxProjectionStateSize:N0} bytes.");
+			return false;
 		}
-		else if (!_largeStateWarningLogged && result.Size >= 8_000_000 && partition.Equals(""))
-		{
-			Log.Warning(
-				"State size for the Projection {projectionName} is greater than 8 MB. State size for a projection must be less than 16 MB. Current state size for Projection {projectionName} is {stateSize} MB.",
-				_namingBuilder.EffectiveProjectionName, _namingBuilder.EffectiveProjectionName,
-				result.Size / Math.Pow(10, 6));
-			_largeStateWarningLogged = true;
-		}
+
+		return true;
 	}
 
 	public void EventProcessed(CheckpointTag checkpointTag, float progress)

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
@@ -64,7 +64,10 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		if (name == "")
 			throw new ArgumentException("name");
 		if (maxProjectionStateSize <= 0)
-			throw new ArgumentException(nameof(maxProjectionStateSize));
+			throw new ArgumentOutOfRangeException(
+				nameof(maxProjectionStateSize),
+				maxProjectionStateSize,
+				"Max projection state size must be positive.");
 
 		_lastProcessedEventPosition = new PositionTracker(positionTagger);
 		_zeroTag = positionTagger.MakeZeroCheckpointTag();

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointWriter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointWriter.cs
@@ -30,7 +30,7 @@ public class CoreProjectionCheckpointWriter
 	private const int MinAttemptWarnThreshold = 5;
 	private bool _metaStreamWritten;
 	private Random _random = new Random();
-	private bool _largeCheckpointStateWarningLogged = false;
+	private bool _largeCheckpointWarningLogged = false;
 
 	public CoreProjectionCheckpointWriter(
 		string projectionCheckpointStreamId, IODispatcher ioDispatcher, ProjectionVersion projectionVersion,
@@ -183,22 +183,22 @@ public class CoreProjectionCheckpointWriter
 
 	private void PublishWriteCheckpointEvent()
 	{
-		CheckpointStateSizeCheck();
+		CheckpointSizeCheck();
 		_writeRequestId = _ioDispatcher.WriteEvent(
 			_projectionCheckpointStreamId, _lastWrittenCheckpointEventNumber, _checkpointEventToBePublished,
 			SystemAccounts.System,
 			msg => WriteCheckpointEventCompleted(_projectionCheckpointStreamId, msg.Result, msg.FirstEventNumber));
 	}
 
-	private void CheckpointStateSizeCheck()
+	private void CheckpointSizeCheck()
 	{
-		if (!_largeCheckpointStateWarningLogged && _checkpointEventToBePublished.Data.Length >= 8_000_000)
+		if (!_largeCheckpointWarningLogged && _checkpointEventToBePublished.Data.Length >= 8_000_000)
 		{
 			Log.Warning(
-				"State size for the Projection {projectionName} is greater than 8 MB. State size for a projection should be less than 16 MB. Current state size for Projection {projectionName} is {stateSize} MB.",
+				"Checkpoint size for the Projection {projectionName} is greater than 8 MB. Checkpoint size for a projection should be less than 16 MB. Current checkpoint size for Projection {projectionName} is {stateSize} MB.",
 				_name, _name,
 				_checkpointEventToBePublished.Data.Length / Math.Pow(10, 6));
-			_largeCheckpointStateWarningLogged = true;
+			_largeCheckpointWarningLogged = true;
 		}
 	}
 

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/DefaultCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/DefaultCheckpointManager.cs
@@ -33,10 +33,10 @@ public class DefaultCheckpointManager : CoreProjectionCheckpointManager,
 		IODispatcher ioDispatcher, ProjectionConfig projectionConfig, string name, PositionTagger positionTagger,
 		ProjectionNamesBuilder namingBuilder, bool usePersistentCheckpoints, bool producesRunningResults,
 		bool definesFold,
-		CoreProjectionCheckpointWriter coreProjectionCheckpointWriter)
+		CoreProjectionCheckpointWriter coreProjectionCheckpointWriter, int maxProjectionStateSize = int.MaxValue)
 		: base(
 			publisher, projectionCorrelationId, projectionConfig, name, positionTagger, namingBuilder,
-			usePersistentCheckpoints)
+			usePersistentCheckpoints, maxProjectionStateSize)
 	{
 		if (ioDispatcher == null)
 			throw new ArgumentNullException("ioDispatcher");

--- a/src/EventStore.Projections.Core/Services/Processing/MultiStream/MultiStreamMultiOutputCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/MultiStream/MultiStreamMultiOutputCheckpointManager.cs
@@ -31,11 +31,11 @@ public partial class MultiStreamMultiOutputCheckpointManager : DefaultCheckpoint
 		IODispatcher ioDispatcher, ProjectionConfig projectionConfig, string name, PositionTagger positionTagger,
 		ProjectionNamesBuilder namingBuilder, bool usePersistentCheckpoints, bool producesRunningResults,
 		bool definesFold,
-		CoreProjectionCheckpointWriter coreProjectionCheckpointWriter)
+		CoreProjectionCheckpointWriter coreProjectionCheckpointWriter, int maxProjectionStateSize = int.MaxValue)
 		: base(
 			publisher, projectionCorrelationId, projectionVersion, runAs, ioDispatcher, projectionConfig, name,
 			positionTagger, namingBuilder, usePersistentCheckpoints, producesRunningResults, definesFold,
-			coreProjectionCheckpointWriter)
+			coreProjectionCheckpointWriter, maxProjectionStateSize)
 	{
 		_positionTagger = positionTagger;
 	}

--- a/src/EventStore.Projections.Core/Services/Processing/Partitioning/PartitionState.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Partitioning/PartitionState.cs
@@ -58,7 +58,7 @@ public class PartitionState
 	private readonly string _state;
 	private readonly string _result;
 	private readonly CheckpointTag _causedBy;
-	private int _size;
+	private readonly int _size;
 
 	public PartitionState(string state, string result, CheckpointTag causedBy)
 	{
@@ -70,7 +70,7 @@ public class PartitionState
 		_state = state;
 		_result = result;
 		_causedBy = causedBy;
-		_size = _state.Length + _result?.Length ?? 0;
+		_size = _state.Length + (_result?.Length ?? 0);
 	}
 
 	public string State

--- a/src/EventStore.Projections.Core/Services/Processing/Partitioning/PartitionState.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Partitioning/PartitionState.cs
@@ -70,7 +70,8 @@ public class PartitionState
 		_state = state;
 		_result = result;
 		_causedBy = causedBy;
-		_size = _state.Length + (_result?.Length ?? 0);
+		_size = Helper.UTF8NoBom.GetByteCount(_state)
+			+ (_result is null ? 0 : Helper.UTF8NoBom.GetByteCount(_result));
 	}
 
 	public string State

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
@@ -71,7 +71,9 @@ public class ProjectionCoreService
 		_ioDispatcher = ioDispatcher;
 		_subscriptionDispatcher = subscriptionDispatcher;
 		_timeProvider = timeProvider;
-		_processingStrategySelector = new ProcessingStrategySelector(_subscriptionDispatcher);
+		_processingStrategySelector = new ProcessingStrategySelector(
+			_subscriptionDispatcher,
+			configuration.MaxProjectionStateSize);
 		_factory = new ProjectionStateHandlerFactory(TimeSpan.FromMilliseconds(configuration.ProjectionCompilationTimeout),
 			TimeSpan.FromMilliseconds(configuration.ProjectionExecutionTimeout));
 	}

--- a/src/EventStore.Projections.Core/Services/Processing/Strategies/ContinuousProjectionProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Strategies/ContinuousProjectionProcessingStrategy.cs
@@ -14,10 +14,11 @@ public class ContinuousProjectionProcessingStrategy : DefaultProjectionProcessin
 	public ContinuousProjectionProcessingStrategy(
 		string name, ProjectionVersion projectionVersion, IProjectionStateHandler stateHandler,
 		ProjectionConfig projectionConfig, IQuerySources sourceDefinition, ILogger logger,
-		ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation)
+		ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation,
+		int maxProjectionStateSize = int.MaxValue)
 		: base(
 			name, projectionVersion, stateHandler, projectionConfig, sourceDefinition, logger,
-			subscriptionDispatcher, enableContentTypeValidation)
+			subscriptionDispatcher, enableContentTypeValidation, maxProjectionStateSize)
 	{
 	}
 

--- a/src/EventStore.Projections.Core/Services/Processing/Strategies/DefaultProjectionProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Strategies/DefaultProjectionProcessingStrategy.cs
@@ -16,8 +16,17 @@ public abstract class DefaultProjectionProcessingStrategy : EventReaderBasedProj
 	protected DefaultProjectionProcessingStrategy(
 		string name, ProjectionVersion projectionVersion, IProjectionStateHandler stateHandler,
 		ProjectionConfig projectionConfig, IQuerySources sourceDefinition, ILogger logger,
-		ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation)
-		: base(name, projectionVersion, projectionConfig, sourceDefinition, logger, subscriptionDispatcher, enableContentTypeValidation)
+		ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation,
+		int maxProjectionStateSize)
+		: base(
+			name,
+			projectionVersion,
+			projectionConfig,
+			sourceDefinition,
+			logger,
+			subscriptionDispatcher,
+			enableContentTypeValidation,
+			maxProjectionStateSize)
 	{
 		_stateHandler = stateHandler;
 	}

--- a/src/EventStore.Projections.Core/Services/Processing/Strategies/EventReaderBasedProjectionProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Strategies/EventReaderBasedProjectionProcessingStrategy.cs
@@ -21,8 +21,9 @@ public abstract class EventReaderBasedProjectionProcessingStrategy : ProjectionP
 
 	protected EventReaderBasedProjectionProcessingStrategy(
 		string name, ProjectionVersion projectionVersion, ProjectionConfig projectionConfig,
-		IQuerySources sourceDefinition, Serilog.ILogger logger, ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation)
-		: base(name, projectionVersion, logger)
+		IQuerySources sourceDefinition, Serilog.ILogger logger, ReaderSubscriptionDispatcher subscriptionDispatcher,
+		bool enableContentTypeValidation, int maxProjectionStateSize)
+		: base(name, projectionVersion, logger, maxProjectionStateSize)
 	{
 		_projectionConfig = projectionConfig;
 		_sourceDefinition = sourceDefinition;
@@ -158,7 +159,7 @@ public abstract class EventReaderBasedProjectionProcessingStrategy : ProjectionP
 				publisher, projectionCorrelationId, _projectionVersion, _projectionConfig.RunAs, ioDispatcher,
 				_projectionConfig, _name, readerStrategy.PositionTagger, namingBuilder,
 				_projectionConfig.CheckpointsEnabled, GetProducesRunningResults(), definesFold,
-				coreProjectionCheckpointWriter);
+				coreProjectionCheckpointWriter, _maxProjectionStateSize);
 		}
 		else
 		{
@@ -166,7 +167,7 @@ public abstract class EventReaderBasedProjectionProcessingStrategy : ProjectionP
 				publisher, projectionCorrelationId, _projectionVersion, _projectionConfig.RunAs, ioDispatcher,
 				_projectionConfig, _name, readerStrategy.PositionTagger, namingBuilder,
 				_projectionConfig.CheckpointsEnabled, GetProducesRunningResults(), definesFold,
-				coreProjectionCheckpointWriter);
+				coreProjectionCheckpointWriter, _maxProjectionStateSize);
 		}
 	}
 

--- a/src/EventStore.Projections.Core/Services/Processing/Strategies/ProcessingStrategySelector.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Strategies/ProcessingStrategySelector.cs
@@ -7,11 +7,14 @@ public class ProcessingStrategySelector
 {
 	private readonly ILogger _logger = Serilog.Log.ForContext<ProcessingStrategySelector>();
 	private readonly ReaderSubscriptionDispatcher _subscriptionDispatcher;
+	private readonly int _maxProjectionStateSize;
 
 	public ProcessingStrategySelector(
-		ReaderSubscriptionDispatcher subscriptionDispatcher)
+		ReaderSubscriptionDispatcher subscriptionDispatcher,
+		int maxProjectionStateSize)
 	{
 		_subscriptionDispatcher = subscriptionDispatcher;
+		_maxProjectionStateSize = maxProjectionStateSize;
 	}
 
 	public ProjectionProcessingStrategy CreateProjectionProcessingStrategy(
@@ -33,7 +36,8 @@ public class ProcessingStrategySelector
 				sourceDefinition,
 				_logger,
 				_subscriptionDispatcher,
-				enableContentTypeValidation)
+				enableContentTypeValidation,
+				_maxProjectionStateSize)
 			: new ContinuousProjectionProcessingStrategy(
 				name,
 				projectionVersion,
@@ -42,6 +46,7 @@ public class ProcessingStrategySelector
 				sourceDefinition,
 				_logger,
 				_subscriptionDispatcher,
-				enableContentTypeValidation);
+				enableContentTypeValidation,
+				_maxProjectionStateSize);
 	}
 }

--- a/src/EventStore.Projections.Core/Services/Processing/Strategies/ProjectionProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Strategies/ProjectionProcessingStrategy.cs
@@ -16,12 +16,18 @@ public abstract class ProjectionProcessingStrategy
 	protected readonly string _name;
 	protected readonly ProjectionVersion _projectionVersion;
 	protected readonly ILogger _logger;
+	protected readonly int _maxProjectionStateSize;
 
-	protected ProjectionProcessingStrategy(string name, ProjectionVersion projectionVersion, ILogger logger)
+	protected ProjectionProcessingStrategy(
+		string name,
+		ProjectionVersion projectionVersion,
+		ILogger logger,
+		int maxProjectionStateSize)
 	{
 		_name = name;
 		_projectionVersion = projectionVersion;
 		_logger = logger;
+		_maxProjectionStateSize = maxProjectionStateSize;
 	}
 
 	public CoreProjection Create(

--- a/src/EventStore.Projections.Core/Services/Processing/Strategies/QueryProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Strategies/QueryProcessingStrategy.cs
@@ -16,10 +16,11 @@ public class QueryProcessingStrategy : DefaultProjectionProcessingStrategy
 	public QueryProcessingStrategy(
 		string name, ProjectionVersion projectionVersion, IProjectionStateHandler stateHandler,
 		ProjectionConfig projectionConfig, IQuerySources sourceDefinition, ILogger logger,
-		ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation)
+		ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation,
+		int maxProjectionStateSize = int.MaxValue)
 		: base(
 			name, projectionVersion, stateHandler, projectionConfig, sourceDefinition, logger,
-			subscriptionDispatcher, enableContentTypeValidation)
+			subscriptionDispatcher, enableContentTypeValidation, maxProjectionStateSize)
 	{
 	}
 
@@ -50,7 +51,7 @@ public class QueryProcessingStrategy : DefaultProjectionProcessingStrategy
 		var checkpointManager2 = new DefaultCheckpointManager(
 			publisher, projectionCorrelationId, _projectionVersion, SystemAccounts.System, ioDispatcher,
 			_projectionConfig, _name, new PhasePositionTagger(1), namingBuilder, GetUseCheckpoints(), false,
-			_sourceDefinition.DefinesFold, coreProjectionCheckpointWriter);
+			_sourceDefinition.DefinesFold, coreProjectionCheckpointWriter, _maxProjectionStateSize);
 
 		IProjectionProcessingPhase writeResultsPhase;
 		if (GetProducesRunningResults())


### PR DESCRIPTION
- keep projection workers from continuing after state grows beyond a controllable safety boundary
- make projection size accounting trustworthy so oversized state faults early instead of surfacing later as checkpoint failures
- keep the next migration slice aligned with the operator-visible projections gap that is still open locally