### PR TITLE
fix(archive): keep expected aws traces from looking like failures

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/AwsTraceSerilogListenerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/AwsTraceSerilogListenerTests.cs
@@ -1,7 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
 using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using Amazon.Runtime.Internal.Transform;
 using Amazon.S3;
 using EventStore.Core.Services.Archive.Storage;
 using Serilog;
@@ -72,6 +77,46 @@ public class AwsTraceSerilogListenerTests
 		Assert.Same(exception, logEvent.Exception);
 	}
 
+	[Theory]
+	[InlineData(HttpStatusCode.NotFound)]
+	[InlineData(HttpStatusCode.RequestedRangeNotSatisfiable)]
+	public void logs_expected_http_response_errors_at_verbose(HttpStatusCode statusCode)
+	{
+		var sink = new CollectingSink();
+		var logger = new LoggerConfiguration()
+			.MinimumLevel.Verbose()
+			.WriteTo.Sink(sink)
+			.CreateLogger();
+		var sut = new AwsTraceSerilogListener(logger);
+		var exception = new HttpErrorResponseException("expected", new FakeWebResponseData(statusCode));
+
+		sut.TraceData(null, "Amazon", TraceEventType.Error, 0, new FakeLogMessage("Problem"), exception);
+
+		var logEvent = Assert.Single(sink.Events);
+		Assert.Equal(LogEventLevel.Verbose, logEvent.Level);
+		Assert.Equal("Problem", logEvent.RenderMessage());
+		Assert.Same(exception, logEvent.Exception);
+	}
+
+	[Fact]
+	public void leaves_unexpected_http_response_errors_at_warning()
+	{
+		var sink = new CollectingSink();
+		var logger = new LoggerConfiguration()
+			.MinimumLevel.Verbose()
+			.WriteTo.Sink(sink)
+			.CreateLogger();
+		var sut = new AwsTraceSerilogListener(logger);
+		var exception = new HttpErrorResponseException("expected", new FakeWebResponseData(HttpStatusCode.Forbidden));
+
+		sut.TraceData(null, "Amazon", TraceEventType.Error, 0, new FakeLogMessage("Problem"), exception);
+
+		var logEvent = Assert.Single(sink.Events);
+		Assert.Equal(LogEventLevel.Warning, logEvent.Level);
+		Assert.Equal("Problem", logEvent.RenderMessage());
+		Assert.Same(exception, logEvent.Exception);
+	}
+
 	private sealed class CollectingSink : ILogEventSink
 	{
 		public List<LogEvent> Events { get; } = new();
@@ -85,5 +130,28 @@ public class AwsTraceSerilogListenerTests
 		public string Format => format;
 		public object[] Args => args;
 		public IFormatProvider Provider => null;
+	}
+
+	private sealed class FakeWebResponseData(HttpStatusCode statusCode) : IWebResponseData
+	{
+		public long ContentLength => 0;
+		public string ContentType => "application/xml";
+		public bool IsSuccessStatusCode => false;
+		public IHttpResponseBody ResponseBody => new FakeHttpResponseBody();
+		public HttpStatusCode StatusCode => statusCode;
+
+		public string[] GetHeaderNames() => Array.Empty<string>();
+		public string GetHeaderValue(string headerName) => null;
+		public bool IsHeaderPresent(string headerName) => false;
+	}
+
+	private sealed class FakeHttpResponseBody : IHttpResponseBody
+	{
+		public void Dispose()
+		{
+		}
+
+		public Stream OpenResponse() => Stream.Null;
+		public Task<Stream> OpenResponseAsync() => Task.FromResult<Stream>(Stream.Null);
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/AwsTraceSerilogListenerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/AwsTraceSerilogListenerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Amazon.Runtime;
+using Amazon.S3;
 using EventStore.Core.Services.Archive.Storage;
 using Serilog;
 using Serilog.Core;
@@ -44,8 +45,31 @@ public class AwsTraceSerilogListenerTests
 		sut.TraceData(null, "Amazon", TraceEventType.Error, 0, "plain message");
 
 		var logEvent = Assert.Single(sink.Events);
-		Assert.Equal(LogEventLevel.Error, logEvent.Level);
+		Assert.Equal(LogEventLevel.Warning, logEvent.Level);
 		Assert.Equal("plain message", logEvent.RenderMessage());
+	}
+
+	[Theory]
+	[InlineData("NoSuchKey")]
+	[InlineData("InvalidRange")]
+	public void logs_expected_s3_errors_at_verbose(string errorCode)
+	{
+		var sink = new CollectingSink();
+		var logger = new LoggerConfiguration()
+			.MinimumLevel.Verbose()
+			.WriteTo.Sink(sink)
+			.CreateLogger();
+		var sut = new AwsTraceSerilogListener(logger);
+		var exception = new AmazonS3Exception("expected") {
+			ErrorCode = errorCode,
+		};
+
+		sut.TraceData(null, "Amazon", TraceEventType.Error, 0, new FakeLogMessage("Problem"), exception);
+
+		var logEvent = Assert.Single(sink.Events);
+		Assert.Equal(LogEventLevel.Verbose, logEvent.Level);
+		Assert.Equal("Problem", logEvent.RenderMessage());
+		Assert.Same(exception, logEvent.Exception);
 	}
 
 	private sealed class CollectingSink : ILogEventSink

--- a/src/EventStore.Core/Services/Archive/Storage/AwsTraceLogging.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/AwsTraceLogging.cs
@@ -3,6 +3,8 @@ using System.Diagnostics;
 using System.Threading;
 using Amazon;
 using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using Amazon.S3;
 using Serilog.Events;
 
 namespace EventStore.Core.Services.Archive.Storage;
@@ -82,7 +84,7 @@ public sealed class AwsTraceSerilogListener : TraceListener
 			return;
 
 		var exception = data.Length > 1 ? data[1] as Exception : null;
-		var logLevel = GetLogLevel(eventType);
+		var logLevel = AdjustDefaultLevel(GetLogLevel(eventType), exception);
 
 		switch (data[0])
 		{
@@ -104,6 +106,14 @@ public sealed class AwsTraceSerilogListener : TraceListener
 
 	private void WritePlainMessage(LogEventLevel logLevel, string message) =>
 		_logger.Write(logLevel, "{AwsTraceMessage:l}", message);
+
+	internal static LogEventLevel AdjustDefaultLevel(LogEventLevel logLevel, Exception exception) =>
+		exception is AmazonS3Exception { ErrorCode: "NoSuchKey" or "InvalidRange" }
+			or HttpErrorResponseException
+			? LogEventLevel.Verbose
+			: logLevel == LogEventLevel.Error
+				? LogEventLevel.Warning
+				: logLevel;
 
 	private static LogEventLevel GetLogLevel(TraceEventType eventType) =>
 		eventType switch

--- a/src/EventStore.Core/Services/Archive/Storage/AwsTraceLogging.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/AwsTraceLogging.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Net;
 using System.Threading;
 using Amazon;
 using Amazon.Runtime;
@@ -109,8 +110,11 @@ public sealed class AwsTraceSerilogListener : TraceListener
 
 	internal static LogEventLevel AdjustDefaultLevel(LogEventLevel logLevel, Exception exception) =>
 		exception is AmazonS3Exception { ErrorCode: "NoSuchKey" or "InvalidRange" }
-			or HttpErrorResponseException
 			? LogEventLevel.Verbose
+			: exception is HttpErrorResponseException {
+				Response.StatusCode: HttpStatusCode.NotFound or HttpStatusCode.RequestedRangeNotSatisfiable
+			}
+				? LogEventLevel.Verbose
 			: logLevel == LogEventLevel.Error
 				? LogEventLevel.Warning
 				: logLevel;


### PR DESCRIPTION
- expected S3 misses and range probes are already handled by the archive path and should not surface as application errors
- downgrading AWS SDK trace severity keeps operator logs aligned with actionable failures instead of noisy transport diagnostics
- this keeps the earlier AWS-to-Serilog bridge useful without turning expected archive behavior into alert noise