### PR TITLE
fix(archive): keep AWS diagnostics inside node logging

### DIFF
--- a/src/EventStore.ClusterNode/logconfig.json
+++ b/src/EventStore.ClusterNode/logconfig.json
@@ -1,6 +1,7 @@
 {
 	"Logging": {
 		"LogLevel": {
+			"Amazon": "Warning",
 			"Default": "Debug",
 			"EventStore.Core.Services.Transport.Enumerators": "Information",
 			"System": "Warning",

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/AwsTraceSerilogListenerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/AwsTraceSerilogListenerTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Amazon.Runtime;
+using EventStore.Core.Services.Archive.Storage;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.Archive.Storage;
+
+public class AwsTraceSerilogListenerTests
+{
+	[Fact]
+	public void logs_formatted_aws_trace_messages()
+	{
+		var sink = new CollectingSink();
+		var logger = new LoggerConfiguration()
+			.MinimumLevel.Verbose()
+			.WriteTo.Sink(sink)
+			.CreateLogger();
+		var sut = new AwsTraceSerilogListener(logger);
+		var exception = new InvalidOperationException("boom");
+
+		sut.TraceData(null, "Amazon", TraceEventType.Warning, 0, new FakeLogMessage("Problem {Value}", 42), exception);
+
+		var logEvent = Assert.Single(sink.Events);
+		Assert.Equal(LogEventLevel.Warning, logEvent.Level);
+		Assert.Equal("Problem 42", logEvent.RenderMessage());
+		Assert.Same(exception, logEvent.Exception);
+	}
+
+	[Fact]
+	public void logs_plain_trace_messages()
+	{
+		var sink = new CollectingSink();
+		var logger = new LoggerConfiguration()
+			.MinimumLevel.Verbose()
+			.WriteTo.Sink(sink)
+			.CreateLogger();
+		var sut = new AwsTraceSerilogListener(logger);
+
+		sut.TraceData(null, "Amazon", TraceEventType.Error, 0, "plain message");
+
+		var logEvent = Assert.Single(sink.Events);
+		Assert.Equal(LogEventLevel.Error, logEvent.Level);
+		Assert.Equal("plain message", logEvent.RenderMessage());
+	}
+
+	private sealed class CollectingSink : ILogEventSink
+	{
+		public List<LogEvent> Events { get; } = new();
+
+		public void Emit(LogEvent logEvent) =>
+			Events.Add(logEvent);
+	}
+
+	private sealed class FakeLogMessage(string format, params object[] args) : ILogMessage
+	{
+		public string Format => format;
+		public object[] Args => args;
+		public IFormatProvider Provider => null;
+	}
+}

--- a/src/EventStore.Core/Services/Archive/Storage/AwsTraceLogging.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/AwsTraceLogging.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using Amazon;
+using Amazon.Runtime;
+using Serilog.Events;
+
+namespace EventStore.Core.Services.Archive.Storage;
+
+public sealed class AwsTraceSerilogListener : TraceListener
+{
+	private readonly Serilog.ILogger _logger;
+
+	public AwsTraceSerilogListener() : this(
+		Serilog.Log.ForContext(Serilog.Core.Constants.SourceContextPropertyName, "Amazon"))
+	{
+	}
+
+	public AwsTraceSerilogListener(Serilog.ILogger logger)
+	{
+		_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+	}
+
+	public override void TraceData(TraceEventCache eventCache, string source, TraceEventType eventType, int id,
+		object data) =>
+		Log(eventType, data);
+
+	public override void TraceData(TraceEventCache eventCache, string source, TraceEventType eventType, int id,
+		params object[] data) =>
+		Log(eventType, data);
+
+	public override void TraceEvent(TraceEventCache eventCache, string source, TraceEventType eventType, int id)
+	{
+	}
+
+	public override void TraceEvent(TraceEventCache eventCache, string source, TraceEventType eventType, int id,
+		string format, params object[] args)
+	{
+		if (format is null)
+			return;
+
+		WritePlainMessage(GetLogLevel(eventType), string.Format(format, args ?? Array.Empty<object>()));
+	}
+
+	public override void TraceEvent(TraceEventCache eventCache, string source, TraceEventType eventType, int id,
+		string message)
+	{
+		if (message is null)
+			return;
+
+		WritePlainMessage(GetLogLevel(eventType), message);
+	}
+
+	public override void TraceTransfer(TraceEventCache eventCache, string source, int id, string message,
+		Guid relatedActivityId)
+	{
+		if (message is null)
+			return;
+
+		WritePlainMessage(LogEventLevel.Verbose, $"{message} ({relatedActivityId})");
+	}
+
+	public override void Write(string message)
+	{
+		if (message is null)
+			return;
+
+		WritePlainMessage(LogEventLevel.Information, message);
+	}
+
+	public override void WriteLine(string message)
+	{
+		if (message is null)
+			return;
+
+		WritePlainMessage(LogEventLevel.Information, message);
+	}
+
+	private void Log(TraceEventType eventType, params object[] data)
+	{
+		if (data is null || data.Length is 0)
+			return;
+
+		var exception = data.Length > 1 ? data[1] as Exception : null;
+		var logLevel = GetLogLevel(eventType);
+
+		switch (data[0])
+		{
+			case ILogMessage logMessage:
+				_logger.Write(logLevel, exception, logMessage.Format, logMessage.Args);
+				break;
+			case string message:
+				_logger.Write(logLevel, exception, "{AwsTraceMessage:l}", message);
+				break;
+			default:
+			{
+				var rendered = data[0]?.ToString();
+				if (!string.IsNullOrEmpty(rendered))
+					_logger.Write(logLevel, exception, "{AwsTraceMessage:l}", rendered);
+				break;
+			}
+		}
+	}
+
+	private void WritePlainMessage(LogEventLevel logLevel, string message) =>
+		_logger.Write(logLevel, "{AwsTraceMessage:l}", message);
+
+	private static LogEventLevel GetLogLevel(TraceEventType eventType) =>
+		eventType switch
+		{
+			TraceEventType.Verbose => LogEventLevel.Verbose,
+			TraceEventType.Information => LogEventLevel.Information,
+			TraceEventType.Warning => LogEventLevel.Warning,
+			TraceEventType.Error => LogEventLevel.Error,
+			TraceEventType.Critical => LogEventLevel.Fatal,
+			_ => LogEventLevel.Verbose
+		};
+}
+
+internal static class AwsTraceLogging
+{
+	private static int _configured;
+
+	public static void Configure()
+	{
+		if (Interlocked.CompareExchange(ref _configured, 1, 0) != 0)
+			return;
+
+		try
+		{
+			AWSConfigs.AddTraceListener("Amazon", new AwsTraceSerilogListener {
+				Name = nameof(AwsTraceSerilogListener),
+			});
+			AWSConfigs.LoggingConfig.LogTo = LoggingOptions.SystemDiagnostics;
+			AWSConfigs.LoggingConfig.LogResponses = ResponseLoggingOption.OnError;
+			AWSConfigs.LoggingConfig.LogMetrics = false;
+		}
+		catch
+		{
+			Volatile.Write(ref _configured, 0);
+			throw;
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Archive/Storage/S3Reader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/S3Reader.cs
@@ -24,6 +24,7 @@ public class S3Reader : FluentReader, IArchiveStorageReader
 	public S3Reader(S3Options options, Func<int?, int?, string> getChunkPrefix, string archiveCheckpointFile) : base(
 		archiveCheckpointFile)
 	{
+		AwsTraceLogging.Configure();
 		_options = options;
 		_getChunkPrefix = getChunkPrefix;
 

--- a/src/EventStore.Core/Services/Archive/Storage/S3Writer.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/S3Writer.cs
@@ -10,6 +10,7 @@ public class S3Writer : FluentWriter, IArchiveStorageWriter
 	public S3Writer(S3Options options, Func<int?, int?, string> getChunkPrefix, string archiveCheckpointFile) : base(
 		archiveCheckpointFile)
 	{
+		AwsTraceLogging.Configure();
 		BlobStorage = StorageFactory.Blobs.AwsS3(
 			awsCliProfileName: options.AwsCliProfileName,
 			bucketName: options.Bucket,


### PR DESCRIPTION
- keep S3 archive failures visible through the node logger instead of leaving AWS SDK traces on a separate diagnostics path
- keep AWS trace volume aligned with the existing node logging policy so archive troubleshooting stays readable