### PR TITLE
fix(startup): let host cancellation stop node initialization

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -375,7 +375,7 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable
 	}
 
 	public Task StartAsync(CancellationToken cancellationToken) =>
-		_options.Application.WhatIf ? Task.CompletedTask : Node.StartAsync(false);
+		_options.Application.WhatIf ? Task.CompletedTask : Node.StartAsync(false, cancellationToken);
 
 	public Task StopAsync(CancellationToken cancellationToken) =>
 		Node.StopAsync(cancellationToken: cancellationToken);

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -286,7 +286,7 @@ public class MiniClusterNode<TLogFormat, TStreamId>
 		}
 
 		_host.Start();
-		Node.Start();
+		Node.StartAsync(false).GetAwaiter().GetResult();
 	}
 
 	public HttpClient CreateHttpClient()

--- a/src/EventStore.Core.Tests/Services/VNode/startup_should.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/startup_should.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Authentication;
+using EventStore.Core.Authentication.InternalAuthentication;
+using EventStore.Core.Authorization;
+using EventStore.Core.Authorization.AuthorizationPolicies;
+using EventStore.Core.Certificates;
+using EventStore.Core.Configuration.Sources;
+using EventStore.Core.Services.Monitoring;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Core.Tests.Services.Transport.Tcp;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.VNode;
+
+[TestFixture]
+public class startup_should : SpecificationWithDirectory
+{
+	[Test]
+	public async Task propagate_cancellation_into_startup_tasks()
+	{
+		var startupTaskStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var blockingStartupTask = new BlockingStartupTask(startupTaskStarted);
+		var ip = IPAddress.Loopback;
+		var tcpEndPoint = new IPEndPoint(ip, PortsHelper.GetAvailablePort(ip));
+		var internalEndPoint = new IPEndPoint(ip, PortsHelper.GetAvailablePort(ip));
+		var httpEndPoint = new IPEndPoint(ip, PortsHelper.GetAvailablePort(ip));
+
+		var options = new ClusterVNodeOptions
+		{
+			Application = new()
+			{
+				AllowAnonymousEndpointAccess = true,
+				AllowAnonymousStreamAccess = true,
+				StatsPeriodSec = 60 * 60,
+				WorkerThreads = 1
+			},
+			Interface = new()
+			{
+				ReplicationHeartbeatInterval = 10_000,
+				ReplicationHeartbeatTimeout = 10_000,
+				EnableAtomPubOverHttp = true
+			},
+			Cluster = new()
+			{
+				DiscoverViaDns = false,
+				StreamInfoCacheCapacity = 10_000
+			},
+			Database = new()
+			{
+				ChunkSize = MiniNode.ChunkSize,
+				ChunksCacheSize = MiniNode.CachedChunkSize,
+				SkipDbVerify = true,
+				StatsStorage = StatsStorage.None,
+				DisableScavengeMerging = true,
+				CommitTimeoutMs = 10_000,
+				PrepareTimeoutMs = 10_000,
+				StreamExistenceFilterSize = 10_000
+			},
+			LoadedOptions = ClusterVNodeOptions.GetLoadedOptions(new ConfigurationBuilder()
+				.AddEventStoreDefaultValues()
+				.Build()),
+		}.Secure(new X509Certificate2Collection(ssl_connections.GetRootCertificate()),
+				ssl_connections.GetServerCertificate())
+			.WithReplicationEndpointOn(internalEndPoint)
+			.WithExternalTcpOn(tcpEndPoint)
+			.WithNodeEndpointOn(httpEndPoint)
+			.RunInMemory();
+
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new KeyValuePair<string, string>[] {
+				new("EventStore:TcpUnitTestPlugin:NodeTcpPort", tcpEndPoint.Port.ToString()),
+				new("EventStore:TcpUnitTestPlugin:NodeHeartbeatInterval", "10000"),
+				new("EventStore:TcpUnitTestPlugin:NodeHeartbeatTimeout", "10000"),
+				new("EventStore:TcpUnitTestPlugin:Insecure", options.Application.Insecure.ToString()),
+			})
+			.Build();
+
+		var node = new ClusterVNode<string>(
+			options,
+			LogFormatHelper<LogFormat.V2, string>.LogFormatFactory,
+			new AuthenticationProviderFactory(components =>
+				new InternalAuthenticationProviderFactory(components, options.DefaultUser)),
+			new AuthorizationProviderFactory(components =>
+				new InternalAuthorizationProviderFactory(
+					new StaticAuthorizationPolicyRegistry([new LegacyPolicySelectorFactory(
+						options.Application.AllowAnonymousEndpointAccess,
+						options.Application.AllowAnonymousStreamAccess,
+						options.Application.OverrideAnonymousEndpointAccessForGossip).Create(components.MainQueue)]))),
+			certificateProvider: new OptionsCertificateProvider(),
+			configuration: configuration,
+			configureAdditionalNodeServices: services =>
+				services.Decorate<IReadOnlyList<IClusterVNodeStartupTask>>(
+					startupTasks => [..startupTasks, blockingStartupTask]));
+
+		using var host = new TestServer(
+			new Microsoft.AspNetCore.Hosting.WebHostBuilder().UseStartup(node.Startup));
+
+		using var cancellationTokenSource = new CancellationTokenSource();
+		var startTask = node.StartAsync(false, cancellationTokenSource.Token);
+
+		await startupTaskStarted.Task.WithTimeout(TimeSpan.FromSeconds(5));
+		await cancellationTokenSource.CancelAsync();
+
+		Assert.That(async () => await startTask, Throws.InstanceOf<OperationCanceledException>());
+	}
+
+	private sealed class BlockingStartupTask(TaskCompletionSource<bool> started) : IClusterVNodeStartupTask
+	{
+		public async Task Run(CancellationToken token = default)
+		{
+			started.TrySetResult(true);
+			await Task.Delay(Timeout.InfiniteTimeSpan, token);
+		}
+	}
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1673,11 +1673,20 @@ public class ClusterVNode<TStreamId> :
 				// then we can remove this extra restart
 				Log.Information("Truncation successful. Shutting down.");
 				var shutdownGuid = Guid.NewGuid();
-				using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
-				linkedTokenSource.CancelAfter(ShutdownTimeout);
-				await HandleAsync(
-					new SystemMessage.BecomeShuttingDown(shutdownGuid, exitProcess: true, shutdownHttp: true),
-					linkedTokenSource.Token);
+				try
+				{
+					await HandleAsync(
+						new SystemMessage.BecomeShuttingDown(shutdownGuid, exitProcess: true, shutdownHttp: true),
+						token)
+						.AsTask()
+						.WaitAsync(ShutdownTimeout, token);
+				}
+				catch (TimeoutException)
+				{
+					Log.Warning(
+						"Graceful shutdown did not complete within {shutdownTimeout} after truncation. Continuing with forced shutdown.",
+						ShutdownTimeout);
+				}
 
 				Handle(new SystemMessage.BecomeShutdown(shutdownGuid));
 				Application.Exit(0, "Shutting down after successful truncation.");

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -127,7 +127,7 @@ public abstract class ClusterVNode
 	abstract public bool IsShutdown { get; }
 
 	abstract public void Start();
-	abstract public Task<ClusterVNode> StartAsync(bool waitUntilRead);
+	abstract public Task<ClusterVNode> StartAsync(bool waitUntilRead, CancellationToken cancellationToken = default);
 	abstract public Task StopAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 }
 
@@ -200,6 +200,7 @@ public class ClusterVNode<TStreamId> :
 	private readonly CertificateDelegates.ServerCertificateValidator _externalServerCertificateValidator;
 	private readonly CertificateProvider _certificateProvider;
 	private readonly ClusterVNodeStartup<TStreamId> _startup;
+	private readonly Func<CancellationToken, Task> _start;
 	private readonly INodeHttpClientFactory _nodeHttpClientFactory;
 	private readonly EventStoreClusterClientCache _eventStoreClusterClientCache;
 
@@ -208,6 +209,8 @@ public class ClusterVNode<TStreamId> :
 	private int _shutdownStarted;
 	private int _reloadingConfig;
 	private PosixSignalRegistration _reloadConfigSignalRegistration;
+	private readonly object _startupTaskGate = new();
+	private Task _startupTask = null!;
 
 	public IEnumerable<Task> Tasks
 	{
@@ -1637,6 +1640,8 @@ public class ClusterVNode<TStreamId> :
 			return services;
 		}
 
+		var startupTasks = (IReadOnlyList<IClusterVNodeStartupTask>)Array.Empty<IClusterVNodeStartupTask>();
+
 		void ConfigureNode(IApplicationBuilder app)
 		{
 			var dbTransforms = app.ApplicationServices.GetService<IReadOnlyList<IDbTransform>>();
@@ -1645,19 +1650,13 @@ public class ClusterVNode<TStreamId> :
 			if (!Db.TransformManager.TrySetActiveTransform(options.Database.Transform))
 				throw new InvalidConfigurationException(
 					$"Unknown {nameof(options.Database.Transform)} specified: {options.Database.Transform}");
+
+			startupTasks = app.ApplicationServices.GetRequiredService<IReadOnlyList<IClusterVNodeStartupTask>>();
 		}
 
-		void StartNode(IApplicationBuilder app) {
-			try {
-				StartNodeCore(app);
-			} catch (AggregateException aggEx) when (aggEx.InnerException is { } innerEx) {
-				// We only really care that *something* is wrong - throw the first inner exception.
-				throw innerEx;
-			}
-		}
-
-		void StartNodeCore(IApplicationBuilder app) {
-		// TRUNCATE IF NECESSARY
+		async Task StartNode(CancellationToken token)
+		{
+			// TRUNCATE IF NECESSARY
 			var truncPos = Db.Config.TruncateCheckpoint.Read();
 			if (truncPos != -1)
 			{
@@ -1665,43 +1664,34 @@ public class ClusterVNode<TStreamId> :
 					"Truncate checkpoint is present. Truncate: {truncatePosition} (0x{truncatePosition:X}), Writer: {writerCheckpoint} (0x{writerCheckpoint:X}), Chaser: {chaserCheckpoint} (0x{chaserCheckpoint:X}), Epoch: {epochCheckpoint} (0x{epochCheckpoint:X})",
 					truncPos, truncPos, writerCheckpoint, writerCheckpoint, chaserCheckpoint, chaserCheckpoint,
 					epochCheckpoint, epochCheckpoint);
-					var truncator = new TFChunkDbTruncator(Db.Config,
-						type => Db.TransformManager.GetFactoryForExistingChunk(type));
-					using (var task = truncator.TruncateDb(truncPos, CancellationToken.None).AsTask()) {
-						task.Wait(ShutdownTimeout);
-					}
+				var truncator = new TFChunkDbTruncator(Db.Config,
+					type => Db.TransformManager.GetFactoryForExistingChunk(type));
+				await truncator.TruncateDb(truncPos, token);
 
 				// The truncator has moved the checkpoints but it is possible that other components in the startup have
 				// already read the old values. If we ensure all checkpoint reads are performed after the truncation
 				// then we can remove this extra restart
 				Log.Information("Truncation successful. Shutting down.");
 				var shutdownGuid = Guid.NewGuid();
-					using (var task = HandleAsync(
-						       new SystemMessage.BecomeShuttingDown(shutdownGuid, exitProcess: true, shutdownHttp: true),
-						       CancellationToken.None).AsTask())
-					{
-						task.Wait(ShutdownTimeout);
-					}
+				using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
+				linkedTokenSource.CancelAfter(ShutdownTimeout);
+				await HandleAsync(
+					new SystemMessage.BecomeShuttingDown(shutdownGuid, exitProcess: true, shutdownHttp: true),
+					linkedTokenSource.Token);
 
 				Handle(new SystemMessage.BecomeShutdown(shutdownGuid));
 				Application.Exit(0, "Shutting down after successful truncation.");
 				return;
 			}
 
-			var startupTasks = (app.ApplicationServices.GetRequiredService<IReadOnlyList<IClusterVNodeStartupTask>>())
-				.Select(x => x.Run())
-				.ToArray();
-			Task.WaitAll(startupTasks);
+			foreach (var startupTask in startupTasks)
+				await startupTask.Run(token);
 
 			AddTask(_controller.Start());
 
-			using (var task = Db.Open(!options.Database.SkipDbVerify, threads: options.Database.InitializationThreads,
-				       createNewChunks: false).AsTask())
-			{
-				task.Wait(); // No timeout or cancellation, this is intended
-			}
-
-			using (var task = epochManager.Init(CancellationToken.None).AsTask()) { task.Wait(); }
+			await Db.Open(!options.Database.SkipDbVerify, threads: options.Database.InitializationThreads,
+				createNewChunks: false, token: token);
+			await epochManager.Init(token);
 
 			storageWriter.Start();
 			AddTasks(storageWriter.Tasks);
@@ -1713,8 +1703,8 @@ public class ClusterVNode<TStreamId> :
 			AddTask(redactionQueue.Start());
 
 			dynamicCacheManager.Start();
-			PublishSystemInitIfNeeded();
 		}
+		_start = StartNode;
 
 		_startup = new ClusterVNodeStartup<TStreamId>(
 			modifiedOptions.PlugableComponents,
@@ -1728,8 +1718,7 @@ public class ClusterVNode<TStreamId> :
 			trackers,
 			options.Cluster.DiscoverViaDns ? options.Cluster.ClusterDns : null,
 			ConfigureNodeServices,
-			ConfigureNode,
-			StartNode);
+			ConfigureNode);
 
 		_mainBus.Subscribe<SystemMessage.SystemReady>(_startup);
 		_mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(_startup);
@@ -1917,6 +1906,15 @@ public class ClusterVNode<TStreamId> :
 		PublishSystemInitIfNeeded();
 	}
 
+	private Task EnsureStartedAsync(CancellationToken cancellationToken)
+	{
+		lock (_startupTaskGate)
+		{
+			_startupTask ??= _start(cancellationToken);
+			return _startupTask;
+		}
+	}
+
 	private void PublishSystemInitIfNeeded()
 	{
 		lock (_systemInitGate)
@@ -2021,7 +2019,7 @@ public class ClusterVNode<TStreamId> :
 #endif
 	}
 
-	public override Task<ClusterVNode> StartAsync(bool waitUntilReady)
+	public override async Task<ClusterVNode> StartAsync(bool waitUntilReady, CancellationToken cancellationToken = default)
 	{
 		var tcs = new TaskCompletionSource<ClusterVNode>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -2034,12 +2032,13 @@ public class ClusterVNode<TStreamId> :
 			tcs.TrySetResult(this);
 		}
 
-		Start();
+		await EnsureStartedAsync(cancellationToken);
+		PublishSystemInitIfNeeded();
 
 		if (IsShutdown)
 			tcs.TrySetResult(this);
 
-		return tcs.Task;
+		return await tcs.Task;
 	}
 
 	public static ValueTuple<bool, string> ValidateServerCertificate(X509Certificate certificate,

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -55,7 +55,6 @@ public class ClusterVNodeStartup<TStreamId> : IStartup, IHandle<SystemMessage.Sy
 	private readonly StatusCheck _statusCheck;
 	private readonly Func<IServiceCollection, IServiceCollection> _configureNodeServices;
 	private readonly Action<IApplicationBuilder> _configureNode;
-	private readonly Action<IApplicationBuilder> _startNode;
 
 	private bool _ready;
 	private readonly IAuthorizationProvider _authorizationProvider;
@@ -78,8 +77,7 @@ public class ClusterVNodeStartup<TStreamId> : IStartup, IHandle<SystemMessage.Sy
 		Trackers trackers,
 		string clusterDns,
 		Func<IServiceCollection, IServiceCollection> configureNodeServices,
-		Action<IApplicationBuilder> configureNode,
-		Action<IApplicationBuilder> startNode)
+		Action<IApplicationBuilder> configureNode)
 	{
 
 		Ensure.Positive(maxAppendSize, nameof(maxAppendSize));
@@ -119,7 +117,6 @@ public class ClusterVNodeStartup<TStreamId> : IStartup, IHandle<SystemMessage.Sy
 		_configureNodeServices =
 			configureNodeServices ?? throw new ArgumentNullException(nameof(configureNodeServices));
 		_configureNode = configureNode ?? throw new ArgumentNullException(nameof(configureNode));
-		_startNode = startNode ?? throw new ArgumentNullException(nameof(startNode));
 		_statusCheck = new StatusCheck(this);
 	}
 
@@ -190,8 +187,6 @@ public class ClusterVNodeStartup<TStreamId> : IStartup, IHandle<SystemMessage.Sy
 					.Build(),
 				_httpService);
 		});
-
-		_startNode(app);
 	}
 
 	public IServiceProvider ConfigureServices(IServiceCollection services)

--- a/src/EventStore.Core/IClusterVNodeStartupTask.cs
+++ b/src/EventStore.Core/IClusterVNodeStartupTask.cs
@@ -1,8 +1,9 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace EventStore.Core;
 
 public interface IClusterVNodeStartupTask
 {
-	Task Run();
+	Task Run(CancellationToken token = default);
 }

--- a/src/EventStore.Core/Services/Archive/ArchiveCatchup/ArchiveCatchup.cs
+++ b/src/EventStore.Core/Services/Archive/ArchiveCatchup/ArchiveCatchup.cs
@@ -49,9 +49,7 @@ public class ArchiveCatchup : IClusterVNodeStartupTask
 		_archiveReader = archiveStorageFactory.CreateReader();
 	}
 
-	public Task Run() => Run(CancellationToken.None);
-
-	private async Task Run(CancellationToken ct)
+	public async Task Run(CancellationToken ct = default)
 	{
 		var writerChk = _writerCheckpoint.Read();
 		var archiveChk = await GetArchiveCheckpoint(ct);


### PR DESCRIPTION
- lets host shutdown and Ctrl+C interrupt node initialization instead of getting stuck behind startup work
- keeps startup responsibilities on the node start path so configuration and startup lifecycles are no longer coupled
- closes the remaining Phase 3 configuration/startup work after reconciling the rows that were already landed locally