### PR TITLE
fix(storage): keep scavenged midpoint startup reads linear

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/PosMapTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/PosMapTests.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Buffers.Binary;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.TransactionLog.Chunks;
+
+public class PosMapTests
+{
+	[Fact]
+	public void can_parse_old_format_from_span()
+	{
+		Span<byte> source = stackalloc byte[PosMap.DeprecatedSize];
+		var actualPos = 1234;
+		var logPos = 5678;
+		BinaryPrimitives.WriteUInt64LittleEndian(source, ((ulong)(uint)logPos << 32) | (uint)actualPos);
+
+		var destination = PosMap.FromOldFormat(source);
+
+		Assert.Equal(logPos, destination.LogPos);
+		Assert.Equal(actualPos, destination.ActualPos);
+	}
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/PosMap.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/PosMap.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers.Binary;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -40,6 +41,16 @@ public struct PosMap : IBinaryFormattable<PosMap>
 
 	public static PosMap FromNewFormat(ReadOnlySpan<byte> source)
 		=> new(source);
+
+	public static PosMap FromOldFormat(ReadOnlySpan<byte> source)
+	{
+		Debug.Assert(source.Length >= DeprecatedSize);
+
+		var posmap = BinaryPrimitives.ReadUInt64LittleEndian(source);
+		var logPos = (int)(posmap >>> 32);
+		var actualPos = (int)(posmap & 0xFFFFFFFF);
+		return new(logPos, actualPos);
+	}
 
 	public static async ValueTask<PosMap> FromOldFormat(Stream stream, Memory<byte> buffer, CancellationToken token)
 	{

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
@@ -222,13 +222,18 @@ public partial class TFChunk
 			if (Chunk.ChunkFooter.MapCount is 0) // empty chunk
 				return [];
 
-			var buffer = Memory.AllocateAtLeast<byte>(PosMap.FullSize);
+			var posMapSize = Chunk.ChunkFooter.IsMap12Bytes ? PosMap.FullSize : PosMap.DeprecatedSize;
+			var posMapsBuffer = Memory.AllocateAtLeast<byte>(checked(Chunk.ChunkFooter.MapSize));
 			try
 			{
 				int midPointsCnt = 1 << depth;
 				int segmentSize;
 				Midpoint[] midpoints;
 				var mapCount = Chunk.ChunkFooter.MapCount;
+				var posMaps = posMapsBuffer.Memory[..checked(mapCount * posMapSize)];
+				workItem.BaseStream.Seek(ChunkHeader.Size + Chunk.ChunkFooter.PhysicalDataSize, SeekOrigin.Begin);
+				await workItem.BaseStream.ReadExactlyAsync(posMaps, token);
+
 				if (mapCount < midPointsCnt)
 				{
 					segmentSize = 1; // we cache all items
@@ -243,11 +248,10 @@ public partial class TFChunk
 				var i = 0;
 				for (int x = 0, xN = mapCount - 1; x < xN; x += segmentSize, i++)
 				{
-					midpoints[i] = new Midpoint(x, await ReadPosMap(workItem, x, buffer.Memory, token));
+					midpoints[i] = new Midpoint(x, ReadPosMap(posMaps.Span, x));
 				}
 
-				var lastMidpoint = new Midpoint(mapCount - 1,
-					await ReadPosMap(workItem, mapCount - 1, buffer.Memory, token));
+				var lastMidpoint = new Midpoint(mapCount - 1, ReadPosMap(posMaps.Span, mapCount - 1));
 				while (i < midpoints.Length)
 				{
 					midpoints[i] = lastMidpoint;
@@ -266,8 +270,18 @@ public partial class TFChunk
 			}
 			finally
 			{
-				buffer.Dispose();
+				posMapsBuffer.Dispose();
 			}
+		}
+
+		private PosMap ReadPosMap(ReadOnlySpan<byte> posMaps, int index)
+		{
+			var posMapSize = Chunk.ChunkFooter.IsMap12Bytes ? PosMap.FullSize : PosMap.DeprecatedSize;
+			var start = checked(index * posMapSize);
+			var buffer = posMaps.Slice(start, posMapSize);
+			return Chunk.ChunkFooter.IsMap12Bytes
+				? PosMap.FromNewFormat(buffer)
+				: PosMap.FromOldFormat(buffer);
 		}
 
 		private ValueTask<PosMap> ReadPosMap(ReaderWorkItem workItem, long index, Memory<byte> buffer,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
@@ -223,9 +223,9 @@ public partial class TFChunk
 				return [];
 
 			var posMapSize = Chunk.ChunkFooter.IsMap12Bytes ? PosMap.FullSize : PosMap.DeprecatedSize;
-			var posMapsBuffer = Memory.AllocateAtLeast<byte>(checked(Chunk.ChunkFooter.MapSize));
 			try
 			{
+				using var posMapsBuffer = Memory.AllocateAtLeast<byte>(checked(Chunk.ChunkFooter.MapSize));
 				int midPointsCnt = 1 << depth;
 				int segmentSize;
 				Midpoint[] midpoints;
@@ -267,10 +267,6 @@ public partial class TFChunk
 			catch (OutOfMemoryException)
 			{
 				return null;
-			}
-			finally
-			{
-				posMapsBuffer.Dispose();
 			}
 		}
 


### PR DESCRIPTION
- scavenged chunks should not pay one seek/read per sampled posmap while rebuilding midpoint caches
- contiguous posmap parsing keeps midpoint warmup from turning startup into a chain of tiny random reads
- span-based old-format parsing keeps the faster startup path safe across both posmap encodings