### PR TITLE
chore(qodana): keep license analysis aware of the prometheus exporter

### DIFF
--- a/src/qodana.yaml
+++ b/src/qodana.yaml
@@ -27,3 +27,10 @@ profile:
 #Install IDE plugins before Qodana execution (Applied in CI/CD pipeline)
 #plugins:
 #  - id: <plugin.id> #(plugin id can be found at https://plugins.jetbrains.com)
+
+dependencyOverrides:
+  - name: "OpenTelemetry.Exporter.Prometheus.AspNetCore"
+    version: "1.4.0-rc.1"
+    licenses:
+      - key: "Apache-2.0"
+        url: "https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/LICENSE.TXT"


### PR DESCRIPTION
- Qodana cannot infer this Prometheus exporter dependency on its own, so license analysis needs an explicit mapping
- keeping the override aligned with the package version this repo actually references avoids false positives in audit output
- this keeps tooling noise low without changing runtime behavior