### PR TITLE
fix(storage): distinguish chunk locators from local paths

### DIFF
--- a/src/EventStore.Core.Tests/Services/RedactionService/EventPositionTests.cs
+++ b/src/EventStore.Core.Tests/Services/RedactionService/EventPositionTests.cs
@@ -28,7 +28,7 @@ public class EventPositionTests<TLogFormat, TStreamId> : RedactionServiceTestFix
 		var chunk = Db.Manager.GetChunkFor(eventRecord.LogPosition);
 		var eventOffset = await chunk.GetActualRawPosition(eventRecord.LogPosition, token);
 		var eventPosition = new EventPosition(
-			eventRecord.LogPosition, Path.GetFileName(chunk.FileName), chunk.ChunkHeader.MinCompatibleVersion,
+			eventRecord.LogPosition, Path.GetFileName(chunk.LocalFileName), chunk.ChunkHeader.MinCompatibleVersion,
 			chunk.IsReadOnly, (uint)eventOffset);
 		_positions[eventNumber].Add(eventPosition);
 	}

--- a/src/EventStore.Core.Tests/Services/RedactionService/SwitchChunkSuccessTests.cs
+++ b/src/EventStore.Core.Tests/Services/RedactionService/SwitchChunkSuccessTests.cs
@@ -26,7 +26,7 @@ public class SwitchChunkSuccess<TLogFormat, TStreamId> : SwitchChunkTests<TLogFo
 			Assert.True(!File.Exists(newChunk));
 			Assert.True(!File.Exists(GetChunk(1, 0, true)));
 			Assert.True(File.Exists(GetChunk(1, 1, true)));
-			Assert.AreEqual(1, Db.Config.FileNamingStrategy.GetVersionFor(Path.GetFileName(Db.Manager.GetChunk(1).FileName)));
+			Assert.AreEqual(1, Db.Config.FileNamingStrategy.GetVersionFor(Path.GetFileName(Db.Manager.GetChunk(1).LocalFileName)));
 			Assert.True(File.Exists(GetChunk(0, 0, true)));
 
 			// can switch again
@@ -37,7 +37,7 @@ public class SwitchChunkSuccess<TLogFormat, TStreamId> : SwitchChunkTests<TLogFo
 			Assert.True(!File.Exists(GetChunk(1, 0, true)));
 			Assert.True(!File.Exists(GetChunk(1, 1, true)));
 			Assert.True(File.Exists(GetChunk(1, 2, true)));
-			Assert.AreEqual(2, Db.Config.FileNamingStrategy.GetVersionFor(Path.GetFileName(Db.Manager.GetChunk(1).FileName)));
+			Assert.AreEqual(2, Db.Config.FileNamingStrategy.GetVersionFor(Path.GetFileName(Db.Manager.GetChunk(1).LocalFileName)));
 			Assert.True(File.Exists(GetChunk(0, 0, true)));
 		}
 	}
@@ -81,7 +81,7 @@ public class SwitchChunkSuccess<TLogFormat, TStreamId> : SwitchChunkTests<TLogFo
 			Assert.True(!File.Exists(newChunk));
 			Assert.True(!File.Exists(GetChunk(1, 0, true)));
 			Assert.True(File.Exists(GetChunk(1, 1, true)));
-			Assert.AreEqual(1, Db.Config.FileNamingStrategy.GetVersionFor(Path.GetFileName(Db.Manager.GetChunk(1).FileName)));
+			Assert.AreEqual(1, Db.Config.FileNamingStrategy.GetVersionFor(Path.GetFileName(Db.Manager.GetChunk(1).LocalFileName)));
 			Assert.True(File.Exists(GetChunk(0, 0, true)));
 		}
 	}

--- a/src/EventStore.Core.Tests/Services/RedactionService/SwitchChunkTests.cs
+++ b/src/EventStore.Core.Tests/Services/RedactionService/SwitchChunkTests.cs
@@ -31,7 +31,7 @@ public abstract class SwitchChunkTests<TLogFormat, TStreamId> : RedactionService
 		await WriteSingleEvent(StreamId, 8, new string('8', 50), retryOnFail: true, token: token);
 
 		var writerPos = Writer.Position;
-		var chunk = Path.GetFileName(Db.Manager.GetChunkFor(writerPos).FileName);
+		var chunk = Path.GetFileName(Db.Manager.GetChunkFor(writerPos).LocalFileName);
 		var chunkNum = Db.Config.FileNamingStrategy.GetIndexFor(chunk);
 		Assert.AreEqual(2, chunkNum);
 

--- a/src/EventStore.Core.Tests/Services/Replication/LogReplication/LogReplicationFixture.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LogReplication/LogReplicationFixture.cs
@@ -527,8 +527,8 @@ public abstract class LogReplicationFixture<TLogFormat, TStreamId> : Specificati
 			var replicaChunk = _replicaInfo.Db.Manager.GetChunk(chunkNum);
 
 			VerifyHeader(leaderChunk.ChunkHeader, replicaChunk.ChunkHeader);
-			var leaderData = ReadChunkData(leaderChunk.FileName, excludeChecksum: leaderChunk.ChunkFooter != null);
-			var replicaData = ReadChunkData(replicaChunk.FileName, excludeChecksum: replicaChunk.ChunkFooter != null);
+			var leaderData = ReadChunkData(leaderChunk.LocalFileName, excludeChecksum: leaderChunk.ChunkFooter != null);
+			var replicaData = ReadChunkData(replicaChunk.LocalFileName, excludeChecksum: replicaChunk.ChunkFooter != null);
 			Assert.True(leaderData.SequenceEqual(replicaData));
 
 			chunkNum = leaderChunk.ChunkHeader.ChunkEndNumber + 1;
@@ -538,7 +538,7 @@ public abstract class LogReplicationFixture<TLogFormat, TStreamId> : Specificati
 		{
 			// verify that the chunk data is empty on the leader
 			var leaderChunk = _leaderInfo.Db.Manager.GetChunk(expectedLogicalChunks);
-			var leaderData = ReadChunkData(leaderChunk.FileName, excludeChecksum: false);
+			var leaderData = ReadChunkData(leaderChunk.LocalFileName, excludeChecksum: false);
 			Assert.True(leaderData.SequenceEqual(new byte[leaderData.Length]));
 		}
 	}

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
@@ -867,7 +867,7 @@ public class Scenario<TLogFormat, TStreamId> : Scenario
 
 			var newChunk = await TFChunk.CreateWithHeader(
 				fileSystem: db.Config.ChunkFileSystem,
-				filename: $"{chunk.FileName}.tmp",
+				filename: $"{chunk.LocalFileName}.tmp",
 				header: newChunkHeader,
 				fileSize: ChunkHeader.Size,
 				inMem: false,

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/TracingChunkWriterForExecutor.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/TracingChunkWriterForExecutor.cs
@@ -22,7 +22,7 @@ public class TracingChunkWriterForExecutor<TStreamId, TRecord> :
 		_tracer = tracer;
 	}
 
-	public string FileName => _wrapped.FileName;
+	public string LocalFileName => _wrapped.LocalFileName;
 
 	public ValueTask WriteRecord(RecordForExecutor<TStreamId, TRecord> record, CancellationToken token)
 		=> _wrapped.WriteRecord(record, token);

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiverServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiverServiceTests.cs
@@ -39,7 +39,7 @@ public class ArchiverServiceTests {
 			ChunkStartPosition = (long) chunkStartNumber * ChunkSize,
 			ChunkEndPosition = (long) (chunkEndNumber + 1) * ChunkSize,
 			IsCompleted = complete,
-			ChunkFileName = $"{chunkStartNumber}-{chunkEndNumber}",
+			ChunkLocator = $"{chunkStartNumber}-{chunkEndNumber}",
 			IsRemote = remote
 		};
 	}

--- a/src/EventStore.Core/Data/ChunkInfo.cs
+++ b/src/EventStore.Core/Data/ChunkInfo.cs
@@ -2,7 +2,7 @@ namespace EventStore.Core.Data;
 
 public record ChunkInfo
 {
-	public string ChunkFileName;
+	public string ChunkLocator;
 	public int ChunkStartNumber;
 	public int ChunkEndNumber;
 	public long ChunkStartPosition;

--- a/src/EventStore.Core/Services/Archive/Archiver/ArchiverService.cs
+++ b/src/EventStore.Core/Services/Archive/Archiver/ArchiverService.cs
@@ -80,7 +80,7 @@ public class ArchiverService :
 		if (!message.ChunkInfo.IsCompleted)
 			return;
 
-		_existingChunks[Path.GetFileName(message.ChunkInfo.ChunkFileName)!] = message.ChunkInfo;
+		_existingChunks[Path.GetFileName(message.ChunkInfo.ChunkLocator)!] = message.ChunkInfo;
 	}
 
 	public void Handle(SystemMessage.ChunkCompleted message)
@@ -165,7 +165,7 @@ public class ArchiverService :
 	{
 		var writeResult = _archiveChunkCommands.Writer.TryWrite(new Commands.ArchiveChunk
 		{
-			ChunkPath = chunkInfo.ChunkFileName,
+			ChunkPath = chunkInfo.ChunkLocator,
 			ChunkStartNumber = chunkInfo.ChunkStartNumber,
 			ChunkEndNumber = chunkInfo.ChunkEndNumber,
 			ChunkEndPosition = chunkInfo.ChunkEndPosition
@@ -174,7 +174,7 @@ public class ArchiverService :
 		Debug.Assert(writeResult); // writes should never fail as the channel's length is unbounded
 
 		Log.Information("Scheduled archiving of {chunkFile} ({chunkType})",
-			Path.GetFileName(chunkInfo.ChunkFileName), chunkType);
+			Path.GetFileName(chunkInfo.ChunkLocator), chunkType);
 	}
 
 	private async Task ArchiveChunks(CancellationToken ct)

--- a/src/EventStore.Core/Services/RedactionService.cs
+++ b/src/EventStore.Core/Services/RedactionService.cs
@@ -100,7 +100,7 @@ public class RedactionService<TStreamId> :
 
 			eventPositions[i] = new EventPosition(
 				logPosition: logPos,
-				chunkFile: Path.GetFileName(chunk.FileName),
+				chunkFile: Path.GetFileName(chunk.LocalFileName),
 				chunkVersion: chunk.ChunkHeader.MinCompatibleVersion,
 				chunkComplete: chunk.ChunkFooter is { IsCompleted: true },
 				chunkEventOffset: (uint)chunkEventOffset);
@@ -251,7 +251,7 @@ public class RedactionService<TStreamId> :
 			return new(SwitchChunkResult.TargetChunkExcessive);
 		}
 
-		if (Path.GetFileName(targetChunk.FileName) != targetChunkFile)
+		if (Path.GetFileName(targetChunk.LocalFileName) != targetChunkFile)
 		{
 			return new(SwitchChunkResult.TargetChunkInactive);
 		}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -67,7 +67,12 @@ public partial class TFChunk : IDisposable
 		get { return _physicalDataSize; }
 	}
 
-	public string FileName
+	public string ChunkLocator
+	{
+		get { return _filename; }
+	}
+
+	public string LocalFileName
 	{
 		get { return _filename; }
 	}
@@ -91,7 +96,7 @@ public partial class TFChunk : IDisposable
 	{
 		get => new()
 		{
-			ChunkFileName = _filename,
+			ChunkLocator = ChunkLocator,
 			ChunkStartNumber = _chunkHeader.ChunkStartNumber,
 			ChunkEndNumber = _chunkHeader.ChunkEndNumber,
 			ChunkStartPosition = _chunkHeader.ChunkStartPosition,
@@ -114,7 +119,7 @@ public partial class TFChunk : IDisposable
 		{
 			return (int)(_writerWorkItem?.WorkingStream.Position
 			             ?? throw new InvalidOperationException(string.Format("TFChunk {0} is not in write mode.",
-				             _filename)));
+				             ChunkLocator)));
 		}
 	}
 
@@ -356,7 +361,7 @@ public partial class TFChunk : IDisposable
 	private async ValueTask InitCompleted(bool verifyHash, ITransactionFileTracker tracker,
 		Func<TransformType, IChunkTransformFactory> getTransformFactory, CancellationToken token)
 	{
-		_handle = await _fileSystem.OpenForReadAsync(_filename, ReadOnlyReadOptimizationHint, _asyncIO, token);
+		_handle = await _fileSystem.OpenForReadAsync(ChunkLocator, ReadOnlyReadOptimizationHint, _asyncIO, token);
 		_fileSize = (int)_handle.Length;
 
 		IsReadOnly = true;
@@ -365,10 +370,10 @@ public partial class TFChunk : IDisposable
 		{
 			_chunkHeader = await ReadHeader(stream, token);
 			Log.Debug("Opened completed {chunk} as version {version} (min. compatible version: {minCompatibleVersion})",
-				_filename, _chunkHeader.Version, _chunkHeader.MinCompatibleVersion);
+				ChunkLocator, _chunkHeader.Version, _chunkHeader.MinCompatibleVersion);
 
 			if (_chunkHeader.MinCompatibleVersion > CurrentChunkVersion)
-				throw new CorruptDatabaseException(new UnsupportedFileVersionException(_filename,
+				throw new CorruptDatabaseException(new UnsupportedFileVersionException(ChunkLocator,
 					_chunkHeader.MinCompatibleVersion,
 					CurrentChunkVersion));
 
@@ -385,7 +390,7 @@ public partial class TFChunk : IDisposable
 			if (!_chunkFooter.IsCompleted)
 			{
 				throw new CorruptDatabaseException(new BadChunkInDatabaseException(
-					$"Chunk file '{_filename}' should be completed, but is not."));
+					$"Chunk file '{ChunkLocator}' should be completed, but is not."));
 			}
 
 			_logicalDataSize = _chunkFooter.LogicalDataSize;
@@ -446,9 +451,9 @@ public partial class TFChunk : IDisposable
 		CancellationToken token)
 	{
 		Ensure.Nonnegative(writePosition, "writePosition");
-		var fileInfo = new FileInfo(_filename);
+		var fileInfo = new FileInfo(LocalFileName);
 		if (!fileInfo.Exists)
-			throw new CorruptDatabaseException(new ChunkNotFoundException(_filename));
+			throw new CorruptDatabaseException(new ChunkNotFoundException(ChunkLocator));
 
 		_fileSize = (int)fileInfo.Length;
 		IsReadOnly = false;
@@ -457,10 +462,10 @@ public partial class TFChunk : IDisposable
 
 		_chunkHeader = await CreateWriterWorkItemForExistingChunk(writePosition, getTransformFactory, token);
 		Log.Debug("Opened ongoing {chunk} as version {version} (min. compatible version: {minCompatibleVersion})",
-			_filename, _chunkHeader.Version, _chunkHeader.MinCompatibleVersion);
+			ChunkLocator, _chunkHeader.Version, _chunkHeader.MinCompatibleVersion);
 
 		if (_chunkHeader.MinCompatibleVersion > CurrentChunkVersion)
-			throw new CorruptDatabaseException(new UnsupportedFileVersionException(_filename,
+			throw new CorruptDatabaseException(new UnsupportedFileVersionException(ChunkLocator,
 				_chunkHeader.MinCompatibleVersion,
 				CurrentChunkVersion));
 
@@ -562,7 +567,7 @@ public partial class TFChunk : IDisposable
 		// create temp file first and set desired length
 		// if there is not enough disk space or something else prevents file to be resized as desired
 		// we'll end up with empty temp file, which won't trigger false error on next DB verification
-		var tempFilename = $"{_filename}.{Guid.NewGuid()}.tmp";
+		var tempFilename = $"{LocalFileName}.{Guid.NewGuid()}.tmp";
 		var options = new FileStreamOptions
 		{
 			Mode = FileMode.CreateNew,
@@ -585,13 +590,13 @@ public partial class TFChunk : IDisposable
 			tempFile.FlushToDisk();
 		}
 
-		File.Move(tempFilename, _filename);
+		File.Move(tempFilename, LocalFileName);
 
 		// reuse FileStreamOptions instance
 		options.Mode = FileMode.Open;
 		options.Options = WritableHandleOptions;
 		options.PreallocationSize = 0L;
-		_handle = new ChunkFileHandle(_filename, options);
+		_handle = new ChunkFileHandle(LocalFileName, options);
 		_writerWorkItem = new(_handle, md5, _unbuffered, _transform.Write, ChunkHeader.Size + transformHeader.Length);
 		await Flush(token); // persist file move result
 	}
@@ -608,7 +613,7 @@ public partial class TFChunk : IDisposable
 			Options = WritableHandleOptions,
 		};
 
-		_handle = new ChunkFileHandle(_filename, options);
+		_handle = new ChunkFileHandle(LocalFileName, options);
 
 		var stream = _handle.CreateStream();
 		ChunkHeader chunkHeader;
@@ -617,7 +622,7 @@ public partial class TFChunk : IDisposable
 			chunkHeader = await ReadHeader(stream, token);
 			if (chunkHeader.Version is (byte)ChunkVersions.Unaligned)
 			{
-				Log.Debug("Upgrading ongoing file {chunk} to version 3", _filename);
+				Log.Debug("Upgrading ongoing file {chunk} to version 3", ChunkLocator);
 				var newHeader = new ChunkHeader((byte)ChunkVersions.Aligned,
 					(byte)ChunkVersions.Aligned,
 					chunkHeader.ChunkSize,
@@ -700,11 +705,11 @@ public partial class TFChunk : IDisposable
 		if (IsRemote)
 		{
 			token.ThrowIfCancellationRequested();
-			Log.Debug("Skipping hash verification for remote TFChunk '{chunk}'.", _filename);
+			Log.Debug("Skipping hash verification for remote TFChunk '{chunk}'.", ChunkLocator);
 			return;
 		}
 
-		Log.Debug("Verifying hash for TFChunk '{chunk}'...", _filename);
+		Log.Debug("Verifying hash for TFChunk '{chunk}'...", ChunkLocator);
 		using var reader = await AcquireRawReader(token);
 		reader.Stream.Seek(0, SeekOrigin.Begin);
 		var stream = reader.Stream;
@@ -733,7 +738,7 @@ public partial class TFChunk : IDisposable
 		if (stream.Length < ChunkHeader.Size)
 		{
 			return ValueTask.FromException<ChunkHeader>(new CorruptDatabaseException(new BadChunkInDatabaseException(
-				$"Chunk file '{_filename}' is too short to even read ChunkHeader, its size is {stream.Length} bytes.")));
+				$"Chunk file '{ChunkLocator}' is too short to even read ChunkHeader, its size is {stream.Length} bytes.")));
 		}
 
 		stream.Seek(0, SeekOrigin.Begin);
@@ -745,7 +750,7 @@ public partial class TFChunk : IDisposable
 		if (stream.Length < ChunkFooter.Size)
 		{
 			return ValueTask.FromException<ChunkFooter>(new CorruptDatabaseException(new BadChunkInDatabaseException(
-				$"Chunk file '{_filename}' is too short to even read ChunkFooter, its size is {stream.Length} bytes.")));
+				$"Chunk file '{ChunkLocator}' is too short to even read ChunkFooter, its size is {stream.Length} bytes.")));
 		}
 
 		stream.Seek(-ChunkFooter.Size, SeekOrigin.End);
@@ -996,7 +1001,7 @@ public partial class TFChunk : IDisposable
 		    || (ChunkHeader.IsScavenged && _logicalDataSize < _physicalDataSize))
 		{
 			throw new Exception(
-				$"Data sizes violation. Chunk: {FileName}, IsScavenged: {ChunkHeader.IsScavenged}, LogicalDataSize: {_logicalDataSize}, PhysicalDataSize: {_physicalDataSize}.");
+				$"Data sizes violation. Chunk: {ChunkLocator}, IsScavenged: {ChunkHeader.IsScavenged}, LogicalDataSize: {_logicalDataSize}, PhysicalDataSize: {_physicalDataSize}.");
 		}
 
 		return RecordWriteResult.Successful(oldPosition, _physicalDataSize);
@@ -1261,14 +1266,14 @@ public partial class TFChunk : IDisposable
 		if (!_inMem)
 		{
 			_handle?.Dispose();
-			Helper.EatException(_filename, static filename => File.SetAttributes(filename, FileAttributes.Normal));
+			Helper.EatException(LocalFileName, static filename => File.SetAttributes(filename, FileAttributes.Normal));
 
 			if (_deleteFile)
 			{
 				Log.Information(
 					"File {chunk} has been marked for delete and will be deleted in TryDestructFileStreams.",
-					Path.GetFileName(_filename));
-				Helper.EatException(_filename, File.Delete);
+					Path.GetFileName(ChunkLocator));
+				Helper.EatException(LocalFileName, File.Delete);
 			}
 		}
 
@@ -1557,7 +1562,7 @@ public partial class TFChunk : IDisposable
 	private async ValueTask<Stream> CreateOwnedReadStreamForBulkReader(CancellationToken token)
 	{
 		token.ThrowIfCancellationRequested();
-		var handle = await _fileSystem.OpenForReadAsync(_filename, ReadOptimizationHint.SequentialScan, asyncIO: false,
+		var handle = await _fileSystem.OpenForReadAsync(ChunkLocator, ReadOptimizationHint.SequentialScan, asyncIO: false,
 			token);
 		try
 		{
@@ -1699,7 +1704,7 @@ public partial class TFChunk : IDisposable
 	public override string ToString()
 	{
 		return string.Format("#{0}-{1} ({2})", _chunkHeader.ChunkStartNumber, _chunkHeader.ChunkEndNumber,
-			Path.GetFileName(_filename));
+			Path.GetFileName(ChunkLocator));
 	}
 
 	private struct Midpoint

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -284,10 +284,10 @@ public class TFChunkManager : IThreadPoolWorkItem
 	{
 		Ensure.NotNull(chunk, "chunk");
 		if (!chunk.IsReadOnly)
-			throw new ArgumentException(string.Format("Passed TFChunk is not completed: {0}.", chunk.FileName));
+			throw new ArgumentException(string.Format("Passed TFChunk is not completed: {0}.", chunk.ChunkLocator));
 
 		var chunkHeader = chunk.ChunkHeader;
-		var oldFileName = chunk.FileName;
+		var oldFileName = chunk.LocalFileName;
 
 		Log.Information("Switching chunk #{chunkStartNumber}-{chunkEndNumber} ({oldFileName})...",
 			chunkHeader.ChunkStartNumber, chunkHeader.ChunkEndNumber, Path.GetFileName(oldFileName));

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -344,7 +344,7 @@ public class TFChunkScavenger<TStreamId> : TFChunkScavenger
 					              + "\nNew chunk: {tmpChunkPath} --> #{chunkStartNumber}-{chunkEndNumber} ({newChunk})."
 					              + "\nOld chunk total size: {oldSize}, scavenged chunk size: {newSize}.",
 						oldChunkName, sw.Elapsed, Path.GetFileName(tmpChunkPath), chunkStartNumber, chunkEndNumber,
-						Path.GetFileName(chunk.FileName), oldSize, newSize);
+						Path.GetFileName(chunk.LocalFileName), oldSize, newSize);
 					var spaceSaved = oldSize - newSize;
 					_scavengerLog.ChunksScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved);
 				}
@@ -551,7 +551,7 @@ public class TFChunkScavenger<TStreamId> : TFChunkScavenger
 					+ "\ncompleted in {elapsed}."
 					+ "\nNew chunk: {tmpChunkPath} --> #{chunkStartNumber}-{chunkEndNumber} ({newChunk}).",
 					oldChunksList, sw.Elapsed, Path.GetFileName(tmpChunkPath), chunkStartNumber, chunkEndNumber,
-					Path.GetFileName(chunk.FileName));
+					Path.GetFileName(chunk.LocalFileName));
 				var spaceSaved = oldChunks.Sum(_ => _.FileSize) - newChunk.FileSize;
 				scavengerLog.ChunksMerged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved);
 				return true;

--- a/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkManagerForExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkManagerForExecutor.cs
@@ -53,6 +53,6 @@ public class ChunkManagerForExecutor<TStreamId> : IChunkManagerForChunkExecutor<
 			throw new Exception("Unexpected error: new chunk is null after switch");
 		}
 
-		return tfChunk.FileName;
+		return tfChunk.LocalFileName;
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkWriterForExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkWriterForExecutor.cs
@@ -65,7 +65,7 @@ public class ChunkWriterForExecutor<TStreamId> : IChunkWriterForExecutor<TStream
 		return new(logger, manager, chunk);
 	}
 
-	public string FileName => _outputChunk.FileName;
+	public string LocalFileName => _outputChunk.LocalFileName;
 
 	public async ValueTask WriteRecord(RecordForExecutor<TStreamId, ILogRecord> record, CancellationToken token)
 	{
@@ -113,7 +113,7 @@ public class ChunkWriterForExecutor<TStreamId> : IChunkWriterForExecutor<TStream
 		if (deleteImmediately)
 		{
 			_outputChunk.Dispose();
-			TFChunkScavenger<TStreamId>.DeleteTempChunk(_logger, FileName, TFChunkScavenger.MaxRetryCount);
+			TFChunkScavenger<TStreamId>.DeleteTempChunk(_logger, LocalFileName, TFChunkScavenger.MaxRetryCount);
 		}
 		else
 		{

--- a/src/EventStore.Core/TransactionLog/Scavenging/Interfaces/IChunkManagerForChunkExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Interfaces/IChunkManagerForChunkExecutor.cs
@@ -12,7 +12,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 	}
 
 	public interface IChunkWriterForExecutor<TStreamId, TRecord> {
-		string FileName { get; }
+		string LocalFileName { get; }
 
 		ValueTask WriteRecord(RecordForExecutor<TStreamId, TRecord> record, CancellationToken token);
 

--- a/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkExecutor.cs
@@ -270,7 +270,7 @@ public class ChunkExecutor<TStreamId, TRecord> : IChunkExecutor<TStreamId>
 			outputChunk = await _chunkManager.CreateChunkWriter(sourceChunk, cancellationToken);
 			_logger.Debug(
 				"SCAVENGING: Resulting temp chunk file: {tmpChunkPath}.",
-				Path.GetFileName(outputChunk.FileName));
+				Path.GetFileName(outputChunk.LocalFileName));
 
 		}
 		catch (IOException ex)
@@ -335,7 +335,7 @@ public class ChunkExecutor<TStreamId, TRecord> : IChunkExecutor<TStreamId>
 				+ "\nOld chunk total size: {oldSize}, scavenged chunk size: {newSize}.",
 				oldChunkName,
 				elapsed,
-				Path.GetFileName(outputChunk.FileName), chunkStartNumber, chunkEndNumber,
+				Path.GetFileName(outputChunk.LocalFileName), chunkStartNumber, chunkEndNumber,
 				Path.GetFileName(newFileName),
 				sourceChunk.FileSize, newFileSize);
 
@@ -349,7 +349,7 @@ public class ChunkExecutor<TStreamId, TRecord> : IChunkExecutor<TStreamId>
 				"SCAVENGING: Got FileBeingDeletedException exception during scavenging, that probably means some chunks were re-replicated."
 				+ "\nStopping scavenging and removing temp chunk '{tmpChunkPath}'..."
 				+ "\nException message: {e}.",
-				outputChunk.FileName,
+				outputChunk.LocalFileName,
 				exc.Message);
 
 			outputChunk.Abort(deleteImmediately: true);


### PR DESCRIPTION
- keep storage callers from treating every chunk locator as a guaranteed local disk path as the chunk filesystem boundary expands
- reduce the risk of redaction, scavenging, replication, and archiver flows drifting back into local-only assumptions