### PR TITLE
fix(metrics): keep static label tests out of parallel noise

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Metrics/MessageLabelConfiguratorTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/MessageLabelConfiguratorTests.cs
@@ -27,6 +27,7 @@ partial class ReadStreamForward : ReadMessage { }
 [DerivedMessage(TestGroup.Reads)]
 partial class ReadStreamBackward : ReadMessage { }
 
+[Collection("MetricsLabelTests")]
 public class MessageLabelConfiguratorTests
 {
 	private readonly Type[] _messageTypes;

--- a/src/EventStore.Core.XUnit.Tests/Metrics/MetricsLabelTestsCollection.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/MetricsLabelTestsCollection.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Metrics;
+
+[CollectionDefinition("MetricsLabelTests", DisableParallelization = true)]
+public class MetricsLabelTestsCollection;


### PR DESCRIPTION
- static message-label tests should not race MiniNode-backed xUnit work because they rewrite shared label state
- isolating the label-mapping collection keeps metrics test results predictable without changing runtime behavior
- this preserves the value of the label assertions while removing suite-level nondeterminism