### PR TITLE
fix(projections): keep content validation cheap at runtime

### DIFF
--- a/src/EventStore.Common.Tests/Utils/JsonTests.cs
+++ b/src/EventStore.Common.Tests/Utils/JsonTests.cs
@@ -1,0 +1,74 @@
+using System.Text;
+using EventStore.Common.Utils;
+
+namespace EventStore.Common.Tests.Utils;
+
+public class JsonTests {
+	[Theory]
+	[InlineData("""
+		{
+			"some": "actually",
+			"correct": ["json", true, false, null]
+		}
+		""")]
+	[InlineData("""
+		// a comment
+		{
+			// b comment
+			"foo": "bar", // cheeky trailing comma
+			// c comment
+		}
+		// d comment
+		""")]
+	public void accepts_valid(string json) {
+		Assert.True(new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes(json)).IsValidUtf8Json());
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("{} invalid")]
+	[InlineData("""{ "foo": "bar", invalid }""")]
+	[InlineData("""
+		// comment
+		{ "foo": "bar" }
+		invalid
+		""")]
+	[InlineData("""
+		{ "foo": "bar" }
+		invalid
+		""")]
+	[InlineData("""
+		{ "foo": "bar" }
+		{ "foo": "bar" }
+		""")]
+	public void rejects_invalid(string invalidJson) {
+		Assert.False(new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes(invalidJson)).IsValidUtf8Json());
+	}
+
+	[Theory]
+	[InlineData(64, true)]
+	[InlineData(65, false)]
+	public void checks_depth(int depth, bool isValid) {
+		var json = new string('[', depth) + new string(']', depth);
+
+		Assert.Equal(isValid, new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes(json)).IsValidUtf8Json());
+	}
+
+	[Fact]
+	public void rejects_bom() {
+		var json = new byte[] {
+			0xEF, 0xBB, 0xBF,
+			(byte)'{',
+			(byte)'}',
+		};
+
+		Assert.False(new ReadOnlyMemory<byte>(json).IsValidUtf8Json());
+	}
+
+	[Fact]
+	public void utf16_is_not_valid() {
+		const string json = """{ "foo": "bar" }""";
+
+		Assert.False(new ReadOnlyMemory<byte>(Encoding.Unicode.GetBytes(json)).IsValidUtf8Json());
+	}
+}

--- a/src/EventStore.Common.Tests/Utils/JsonTests.cs
+++ b/src/EventStore.Common.Tests/Utils/JsonTests.cs
@@ -26,6 +26,9 @@ public class JsonTests {
 
 	[Theory]
 	[InlineData("")]
+	[InlineData(" ")]
+	[InlineData("\t")]
+	[InlineData("\n")]
 	[InlineData("{} invalid")]
 	[InlineData("""{ "foo": "bar", invalid }""")]
 	[InlineData("""

--- a/src/EventStore.Common/Utils/Json.cs
+++ b/src/EventStore.Common/Utils/Json.cs
@@ -116,8 +116,13 @@ public static class Json
 		try
 		{
 			var reader = new Utf8JsonReader(value.Span, Utf8JsonReaderOptions);
-			while (reader.Read())
+			if (!reader.Read())
+				return false;
+
+			do
 				reader.Skip();
+			while (reader.Read());
+
 			return true;
 		}
 		catch

--- a/src/EventStore.Common/Utils/Json.cs
+++ b/src/EventStore.Common/Utils/Json.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json;
 using System.Xml;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -19,6 +20,12 @@ public static class Json
 		MissingMemberHandling = MissingMemberHandling.Ignore,
 		TypeNameHandling = TypeNameHandling.None,
 		Converters = new JsonConverter[] { new StringEnumConverter() }
+	};
+
+	private static readonly JsonReaderOptions Utf8JsonReaderOptions = new() {
+		AllowTrailingCommas = true,
+		CommentHandling = JsonCommentHandling.Skip,
+		MaxDepth = 64,
 	};
 
 	public static byte[] ToJsonBytes(this object source)
@@ -59,7 +66,7 @@ public static class Json
 
 	public static object DeserializeObject(JObject value, Type type, JsonSerializerSettings settings)
 	{
-		JsonSerializer jsonSerializer = JsonSerializer.Create(settings);
+		Newtonsoft.Json.JsonSerializer jsonSerializer = Newtonsoft.Json.JsonSerializer.Create(settings);
 		return jsonSerializer.Deserialize(new JTokenReader(value), type);
 	}
 
@@ -98,17 +105,24 @@ public static class Json
 
 	public static bool IsValidJson(this ReadOnlyMemory<byte> value)
 	{
+		return value.IsValidUtf8Json();
+	}
+
+	public static bool IsValidUtf8Json(this ReadOnlyMemory<byte> value)
+	{
 		if (value.IsEmpty)
-			return false;  //Don't bother letting an Exception getting thrown.
+			return false;
+
 		try
 		{
-			JToken.Parse(Helper.UTF8NoBom.GetString(value.Span));
+			var reader = new Utf8JsonReader(value.Span, Utf8JsonReaderOptions);
+			while (reader.Read())
+				reader.Skip();
+			return true;
 		}
 		catch
 		{
 			return false;
 		}
-
-		return true;
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/index_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/index_checkpoint.cs
@@ -107,7 +107,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_
 					new ReaderSubscriptionManagement.Subscribe(
 						_subscriptionId, fromZeroPosition, _readerStrategy, _readerSubscriptionOptions);
 				//DisableTimer();
-				yield return CreateWriteEvent("test-stream", "type1", "{Data: 3}", "{}");
+				yield return CreateWriteEvent("test-stream", "type1", """{"Data": 3}""", "{}");
 				_tfPos3 = _all.Last(v => v.Value.EventStreamId == "test-stream").Key;
 
 				yield return

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_events_with_content_type_validation.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_events_with_content_type_validation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Text;
 using EventStore.Core.Data;
 using EventStore.Projections.Core.Messages;
@@ -27,6 +28,17 @@ public class when_handling_events_with_content_type_validation
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					Guid.NewGuid(), new TFPos(300, 300), "test-stream", 2, false, Guid.NewGuid(),
 					"valid-json", true, Encoding.UTF8.GetBytes("{\"foo\":\"bar\"}"), new byte[0]));
+			_subscription.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					Guid.NewGuid(), new TFPos(400, 400), "test-stream", 3, false, Guid.NewGuid(),
+					"commented-json", true,
+					Encoding.UTF8.GetBytes("""
+						// comment
+						{
+							"foo": "bar",
+						}
+						"""),
+					new byte[0]));
 		}
 
 		protected override IReaderSubscription CreateProjectionSubscription()
@@ -49,8 +61,9 @@ public class when_handling_events_with_content_type_validation
 		[Test]
 		public void only_the_valid_json_is_handled()
 		{
-			Assert.AreEqual(1, _eventHandler.HandledMessages.Count);
-			Assert.AreEqual("valid-json", _eventHandler.HandledMessages[0].Data.EventType);
+			Assert.AreEqual(2, _eventHandler.HandledMessages.Count);
+			Assert.That(_eventHandler.HandledMessages.Select(x => x.Data.EventType),
+				Is.EquivalentTo(new[] { "valid-json", "commented-json" }));
 		}
 	}
 

--- a/src/EventStore.Projections.Core/Services/Processing/EventFilter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventFilter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using EventStore.Common.Utils;
 
@@ -32,15 +33,9 @@ public abstract class EventFilter
 				   && (!isStreamDeletedEvent || _includeDeletedStreamEvents));
 	}
 
-	public bool PassesValidation(bool isJson, string data)
+	public bool PassesValidation(bool isJson, ReadOnlyMemory<byte> data)
 	{
-		if (!isJson)
-			return true;
-		if (data is null)
-		{
-			return false;
-		}
-		return data.IsValidJson();
+		return !isJson || data.IsValidUtf8Json();
 	}
 
 	protected abstract bool DeletedNotificationPasses(string positionStreamId);

--- a/src/EventStore.Projections.Core/Services/Processing/ResolvedEvent.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ResolvedEvent.cs
@@ -27,6 +27,7 @@ public class ResolvedEvent
 	public readonly string EventType;
 	public readonly bool IsJson;
 	public readonly DateTime Timestamp;
+	public readonly ReadOnlyMemory<byte> DataMemory;
 
 	public readonly string Data;
 	public readonly string Metadata;
@@ -50,6 +51,7 @@ public class ResolvedEvent
 		EventType = @event != null ? @event.EventType : null;
 		IsJson = @event != null && (@event.Flags & PrepareFlags.IsJson) != 0;
 		Timestamp = positionEvent.TimeStamp;
+		DataMemory = @event?.Data ?? ReadOnlyMemory<byte>.Empty;
 
 		//TODO: handle utf-8 conversion exception
 		Data = @event != null && @event.Data.Length > 0 ? Helper.UTF8NoBom.GetString(@event.Data.Span) : null;
@@ -85,7 +87,7 @@ public class ResolvedEvent
 					tag = positionEvent.Metadata.ParseCheckpointTagJson();
 					var parsedPosition = tag.Position;
 					if (parsedPosition == new TFPos(long.MinValue, long.MinValue) &&
-						@event.Metadata.IsValidJson())
+						@event.Metadata.IsValidUtf8Json())
 					{
 						tag = @event.Metadata.ParseCheckpointTagJson();
 						if (tag != null)
@@ -145,6 +147,7 @@ public class ResolvedEvent
 		EventType = eventType;
 		IsJson = isJson;
 		Timestamp = timestamp;
+		DataMemory = data ?? ReadOnlyMemory<byte>.Empty;
 
 		//TODO: handle utf-8 conversion exception
 		Data = data != null ? Helper.UTF8NoBom.GetString(data) : null;
@@ -176,6 +179,7 @@ public class ResolvedEvent
 		IsJson = isJson;
 		Timestamp = timestamp;
 
+		DataMemory = data is not null ? Helper.UTF8NoBom.GetBytes(data) : ReadOnlyMemory<byte>.Empty;
 		Data = data;
 		Metadata = metadata;
 		PositionMetadata = positionMetadata;

--- a/src/EventStore.Projections.Core/Services/Processing/Subscriptions/ReaderSubscriptionBase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Subscriptions/ReaderSubscriptionBase.cs
@@ -100,7 +100,7 @@ public class ReaderSubscriptionBase
 
 		bool passesStreamSourceFilter = _eventFilter.PassesSource(message.Data.ResolvedLinkTo, message.Data.PositionStreamId, message.Data.EventType);
 		bool passesEventFilter = _eventFilter.Passes(message.Data.ResolvedLinkTo, message.Data.PositionStreamId, message.Data.EventType, message.Data.IsStreamDeletedEvent);
-		bool isValid = !_enableContentTypeValidation || _eventFilter.PassesValidation(message.Data.IsJson, message.Data.Data);
+		bool isValid = !_enableContentTypeValidation || _eventFilter.PassesValidation(message.Data.IsJson, message.Data.DataMemory);
 		if (!isValid)
 		{
 			_logger.Verbose($"Event {message.Data.EventSequenceNumber}@{message.Data.EventStreamId} is not valid json. Data: ({message.Data.Data})");


### PR DESCRIPTION
- Keep projection content validation from paying avoidable allocation costs on every JSON event while preserving the permissive syntax the runtime already accepts.
- Keep the projection reader and shared JSON utility aligned so content validation still rejects malformed payloads without regressing valid commented or trailing-comma JSON.