### PR TITLE
fix(storage): keep completed chunk access behind one filesystem seam

### DIFF
--- a/src/EventStore.Core.Tests/Integration/when_a_single_node_is_restarted_multiple_times.cs
+++ b/src/EventStore.Core.Tests/Integration/when_a_single_node_is_restarted_multiple_times.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,27 +30,46 @@ public class when_a_single_node_is_restarted_multiple_times<TLogFormat, TStreamI
 
 	protected override async Task Given()
 	{
-		_epochIds.Add(await GetLastEpochId());
+		Guid? previousEpochId = null;
+		var epochId = await GetLastEpochId(previousEpochId);
+		_epochIds.Add(epochId);
+		previousEpochId = epochId;
 
 		for (int i = 0; i < _numberOfNodeStarts - 1; i++)
 		{
 			await ShutdownNode();
 			await StartNode();
-			_epochIds.Add(await GetLastEpochId());
+			epochId = await GetLastEpochId(previousEpochId);
+			_epochIds.Add(epochId);
+			previousEpochId = epochId;
 		}
 
 		await base.Given();
 	}
 
-	private async Task<Guid> GetLastEpochId()
+	private async Task<Guid> GetLastEpochId(Guid? previousEpochId)
 	{
 		_logFormat ??= LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory.Create(new() {
 			IndexDirectory = GetFilePathFor("epoch-index"),
 		});
 
-		await _node.Started.WaitAsync(RestartTimeout);
 		await _node.WaitForTcpEndPoint().WaitAsync(RestartTimeout);
+		var wait = Stopwatch.StartNew();
+		while (wait.Elapsed < RestartTimeout)
+		{
+			var epochId = await TryGetLastEpochId();
+			if (epochId is { } currentEpochId && currentEpochId != previousEpochId)
+				return currentEpochId;
 
+			await Task.Delay(TimeSpan.FromMilliseconds(100));
+		}
+
+		throw new TimeoutException(
+			$"Expected startup to persist a new epoch before restart assertions. Previous epoch: {previousEpochId}");
+	}
+
+	private async Task<Guid?> TryGetLastEpochId()
+	{
 		var bus = new SynchronousScheduler(nameof(when_a_single_node_is_restarted_multiple_times<TLogFormat, TStreamId>));
 		await using var writer = new TFChunkWriter(_node.Db);
 		writer.Open();
@@ -71,9 +91,7 @@ public class when_a_single_node_is_restarted_multiple_times<TLogFormat, TStreamI
 			Guid.NewGuid());
 		await epochManager.Init(CancellationToken.None);
 
-		var epoch = epochManager.GetLastEpoch();
-		Assert.That(epoch, Is.Not.Null, "Expected startup to persist an epoch before restart assertions.");
-		return epoch.EpochId;
+		return epochManager.GetLastEpoch()?.EpochId;
 	}
 
 	[OneTimeTearDown]

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
@@ -1,8 +1,10 @@
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
@@ -21,7 +23,9 @@ public class WhenOpeningExistingTfchunk : SpecificationWithFilePerTestFixture
 		await base.TestFixtureSetUp();
 		_chunk = await TFChunkHelper.CreateNewChunk(Filename);
 		await _chunk.Complete(CancellationToken.None);
-		_testChunk = await TFChunk.FromCompletedFile(Filename, true, false,
+		_testChunk = await TFChunk.FromCompletedFile(
+			new ChunkLocalFileSystem(new VersionedPatternFileNamingStrategy(Path.GetDirectoryName(Filename), "chunk-")),
+			Filename, true, false,
 			reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
 			getTransformFactory: _ => new IdentityChunkTransformFactory());
 	}

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
@@ -1,8 +1,10 @@
 using EventStore.Core.Exceptions;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
+using System.IO;
 
 namespace EventStore.Core.Tests.TransactionLog;
 
@@ -12,7 +14,9 @@ public class WhenOpeningTfchunkFromNonExistingFile : SpecificationWithFile
 	[Test]
 	public void it_should_throw_a_file_not_found_exception()
 	{
-		Assert.ThrowsAsync<CorruptDatabaseException>(async () => await TFChunk.FromCompletedFile(Filename, verifyHash: true,
+		Assert.ThrowsAsync<CorruptDatabaseException>(async () => await TFChunk.FromCompletedFile(
+			new ChunkLocalFileSystem(new VersionedPatternFileNamingStrategy(Path.GetDirectoryName(Filename), "chunk-")),
+			Filename, verifyHash: true,
 			unbufferedRead: false, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
 			getTransformFactory: _ => new IdentityChunkTransformFactory()));
 	}

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
@@ -5,6 +5,7 @@ using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
 using System.IO;
+using System.Threading;
 
 namespace EventStore.Core.Tests.TransactionLog;
 
@@ -19,5 +20,33 @@ public class WhenOpeningTfchunkFromNonExistingFile : SpecificationWithFile
 			Filename, verifyHash: true,
 			unbufferedRead: false, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
 			getTransformFactory: _ => new IdentityChunkTransformFactory()));
+	}
+
+	[Test]
+	public void it_should_map_missing_parent_directory_to_chunk_not_found_when_opening_a_completed_chunk()
+	{
+		var missingDirectory = Path.Combine(Path.GetDirectoryName(Filename)!, "missing");
+		var fileName = Path.Combine(missingDirectory, Path.GetFileName(Filename));
+
+		var ex = Assert.ThrowsAsync<CorruptDatabaseException>(async () => await TFChunk.FromCompletedFile(
+			new ChunkLocalFileSystem(new VersionedPatternFileNamingStrategy(missingDirectory, "chunk-")),
+			fileName, verifyHash: true,
+			unbufferedRead: false, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
+			getTransformFactory: _ => new IdentityChunkTransformFactory()));
+
+		Assert.That(ex?.InnerException, Is.TypeOf<ChunkNotFoundException>());
+	}
+
+	[Test]
+	public void it_should_map_missing_parent_directory_to_chunk_not_found_when_reading_metadata()
+	{
+		var missingDirectory = Path.Combine(Path.GetDirectoryName(Filename)!, "missing");
+		var fileName = Path.Combine(missingDirectory, Path.GetFileName(Filename));
+		var fileSystem = new ChunkLocalFileSystem(new VersionedPatternFileNamingStrategy(missingDirectory, "chunk-"));
+
+		var ex = Assert.ThrowsAsync<CorruptDatabaseException>(async () =>
+			await fileSystem.ReadHeaderAsync(fileName, CancellationToken.None));
+
+		Assert.That(ex?.InnerException, Is.TypeOf<ChunkNotFoundException>());
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
@@ -1,9 +1,11 @@
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
@@ -35,7 +37,9 @@ public class when_reading_from_a_cached_tfchunk<TLogFormat, TStreamId> : Specifi
 		_result = await _chunk.TryAppend(_record, CancellationToken.None);
 		await _chunk.Flush(CancellationToken.None);
 		await _chunk.Complete(CancellationToken.None);
-		_cachedChunk = await TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false,
+		_cachedChunk = await TFChunk.FromCompletedFile(
+			new ChunkLocalFileSystem(new VersionedPatternFileNamingStrategy(Path.GetDirectoryName(Filename), "chunk-")),
+			Filename, verifyHash: true, unbufferedRead: false,
 			reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
 			getTransformFactory: _ => new IdentityChunkTransformFactory());
 		await _cachedChunk.CacheInMemory(CancellationToken.None);

--- a/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
@@ -1,9 +1,11 @@
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Transforms.Identity;
 using NUnit.Framework;
@@ -35,7 +37,9 @@ public class when_uncaching_a_tfchunk<TLogFormat, TStreamId> : SpecificationWith
 		_result = await _chunk.TryAppend(_record, CancellationToken.None);
 		await _chunk.Flush(CancellationToken.None);
 		await _chunk.Complete(CancellationToken.None);
-		_uncachedChunk = await TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false,
+		_uncachedChunk = await TFChunk.FromCompletedFile(
+			new ChunkLocalFileSystem(new VersionedPatternFileNamingStrategy(Path.GetDirectoryName(Filename), "chunk-")),
+			Filename, verifyHash: true, unbufferedRead: false,
 			reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp(),
 			getTransformFactory: _ => new IdentityChunkTransformFactory());
 		await _uncachedChunk.CacheInMemory(CancellationToken.None);

--- a/src/EventStore.Core.Tests/TransactionLog/with_tfchunk_enumerator.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/with_tfchunk_enumerator.cs
@@ -32,7 +32,14 @@ public class with_tfchunk_enumerator : SpecificationWithDirectory
 		public string[] GetAllTempFiles() => inner.GetAllTempFiles();
 		public int GetIndexFor(string fileName) => inner.GetIndexFor(fileName);
 		public int GetVersionFor(string fileName) => inner.GetVersionFor(fileName);
-		public string GetPrefixFor(int? index, int? version) => inner.GetPrefixFor(index, version);
+			public string GetPrefixFor(int? index, int? version) => inner.GetPrefixFor(index, version);
+		}
+
+	[Test]
+	public void throws_argumentnullexception_when_constructed_with_null_naming_strategy()
+	{
+		var ex = Assert.Throws<ArgumentNullException>(() => new ChunkLocalFileSystem(null));
+		Assert.That(ex.ParamName, Is.EqualTo("namingStrategy"));
 	}
 
 	[Test]

--- a/src/EventStore.Core.Tests/TransactionLog/with_tfchunk_enumerator.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/with_tfchunk_enumerator.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
 using NUnit.Framework;
 
@@ -12,6 +13,27 @@ namespace EventStore.Core.Tests.TransactionLog;
 [TestFixture]
 public class with_tfchunk_enumerator : SpecificationWithDirectory
 {
+	private sealed class CountingNamingStrategy(IVersionedFileNamingStrategy inner) : IVersionedFileNamingStrategy
+	{
+		public int GetAllPresentFilesCalls { get; private set; }
+
+		public string GetFilenameFor(int index, int version) => inner.GetFilenameFor(index, version);
+		public string DetermineBestVersionFilenameFor(int index, int initialVersion) =>
+			inner.DetermineBestVersionFilenameFor(index, initialVersion);
+		public string[] GetAllVersionsFor(int index) => inner.GetAllVersionsFor(index);
+
+		public string[] GetAllPresentFiles()
+		{
+			GetAllPresentFilesCalls++;
+			return inner.GetAllPresentFiles();
+		}
+
+		public string GetTempFilename() => inner.GetTempFilename();
+		public string[] GetAllTempFiles() => inner.GetAllTempFiles();
+		public int GetIndexFor(string fileName) => inner.GetIndexFor(fileName);
+		public int GetVersionFor(string fileName) => inner.GetVersionFor(fileName);
+		public string GetPrefixFor(int? index, int? version) => inner.GetPrefixFor(index, version);
+	}
 
 	[Test]
 	public async Task iterates_chunks_with_correct_callback_order()
@@ -89,5 +111,31 @@ public class with_tfchunk_enumerator : SpecificationWithDirectory
 			"missing chunk-000016.000000 16"
 		};
 		Assert.AreEqual(expectedResult, result);
+	}
+
+	[Test]
+	public async Task reuses_directory_listing_cache_within_the_same_enumerator_session()
+	{
+		File.Create(GetFilePathFor("chunk-000001.000000")).Close();
+		File.Create(GetFilePathFor("chunk-000002.000000")).Close();
+
+		var strategy = new CountingNamingStrategy(new VersionedPatternFileNamingStrategy(PathName, "chunk-"));
+		var chunkFileSystem = new ChunkLocalFileSystem(strategy);
+		var chunkEnumerator = chunkFileSystem.CreateChunkEnumerator();
+
+		var firstPass = new List<TFChunkInfo>();
+		await foreach (var chunkInfo in chunkEnumerator.EnumerateChunks(2, CancellationToken.None))
+		{
+			firstPass.Add(chunkInfo);
+		}
+
+		var secondPass = new List<TFChunkInfo>();
+		await foreach (var chunkInfo in chunkEnumerator.EnumerateChunks(2, CancellationToken.None))
+		{
+			secondPass.Add(chunkInfo);
+		}
+
+		Assert.That(strategy.GetAllPresentFilesCalls, Is.EqualTo(1));
+		Assert.That(secondPass, Is.EqualTo(firstPass));
 	}
 }

--- a/src/EventStore.Core/Services/RedactionService.cs
+++ b/src/EventStore.Core/Services/RedactionService.cs
@@ -306,6 +306,7 @@ public class RedactionService<TStreamId> :
 		{
 			// temporarily open the chunk to verify its integrity
 			return await TFChunk.FromCompletedFile(
+				fileSystem: _db.Config.ChunkFileSystem,
 				filename: newChunkPath,
 				verifyHash: true,
 				unbufferedRead: _db.Config.Unbuffered,

--- a/src/EventStore.Core/TransactionLog/Chunks/IChunkEnumerator.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/IChunkEnumerator.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+using System.Threading;
+
+namespace EventStore.Core.TransactionLog.Chunks;
+
+public interface IChunkEnumerator
+{
+	IAsyncEnumerable<TFChunkInfo> EnumerateChunks(int lastChunkNumber, CancellationToken token);
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkFileReadHelper.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkFileReadHelper.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Exceptions;
+using Microsoft.Win32.SafeHandles;
+
+namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
+
+internal static class ChunkFileReadHelper
+{
+	public static SafeFileHandle OpenValidatedMetadataReadHandle(string fileName, out long length)
+	{
+		var handle = File.OpenHandle(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
+			FileOptions.Asynchronous);
+		length = RandomAccess.GetLength(handle);
+		if (length >= ChunkFooter.Size + ChunkHeader.Size)
+			return handle;
+
+		handle.Dispose();
+		throw new CorruptDatabaseException(new BadChunkInDatabaseException(
+			$"Chunk file '{fileName}' is bad. It does not have enough size for header and footer. File size is {length} bytes."));
+	}
+
+	public static async ValueTask ReadExactlyAsync(SafeFileHandle handle, Memory<byte> buffer, long offset,
+		string fileName, CancellationToken token)
+	{
+		var totalRead = 0;
+		while (totalRead < buffer.Length)
+		{
+			var bytesRead = await RandomAccess.ReadAsync(handle, buffer[totalRead..], offset + totalRead, token);
+			if (bytesRead == 0)
+			{
+				throw new CorruptDatabaseException(new BadChunkInDatabaseException(
+					$"Chunk file '{fileName}' was truncated while reading metadata."));
+			}
+
+			totalRead += bytesRead;
+		}
+	}
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkFileReadHelper.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkFileReadHelper.cs
@@ -11,15 +11,23 @@ internal static class ChunkFileReadHelper
 {
 	public static SafeFileHandle OpenValidatedMetadataReadHandle(string fileName, out long length)
 	{
-		var handle = File.OpenHandle(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
-			FileOptions.Asynchronous);
-		length = RandomAccess.GetLength(handle);
-		if (length >= ChunkFooter.Size + ChunkHeader.Size)
-			return handle;
+		try
+		{
+			var handle = File.OpenHandle(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
+				FileOptions.Asynchronous);
+			length = RandomAccess.GetLength(handle);
+			if (length >= ChunkFooter.Size + ChunkHeader.Size)
+				return handle;
 
-		handle.Dispose();
-		throw new CorruptDatabaseException(new BadChunkInDatabaseException(
-			$"Chunk file '{fileName}' is bad. It does not have enough size for header and footer. File size is {length} bytes."));
+			handle.Dispose();
+			throw new CorruptDatabaseException(new BadChunkInDatabaseException(
+				$"Chunk file '{fileName}' is bad. It does not have enough size for header and footer. File size is {length} bytes."));
+		}
+		catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+		{
+			length = 0;
+			throw new CorruptDatabaseException(new ChunkNotFoundException(fileName));
+		}
 	}
 
 	public static async ValueTask ReadExactlyAsync(SafeFileHandle handle, Memory<byte> buffer, long offset,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -57,8 +56,7 @@ public sealed class ChunkLocalFileSystem(IVersionedFileNamingStrategy namingStra
 		return new(buffer.Span);
 	}
 
-	public IAsyncEnumerable<TFChunkInfo> EnumerateChunks(int lastChunkNumber, CancellationToken token) =>
-		new TFChunkEnumerator(NamingStrategy).EnumerateChunks(lastChunkNumber, token: token);
+	public IChunkEnumerator CreateChunkEnumerator() => new TFChunkEnumerator(NamingStrategy);
 
 	private static SafeFileHandle OpenValidatedReadHandle(string fileName, out long length)
 	{

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using DotNext.Buffers;
 using EventStore.Core.Exceptions;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
-using Microsoft.Win32.SafeHandles;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
 
@@ -42,34 +41,21 @@ public sealed class ChunkLocalFileSystem(IVersionedFileNamingStrategy namingStra
 
 	public async ValueTask<ChunkHeader> ReadHeaderAsync(string fileName, CancellationToken token)
 	{
-		using var handle = OpenValidatedReadHandle(fileName, out _);
+		using var handle = ChunkFileReadHelper.OpenValidatedMetadataReadHandle(fileName, out _);
 
 		using var buffer = Memory.AllocateExactly<byte>(ChunkHeader.Size);
-		await RandomAccess.ReadAsync(handle, buffer.Memory, 0L, token);
+		await ChunkFileReadHelper.ReadExactlyAsync(handle, buffer.Memory, 0L, fileName, token);
 		return new(buffer.Span);
 	}
 
 	public async ValueTask<ChunkFooter> ReadFooterAsync(string fileName, CancellationToken token)
 	{
-		using var handle = OpenValidatedReadHandle(fileName, out var length);
+		using var handle = ChunkFileReadHelper.OpenValidatedMetadataReadHandle(fileName, out var length);
 
 		using var buffer = Memory.AllocateExactly<byte>(ChunkFooter.Size);
-		await RandomAccess.ReadAsync(handle, buffer.Memory, length - ChunkFooter.Size, token);
+		await ChunkFileReadHelper.ReadExactlyAsync(handle, buffer.Memory, length - ChunkFooter.Size, fileName, token);
 		return new(buffer.Span);
 	}
 
 	public IChunkEnumerator CreateChunkEnumerator() => new TFChunkEnumerator(NamingStrategy);
-
-	private static SafeFileHandle OpenValidatedReadHandle(string fileName, out long length)
-	{
-		var handle = File.OpenHandle(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
-			FileOptions.Asynchronous);
-		length = RandomAccess.GetLength(handle);
-		if (length >= ChunkFooter.Size + ChunkHeader.Size)
-			return handle;
-
-		handle.Dispose();
-		throw new CorruptDatabaseException(new BadChunkInDatabaseException(
-			$"Chunk file '{fileName}' is bad. It does not have enough size for header and footer. File size is {length} bytes."));
-	}
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,7 +11,8 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
 
 public sealed class ChunkLocalFileSystem(IVersionedFileNamingStrategy namingStrategy) : IChunkFileSystem
 {
-	public IVersionedFileNamingStrategy NamingStrategy { get; } = namingStrategy;
+	public IVersionedFileNamingStrategy NamingStrategy { get; } =
+		namingStrategy ?? throw new ArgumentNullException(nameof(namingStrategy));
 
 	public ValueTask<IChunkHandle> OpenForReadAsync(string fileName, bool reduceFileCachePressure, bool asyncIO,
 		CancellationToken token)

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using DotNext.Buffers;
 using EventStore.Core.Exceptions;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
+using Microsoft.Win32.SafeHandles;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
 
@@ -40,14 +41,7 @@ public sealed class ChunkLocalFileSystem(IVersionedFileNamingStrategy namingStra
 
 	public async ValueTask<ChunkHeader> ReadHeaderAsync(string fileName, CancellationToken token)
 	{
-		using var handle = File.OpenHandle(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
-			FileOptions.Asynchronous);
-		var length = RandomAccess.GetLength(handle);
-		if (length < ChunkFooter.Size + ChunkHeader.Size)
-		{
-			throw new CorruptDatabaseException(new BadChunkInDatabaseException(
-				$"Chunk file '{fileName}' is bad. It does not have enough size for header and footer. File size is {length} bytes."));
-		}
+		using var handle = OpenValidatedReadHandle(fileName, out _);
 
 		using var buffer = Memory.AllocateExactly<byte>(ChunkHeader.Size);
 		await RandomAccess.ReadAsync(handle, buffer.Memory, 0L, token);
@@ -56,14 +50,7 @@ public sealed class ChunkLocalFileSystem(IVersionedFileNamingStrategy namingStra
 
 	public async ValueTask<ChunkFooter> ReadFooterAsync(string fileName, CancellationToken token)
 	{
-		using var handle = File.OpenHandle(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
-			FileOptions.Asynchronous);
-		var length = RandomAccess.GetLength(handle);
-		if (length < ChunkFooter.Size + ChunkHeader.Size)
-		{
-			throw new CorruptDatabaseException(new BadChunkInDatabaseException(
-				$"Chunk file '{fileName}' is bad. It does not have enough size for header and footer. File size is {length} bytes."));
-		}
+		using var handle = OpenValidatedReadHandle(fileName, out var length);
 
 		using var buffer = Memory.AllocateExactly<byte>(ChunkFooter.Size);
 		await RandomAccess.ReadAsync(handle, buffer.Memory, length - ChunkFooter.Size, token);
@@ -72,4 +59,17 @@ public sealed class ChunkLocalFileSystem(IVersionedFileNamingStrategy namingStra
 
 	public IAsyncEnumerable<TFChunkInfo> EnumerateChunks(int lastChunkNumber, CancellationToken token) =>
 		new TFChunkEnumerator(NamingStrategy).EnumerateChunks(lastChunkNumber, token: token);
+
+	private static SafeFileHandle OpenValidatedReadHandle(string fileName, out long length)
+	{
+		var handle = File.OpenHandle(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
+			FileOptions.Asynchronous);
+		length = RandomAccess.GetLength(handle);
+		if (length >= ChunkFooter.Size + ChunkHeader.Size)
+			return handle;
+
+		handle.Dispose();
+		throw new CorruptDatabaseException(new BadChunkInDatabaseException(
+			$"Chunk file '{fileName}' is bad. It does not have enough size for header and footer. File size is {length} bytes."));
+	}
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
@@ -32,7 +32,7 @@ public sealed class ChunkLocalFileSystem(IVersionedFileNamingStrategy namingStra
 				Options = options,
 			}));
 		}
-		catch (FileNotFoundException)
+		catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
 		{
 			return ValueTask.FromException<IChunkHandle>(
 				new CorruptDatabaseException(new ChunkNotFoundException(fileName)));

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNext.Buffers;
+using EventStore.Core.Exceptions;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+
+namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
+
+public sealed class ChunkLocalFileSystem(IVersionedFileNamingStrategy namingStrategy) : IChunkFileSystem
+{
+	public IVersionedFileNamingStrategy NamingStrategy { get; } = namingStrategy;
+
+	public ValueTask<IChunkHandle> OpenForReadAsync(string fileName, bool reduceFileCachePressure, bool asyncIO,
+		CancellationToken token)
+	{
+		token.ThrowIfCancellationRequested();
+
+		try
+		{
+			var options = reduceFileCachePressure ? FileOptions.None : FileOptions.RandomAccess;
+			if (asyncIO)
+				options |= FileOptions.Asynchronous;
+
+			return ValueTask.FromResult<IChunkHandle>(new ChunkFileHandle(fileName, new FileStreamOptions
+			{
+				Mode = FileMode.Open,
+				Access = FileAccess.Read,
+				Share = FileShare.ReadWrite,
+				Options = options,
+			}));
+		}
+		catch (FileNotFoundException)
+		{
+			return ValueTask.FromException<IChunkHandle>(
+				new CorruptDatabaseException(new ChunkNotFoundException(fileName)));
+		}
+	}
+
+	public async ValueTask<ChunkHeader> ReadHeaderAsync(string fileName, CancellationToken token)
+	{
+		using var handle = File.OpenHandle(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
+			FileOptions.Asynchronous);
+		var length = RandomAccess.GetLength(handle);
+		if (length < ChunkFooter.Size + ChunkHeader.Size)
+		{
+			throw new CorruptDatabaseException(new BadChunkInDatabaseException(
+				$"Chunk file '{fileName}' is bad. It does not have enough size for header and footer. File size is {length} bytes."));
+		}
+
+		using var buffer = Memory.AllocateExactly<byte>(ChunkHeader.Size);
+		await RandomAccess.ReadAsync(handle, buffer.Memory, 0L, token);
+		return new(buffer.Span);
+	}
+
+	public async ValueTask<ChunkFooter> ReadFooterAsync(string fileName, CancellationToken token)
+	{
+		using var handle = File.OpenHandle(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
+			FileOptions.Asynchronous);
+		var length = RandomAccess.GetLength(handle);
+		if (length < ChunkFooter.Size + ChunkHeader.Size)
+		{
+			throw new CorruptDatabaseException(new BadChunkInDatabaseException(
+				$"Chunk file '{fileName}' is bad. It does not have enough size for header and footer. File size is {length} bytes."));
+		}
+
+		using var buffer = Memory.AllocateExactly<byte>(ChunkFooter.Size);
+		await RandomAccess.ReadAsync(handle, buffer.Memory, length - ChunkFooter.Size, token);
+		return new(buffer.Span);
+	}
+
+	public IAsyncEnumerable<TFChunkInfo> EnumerateChunks(int lastChunkNumber, CancellationToken token) =>
+		new TFChunkEnumerator(NamingStrategy).EnumerateChunks(lastChunkNumber, token: token);
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
@@ -57,5 +57,5 @@ public sealed class ChunkLocalFileSystem(IVersionedFileNamingStrategy namingStra
 		return new(buffer.Span);
 	}
 
-	public IChunkEnumerator CreateChunkEnumerator() => new TFChunkEnumerator(NamingStrategy);
+	public IChunkEnumerator CreateChunkEnumerator() => new TFChunkEnumerator(NamingStrategy, ReadHeaderAsync);
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkFileSystem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkFileSystem.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+
+namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
+
+public interface IChunkFileSystem
+{
+	IVersionedFileNamingStrategy NamingStrategy { get; }
+
+	ValueTask<IChunkHandle> OpenForReadAsync(string fileName, bool reduceFileCachePressure, bool asyncIO,
+		CancellationToken token);
+
+	ValueTask<ChunkHeader> ReadHeaderAsync(string fileName, CancellationToken token);
+
+	ValueTask<ChunkFooter> ReadFooterAsync(string fileName, CancellationToken token);
+
+	IAsyncEnumerable<TFChunkInfo> EnumerateChunks(int lastChunkNumber, CancellationToken token);
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkFileSystem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkFileSystem.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.TransactionLog.Chunks;
@@ -17,5 +16,5 @@ public interface IChunkFileSystem
 
 	ValueTask<ChunkFooter> ReadFooterAsync(string fileName, CancellationToken token);
 
-	IAsyncEnumerable<TFChunkInfo> EnumerateChunks(int lastChunkNumber, CancellationToken token);
+	IChunkEnumerator CreateChunkEnumerator();
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -224,7 +224,8 @@ public partial class TFChunk : IDisposable
 	}
 
 	// local or remote
-	public static async ValueTask<TFChunk> FromCompletedFile(string filename, bool verifyHash, bool unbufferedRead,
+	public static async ValueTask<TFChunk> FromCompletedFile(IChunkFileSystem fileSystem, string filename,
+		bool verifyHash, bool unbufferedRead,
 		ITransactionFileTracker tracker, Func<TransformType, IChunkTransformFactory> getTransformFactory,
 		bool reduceFileCachePressure = false, bool asyncIO = false, CancellationToken token = default)
 	{
@@ -233,7 +234,7 @@ public partial class TFChunk : IDisposable
 			TFConsts.MidpointsDepth, false, unbufferedRead, false, reduceFileCachePressure, asyncIO);
 		try
 		{
-			await chunk.InitCompleted(verifyHash, tracker, getTransformFactory, token);
+			await chunk.InitCompleted(fileSystem, verifyHash, tracker, getTransformFactory, token);
 		}
 		catch
 		{
@@ -343,20 +344,10 @@ public partial class TFChunk : IDisposable
 		return chunk;
 	}
 
-	private async ValueTask InitCompleted(bool verifyHash, ITransactionFileTracker tracker,
+	private async ValueTask InitCompleted(IChunkFileSystem fileSystem, bool verifyHash, ITransactionFileTracker tracker,
 		Func<TransformType, IChunkTransformFactory> getTransformFactory, CancellationToken token)
 	{
-		if (!File.Exists(_filename))
-			throw new CorruptDatabaseException(new ChunkNotFoundException(_filename));
-
-		var options = new FileStreamOptions
-		{
-			Mode = FileMode.Open,
-			Access = FileAccess.Read,
-			Share = FileShare.ReadWrite,
-			Options = ReadOnlyHandleOptions
-		};
-		_handle = new ChunkFileHandle(_filename, options);
+		_handle = await fileSystem.OpenForReadAsync(_filename, _reduceFileCachePressure, _asyncIO, token);
 		_fileSize = (int)_handle.Length;
 
 		IsReadOnly = true;

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -306,23 +306,6 @@ public class TFChunkDb : IAsyncDisposable
 		return new(buffer.Span);
 	}
 
-	private static async ValueTask<ChunkFooter> ReadChunkFooter(string chunkFileName, CancellationToken token)
-	{
-		using var handle = File.OpenHandle(chunkFileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
-			FileOptions.Asynchronous);
-
-		var length = RandomAccess.GetLength(handle);
-		if (length < ChunkFooter.Size + ChunkHeader.Size)
-		{
-			throw new CorruptDatabaseException(new BadChunkInDatabaseException(
-				$"Chunk file '{chunkFileName}' is bad. It does not have enough size for header and footer. File size is {length} bytes."));
-		}
-
-		using var buffer = Memory.AllocateExactly<byte>(ChunkFooter.Size);
-		await RandomAccess.ReadAsync(handle, buffer.Memory, length - ChunkFooter.Size, token);
-		return new(buffer.Span);
-	}
-
 	private async ValueTask EnsureNoExcessiveChunks(IChunkEnumerator chunkEnumerator, int lastChunkNum,
 		CancellationToken token)
 	{

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -51,10 +51,10 @@ public class TFChunkDb : IAsyncDisposable
 		public string ChunkFileName;
 	}
 
-	private async IAsyncEnumerable<ChunkInfo> GetAllLatestChunksExceptLast(int lastChunkNum,
+	private async IAsyncEnumerable<ChunkInfo> GetAllLatestChunksExceptLast(IChunkEnumerator chunkEnumerator, int lastChunkNum,
 		[EnumeratorCancellation] CancellationToken token)
 	{
-		await foreach (var chunkInfo in Manager.FileSystem.EnumerateChunks(lastChunkNum, token)
+		await foreach (var chunkInfo in chunkEnumerator.EnumerateChunks(lastChunkNum, token)
 			               .WithCancellation(token))
 		{
 			switch (chunkInfo)
@@ -90,10 +90,11 @@ public class TFChunkDb : IAsyncDisposable
 		}
 
 		var lastChunkNum = (int)(checkpoint / Config.ChunkSize);
+		var chunkEnumerator = Manager.FileSystem.CreateChunkEnumerator();
 		var lastChunkVersions = Manager.FileSystem.NamingStrategy.GetAllVersionsFor(lastChunkNum);
 
 		await Parallel.ForEachAsync(
-			GetAllLatestChunksExceptLast(lastChunkNum,
+			GetAllLatestChunksExceptLast(chunkEnumerator, lastChunkNum,
 				token), // the last chunk is dealt with separately
 			new ParallelOptions { MaxDegreeOfParallelism = threads, CancellationToken = token },
 			async (chunkInfo, token) =>
@@ -225,13 +226,13 @@ public class TFChunkDb : IAsyncDisposable
 		}
 
 		_log.Information("Ensuring no excessive chunks...");
-		await EnsureNoExcessiveChunks(lastChunkNum, token);
+			await EnsureNoExcessiveChunks(chunkEnumerator, lastChunkNum, token);
 		_log.Information("Done ensuring no excessive chunks.");
 
 		if (!readOnly)
 		{
 			_log.Information("Removing old chunk versions...");
-			await RemoveOldChunksVersions(lastChunkNum, token);
+				await RemoveOldChunksVersions(chunkEnumerator, lastChunkNum, token);
 			_log.Information("Done removing old chunk versions.");
 
 			_log.Information("Cleaning up temp files...");
@@ -322,12 +323,12 @@ public class TFChunkDb : IAsyncDisposable
 		return new(buffer.Span);
 	}
 
-	private async ValueTask EnsureNoExcessiveChunks(int lastChunkNum,
+	private async ValueTask EnsureNoExcessiveChunks(IChunkEnumerator chunkEnumerator, int lastChunkNum,
 		CancellationToken token)
 	{
 		var extraneousFiles = new List<string>();
 
-		await foreach (var chunkInfo in Manager.FileSystem.EnumerateChunks(lastChunkNum, token)
+		await foreach (var chunkInfo in chunkEnumerator.EnumerateChunks(lastChunkNum, token)
 			               .WithCancellation(token))
 		{
 			switch (chunkInfo)
@@ -356,10 +357,10 @@ public class TFChunkDb : IAsyncDisposable
 		}
 	}
 
-	private async ValueTask RemoveOldChunksVersions(int lastChunkNum,
+	private async ValueTask RemoveOldChunksVersions(IChunkEnumerator chunkEnumerator, int lastChunkNum,
 		CancellationToken token)
 	{
-		await foreach (var chunkInfo in Manager.FileSystem.EnumerateChunks(lastChunkNum, token)
+		await foreach (var chunkInfo in chunkEnumerator.EnumerateChunks(lastChunkNum, token)
 			               .WithCancellation(token))
 		{
 			switch (chunkInfo)

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -291,18 +291,10 @@ public class TFChunkDb : IAsyncDisposable
 
 	internal static async ValueTask<ChunkHeader> ReadChunkHeader(string chunkFileName, CancellationToken token)
 	{
-		using var handle = File.OpenHandle(chunkFileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
-			FileOptions.Asynchronous);
-
-		var length = RandomAccess.GetLength(handle);
-		if (length < ChunkFooter.Size + ChunkHeader.Size)
-		{
-			throw new CorruptDatabaseException(new BadChunkInDatabaseException(
-				$"Chunk file '{chunkFileName}' is bad. It does not have enough size for header and footer. File size is {length} bytes."));
-		}
+		using var handle = ChunkFileReadHelper.OpenValidatedMetadataReadHandle(chunkFileName, out _);
 
 		using var buffer = Memory.AllocateExactly<byte>(ChunkHeader.Size);
-		await RandomAccess.ReadAsync(handle, buffer.Memory, 0L, token);
+		await ChunkFileReadHelper.ReadExactlyAsync(handle, buffer.Memory, 0L, chunkFileName, token);
 		return new(buffer.Span);
 	}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using DotNext.Buffers;
 using EventStore.Common.Utils;
 using EventStore.Core.Exceptions;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.Transforms;
 using ILogger = Serilog.ILogger;
 
@@ -50,10 +51,11 @@ public class TFChunkDb : IAsyncDisposable
 		public string ChunkFileName;
 	}
 
-	private async IAsyncEnumerable<ChunkInfo> GetAllLatestChunksExceptLast(TFChunkEnumerator chunkEnumerator,
-		int lastChunkNum, [EnumeratorCancellation] CancellationToken token)
+	private async IAsyncEnumerable<ChunkInfo> GetAllLatestChunksExceptLast(int lastChunkNum,
+		[EnumeratorCancellation] CancellationToken token)
 	{
-		await foreach (var chunkInfo in chunkEnumerator.EnumerateChunks(lastChunkNum, token: token))
+		await foreach (var chunkInfo in Manager.FileSystem.EnumerateChunks(lastChunkNum, token)
+			               .WithCancellation(token))
 		{
 			switch (chunkInfo)
 			{
@@ -88,11 +90,10 @@ public class TFChunkDb : IAsyncDisposable
 		}
 
 		var lastChunkNum = (int)(checkpoint / Config.ChunkSize);
-		var lastChunkVersions = Config.FileNamingStrategy.GetAllVersionsFor(lastChunkNum);
-		var chunkEnumerator = new TFChunkEnumerator(Config.FileNamingStrategy);
+		var lastChunkVersions = Manager.FileSystem.NamingStrategy.GetAllVersionsFor(lastChunkNum);
 
 		await Parallel.ForEachAsync(
-			GetAllLatestChunksExceptLast(chunkEnumerator, lastChunkNum,
+			GetAllLatestChunksExceptLast(lastChunkNum,
 				token), // the last chunk is dealt with separately
 			new ParallelOptions { MaxDegreeOfParallelism = threads, CancellationToken = token },
 			async (chunkInfo, token) =>
@@ -104,9 +105,10 @@ public class TFChunkDb : IAsyncDisposable
 					// The situation where the logical data size is exactly divisible by ChunkSize,
 					// so it might happen that we have checkpoint indicating one more chunk should exist,
 					// but the actual last chunk is (lastChunkNum-1) one and it could be not completed yet -- perfectly valid situation.
-					var footer = await ReadChunkFooter(chunkInfo.ChunkFileName, token);
+					var footer = await Manager.FileSystem.ReadFooterAsync(chunkInfo.ChunkFileName, token);
 					if (footer.IsCompleted)
-						chunk = await TFChunk.TFChunk.FromCompletedFile(chunkInfo.ChunkFileName, verifyHash: false,
+						chunk = await TFChunk.TFChunk.FromCompletedFile(Manager.FileSystem, chunkInfo.ChunkFileName,
+							verifyHash: false,
 							unbufferedRead: Config.Unbuffered,
 							tracker: _tracker,
 							reduceFileCachePressure: Config.ReduceFileCachePressure,
@@ -130,7 +132,8 @@ public class TFChunkDb : IAsyncDisposable
 				}
 				else
 				{
-					chunk = await TFChunk.TFChunk.FromCompletedFile(chunkInfo.ChunkFileName, verifyHash: false,
+					chunk = await TFChunk.TFChunk.FromCompletedFile(Manager.FileSystem, chunkInfo.ChunkFileName,
+						verifyHash: false,
 						unbufferedRead: Config.Unbuffered,
 						reduceFileCachePressure: Config.ReduceFileCachePressure,
 						asyncIO: Config.AsyncIO,
@@ -156,7 +159,7 @@ public class TFChunkDb : IAsyncDisposable
 		else
 		{
 			var chunkFileName = lastChunkVersions[0];
-			var chunkHeader = await ReadChunkHeader(chunkFileName, token);
+			var chunkHeader = await Manager.FileSystem.ReadHeaderAsync(chunkFileName, token);
 			var chunkLocalPos = chunkHeader.GetLocalLogPosition(checkpoint);
 			if (chunkHeader.IsScavenged)
 			{
@@ -177,7 +180,8 @@ public class TFChunkDb : IAsyncDisposable
 						$"Writer checkpoint: {checkpoint}."));
 				}
 
-				var lastChunk = await TFChunk.TFChunk.FromCompletedFile(chunkFileName, verifyHash: false,
+				var lastChunk = await TFChunk.TFChunk.FromCompletedFile(Manager.FileSystem, chunkFileName,
+					verifyHash: false,
 					unbufferedRead: Config.Unbuffered,
 					reduceFileCachePressure: Config.ReduceFileCachePressure,
 					asyncIO: Config.AsyncIO,
@@ -221,13 +225,13 @@ public class TFChunkDb : IAsyncDisposable
 		}
 
 		_log.Information("Ensuring no excessive chunks...");
-		await EnsureNoExcessiveChunks(chunkEnumerator, lastChunkNum, token);
+		await EnsureNoExcessiveChunks(lastChunkNum, token);
 		_log.Information("Done ensuring no excessive chunks.");
 
 		if (!readOnly)
 		{
 			_log.Information("Removing old chunk versions...");
-			await RemoveOldChunksVersions(chunkEnumerator, lastChunkNum, token);
+			await RemoveOldChunksVersions(lastChunkNum, token);
 			_log.Information("Done removing old chunk versions.");
 
 			_log.Information("Cleaning up temp files...");
@@ -318,12 +322,13 @@ public class TFChunkDb : IAsyncDisposable
 		return new(buffer.Span);
 	}
 
-	private async ValueTask EnsureNoExcessiveChunks(TFChunkEnumerator chunkEnumerator, int lastChunkNum,
+	private async ValueTask EnsureNoExcessiveChunks(int lastChunkNum,
 		CancellationToken token)
 	{
 		var extraneousFiles = new List<string>();
 
-		await foreach (var chunkInfo in chunkEnumerator.EnumerateChunks(lastChunkNum, token: token))
+		await foreach (var chunkInfo in Manager.FileSystem.EnumerateChunks(lastChunkNum, token)
+			               .WithCancellation(token))
 		{
 			switch (chunkInfo)
 			{
@@ -351,10 +356,11 @@ public class TFChunkDb : IAsyncDisposable
 		}
 	}
 
-	private async ValueTask RemoveOldChunksVersions(TFChunkEnumerator chunkEnumerator, int lastChunkNum,
+	private async ValueTask RemoveOldChunksVersions(int lastChunkNum,
 		CancellationToken token)
 	{
-		await foreach (var chunkInfo in chunkEnumerator.EnumerateChunks(lastChunkNum, token: token))
+		await foreach (var chunkInfo in Manager.FileSystem.EnumerateChunks(lastChunkNum, token)
+			               .WithCancellation(token))
 		{
 			switch (chunkInfo)
 			{

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -226,13 +226,13 @@ public class TFChunkDb : IAsyncDisposable
 		}
 
 		_log.Information("Ensuring no excessive chunks...");
-			await EnsureNoExcessiveChunks(chunkEnumerator, lastChunkNum, token);
+		await EnsureNoExcessiveChunks(chunkEnumerator, lastChunkNum, token);
 		_log.Information("Done ensuring no excessive chunks.");
 
 		if (!readOnly)
 		{
 			_log.Information("Removing old chunk versions...");
-				await RemoveOldChunksVersions(chunkEnumerator, lastChunkNum, token);
+			await RemoveOldChunksVersions(chunkEnumerator, lastChunkNum, token);
 			_log.Information("Done removing old chunk versions.");
 
 			_log.Information("Cleaning up temp files...");

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using DotNext.Buffers;
 using EventStore.Common.Utils;
 using EventStore.Core.Exceptions;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
@@ -287,15 +286,6 @@ public class TFChunkDb : IAsyncDisposable
 			if (checkpoint.Read() > current)
 				throw new CorruptDatabaseException(new ReaderCheckpointHigherThanWriterException(checkpoint.Name));
 		}
-	}
-
-	internal static async ValueTask<ChunkHeader> ReadChunkHeader(string chunkFileName, CancellationToken token)
-	{
-		using var handle = ChunkFileReadHelper.OpenValidatedMetadataReadHandle(chunkFileName, out _);
-
-		using var buffer = Memory.AllocateExactly<byte>(ChunkHeader.Size);
-		await ChunkFileReadHelper.ReadExactlyAsync(handle, buffer.Memory, 0L, chunkFileName, token);
-		return new(buffer.Span);
 	}
 
 	private async ValueTask EnsureNoExcessiveChunks(IChunkEnumerator chunkEnumerator, int lastChunkNum,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
@@ -1,5 +1,6 @@
 using EventStore.Common.Utils;
 using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
 
 namespace EventStore.Core.TransactionLog.Chunks {
@@ -15,7 +16,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		public readonly ICheckpoint ReplicationCheckpoint;
 		public readonly ICheckpoint IndexCheckpoint;
 		public readonly ICheckpoint StreamExistenceFilterCheckpoint;
-		public readonly IVersionedFileNamingStrategy FileNamingStrategy;
+		public readonly IChunkFileSystem ChunkFileSystem;
 		public readonly bool InMemDb;
 		public readonly bool Unbuffered;
 		public readonly bool WriteThrough;
@@ -40,9 +41,48 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			bool writethrough = false,
 			bool reduceFileCachePressure = false,
 			long maxTruncation = 256 * 1024 * 1024,
+			bool asyncIO = false)
+			: this(
+				path,
+				new ChunkLocalFileSystem(fileNamingStrategy),
+				chunkSize,
+				maxChunksCacheSize,
+				writerCheckpoint,
+				chaserCheckpoint,
+				epochCheckpoint,
+				proposalCheckpoint,
+				truncateCheckpoint,
+				replicationCheckpoint,
+				indexCheckpoint,
+				streamExistenceFilterCheckpoint,
+				inMemDb,
+				unbuffered,
+				writethrough,
+				reduceFileCachePressure,
+				maxTruncation,
+				asyncIO) {
+		}
+
+		public TFChunkDbConfig(string path,
+			IChunkFileSystem chunkFileSystem,
+			int chunkSize,
+			long maxChunksCacheSize,
+			ICheckpoint writerCheckpoint,
+			ICheckpoint chaserCheckpoint,
+			ICheckpoint epochCheckpoint,
+			ICheckpoint proposalCheckpoint,
+			ICheckpoint truncateCheckpoint,
+			ICheckpoint replicationCheckpoint,
+			ICheckpoint indexCheckpoint,
+			ICheckpoint streamExistenceFilterCheckpoint,
+			bool inMemDb = false,
+			bool unbuffered = false,
+			bool writethrough = false,
+			bool reduceFileCachePressure = false,
+			long maxTruncation = 256 * 1024 * 1024,
 			bool asyncIO = false) {
 			Ensure.NotNullOrEmpty(path, "path");
-			Ensure.NotNull(fileNamingStrategy, "fileNamingStrategy");
+			Ensure.NotNull(chunkFileSystem, "chunkFileSystem");
 			Ensure.Positive(chunkSize, "chunkSize");
 			Ensure.Nonnegative(maxChunksCacheSize, "maxChunksCacheSize");
 			Ensure.NotNull(writerCheckpoint, "writerCheckpoint");
@@ -65,7 +105,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			ReplicationCheckpoint = replicationCheckpoint;
 			IndexCheckpoint = indexCheckpoint;
 			StreamExistenceFilterCheckpoint = streamExistenceFilterCheckpoint;
-			FileNamingStrategy = fileNamingStrategy;
+			ChunkFileSystem = chunkFileSystem;
 			InMemDb = inMemDb;
 			Unbuffered = unbuffered;
 			WriteThrough = writethrough;
@@ -73,5 +113,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			MaxTruncation = maxTruncation;
 			AsyncIO = asyncIO;
 		}
+
+		public IVersionedFileNamingStrategy FileNamingStrategy => ChunkFileSystem.NamingStrategy;
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbTruncator.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbTruncator.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Common.Utils;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Plugins.Transforms;
 using ILogger = Serilog.ILogger;
 
@@ -39,7 +40,6 @@ public class TFChunkDbTruncator
 
 		var oldLastChunkNum = (int)(writerChk / _config.ChunkSize);
 		var newLastChunkNum = (int)(truncateChk / _config.ChunkSize);
-		var chunkEnumerator = new TFChunkEnumerator(_config.FileNamingStrategy);
 		var truncatingToBoundary = truncateChk % _config.ChunkSize == 0;
 
 		var excessiveChunks = _config.FileNamingStrategy.GetAllVersionsFor(oldLastChunkNum + 1);
@@ -51,13 +51,14 @@ public class TFChunkDbTruncator
 		string newLastChunkFilename = null;
 
 		// find the chunk to truncate to
-		await foreach (var chunkInfo in chunkEnumerator.EnumerateChunks(oldLastChunkNum, token: token))
+		await foreach (var chunkInfo in _config.ChunkFileSystem.EnumerateChunks(oldLastChunkNum, token)
+			               .WithCancellation(token))
 		{
 			switch (chunkInfo)
 			{
 				case LatestVersion(var fileName, var _, var end):
 					if (newLastChunkFilename != null || end < newLastChunkNum) break;
-					newLastChunkHeader = await TFChunkDb.ReadChunkHeader(fileName, token);
+					newLastChunkHeader = await _config.ChunkFileSystem.ReadHeaderAsync(fileName, token);
 					newLastChunkFilename = fileName;
 					break;
 				case MissingVersion(var fileName, var chunkNum) when (chunkNum < newLastChunkNum):
@@ -85,7 +86,8 @@ public class TFChunkDbTruncator
 				chunkNumToDeleteFrom--;
 			}
 
-			await foreach (var chunkInfo in chunkEnumerator.EnumerateChunks(oldLastChunkNum, token: token))
+			await foreach (var chunkInfo in _config.ChunkFileSystem.EnumerateChunks(oldLastChunkNum, token)
+				               .WithCancellation(token))
 			{
 				switch (chunkInfo)
 				{

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbTruncator.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbTruncator.cs
@@ -46,12 +46,13 @@ public class TFChunkDbTruncator
 		if (excessiveChunks.Length > 0)
 			throw new Exception(
 				$"During truncation of DB excessive TFChunks were found:\n{string.Join("\n", excessiveChunks)}.");
+		var chunkEnumerator = _config.ChunkFileSystem.CreateChunkEnumerator();
 
 		ChunkHeader newLastChunkHeader = null;
 		string newLastChunkFilename = null;
 
 		// find the chunk to truncate to
-		await foreach (var chunkInfo in _config.ChunkFileSystem.EnumerateChunks(oldLastChunkNum, token)
+		await foreach (var chunkInfo in chunkEnumerator.EnumerateChunks(oldLastChunkNum, token)
 			               .WithCancellation(token))
 		{
 			switch (chunkInfo)
@@ -86,7 +87,7 @@ public class TFChunkDbTruncator
 				chunkNumToDeleteFrom--;
 			}
 
-			await foreach (var chunkInfo in _config.ChunkFileSystem.EnumerateChunks(oldLastChunkNum, token)
+			await foreach (var chunkInfo in chunkEnumerator.EnumerateChunks(oldLastChunkNum, token)
 				               .WithCancellation(token))
 			{
 				switch (chunkInfo)

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkEnumerator.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkEnumerator.cs
@@ -9,10 +9,19 @@ using EventStore.Core.TransactionLog.FileNamingStrategy;
 
 namespace EventStore.Core.TransactionLog.Chunks;
 
-public class TFChunkEnumerator(IVersionedFileNamingStrategy chunkFileNamingStrategy) : IChunkEnumerator
+public class TFChunkEnumerator : IChunkEnumerator
 {
+	private readonly IVersionedFileNamingStrategy _chunkFileNamingStrategy;
+	private readonly Func<string, CancellationToken, ValueTask<ChunkHeader>> _readHeaderAsync;
 	private string[] _allFiles = null;
 	private readonly Dictionary<string, int> _nextChunkNumber = new();
+
+	public TFChunkEnumerator(IVersionedFileNamingStrategy chunkFileNamingStrategy,
+		Func<string, CancellationToken, ValueTask<ChunkHeader>> readHeaderAsync = null)
+	{
+		_chunkFileNamingStrategy = chunkFileNamingStrategy;
+		_readHeaderAsync = readHeaderAsync;
+	}
 
 	public IAsyncEnumerable<TFChunkInfo> EnumerateChunks(int lastChunkNumber, CancellationToken token) =>
 		EnumerateChunks(lastChunkNumber, getNextChunkNumber: null, token);
@@ -25,7 +34,7 @@ public class TFChunkEnumerator(IVersionedFileNamingStrategy chunkFileNamingStrat
 
 		if (_allFiles is null)
 		{
-			var allFiles = chunkFileNamingStrategy.GetAllPresentFiles();
+			var allFiles = _chunkFileNamingStrategy.GetAllPresentFiles();
 			Array.Sort(allFiles, StringComparer.CurrentCultureIgnoreCase);
 			_allFiles = allFiles;
 		}
@@ -34,10 +43,10 @@ public class TFChunkEnumerator(IVersionedFileNamingStrategy chunkFileNamingStrat
 		for (int i = 0; i < _allFiles.Length; i++)
 		{
 			var chunkFileName = _allFiles[i];
-			var chunkNumber = chunkFileNamingStrategy.GetIndexFor(Path.GetFileName(_allFiles[i]));
+			var chunkNumber = _chunkFileNamingStrategy.GetIndexFor(Path.GetFileName(_allFiles[i]));
 			var nextChunkNumber = -1;
 			if (i + 1 < _allFiles.Length)
-				nextChunkNumber = chunkFileNamingStrategy.GetIndexFor(Path.GetFileName(_allFiles[i + 1]));
+				nextChunkNumber = _chunkFileNamingStrategy.GetIndexFor(Path.GetFileName(_allFiles[i + 1]));
 
 			if (chunkNumber < expectedChunkNumber)
 			{
@@ -51,7 +60,7 @@ public class TFChunkEnumerator(IVersionedFileNamingStrategy chunkFileNamingStrat
 				// one or more chunks are missing
 				for (int j = expectedChunkNumber; j < chunkNumber; j++)
 				{
-					yield return new MissingVersion(chunkFileNamingStrategy.GetFilenameFor(j, 0), j);
+					yield return new MissingVersion(_chunkFileNamingStrategy.GetFilenameFor(j, 0), j);
 				}
 
 				// set the expected chunk number to prevent calling onFileMissing() again for the same chunk numbers
@@ -67,14 +76,14 @@ public class TFChunkEnumerator(IVersionedFileNamingStrategy chunkFileNamingStrat
 			{
 				// latest version of chunk with the expected chunk number
 				expectedChunkNumber = await getNextChunkNumber(chunkFileName, chunkNumber,
-					chunkFileNamingStrategy.GetVersionFor(Path.GetFileName(chunkFileName)), token);
+					_chunkFileNamingStrategy.GetVersionFor(Path.GetFileName(chunkFileName)), token);
 				yield return new LatestVersion(chunkFileName, chunkNumber, expectedChunkNumber - 1);
 			}
 		}
 
 		for (int i = expectedChunkNumber; i <= lastChunkNumber; i++)
 		{
-			yield return new MissingVersion(chunkFileNamingStrategy.GetFilenameFor(i, 0), i);
+			yield return new MissingVersion(_chunkFileNamingStrategy.GetFilenameFor(i, 0), i);
 		}
 	}
 
@@ -88,7 +97,10 @@ public class TFChunkEnumerator(IVersionedFileNamingStrategy chunkFileNamingStrat
 		if (_nextChunkNumber.TryGetValue(chunkFileName, out var nextChunkNumber))
 			return nextChunkNumber;
 
-		var header = await TFChunkDb.ReadChunkHeader(chunkFileName, token);
+		if (_readHeaderAsync is null)
+			throw new InvalidOperationException("No chunk header reader was provided for versioned chunk enumeration.");
+
+		var header = await _readHeaderAsync(chunkFileName, token);
 		_nextChunkNumber[chunkFileName] = header.ChunkEndNumber + 1;
 		return header.ChunkEndNumber + 1;
 	}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkEnumerator.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkEnumerator.cs
@@ -9,10 +9,13 @@ using EventStore.Core.TransactionLog.FileNamingStrategy;
 
 namespace EventStore.Core.TransactionLog.Chunks;
 
-public class TFChunkEnumerator(IVersionedFileNamingStrategy chunkFileNamingStrategy)
+public class TFChunkEnumerator(IVersionedFileNamingStrategy chunkFileNamingStrategy) : IChunkEnumerator
 {
 	private string[] _allFiles = null;
 	private readonly Dictionary<string, int> _nextChunkNumber = new();
+
+	public IAsyncEnumerable<TFChunkInfo> EnumerateChunks(int lastChunkNumber, CancellationToken token) =>
+		EnumerateChunks(lastChunkNumber, getNextChunkNumber: null, token);
 
 	public async IAsyncEnumerable<TFChunkInfo> EnumerateChunks(int lastChunkNumber,
 		Func<string, int, int, CancellationToken, ValueTask<int>> getNextChunkNumber = null,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using DotNext.Threading;
 using EventStore.Core.Transforms;
 using EventStore.Core.Transforms.Identity;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using ChunkInfo = EventStore.Core.Data.ChunkInfo;
 using ILogger = Serilog.ILogger;
 
@@ -30,6 +31,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 	private readonly TFChunk.TFChunk[] _chunks = new TFChunk.TFChunk[MaxChunksCount];
 	private readonly ITransactionFileTracker _tracker;
 	private readonly DbTransformManager _transformManager;
+	public IChunkFileSystem FileSystem => _config.ChunkFileSystem;
 
 	private volatile int _chunksCount;
 	private volatile bool _cachingEnabled;
@@ -134,7 +136,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 
 	public ValueTask<TFChunk.TFChunk> CreateTempChunk(ChunkHeader chunkHeader, int fileSize, CancellationToken token)
 	{
-		var chunkFileName = _config.FileNamingStrategy.GetTempFilename();
+		var chunkFileName = FileSystem.NamingStrategy.GetTempFilename();
 		return TFChunk.TFChunk.CreateWithHeader(chunkFileName,
 			chunkHeader,
 			fileSize,
@@ -161,7 +163,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 		try
 		{
 			var chunkNumber = _chunksCount;
-			var chunkName = _config.FileNamingStrategy.GetFilenameFor(chunkNumber, 0);
+			var chunkName = FileSystem.NamingStrategy.GetFilenameFor(chunkNumber, 0);
 			chunk = await TFChunk.TFChunk.CreateNew(chunkName,
 				_config.ChunkSize,
 				chunkNumber,
@@ -205,7 +207,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 					"Received request to create a new ongoing chunk #{0}-{1}, but current chunks count is {2}.",
 					chunkHeader.ChunkStartNumber, chunkHeader.ChunkEndNumber, _chunksCount));
 
-			var chunkName = _config.FileNamingStrategy.GetFilenameFor(chunkHeader.ChunkStartNumber, 0);
+			var chunkName = FileSystem.NamingStrategy.GetFilenameFor(chunkHeader.ChunkStartNumber, 0);
 			chunk = await TFChunk.TFChunk.CreateWithHeader(chunkName,
 				chunkHeader,
 				fileSize,
@@ -307,7 +309,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 			}
 
 			var newFileName =
-				_config.FileNamingStrategy.DetermineBestVersionFilenameFor(chunkHeader.ChunkStartNumber,
+				FileSystem.NamingStrategy.DetermineBestVersionFilenameFor(chunkHeader.ChunkStartNumber,
 					initialVersion: 1);
 			Log.Information("File {oldFileName} will be moved to file {newFileName}", Path.GetFileName(oldFileName),
 				Path.GetFileName(newFileName));
@@ -322,7 +324,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 				throw;
 			}
 
-			newChunk = await TFChunk.TFChunk.FromCompletedFile(newFileName, verifyHash, _config.Unbuffered,
+			newChunk = await TFChunk.TFChunk.FromCompletedFile(FileSystem, newFileName, verifyHash, _config.Unbuffered,
 				_tracker, type => _transformManager.GetFactoryForExistingChunk(type),
 				_config.ReduceFileCachePressure, _config.AsyncIO, token: token);
 		}


### PR DESCRIPTION
- Existing chunk discovery and opening still depended on local file naming in several places, which blocked the next storage work from moving behind one stable boundary.
- The storage migration needs one seam for completed chunk naming, header/footer reads, and enumeration before later local-vs-remote or bulk-reader changes can stay reviewable.
- Keeping this as the first storage batch lowers risk by moving the shared boundary now instead of mixing it with later archive and bulk-read behavior changes.