### PR TITLE
fix(storage): keep chunk reads behind one filesystem seam

### DIFF
--- a/src/EventStore.Core.Tests/Services/RedactionService/SwitchChunkFailureTests.cs
+++ b/src/EventStore.Core.Tests/Services/RedactionService/SwitchChunkFailureTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using EventStore.Core.Data.Redaction;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.Transforms.Identity;
 using EventStore.Plugins.Transforms;
 using NUnit.Framework;
@@ -151,7 +152,9 @@ public class SwitchChunkFailureTests<TLogFormat, TStreamId> : SwitchChunkTests<T
 
 		newChunk = $"{nameof(cannot_switch_with_chunk_having_mismatched_range)}-chunk-0-2.tmp";
 		var chunkHeader = new ChunkHeader(1, 1, 1024, 0, 2, true, Guid.NewGuid(), TransformType.Identity);
-		var chunk = await TFChunk.CreateWithHeader(Path.Combine(PathName, newChunk), chunkHeader, 1024, false, false,
+		var chunk = await TFChunk.CreateWithHeader(
+			new ChunkLocalFileSystem(new VersionedPatternFileNamingStrategy(PathName, "chunk-")),
+			Path.Combine(PathName, newChunk), chunkHeader, 1024, false, false,
 			false, false, false,
 			new TFChunkTracker.NoOp(), new IdentityChunkTransformFactory(), ReadOnlyMemory<byte>.Empty,
 			CancellationToken.None);

--- a/src/EventStore.Core.Tests/Services/Replication/LogReplication/LogReplicationWithExistingDbFixture.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LogReplication/LogReplicationWithExistingDbFixture.cs
@@ -48,6 +48,7 @@ public abstract class
 			transformType: TransformType.Identity);
 
 		var chunk = await TFChunk.CreateWithHeader(
+			fileSystem: db.Config.ChunkFileSystem,
 			filename: filename,
 			header: header,
 			fileSize: TFChunk.GetAlignedSize(db.Config.ChunkSize + ChunkHeader.Size + ChunkFooter.Size),

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
@@ -17,7 +17,7 @@ public class ScavengedChunk : SpecificationWithFile
 	public async Task is_fully_resident_in_memory_when_cached()
 	{
 		var map = new List<PosMap>();
-		var chunk = await TFChunk.CreateNew(Filename, 1024 * 1024, 0, 0, true, false, false, false,
+		var chunk = await TFChunk.CreateNew(TFChunkHelper.CreateLocalFileSystem(Filename), Filename, 1024 * 1024, 0, 0, true, false, false, false,
 			false, false,
 			new TFChunkTracker.NoOp(),
 			new IdentityChunkTransformFactory(),

--- a/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Settings;
@@ -77,10 +78,13 @@ public static class TFChunkHelper
 
 	public static ValueTask<TFChunk> CreateNewChunk(string fileName, int chunkSize = 4096, bool isScavenged = false, CancellationToken token = default)
 	{
-		return TFChunk.CreateNew(fileName, chunkSize, 0, 0,
+		return TFChunk.CreateNew(CreateLocalFileSystem(fileName), fileName, chunkSize, 0, 0,
 			isScavenged: isScavenged, inMem: false, unbuffered: false,
 			writethrough: false, reduceFileCachePressure: false, asyncIO: false, tracker: new TFChunkTracker.NoOp(),
 			transformFactory: new IdentityChunkTransformFactory(),
 			token);
 	}
+
+	public static IChunkFileSystem CreateLocalFileSystem(string fileName) =>
+		new ChunkLocalFileSystem(new VersionedPatternFileNamingStrategy(Path.GetDirectoryName(fileName), "chunk-"));
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_accessing_tfchunk_stream_synchronously.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_accessing_tfchunk_stream_synchronously.cs
@@ -80,6 +80,7 @@ public class when_accessing_tfchunk_stream_synchronously : SpecificationWithFile
 	private async Task CreateChunk(bool asyncIO)
 	{
 		_chunk = await TFChunk.CreateNew(
+			fileSystem: TFChunkHelper.CreateLocalFileSystem(Filename),
 			filename: Filename,
 			chunkDataSize: 4096,
 			chunkStartNumber: 0,

--- a/src/EventStore.Core.Tests/TransactionLog/when_closing_the_database.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_closing_the_database.cs
@@ -76,7 +76,7 @@ public class when_closing_the_database<TLogFormat, TStreamId> : SpecificationWit
 		if (!chunksClosed)
 		{
 			// acquire a reader to prevent the chunk from being properly closed
-			_db.Manager.GetChunk(0).AcquireRawReader();
+			await _db.Manager.GetChunk(0).AcquireRawReader();
 		}
 
 		var writer = new TFChunkWriter(_db);

--- a/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_with_a_cancelable_token.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_with_a_cancelable_token.cs
@@ -26,7 +26,7 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 		Filename = Path.Combine(Path.GetTempPath(), $"{nameof(when_completing_a_tfchunk_with_a_cancelable_token)}-{Guid.NewGuid()}");
 
 		_writeState = new ObservingWriteState();
-		_chunk = await TFChunk.CreateNew(Filename, 4096, 0, 0,
+		_chunk = await TFChunk.CreateNew(TFChunkHelper.CreateLocalFileSystem(Filename), Filename, 4096, 0, 0,
 			isScavenged: false, inMem: false, unbuffered: false,
 			writethrough: false, reduceFileCachePressure: false, asyncIO: false, tracker: new TFChunkTracker.NoOp(),
 			transformFactory: new ObservingChunkTransformFactory(_writeState),
@@ -237,7 +237,7 @@ public class when_completing_a_tfchunk_with_a_cancelable_token : SpecificationWi
 			return inner.SetReadOnlyAsync(value, token);
 		}
 
-		public Stream CreateStream() => inner.CreateStream();
+		public Stream CreateStream(bool leaveOpen = true) => inner.CreateStream(leaveOpen);
 
 		public void Dispose() => inner.Dispose();
 	}

--- a/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_writer_with_a_cancelable_token.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_completing_a_tfchunk_writer_with_a_cancelable_token.cs
@@ -46,7 +46,8 @@ public class when_completing_a_tfchunk_writer_with_a_cancelable_token : Specific
 	public async Task complete_chunk_flushes_the_writer_checkpoint_even_if_cancellation_arrives_after_completion()
 	{
 		using var cancellationTokenSource = new CancellationTokenSource();
-		_chunk = await TFChunk.CreateNew(GetFilePathFor("chunk-000000.000000"), 4096, 0, 0,
+		_chunk = await TFChunk.CreateNew(TFChunkHelper.CreateLocalFileSystem(GetFilePathFor("chunk-000000.000000")),
+			GetFilePathFor("chunk-000000.000000"), 4096, 0, 0,
 			isScavenged: false, inMem: false, unbuffered: false,
 			writethrough: false, reduceFileCachePressure: false, asyncIO: false, tracker: new TFChunkTracker.NoOp(),
 			transformFactory: new CancelDuringCompletionTransformFactory(cancellationTokenSource),

--- a/src/EventStore.Core.Tests/TransactionLog/when_destroying_a_tfchunk_that_is_locked.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_destroying_a_tfchunk_that_is_locked.cs
@@ -20,7 +20,7 @@ public class when_destroying_a_tfchunk_that_is_locked : SpecificationWithFile
 		_chunk = await TFChunkHelper.CreateNewChunk(Filename, 1000);
 		await _chunk.Complete(CancellationToken.None);
 		_chunk.UnCacheFromMemory();
-		_reader = _chunk.AcquireRawReader();
+		_reader = await _chunk.AcquireRawReader();
 		_chunk.MarkForDeletion();
 	}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_marking_for_deletion_a_tfchunk_that_has_been_locked_and_unlocked.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_marking_for_deletion_a_tfchunk_that_has_been_locked_and_unlocked.cs
@@ -15,7 +15,7 @@ public class WhenMarkingForDeletionATfchunkThatHasBeenLockedAndUnlocked : Specif
 	{
 		await base.SetUp();
 		_chunk = await TFChunkHelper.CreateNewChunk(Filename, 1000);
-		var reader = _chunk.AcquireRawReader();
+		var reader = await _chunk.AcquireRawReader();
 		_chunk.MarkForDeletion();
 		reader.Release();
 	}

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_logical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_logical_bytes_bulk_from_a_chunk.cs
@@ -17,7 +17,7 @@ public class when_reading_logical_bytes_bulk_from_a_chunk<TLogFormat, TStreamId>
 	public async Task the_file_will_not_be_deleted_until_reader_released()
 	{
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 2000);
-		using (var reader = chunk.AcquireDataReader())
+		using (var reader = await chunk.AcquireDataReader())
 		{
 			chunk.MarkForDeletion();
 			var buffer = new byte[1024];
@@ -33,7 +33,7 @@ public class when_reading_logical_bytes_bulk_from_a_chunk<TLogFormat, TStreamId>
 	public async Task a_read_on_new_file_can_be_performed_but_returns_nothing()
 	{
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 2000);
-		using (var reader = chunk.AcquireDataReader())
+		using (var reader = await chunk.AcquireDataReader())
 		{
 			var buffer = new byte[1024];
 			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
@@ -50,7 +50,7 @@ public class when_reading_logical_bytes_bulk_from_a_chunk<TLogFormat, TStreamId>
 	{
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 300);
 		await chunk.Complete(CancellationToken.None); // chunk has 0 bytes of actual data
-		using (var reader = chunk.AcquireDataReader())
+		using (var reader = await chunk.AcquireDataReader())
 		{
 			var buffer = new byte[1024];
 			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
@@ -67,7 +67,7 @@ public class when_reading_logical_bytes_bulk_from_a_chunk<TLogFormat, TStreamId>
 	{
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("afile"), 200, isScavenged: true);
 		await chunk.CompleteScavenge([new PosMap(0, 0), new PosMap(1, 1)], CancellationToken.None);
-		using (var reader = chunk.AcquireDataReader())
+		using (var reader = await chunk.AcquireDataReader())
 		{
 			var buffer = new byte[1024];
 			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
@@ -91,7 +91,7 @@ public class when_reading_logical_bytes_bulk_from_a_chunk<TLogFormat, TStreamId>
 			new byte[2000], null);
 		Assert.IsTrue((await chunk.TryAppend(rec, CancellationToken.None)).Success, "Record was not appended");
 
-		using (var reader = chunk.AcquireDataReader())
+		using (var reader = await chunk.AcquireDataReader())
 		{
 			var buffer = new byte[1024];
 			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
@@ -109,7 +109,7 @@ public class when_reading_logical_bytes_bulk_from_a_chunk<TLogFormat, TStreamId>
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 300);
 		var rec = LogRecord.Commit(0, Guid.NewGuid(), 0, 0);
 		Assert.IsTrue((await chunk.TryAppend(rec, CancellationToken.None)).Success, "Record was not appended");
-		using (var reader = chunk.AcquireDataReader())
+		using (var reader = await chunk.AcquireDataReader())
 		{
 			var buffer = new byte[1024];
 			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
@@ -132,7 +132,7 @@ public class when_reading_logical_bytes_bulk_from_a_chunk<TLogFormat, TStreamId>
 		Assert.IsTrue((await chunk.TryAppend(rec, CancellationToken.None)).Success, "Record was not appended");
 		await chunk.Complete(CancellationToken.None);
 
-		using (var reader = chunk.AcquireDataReader())
+		using (var reader = await chunk.AcquireDataReader())
 		{
 			var buffer = new byte[1024];
 			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_logical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_logical_bytes_bulk_from_a_chunk.cs
@@ -1,10 +1,16 @@
 using System;
+using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.LogAbstraction;
 using EventStore.Core.LogV2;
+using EventStore.Core.Transforms.Identity;
+using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Plugins.Transforms;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog;
@@ -144,5 +150,108 @@ public class when_reading_logical_bytes_bulk_from_a_chunk<TLogFormat, TStreamId>
 
 		chunk.MarkForDeletion();
 		chunk.WaitForDestroy(5000);
+	}
+
+	[Test]
+	public async Task a_failed_data_reader_wrap_disposes_the_owned_stream()
+	{
+		var fileSystem = new TrackingChunkFileSystem(
+			new ChunkLocalFileSystem(new VersionedPatternFileNamingStrategy(PathName, "chunk-")));
+		var chunk = await TFChunk.CreateNew(
+			fileSystem: fileSystem,
+			filename: GetFilePathFor("file1"),
+			chunkDataSize: 300,
+			chunkStartNumber: 0,
+			chunkEndNumber: 0,
+			isScavenged: false,
+			inMem: false,
+			unbuffered: false,
+			writethrough: false,
+			reduceFileCachePressure: false,
+			asyncIO: false,
+			tracker: new TFChunkTracker.NoOp(),
+			transformFactory: new IdentityChunkTransformFactory(),
+			token: CancellationToken.None);
+		await chunk.Complete(CancellationToken.None);
+		chunk.UnCacheFromMemory();
+		typeof(TFChunk)
+			.GetField("_transform", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.SetValue(chunk, new ThrowingReadChunkTransform());
+
+		var exception = Assert.ThrowsAsync<InvalidOperationException>(async () => await chunk.AcquireDataReader());
+		Assert.That(exception!.Message, Is.EqualTo("boom"));
+		Assert.That(fileSystem.LastHandle, Is.Not.Null);
+		Assert.That(fileSystem.LastHandle!.IsDisposed, Is.True);
+
+		chunk.MarkForDeletion();
+		chunk.WaitForDestroy(5000);
+	}
+
+	private sealed class ThrowingReadChunkTransform : IChunkTransform
+	{
+		public IChunkReadTransform Read { get; } = new ThrowingReadChunkReadTransform();
+		public IChunkWriteTransform Write { get; } = new IdentityChunkWriteTransform();
+	}
+
+	private sealed class ThrowingReadChunkReadTransform : IChunkReadTransform
+	{
+		public ChunkDataReadStream TransformData(ChunkDataReadStream stream) =>
+			throw new InvalidOperationException("boom");
+	}
+
+	private sealed class TrackingChunkFileSystem(IChunkFileSystem inner) : IChunkFileSystem
+	{
+		public TrackingChunkHandle LastHandle { get; private set; }
+
+		public IVersionedFileNamingStrategy NamingStrategy => inner.NamingStrategy;
+
+		public async ValueTask<IChunkHandle> OpenForReadAsync(string fileName, ReadOptimizationHint readOptimizationHint,
+			bool asyncIO, CancellationToken token)
+		{
+			LastHandle = new TrackingChunkHandle(await inner.OpenForReadAsync(fileName, readOptimizationHint, asyncIO, token));
+			return LastHandle;
+		}
+
+		public ValueTask<ChunkHeader> ReadHeaderAsync(string fileName, CancellationToken token) =>
+			inner.ReadHeaderAsync(fileName, token);
+
+		public ValueTask<ChunkFooter> ReadFooterAsync(string fileName, CancellationToken token) =>
+			inner.ReadFooterAsync(fileName, token);
+
+		public IChunkEnumerator CreateChunkEnumerator() => inner.CreateChunkEnumerator();
+	}
+
+	private sealed class TrackingChunkHandle(IChunkHandle inner) : IChunkHandle
+	{
+		public bool IsDisposed { get; private set; }
+
+		public void Flush() => inner.Flush();
+
+		public ValueTask WriteAsync(ReadOnlyMemory<byte> data, long offset, CancellationToken token) =>
+			inner.WriteAsync(data, offset, token);
+
+		public ValueTask<int> ReadAsync(Memory<byte> buffer, long offset, CancellationToken token) =>
+			inner.ReadAsync(buffer, offset, token);
+
+		public long Length
+		{
+			get => inner.Length;
+			set => inner.Length = value;
+		}
+
+		public string Name => inner.Name;
+		public FileAccess Access => inner.Access;
+
+		public ValueTask SetReadOnlyAsync(bool value, CancellationToken token) =>
+			inner.SetReadOnlyAsync(value, token);
+
+		public void Dispose()
+		{
+			if (IsDisposed)
+				return;
+
+			IsDisposed = true;
+			inner.Dispose();
+		}
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
@@ -176,11 +176,46 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 			Assert.IsFalse(reader.IsMemory);
 			Assert.That(fileSystem.BulkReaderOpenHints.Count, Is.EqualTo(bulkReaderOpenCount + 1));
 			Assert.That(fileSystem.BulkReaderOpenHints[^1], Is.EqualTo(ReadOptimizationHint.SequentialScan));
+			Assert.That(fileSystem.BulkReaderOpenAsyncFlags[^1], Is.False);
 
 			var buffer = new byte[1024];
 			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
 			Assert.IsFalse(result.IsEOF);
 			Assert.Greater(result.BytesRead, 0);
+		}
+
+		chunk.MarkForDeletion();
+		chunk.WaitForDestroy(5000);
+	}
+
+	[Test]
+	public async Task a_dedicated_raw_reader_on_completed_chunk_keeps_bulk_reader_opens_synchronous_even_when_async_io_is_enabled()
+	{
+		var fileSystem = new ObservingChunkFileSystem(
+			new ChunkLocalFileSystem(new VersionedPatternFileNamingStrategy(PathName, "chunk-")));
+		var chunk = await TFChunk.CreateNew(
+			fileSystem: fileSystem,
+			filename: GetFilePathFor("file1"),
+			chunkDataSize: 2000,
+			chunkStartNumber: 0,
+			chunkEndNumber: 0,
+			isScavenged: false,
+			inMem: false,
+			unbuffered: false,
+			writethrough: false,
+			reduceFileCachePressure: false,
+			asyncIO: true,
+			tracker: new TFChunkTracker.NoOp(),
+			transformFactory: new WithHeaderChunkTransformFactory(),
+			token: CancellationToken.None);
+		await chunk.Complete(CancellationToken.None);
+		chunk.UnCacheFromMemory();
+
+		using (var reader = await chunk.AcquireRawReader())
+		{
+			Assert.IsFalse(reader.IsMemory);
+			Assert.That(fileSystem.BulkReaderOpenHints[^1], Is.EqualTo(ReadOptimizationHint.SequentialScan));
+			Assert.That(fileSystem.BulkReaderOpenAsyncFlags[^1], Is.False);
 		}
 
 		chunk.MarkForDeletion();
@@ -269,6 +304,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 	private sealed class ObservingChunkFileSystem(IChunkFileSystem inner) : IChunkFileSystem
 	{
 		public List<ReadOptimizationHint> BulkReaderOpenHints { get; } = [];
+		public List<bool> BulkReaderOpenAsyncFlags { get; } = [];
 
 		public IVersionedFileNamingStrategy NamingStrategy => inner.NamingStrategy;
 
@@ -279,6 +315,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 			if (readOptimizationHint == ReadOptimizationHint.SequentialScan)
 			{
 				BulkReaderOpenHints.Add(readOptimizationHint);
+				BulkReaderOpenAsyncFlags.Add(asyncIO);
 			}
 
 			return handle;

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using DotNext.Threading;
 using EventStore.Core.Tests.Transforms.WithHeader;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
@@ -183,6 +185,48 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 
 		chunk.MarkForDeletion();
 		chunk.WaitForDestroy(5000);
+	}
+
+	[Test]
+	public async Task a_dedicated_raw_reader_on_completed_in_memory_chunk_can_fall_back_without_a_file()
+	{
+		var chunk = await TFChunk.CreateNew(
+			fileSystem: TFChunkHelper.CreateLocalFileSystem(GetFilePathFor("file1")),
+			filename: GetFilePathFor("file1"),
+			chunkDataSize: 2000,
+			chunkStartNumber: 0,
+			chunkEndNumber: 0,
+			isScavenged: false,
+			inMem: true,
+			unbuffered: false,
+			writethrough: false,
+			reduceFileCachePressure: false,
+			asyncIO: false,
+			tracker: new TFChunkTracker.NoOp(),
+			transformFactory: new WithHeaderChunkTransformFactory(),
+			token: CancellationToken.None);
+		await chunk.Complete(CancellationToken.None);
+
+		var cachedDataLock = (AsyncExclusiveLock)typeof(TFChunk)
+			.GetField("_cachedDataLock", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.GetValue(chunk)!;
+
+		cachedDataLock.TryAcquire(System.Threading.Timeout.InfiniteTimeSpan);
+		try
+		{
+			using var reader = await chunk.AcquireRawReader();
+			Assert.IsFalse(reader.IsMemory);
+
+			var buffer = new byte[1024];
+			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
+			Assert.IsFalse(result.IsEOF);
+			Assert.Greater(result.BytesRead, 0);
+		}
+		finally
+		{
+			cachedDataLock.Release();
+			chunk.Dispose();
+		}
 	}
 
 	private sealed class ObservingChunkFileSystem(IChunkFileSystem inner) : IChunkFileSystem

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
@@ -260,7 +260,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 	}
 
 	[Test]
-	public async Task a_dedicated_raw_reader_on_completed_in_memory_chunk_can_fall_back_without_a_file()
+	public async Task a_dedicated_raw_reader_on_completed_in_memory_chunk_waits_for_a_real_mem_reader()
 	{
 		var chunk = await TFChunk.CreateNew(
 			fileSystem: TFChunkHelper.CreateLocalFileSystem(GetFilePathFor("file1")),
@@ -286,8 +286,14 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 		cachedDataLock.TryAcquire(System.Threading.Timeout.InfiniteTimeSpan);
 		try
 		{
-			using var reader = await chunk.AcquireRawReader();
-			Assert.IsFalse(reader.IsMemory);
+			var acquireTask = Task.Run(async () => await chunk.AcquireRawReader());
+			await Task.Delay(100);
+			Assert.That(acquireTask.IsCompleted, Is.False);
+
+			cachedDataLock.Release();
+
+			using var reader = await acquireTask;
+			Assert.IsTrue(reader.IsMemory);
 
 			var buffer = new byte[1024];
 			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
@@ -296,7 +302,8 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 		}
 		finally
 		{
-			cachedDataLock.Release();
+			if (cachedDataLock.IsLockHeld)
+				cachedDataLock.Release();
 			chunk.Dispose();
 		}
 	}

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
@@ -188,6 +188,43 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 	}
 
 	[Test]
+	public async Task a_dedicated_raw_reader_on_completed_chunk_propagates_open_cancellation()
+	{
+		var openStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var fileSystem = new BlockingBulkReaderOpenChunkFileSystem(
+			new ChunkLocalFileSystem(new VersionedPatternFileNamingStrategy(PathName, "chunk-")),
+			openStarted);
+		var chunk = await TFChunk.CreateNew(
+			fileSystem: fileSystem,
+			filename: GetFilePathFor("file1"),
+			chunkDataSize: 2000,
+			chunkStartNumber: 0,
+			chunkEndNumber: 0,
+			isScavenged: false,
+			inMem: false,
+			unbuffered: false,
+			writethrough: false,
+			reduceFileCachePressure: false,
+			asyncIO: false,
+			tracker: new TFChunkTracker.NoOp(),
+			transformFactory: new WithHeaderChunkTransformFactory(),
+			token: CancellationToken.None);
+		await chunk.Complete(CancellationToken.None);
+		chunk.UnCacheFromMemory();
+		fileSystem.BlockSequentialScanOpens = true;
+
+		using var cancellationTokenSource = new CancellationTokenSource();
+		var acquireTask = chunk.AcquireRawReader(cancellationTokenSource.Token).AsTask();
+		await openStarted.Task;
+		cancellationTokenSource.Cancel();
+
+		Assert.That(async () => await acquireTask, Throws.InstanceOf<OperationCanceledException>());
+
+		chunk.MarkForDeletion();
+		chunk.WaitForDestroy(5000);
+	}
+
+	[Test]
 	public async Task a_dedicated_raw_reader_on_completed_in_memory_chunk_can_fall_back_without_a_file()
 	{
 		var chunk = await TFChunk.CreateNew(
@@ -245,6 +282,35 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 			}
 
 			return handle;
+		}
+
+		public ValueTask<ChunkHeader> ReadHeaderAsync(string fileName, CancellationToken token) =>
+			inner.ReadHeaderAsync(fileName, token);
+
+		public ValueTask<ChunkFooter> ReadFooterAsync(string fileName, CancellationToken token) =>
+			inner.ReadFooterAsync(fileName, token);
+
+		public IChunkEnumerator CreateChunkEnumerator() => inner.CreateChunkEnumerator();
+	}
+
+	private sealed class BlockingBulkReaderOpenChunkFileSystem(
+		IChunkFileSystem inner,
+		TaskCompletionSource openStarted) : IChunkFileSystem
+	{
+		public bool BlockSequentialScanOpens { get; set; }
+
+		public IVersionedFileNamingStrategy NamingStrategy => inner.NamingStrategy;
+
+		public async ValueTask<IChunkHandle> OpenForReadAsync(string fileName, ReadOptimizationHint readOptimizationHint,
+			bool asyncIO, CancellationToken token)
+		{
+			if (BlockSequentialScanOpens && readOptimizationHint == ReadOptimizationHint.SequentialScan)
+			{
+				openStarted.TrySetResult();
+				await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
+			}
+
+			return await inner.OpenForReadAsync(fileName, readOptimizationHint, asyncIO, token);
 		}
 
 		public ValueTask<ChunkHeader> ReadHeaderAsync(string fileName, CancellationToken token) =>

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
@@ -1,8 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.Transforms.WithHeader;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.TransactionLog;
@@ -14,7 +18,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 	public async Task the_file_will_not_be_deleted_until_reader_released()
 	{
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 2000);
-		using (var reader = chunk.AcquireRawReader())
+		using (var reader = await chunk.AcquireRawReader())
 		{
 			chunk.MarkForDeletion();
 			var buffer = new byte[1024];
@@ -30,7 +34,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 	public async Task a_read_on_new_file_can_be_performed()
 	{
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 2000);
-		using (var reader = chunk.AcquireRawReader())
+		using (var reader = await chunk.AcquireRawReader())
 		{
 			var buffer = new byte[1024];
 			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
@@ -79,7 +83,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 	public async Task if_asked_for_more_than_buffer_size_will_only_read_buffer_size()
 	{
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 3000);
-		using (var reader = chunk.AcquireRawReader())
+		using (var reader = await chunk.AcquireRawReader())
 		{
 			var buffer = new byte[1024];
 			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
@@ -95,7 +99,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 	public async Task a_read_past_eof_returns_eof_and_no_footer()
 	{
 		var chunk = await TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 300);
-		using (var reader = chunk.AcquireRawReader())
+		using (var reader = await chunk.AcquireRawReader())
 		{
 			var buffer = new byte[8092];
 			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
@@ -111,10 +115,11 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 	public async Task a_raw_read_on_completed_transformed_chunk_falls_back_from_stale_cache()
 	{
 		var chunk = await TFChunk.CreateNew(
-			GetFilePathFor("file1"),
-			2000,
-			0,
-			0,
+			fileSystem: TFChunkHelper.CreateLocalFileSystem(GetFilePathFor("file1")),
+			filename: GetFilePathFor("file1"),
+			chunkDataSize: 2000,
+			chunkStartNumber: 0,
+			chunkEndNumber: 0,
 			isScavenged: false,
 			inMem: false,
 			unbuffered: false,
@@ -126,7 +131,7 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 			token: CancellationToken.None);
 		await chunk.Complete(CancellationToken.None);
 
-		using (var reader = chunk.AcquireRawReader())
+		using (var reader = await chunk.AcquireRawReader())
 		{
 			Assert.IsFalse(reader.IsMemory);
 
@@ -138,5 +143,72 @@ public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDi
 
 		chunk.MarkForDeletion();
 		chunk.WaitForDestroy(5000);
+	}
+
+	[Test]
+	public async Task a_dedicated_raw_reader_on_completed_chunk_uses_the_chunk_file_system()
+	{
+		var fileSystem = new ObservingChunkFileSystem(
+			new ChunkLocalFileSystem(new VersionedPatternFileNamingStrategy(PathName, "chunk-")));
+		var chunk = await TFChunk.CreateNew(
+			fileSystem: fileSystem,
+			filename: GetFilePathFor("file1"),
+			chunkDataSize: 2000,
+			chunkStartNumber: 0,
+			chunkEndNumber: 0,
+			isScavenged: false,
+			inMem: false,
+			unbuffered: false,
+			writethrough: false,
+			reduceFileCachePressure: false,
+			asyncIO: false,
+			tracker: new TFChunkTracker.NoOp(),
+			transformFactory: new WithHeaderChunkTransformFactory(),
+			token: CancellationToken.None);
+		await chunk.Complete(CancellationToken.None);
+		chunk.UnCacheFromMemory();
+		var bulkReaderOpenCount = fileSystem.BulkReaderOpenHints.Count;
+
+		using (var reader = await chunk.AcquireRawReader())
+		{
+			Assert.IsFalse(reader.IsMemory);
+			Assert.That(fileSystem.BulkReaderOpenHints.Count, Is.EqualTo(bulkReaderOpenCount + 1));
+			Assert.That(fileSystem.BulkReaderOpenHints[^1], Is.EqualTo(ReadOptimizationHint.SequentialScan));
+
+			var buffer = new byte[1024];
+			var result = await reader.ReadNextBytes(buffer, CancellationToken.None);
+			Assert.IsFalse(result.IsEOF);
+			Assert.Greater(result.BytesRead, 0);
+		}
+
+		chunk.MarkForDeletion();
+		chunk.WaitForDestroy(5000);
+	}
+
+	private sealed class ObservingChunkFileSystem(IChunkFileSystem inner) : IChunkFileSystem
+	{
+		public List<ReadOptimizationHint> BulkReaderOpenHints { get; } = [];
+
+		public IVersionedFileNamingStrategy NamingStrategy => inner.NamingStrategy;
+
+		public async ValueTask<IChunkHandle> OpenForReadAsync(string fileName, ReadOptimizationHint readOptimizationHint,
+			bool asyncIO, CancellationToken token)
+		{
+			var handle = await inner.OpenForReadAsync(fileName, readOptimizationHint, asyncIO, token);
+			if (readOptimizationHint == ReadOptimizationHint.SequentialScan)
+			{
+				BulkReaderOpenHints.Add(readOptimizationHint);
+			}
+
+			return handle;
+		}
+
+		public ValueTask<ChunkHeader> ReadHeaderAsync(string fileName, CancellationToken token) =>
+			inner.ReadHeaderAsync(fileName, token);
+
+		public ValueTask<ChunkFooter> ReadFooterAsync(string fileName, CancellationToken token) =>
+			inner.ReadFooterAsync(fileName, token);
+
+		public IChunkEnumerator CreateChunkEnumerator() => inner.CreateChunkEnumerator();
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_unlocking_a_tfchunk_that_has_been_marked_for_deletion.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_unlocking_a_tfchunk_that_has_been_marked_for_deletion.cs
@@ -15,7 +15,7 @@ public class when_unlocking_a_tfchunk_that_has_been_marked_for_deletion : Specif
 	{
 		await base.SetUp();
 		_chunk = await TFChunkHelper.CreateNewChunk(Filename, 1000);
-		var reader = _chunk.AcquireRawReader();
+		var reader = await _chunk.AcquireRawReader();
 		_chunk.MarkForDeletion();
 		reader.Release();
 	}

--- a/src/EventStore.Core.Tests/TransactionLog/when_verifying_a_remote_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_verifying_a_remote_tfchunk.cs
@@ -93,7 +93,7 @@ public class when_verifying_a_remote_tfchunk : SpecificationWithFilePerTestFixtu
 
 		public ValueTask SetReadOnlyAsync(bool value, CancellationToken token) => ValueTask.CompletedTask;
 
-		public Stream CreateStream() {
+		public Stream CreateStream(bool leaveOpen = true) {
 			StreamRequests++;
 			throw new AssertionException("Remote hash verification should not acquire a stream.");
 		}

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
@@ -866,6 +866,7 @@ public class Scenario<TLogFormat, TStreamId> : Scenario
 			transformFactory.CreateTransformHeader(transformHeader);
 
 			var newChunk = await TFChunk.CreateWithHeader(
+				fileSystem: db.Config.ChunkFileSystem,
 				filename: $"{chunk.FileName}.tmp",
 				header: newChunkHeader,
 				fileSize: ChunkHeader.Size,

--- a/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
@@ -288,7 +288,7 @@ public class LeaderReplicationService : IMonitoredQueue,
 			var epochCorrectedLogPos =
 				await GetValidLogPosition(logPosition, epochs, replica.ReplicaEndPoint, replica.SubscriptionId, token);
 			var subscriptionPos = await SetSubscriptionPosition(replica, epochCorrectedLogPos, chunkId,
-				replicationStart: true, verbose: true, trial: 0);
+				replicationStart: true, verbose: true, trial: 0, token);
 			Interlocked.Exchange(ref replica.AckedLogPosition, subscriptionPos);
 
 			if (subscriptionPos != logPosition)
@@ -408,7 +408,8 @@ public class LeaderReplicationService : IMonitoredQueue,
 		Guid chunkId,
 		bool replicationStart,
 		bool verbose,
-		int trial)
+		int trial,
+		CancellationToken token)
 	{
 		if (trial >= 10)
 			throw new Exception("Too many retrials to acquire reader for subscriber.");
@@ -420,7 +421,9 @@ public class LeaderReplicationService : IMonitoredQueue,
 				"Chunk for LogPosition {0} (0x{0:X}) is null in LeaderReplicationService! Replica: [{1},C:{2},S:{3}]",
 				logPosition, sub.ReplicaEndPoint, sub.ConnectionId, sub.SubscriptionId));
 			var rawSend = chunk.ChunkHeader.IsScavenged;
-			var bulkReader = rawSend ? await chunk.AcquireRawReader() : await chunk.AcquireDataReader();
+			var bulkReader = rawSend
+				? await chunk.AcquireRawReader(token)
+				: await chunk.AcquireDataReader(token);
 			if (rawSend)
 			{
 				var chunkStartPos = chunk.ChunkHeader.ChunkStartPosition;
@@ -486,7 +489,8 @@ public class LeaderReplicationService : IMonitoredQueue,
 		}
 		catch (FileBeingDeletedException)
 		{
-			return await SetSubscriptionPosition(sub, logPosition, chunkId, replicationStart, verbose, trial + 1);
+			return await SetSubscriptionPosition(sub, logPosition, chunkId, replicationStart, verbose, trial + 1,
+				token);
 		}
 	}
 
@@ -749,7 +753,7 @@ public class LeaderReplicationService : IMonitoredQueue,
 			{
 				dataFound = true;
 				await SetSubscriptionPosition(subscription, newLogPosition, Guid.Empty, replicationStart: false,
-					verbose: true, trial: 0);
+					verbose: true, trial: 0, token);
 			}
 		}
 

--- a/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
@@ -287,7 +287,7 @@ public class LeaderReplicationService : IMonitoredQueue,
 
 			var epochCorrectedLogPos =
 				await GetValidLogPosition(logPosition, epochs, replica.ReplicaEndPoint, replica.SubscriptionId, token);
-			var subscriptionPos = SetSubscriptionPosition(replica, epochCorrectedLogPos, chunkId,
+			var subscriptionPos = await SetSubscriptionPosition(replica, epochCorrectedLogPos, chunkId,
 				replicationStart: true, verbose: true, trial: 0);
 			Interlocked.Exchange(ref replica.AckedLogPosition, subscriptionPos);
 
@@ -403,7 +403,7 @@ public class LeaderReplicationService : IMonitoredQueue,
 		return Math.Min(replicaPosition, nextEpoch.EpochPosition);
 	}
 
-	private long SetSubscriptionPosition(ReplicaSubscription sub,
+	private async ValueTask<long> SetSubscriptionPosition(ReplicaSubscription sub,
 		long logPosition,
 		Guid chunkId,
 		bool replicationStart,
@@ -420,7 +420,7 @@ public class LeaderReplicationService : IMonitoredQueue,
 				"Chunk for LogPosition {0} (0x{0:X}) is null in LeaderReplicationService! Replica: [{1},C:{2},S:{3}]",
 				logPosition, sub.ReplicaEndPoint, sub.ConnectionId, sub.SubscriptionId));
 			var rawSend = chunk.ChunkHeader.IsScavenged;
-			var bulkReader = rawSend ? chunk.AcquireRawReader() : chunk.AcquireDataReader();
+			var bulkReader = rawSend ? await chunk.AcquireRawReader() : await chunk.AcquireDataReader();
 			if (rawSend)
 			{
 				var chunkStartPos = chunk.ChunkHeader.ChunkStartPosition;
@@ -486,7 +486,7 @@ public class LeaderReplicationService : IMonitoredQueue,
 		}
 		catch (FileBeingDeletedException)
 		{
-			return SetSubscriptionPosition(sub, logPosition, chunkId, replicationStart, verbose, trial + 1);
+			return await SetSubscriptionPosition(sub, logPosition, chunkId, replicationStart, verbose, trial + 1);
 		}
 	}
 
@@ -748,7 +748,7 @@ public class LeaderReplicationService : IMonitoredQueue,
 			if (newLogPosition < leaderCheckpoint)
 			{
 				dataFound = true;
-				SetSubscriptionPosition(subscription, newLogPosition, Guid.Empty, replicationStart: false,
+				await SetSubscriptionPosition(subscription, newLogPosition, Guid.Empty, replicationStart: false,
 					verbose: true, trial: 0);
 			}
 		}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkFileHandle.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkFileHandle.cs
@@ -123,7 +123,7 @@ internal sealed class ChunkFileHandle : Disposable, IChunkHandle
 
 	internal int Read(Span<byte> buffer, long offset) => RandomAccess.Read(_handle, buffer, offset);
 
-	internal Stream CreateSynchronousStream() => new SynchronousStream(this);
+	internal Stream CreateSynchronousStream(bool leaveOpen) => new SynchronousStream(this, leaveOpen);
 
 	private static void SetReadOnly(SafeFileHandle handle, bool value)
 	{
@@ -148,7 +148,7 @@ internal sealed class ChunkFileHandle : Disposable, IChunkHandle
 		}
 	}
 
-	private sealed class SynchronousStream(ChunkFileHandle handle) : RandomAccessStream
+	private sealed class SynchronousStream(ChunkFileHandle handle, bool leaveOpen) : RandomAccessStream
 	{
 		public override void Flush() => handle.Flush();
 
@@ -180,6 +180,14 @@ internal sealed class ChunkFileHandle : Disposable, IChunkHandle
 
 		protected override ValueTask<int> ReadAsync(Memory<byte> buffer, long offset, CancellationToken token) =>
 			handle.ReadAsync(buffer, offset, token);
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && !leaveOpen)
+				handle.Dispose();
+
+			base.Dispose(disposing);
+		}
 	}
 
 	protected override void Dispose(bool disposing)

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkLocalFileSystem.cs
@@ -13,14 +13,21 @@ public sealed class ChunkLocalFileSystem(IVersionedFileNamingStrategy namingStra
 	public IVersionedFileNamingStrategy NamingStrategy { get; } =
 		namingStrategy ?? throw new ArgumentNullException(nameof(namingStrategy));
 
-	public ValueTask<IChunkHandle> OpenForReadAsync(string fileName, bool reduceFileCachePressure, bool asyncIO,
+	public ValueTask<IChunkHandle> OpenForReadAsync(string fileName, ReadOptimizationHint readOptimizationHint,
+		bool asyncIO,
 		CancellationToken token)
 	{
 		token.ThrowIfCancellationRequested();
 
 		try
 		{
-			var options = reduceFileCachePressure ? FileOptions.None : FileOptions.RandomAccess;
+			var options = readOptimizationHint switch
+			{
+				ReadOptimizationHint.None => FileOptions.None,
+				ReadOptimizationHint.RandomAccess => FileOptions.RandomAccess,
+				ReadOptimizationHint.SequentialScan => FileOptions.SequentialScan,
+				_ => throw new ArgumentOutOfRangeException(nameof(readOptimizationHint), readOptimizationHint, null)
+			};
 			if (asyncIO)
 				options |= FileOptions.Asynchronous;
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkFileSystem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkFileSystem.cs
@@ -5,11 +5,18 @@ using EventStore.Core.TransactionLog.FileNamingStrategy;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
 
+public enum ReadOptimizationHint
+{
+	None,
+	RandomAccess,
+	SequentialScan
+}
+
 public interface IChunkFileSystem
 {
 	IVersionedFileNamingStrategy NamingStrategy { get; }
 
-	ValueTask<IChunkHandle> OpenForReadAsync(string fileName, bool reduceFileCachePressure, bool asyncIO,
+	ValueTask<IChunkHandle> OpenForReadAsync(string fileName, ReadOptimizationHint readOptimizationHint, bool asyncIO,
 		CancellationToken token);
 
 	ValueTask<ChunkHeader> ReadHeaderAsync(string fileName, CancellationToken token);

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkHandle.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/IChunkHandle.cs
@@ -41,14 +41,14 @@ public interface IChunkHandle : IFlushable, IDisposable
 	/// Creates an unbuffered stream for this handle.
 	/// </summary>
 	/// <returns>The unbuffered stream for this handle.</returns>
-	Stream CreateStream() => CreateStream(this, 60_000);
+	Stream CreateStream(bool leaveOpen = true) => CreateStream(this, leaveOpen, 60_000);
 
-	protected static Stream CreateStream(IChunkHandle handle, int synchronousTimeout)
+	protected static Stream CreateStream(IChunkHandle handle, bool leaveOpen, int synchronousTimeout)
 		=> handle is ChunkFileHandle { Asynchronous: false } chunkFileHandle
-			? chunkFileHandle.CreateSynchronousStream()
-			: new UnbufferedStream(handle) { ReadTimeout = synchronousTimeout, WriteTimeout = synchronousTimeout };
+			? chunkFileHandle.CreateSynchronousStream(leaveOpen)
+			: new UnbufferedStream(handle, leaveOpen) { ReadTimeout = synchronousTimeout, WriteTimeout = synchronousTimeout };
 
-	private sealed class UnbufferedStream(IChunkHandle handle) : RandomAccessStream
+	private sealed class UnbufferedStream(IChunkHandle handle, bool leaveOpen) : RandomAccessStream
 	{
 		private int _readTimeout, _writeTimeout;
 		private int _readWarningLogged;
@@ -198,6 +198,8 @@ public interface IChunkHandle : IFlushable, IDisposable
 			if (disposing)
 			{
 				_timeoutSource?.Dispose();
+				if (!leaveOpen)
+					handle.Dispose();
 			}
 
 			base.Dispose(disposing);

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -1554,7 +1554,7 @@ public partial class TFChunk : IDisposable
 	private async ValueTask<Stream> CreateOwnedReadStreamForBulkReader(CancellationToken token)
 	{
 		token.ThrowIfCancellationRequested();
-		var handle = await _fileSystem.OpenForReadAsync(_filename, ReadOptimizationHint.SequentialScan, _asyncIO,
+		var handle = await _fileSystem.OpenForReadAsync(_filename, ReadOptimizationHint.SequentialScan, asyncIO: false,
 			token);
 		try
 		{

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -1523,9 +1523,10 @@ public partial class TFChunk : IDisposable
 
 		// if we get here, then we reserved TFChunk for sure so no one should dispose of chunk file
 		// until client returns dedicated reader
+		Stream stream = null;
 		try
 		{
-			var stream = await CreateFileStreamForBulkReader(token);
+			stream = await CreateFileStreamForBulkReader(token);
 
 			if (raw)
 			{
@@ -1533,10 +1534,12 @@ public partial class TFChunk : IDisposable
 			}
 
 			var streamToUse = _transform.Read.TransformData(new ChunkDataReadStream(stream));
+			stream = null;
 			return new TFChunkBulkDataReader(this, streamToUse, isMemory: false);
 		}
 		catch
 		{
+			stream?.Dispose();
 			if (Interlocked.Decrement(ref _fileStreamCount) == 0 && _selfdestructin54321)
 				CleanUpFileStreamDestruction();
 			throw;

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -1542,7 +1542,15 @@ public partial class TFChunk : IDisposable
 		}
 	}
 
-	private async ValueTask<Stream> CreateFileStreamForBulkReader()
+	private unsafe ValueTask<Stream> CreateFileStreamForBulkReader()
+	{
+		if (_inMem)
+			return ValueTask.FromResult<Stream>(new UnmanagedMemoryStream((byte*)_cachedData, _fileSize));
+
+		return CreateOwnedReadStreamForBulkReader();
+	}
+
+	private async ValueTask<Stream> CreateOwnedReadStreamForBulkReader()
 	{
 		var handle = await _fileSystem.OpenForReadAsync(_filename, ReadOptimizationHint.SequentialScan, _asyncIO,
 			CancellationToken.None);

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -119,6 +119,7 @@ public partial class TFChunk : IDisposable
 	}
 
 	private readonly bool _inMem;
+	private readonly IChunkFileSystem _fileSystem;
 	private readonly string _filename;
 	private IChunkHandle _handle;
 	private int _fileSize;
@@ -191,7 +192,8 @@ public partial class TFChunk : IDisposable
 	private IChunkTransform _transform;
 	private ReadOnlyMemory<byte> _transformHeader;
 
-	private TFChunk(string filename,
+	private TFChunk(IChunkFileSystem fileSystem,
+		string filename,
 		int midpointsDepth,
 		bool inMem,
 		bool unbuffered,
@@ -199,9 +201,11 @@ public partial class TFChunk : IDisposable
 		bool reduceFileCachePressure,
 		bool asyncIO)
 	{
+		Ensure.NotNull(fileSystem, nameof(fileSystem));
 		Ensure.NotNullOrEmpty(filename, "filename");
 		Ensure.Nonnegative(midpointsDepth, "midpointsDepth");
 
+		_fileSystem = fileSystem;
 		_filename = filename;
 		_midpointsDepth = midpointsDepth;
 		_inMem = inMem;
@@ -230,11 +234,12 @@ public partial class TFChunk : IDisposable
 		bool reduceFileCachePressure = false, bool asyncIO = false, CancellationToken token = default)
 	{
 
-		var chunk = new TFChunk(filename,
+		var chunk = new TFChunk(fileSystem,
+			filename,
 			TFConsts.MidpointsDepth, false, unbufferedRead, false, reduceFileCachePressure, asyncIO);
 		try
 		{
-			await chunk.InitCompleted(fileSystem, verifyHash, tracker, getTransformFactory, token);
+			await chunk.InitCompleted(verifyHash, tracker, getTransformFactory, token);
 		}
 		catch
 		{
@@ -246,13 +251,15 @@ public partial class TFChunk : IDisposable
 	}
 
 	// always local
-	public static async ValueTask<TFChunk> FromOngoingFile(string filename, int writePosition, bool unbuffered,
+	public static async ValueTask<TFChunk> FromOngoingFile(IChunkFileSystem fileSystem, string filename,
+		int writePosition, bool unbuffered,
 		bool writethrough, bool reduceFileCachePressure, ITransactionFileTracker tracker,
 		bool asyncIO,
 		Func<TransformType, IChunkTransformFactory> getTransformFactory,
 		CancellationToken token)
 	{
-		var chunk = new TFChunk(filename,
+		var chunk = new TFChunk(fileSystem,
+			filename,
 			TFConsts.MidpointsDepth,
 			false,
 			unbuffered,
@@ -273,7 +280,8 @@ public partial class TFChunk : IDisposable
 	}
 
 	// always local
-	public static async ValueTask<TFChunk> CreateNew(string filename,
+	public static async ValueTask<TFChunk> CreateNew(IChunkFileSystem fileSystem,
+		string filename,
 		int chunkDataSize,
 		int chunkStartNumber,
 		int chunkEndNumber,
@@ -306,12 +314,12 @@ public partial class TFChunk : IDisposable
 		// Without this, the header would be uninitialized (all zeros), causing transform failures.
 		transformFactory.CreateTransformHeader(transformHeader);
 
-		return await CreateWithHeader(filename, chunkHeader, fileSize, inMem, unbuffered, writethrough,
+		return await CreateWithHeader(fileSystem, filename, chunkHeader, fileSize, inMem, unbuffered, writethrough,
 			reduceFileCachePressure, asyncIO, tracker, transformFactory, transformHeader, token);
 	}
 
 	// local only
-	public static async ValueTask<TFChunk> CreateWithHeader(string filename,
+	public static async ValueTask<TFChunk> CreateWithHeader(IChunkFileSystem fileSystem, string filename,
 		ChunkHeader header,
 		int fileSize,
 		bool inMem,
@@ -324,7 +332,8 @@ public partial class TFChunk : IDisposable
 		ReadOnlyMemory<byte> transformHeader,
 		CancellationToken token)
 	{
-		var chunk = new TFChunk(filename,
+		var chunk = new TFChunk(fileSystem,
+			filename,
 			TFConsts.MidpointsDepth,
 			inMem,
 			unbuffered,
@@ -344,10 +353,10 @@ public partial class TFChunk : IDisposable
 		return chunk;
 	}
 
-	private async ValueTask InitCompleted(IChunkFileSystem fileSystem, bool verifyHash, ITransactionFileTracker tracker,
+	private async ValueTask InitCompleted(bool verifyHash, ITransactionFileTracker tracker,
 		Func<TransformType, IChunkTransformFactory> getTransformFactory, CancellationToken token)
 	{
-		_handle = await fileSystem.OpenForReadAsync(_filename, _reduceFileCachePressure, _asyncIO, token);
+		_handle = await _fileSystem.OpenForReadAsync(_filename, ReadOnlyReadOptimizationHint, _asyncIO, token);
 		_fileSize = (int)_handle.Length;
 
 		IsReadOnly = true;
@@ -525,6 +534,9 @@ public partial class TFChunk : IDisposable
 	private FileOptions ReadOnlyHandleOptions =>
 		ComposeHandleOptions(_reduceFileCachePressure ? FileOptions.None : FileOptions.RandomAccess);
 
+	private ReadOptimizationHint ReadOnlyReadOptimizationHint =>
+		_reduceFileCachePressure ? ReadOptimizationHint.None : ReadOptimizationHint.RandomAccess;
+
 	private FileOptions WritableHandleOptions
 	{
 		get
@@ -693,7 +705,7 @@ public partial class TFChunk : IDisposable
 		}
 
 		Log.Debug("Verifying hash for TFChunk '{chunk}'...", _filename);
-		using var reader = AcquireRawReader();
+		using var reader = await AcquireRawReader();
 		reader.Stream.Seek(0, SeekOrigin.Begin);
 		var stream = reader.Stream;
 		var footer = _chunkFooter;
@@ -797,7 +809,7 @@ public partial class TFChunk : IDisposable
 					// it's not necessary as the cache is used only for reading data.
 					await BuildCacheArray(
 						size: GetAlignedSize(ChunkHeader.Size + _chunkHeader.ChunkSize + ChunkFooter.Size),
-						reader: AcquireFileReader(raw: false),
+						reader: await AcquireFileReader(raw: false),
 						offset: ChunkHeader.Size,
 						count: _physicalDataSize,
 						transformed: false,
@@ -805,7 +817,7 @@ public partial class TFChunk : IDisposable
 				else
 					await BuildCacheArray(
 						size: _fileSize,
-						reader: AcquireFileReader(raw: true),
+						reader: await AcquireFileReader(raw: true),
 						offset: 0,
 						count: _fileSize,
 						transformed: true,
@@ -1479,23 +1491,23 @@ public partial class TFChunk : IDisposable
 		}
 	}
 
-	public TFChunkBulkReader AcquireDataReader()
+	public ValueTask<TFChunkBulkReader> AcquireDataReader()
 	{
 		if (TryAcquireBulkMemReader(raw: false, out var reader))
-			return reader;
+			return ValueTask.FromResult(reader);
 
 		return AcquireFileReader(raw: false);
 	}
 
-	public TFChunkBulkReader AcquireRawReader()
+	public ValueTask<TFChunkBulkReader> AcquireRawReader()
 	{
 		if (TryAcquireBulkMemReader(raw: true, out var reader))
-			return reader;
+			return ValueTask.FromResult(reader);
 
 		return AcquireFileReader(raw: true);
 	}
 
-	private TFChunkBulkReader AcquireFileReader(bool raw)
+	private async ValueTask<TFChunkBulkReader> AcquireFileReader(bool raw)
 	{
 		Interlocked.Increment(ref _fileStreamCount);
 		if (_selfdestructin54321)
@@ -1510,21 +1522,40 @@ public partial class TFChunk : IDisposable
 
 		// if we get here, then we reserved TFChunk for sure so no one should dispose of chunk file
 		// until client returns dedicated reader
-		var stream = CreateFileStreamForBulkReader();
-
-		if (raw)
+		try
 		{
-			return new TFChunkBulkRawReader(this, stream, isMemory: false);
-		}
+			var stream = await CreateFileStreamForBulkReader();
 
-		var streamToUse = _transform.Read.TransformData(new ChunkDataReadStream(stream));
-		return new TFChunkBulkDataReader(this, streamToUse, isMemory: false);
+			if (raw)
+			{
+				return new TFChunkBulkRawReader(this, stream, isMemory: false);
+			}
+
+			var streamToUse = _transform.Read.TransformData(new ChunkDataReadStream(stream));
+			return new TFChunkBulkDataReader(this, streamToUse, isMemory: false);
+		}
+		catch
+		{
+			if (Interlocked.Decrement(ref _fileStreamCount) == 0 && _selfdestructin54321)
+				CleanUpFileStreamDestruction();
+			throw;
+		}
 	}
 
-	private unsafe Stream CreateFileStreamForBulkReader() => _inMem
-		? new UnmanagedMemoryStream((byte*)_cachedData, _fileSize)
-		: new FileStream(_filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 65536,
-			FileOptions.SequentialScan);
+	private async ValueTask<Stream> CreateFileStreamForBulkReader()
+	{
+		var handle = await _fileSystem.OpenForReadAsync(_filename, ReadOptimizationHint.SequentialScan, _asyncIO,
+			CancellationToken.None);
+		try
+		{
+			return handle.CreateStream(leaveOpen: false);
+		}
+		catch
+		{
+			handle.Dispose();
+			throw;
+		}
+	}
 
 	// tries to acquire a bulk reader over a memstream but
 	// (a) doesn't block if a file reader would be acceptable instead

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -705,7 +705,7 @@ public partial class TFChunk : IDisposable
 		}
 
 		Log.Debug("Verifying hash for TFChunk '{chunk}'...", _filename);
-		using var reader = await AcquireRawReader();
+		using var reader = await AcquireRawReader(token);
 		reader.Stream.Seek(0, SeekOrigin.Begin);
 		var stream = reader.Stream;
 		var footer = _chunkFooter;
@@ -809,7 +809,7 @@ public partial class TFChunk : IDisposable
 					// it's not necessary as the cache is used only for reading data.
 					await BuildCacheArray(
 						size: GetAlignedSize(ChunkHeader.Size + _chunkHeader.ChunkSize + ChunkFooter.Size),
-						reader: await AcquireFileReader(raw: false),
+						reader: await AcquireFileReader(raw: false, token),
 						offset: ChunkHeader.Size,
 						count: _physicalDataSize,
 						transformed: false,
@@ -817,7 +817,7 @@ public partial class TFChunk : IDisposable
 				else
 					await BuildCacheArray(
 						size: _fileSize,
-						reader: await AcquireFileReader(raw: true),
+						reader: await AcquireFileReader(raw: true, token),
 						offset: 0,
 						count: _fileSize,
 						transformed: true,
@@ -1491,24 +1491,25 @@ public partial class TFChunk : IDisposable
 		}
 	}
 
-	public ValueTask<TFChunkBulkReader> AcquireDataReader()
+	public ValueTask<TFChunkBulkReader> AcquireDataReader(CancellationToken token = default)
 	{
 		if (TryAcquireBulkMemReader(raw: false, out var reader))
 			return ValueTask.FromResult(reader);
 
-		return AcquireFileReader(raw: false);
+		return AcquireFileReader(raw: false, token);
 	}
 
-	public ValueTask<TFChunkBulkReader> AcquireRawReader()
+	public ValueTask<TFChunkBulkReader> AcquireRawReader(CancellationToken token = default)
 	{
 		if (TryAcquireBulkMemReader(raw: true, out var reader))
 			return ValueTask.FromResult(reader);
 
-		return AcquireFileReader(raw: true);
+		return AcquireFileReader(raw: true, token);
 	}
 
-	private async ValueTask<TFChunkBulkReader> AcquireFileReader(bool raw)
+	private async ValueTask<TFChunkBulkReader> AcquireFileReader(bool raw, CancellationToken token)
 	{
+		token.ThrowIfCancellationRequested();
 		Interlocked.Increment(ref _fileStreamCount);
 		if (_selfdestructin54321)
 		{
@@ -1524,7 +1525,7 @@ public partial class TFChunk : IDisposable
 		// until client returns dedicated reader
 		try
 		{
-			var stream = await CreateFileStreamForBulkReader();
+			var stream = await CreateFileStreamForBulkReader(token);
 
 			if (raw)
 			{
@@ -1542,18 +1543,19 @@ public partial class TFChunk : IDisposable
 		}
 	}
 
-	private unsafe ValueTask<Stream> CreateFileStreamForBulkReader()
+	private unsafe ValueTask<Stream> CreateFileStreamForBulkReader(CancellationToken token)
 	{
 		if (_inMem)
 			return ValueTask.FromResult<Stream>(new UnmanagedMemoryStream((byte*)_cachedData, _fileSize));
 
-		return CreateOwnedReadStreamForBulkReader();
+		return CreateOwnedReadStreamForBulkReader(token);
 	}
 
-	private async ValueTask<Stream> CreateOwnedReadStreamForBulkReader()
+	private async ValueTask<Stream> CreateOwnedReadStreamForBulkReader(CancellationToken token)
 	{
+		token.ThrowIfCancellationRequested();
 		var handle = await _fileSystem.OpenForReadAsync(_filename, ReadOptimizationHint.SequentialScan, _asyncIO,
-			CancellationToken.None);
+			token);
 		try
 		{
 			return handle.CreateStream(leaveOpen: false);

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -1549,7 +1549,7 @@ public partial class TFChunk : IDisposable
 	private unsafe ValueTask<Stream> CreateFileStreamForBulkReader(CancellationToken token)
 	{
 		if (_inMem)
-			return ValueTask.FromResult<Stream>(new UnmanagedMemoryStream((byte*)_cachedData, _fileSize));
+			throw new InvalidOperationException("In-memory chunks must use memory readers.");
 
 		return CreateOwnedReadStreamForBulkReader(token);
 	}
@@ -1580,6 +1580,9 @@ public partial class TFChunk : IDisposable
 
 		if (IsReadOnly)
 		{
+			if (_inMem)
+				return TryCreateBulkMemReader(raw, out reader);
+
 			// chunk is definitely readonly and will remain so, so a filestream would be acceptable.
 			// we might be able to get a memstream but we don't want to wait for the lock in case we
 			// are currently performing a slow operation with it such as caching.

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -117,7 +117,8 @@ public class TFChunkDb : IAsyncDisposable
 							token: token);
 					else
 					{
-						chunk = await TFChunk.TFChunk.FromOngoingFile(chunkInfo.ChunkFileName, Config.ChunkSize,
+						chunk = await TFChunk.TFChunk.FromOngoingFile(Manager.FileSystem, chunkInfo.ChunkFileName,
+							Config.ChunkSize,
 							unbuffered: Config.Unbuffered,
 							writethrough: Config.WriteThrough,
 							reduceFileCachePressure: Config.ReduceFileCachePressure,
@@ -212,7 +213,8 @@ public class TFChunkDb : IAsyncDisposable
 			}
 			else
 			{
-				var lastChunk = await TFChunk.TFChunk.FromOngoingFile(chunkFileName, (int)chunkLocalPos,
+				var lastChunk = await TFChunk.TFChunk.FromOngoingFile(Manager.FileSystem, chunkFileName,
+					(int)chunkLocalPos,
 					unbuffered: Config.Unbuffered,
 					writethrough: Config.WriteThrough,
 					reduceFileCachePressure: Config.ReduceFileCachePressure,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -137,7 +137,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 	public ValueTask<TFChunk.TFChunk> CreateTempChunk(ChunkHeader chunkHeader, int fileSize, CancellationToken token)
 	{
 		var chunkFileName = FileSystem.NamingStrategy.GetTempFilename();
-		return TFChunk.TFChunk.CreateWithHeader(chunkFileName,
+		return TFChunk.TFChunk.CreateWithHeader(FileSystem, chunkFileName,
 			chunkHeader,
 			fileSize,
 			_config.InMemDb,
@@ -164,7 +164,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 		{
 			var chunkNumber = _chunksCount;
 			var chunkName = FileSystem.NamingStrategy.GetFilenameFor(chunkNumber, 0);
-			chunk = await TFChunk.TFChunk.CreateNew(chunkName,
+			chunk = await TFChunk.TFChunk.CreateNew(FileSystem, chunkName,
 				_config.ChunkSize,
 				chunkNumber,
 				chunkNumber,
@@ -208,7 +208,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 					chunkHeader.ChunkStartNumber, chunkHeader.ChunkEndNumber, _chunksCount));
 
 			var chunkName = FileSystem.NamingStrategy.GetFilenameFor(chunkHeader.ChunkStartNumber, 0);
-			chunk = await TFChunk.TFChunk.CreateWithHeader(chunkName,
+			chunk = await TFChunk.TFChunk.CreateWithHeader(FileSystem, chunkName,
 				chunkHeader,
 				fileSize,
 				_config.InMemDb,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -220,7 +220,7 @@ public class TFChunkScavenger<TStreamId> : TFChunkScavenger
 		TFChunk.TFChunk newChunk;
 		try
 		{
-			newChunk = await TFChunk.TFChunk.CreateNew(tmpChunkPath,
+			newChunk = await TFChunk.TFChunk.CreateNew(_db.Manager.FileSystem, tmpChunkPath,
 				_db.Config.ChunkSize,
 				chunkStartNumber,
 				chunkEndNumber,
@@ -490,7 +490,7 @@ public class TFChunkScavenger<TStreamId> : TFChunkScavenger
 		TFChunk.TFChunk newChunk;
 		try
 		{
-			newChunk = await TFChunk.TFChunk.CreateNew(tmpChunkPath,
+			newChunk = await TFChunk.TFChunk.CreateNew(db.Manager.FileSystem, tmpChunkPath,
 				db.Config.ChunkSize,
 				chunkStartNumber,
 				chunkEndNumber,

--- a/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkWriterForExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkWriterForExecutor.cs
@@ -47,6 +47,7 @@ public class ChunkWriterForExecutor<TStreamId> : IChunkWriterForExecutor<TStream
 
 		// from TFChunkScavenger.ScavengeChunk
 		var chunk = await TFChunk.CreateNew(
+			fileSystem: dbConfig.ChunkFileSystem,
 			filename: Path.Combine(dbConfig.Path, Guid.NewGuid() + ".scavenge.tmp"),
 			chunkDataSize: dbConfig.ChunkSize,
 			chunkStartNumber: sourceChunk.ChunkStartNumber,

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/SpecificationWithNodeAndProjectionsManager.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/SpecificationWithNodeAndProjectionsManager.cs
@@ -26,6 +26,7 @@ public abstract class SpecificationWithNodeAndProjectionsManager<TLogFormat, TSt
 	protected UserCredentials _credentials;
 	protected TimeSpan _timeout;
 	protected string _tag;
+	protected virtual TimeSpan StartupTimeout => TimeSpan.FromMinutes(5);
 	private Task _systemProjectionsCreated;
 	private ProjectionsSubsystem _projectionsSubsystem;
 
@@ -40,15 +41,15 @@ public abstract class SpecificationWithNodeAndProjectionsManager<TLogFormat, TSt
 		_tag = "_1";
 
 		_node = CreateNode();
-		await _node.Start();
-		await _node.WaitForTcpEndPoint().WithTimeout(TimeSpan.FromSeconds(60));
+		await _node.Start(StartupTimeout);
+		await _node.WaitForTcpEndPoint().WithTimeout(StartupTimeout);
 
 		await _systemProjectionsCreated.WithTimeout(_timeout);
 
 		_connection = await TestConnectionLifecycle.ReconnectUntilReady(
 			() => TestConnection.CreateMiniNodeClient(_node.TcpEndPoint),
 			connection => connection.ReadAllEventsForwardAsync(Position.Start, 1, false, _credentials),
-			_timeout);
+			StartupTimeout);
 
 		_projManager = new ProjectionsManager(new ConsoleLogger(), _node.HttpEndPoint, _timeout, _node.HttpMessageHandler);
 		try

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
@@ -25,6 +25,7 @@ public abstract class specification_with_standard_projections_runnning<TLogForma
 	protected UserCredentials _admin = DefaultData.AdminCredentials;
 	protected ProjectionsManager _manager;
 	protected QueryManager _queryManager;
+	protected virtual TimeSpan StartupTimeout => TimeSpan.FromMinutes(5);
 
 	private Task _projectionsCreated;
 	private ProjectionsSubsystem _projections;
@@ -50,12 +51,12 @@ public abstract class specification_with_standard_projections_runnning<TLogForma
 			subsystems: [_projections]);
 		_projectionsCreated = SystemProjections.Created(_projections.LeaderInputBus);
 
-		await _node.Start();
-		await _node.WaitForTcpEndPoint().WithTimeout(TimeSpan.FromSeconds(60));
+		await _node.Start(StartupTimeout);
+		await _node.WaitForTcpEndPoint().WithTimeout(StartupTimeout);
 		_conn = await TestConnectionLifecycle.ReconnectUntilReady(
 			CreateConnection,
 			connection => connection.ReadAllEventsForwardAsync(Position.Start, 1, false, _admin),
-			TimeSpan.FromSeconds(20));
+			StartupTimeout);
 
 		_manager = new ProjectionsManager(
 			new ConsoleLogger(),


### PR DESCRIPTION
- keep dedicated chunk bulk reads on the filesystem seam so the storage abstraction does not stop at completed-chunk initialization
- let reader-owned streams close their own handles so removing the direct local file fallback does not trade one storage leak for another
- thread the filesystem through local chunk creation and open paths now so later locator and archive work builds on one consistent chunk access story