### PR TITLE
fix(storage): keep chunk naming boundaries explicit

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/versioned_pattern_filenaming_strategy.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/versioned_pattern_filenaming_strategy.cs
@@ -142,8 +142,8 @@ public class versioned_pattern_filenaming_strategy : SpecificationWithDirectory
 		var strategy = new VersionedPatternFileNamingStrategy(PathName, "chunk-");
 		Assert.AreEqual(0, strategy.GetAllTempFiles().Length);
 
-		var tmp1 = strategy.GetTempFilename();
-		var tmp2 = strategy.GetTempFilename();
+		var tmp1 = strategy.CreateTempFilename();
+		var tmp2 = strategy.CreateTempFilename();
 		File.Create(tmp1).Close();
 		File.Create(tmp2).Close();
 		var tmp = new[] { tmp1, tmp2 };
@@ -192,14 +192,9 @@ public class versioned_pattern_filenaming_strategy : SpecificationWithDirectory
 	}
 
 	[Test]
-	public void returns_correct_prefix_with_get_prefix_for()
+	public void returns_chunk_prefix()
 	{
 		var strategy = new VersionedPatternFileNamingStrategy(PathName, "chunk-");
-		Assert.AreEqual("chunk-", strategy.GetPrefixFor(null, null));
-		Assert.AreEqual("chunk-000000.", strategy.GetPrefixFor(0, null));
-		Assert.AreEqual("chunk-001337.", strategy.GetPrefixFor(1337, null));
-		Assert.AreEqual("chunk-000000.000000", strategy.GetPrefixFor(0, 0));
-		Assert.AreEqual("chunk-000000.001337", strategy.GetPrefixFor(0, 1337));
-		Assert.AreEqual("chunk-001234.005678", strategy.GetPrefixFor(1234, 5678));
+		Assert.AreEqual("chunk-", strategy.Prefix);
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/with_tfchunk_enumerator.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/with_tfchunk_enumerator.cs
@@ -17,9 +17,10 @@ public class with_tfchunk_enumerator : SpecificationWithDirectory
 	{
 		public int GetAllPresentFilesCalls { get; private set; }
 
+		public string Prefix => inner.Prefix;
 		public string GetFilenameFor(int index, int version) => inner.GetFilenameFor(index, version);
-		public string DetermineBestVersionFilenameFor(int index, int initialVersion) =>
-			inner.DetermineBestVersionFilenameFor(index, initialVersion);
+		public string DetermineNewVersionFilenameForIndex(int index, int defaultVersion) =>
+			inner.DetermineNewVersionFilenameForIndex(index, defaultVersion);
 		public string[] GetAllVersionsFor(int index) => inner.GetAllVersionsFor(index);
 
 		public string[] GetAllPresentFiles()
@@ -28,12 +29,11 @@ public class with_tfchunk_enumerator : SpecificationWithDirectory
 			return inner.GetAllPresentFiles();
 		}
 
-		public string GetTempFilename() => inner.GetTempFilename();
+		public string CreateTempFilename() => inner.CreateTempFilename();
 		public string[] GetAllTempFiles() => inner.GetAllTempFiles();
 		public int GetIndexFor(string fileName) => inner.GetIndexFor(fileName);
 		public int GetVersionFor(string fileName) => inner.GetVersionFor(fileName);
-			public string GetPrefixFor(int? index, int? version) => inner.GetPrefixFor(index, version);
-		}
+	}
 
 	[Test]
 	public void throws_argumentnullexception_when_constructed_with_null_naming_strategy()

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/CustomNamingStrategy.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/CustomNamingStrategy.cs
@@ -5,13 +5,15 @@ namespace EventStore.Core.XUnit.Tests.Services.Archive.ArchiveCatchup;
 
 internal class CustomNamingStrategy : IVersionedFileNamingStrategy
 {
+	public string Prefix => "chunk-";
+
 	public string GetFilenameFor(int chunkStartNumber, int chunkEndNumber) =>
 		$"chunk-{chunkStartNumber}.{chunkEndNumber}";
 
-	public string DetermineBestVersionFilenameFor(int index, int initialVersion) => throw new NotImplementedException();
+	public string DetermineNewVersionFilenameForIndex(int index, int defaultVersion) => throw new NotImplementedException();
 	public string[] GetAllVersionsFor(int index) => throw new NotImplementedException();
 	public string[] GetAllPresentFiles() => throw new NotImplementedException();
-	public string GetTempFilename() => throw new NotImplementedException();
+	public string CreateTempFilename() => throw new NotImplementedException();
 	public string[] GetAllTempFiles() => throw new NotImplementedException();
 
 	public int GetIndexFor(string fileName)
@@ -26,6 +28,4 @@ internal class CustomNamingStrategy : IVersionedFileNamingStrategy
 		var idx = fileName.IndexOf('.') + 1;
 		return int.Parse(fileName[idx..]);
 	}
-
-	public string GetPrefixFor(int? index, int? version) => throw new NotImplementedException();
 }

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/FakeArchiveStorage.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/FakeArchiveStorage.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Core.Services.Archive.Naming;
 using EventStore.Core.Services.Archive.Storage;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
@@ -46,6 +47,8 @@ internal class FakeArchiveStorage : IArchiveStorageWriter, IArchiveStorageReader
 		_onGetChunk = onGetChunk;
 		_chunkGets = new();
 	}
+
+	public IArchiveChunkNamer ChunkNamer { get; } = new ArchiveChunkNamer(new CustomNamingStrategy());
 
 	public IArchiveStorageReader CreateReader() => this;
 	public IArchiveStorageWriter CreateWriter() => this;

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiverServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiverServiceTests.cs
@@ -65,7 +65,7 @@ public class ArchiverServiceTests {
 
 		await WaitFor(archive, numStores: 1);
 
-		Assert.Equal(["0-0.renamed"], archive.Chunks);
+		Assert.Equal(["chunk-0-0.renamed"], archive.Chunks);
 	}
 
 	[Fact]
@@ -93,7 +93,7 @@ public class ArchiverServiceTests {
 
 		await WaitFor(archive, numStores: 1);
 
-		Assert.Equal(["0-0.renamed"], archive.Chunks);
+		Assert.Equal(["chunk-0-0.renamed"], archive.Chunks);
 	}
 
 	[Fact]
@@ -131,7 +131,7 @@ public class ArchiverServiceTests {
 
 		await WaitFor(archive, numStores: 1);
 
-		Assert.Equal(["0-0.renamed"], archive.Chunks);
+		Assert.Equal(["chunk-0-0.renamed"], archive.Chunks);
 	}
 
 	[Fact]
@@ -163,7 +163,7 @@ public class ArchiverServiceTests {
 
 		await WaitFor(archive, numStores: 5);
 
-		Assert.Equal(["0-0.renamed", "1-1.renamed", "2-2.renamed", "3-3.renamed", "4-4.renamed"], archive.Chunks);
+		Assert.Equal(["chunk-0-0.renamed", "chunk-1-1.renamed", "chunk-2-2.renamed", "chunk-3-3.renamed", "chunk-4-4.renamed"], archive.Chunks);
 	}
 
 	[Fact]
@@ -185,12 +185,12 @@ public class ArchiverServiceTests {
 
 		await WaitFor(archive, numStores: 5);
 
-		Assert.Equal(["3-3.renamed", "4-4.renamed", "1-1.renamed", "2-2.renamed", "5-5.renamed"], archive.Chunks);
+		Assert.Equal(["chunk-3-3.renamed", "chunk-4-4.renamed", "chunk-1-1.renamed", "chunk-2-2.renamed", "chunk-5-5.renamed"], archive.Chunks);
 	}
 
 	[Fact]
 	public async Task doesnt_archive_existing_chunks_that_were_already_archived() {
-		var (sut, archive) = CreateSut(existingChunks:	[ "0-0", "1-1" ], existingCheckpoint: 2 * TFConsts.ChunkSize);
+		var (sut, archive) = CreateSut(existingChunks:	[ "chunk-0-0", "chunk-1-1" ], existingCheckpoint: 2 * TFConsts.ChunkSize);
 
 		sut.Handle(new SystemMessage.ChunkLoaded(GetChunkInfo(0, 0, complete: true)));
 		sut.Handle(new SystemMessage.ChunkLoaded(GetChunkInfo(1, 1, complete: true)));
@@ -200,12 +200,12 @@ public class ArchiverServiceTests {
 
 		await WaitFor(archive, numStores: 2);
 
-		Assert.Equal([ "0-0", "1-1", "2-2.renamed", "3-3.renamed" ], archive.Chunks);
+		Assert.Equal([ "chunk-0-0", "chunk-1-1", "chunk-2-2.renamed", "chunk-3-3.renamed" ], archive.Chunks);
 	}
 
 	[Fact]
 	public async Task archives_an_existing_chunk_if_it_starts_before_but_ends_after_the_checkpoint() {
-		var (sut, archive) = CreateSut(existingChunks:	[ "0-0", "1-1" ], existingCheckpoint: 2 * TFConsts.ChunkSize);
+		var (sut, archive) = CreateSut(existingChunks:	[ "chunk-0-0", "chunk-1-1" ], existingCheckpoint: 2 * TFConsts.ChunkSize);
 
 		sut.Handle(new SystemMessage.ChunkLoaded(GetChunkInfo(0, 0, complete: true)));
 		sut.Handle(new SystemMessage.ChunkLoaded(GetChunkInfo(1, 2, complete: true))); // <-- the chunk being tested
@@ -214,7 +214,7 @@ public class ArchiverServiceTests {
 
 		await WaitFor(archive, numStores: 3);
 
-		Assert.Equal([ "0-0", "1-1", "1-1.renamed", "2-2.renamed", "3-3.renamed" ], archive.Chunks);
+		Assert.Equal([ "chunk-0-0", "chunk-1-1", "chunk-1-1.renamed", "chunk-2-2.renamed", "chunk-3-3.renamed" ], archive.Chunks);
 	}
 
 	[Fact]
@@ -289,7 +289,7 @@ public class ArchiverServiceTests {
 
 		await WaitFor(archive, numStores: 8);
 
-		Assert.Equal(["0-0.renamed", "1-1.renamed", "2-2.renamed", "3-3.renamed", "4-4.renamed", "5-5.renamed", "6-6.renamed", "7-7.renamed"],
+		Assert.Equal(["chunk-0-0.renamed", "chunk-1-1.renamed", "chunk-2-2.renamed", "chunk-3-3.renamed", "chunk-4-4.renamed", "chunk-5-5.renamed", "chunk-6-6.renamed", "chunk-7-7.renamed"],
 			archive.Chunks);
 	}
 }
@@ -309,9 +309,9 @@ internal class FakeUnmerger : IChunkUnmerger {
 }
 
 internal class FakeArchiveChunkNamer : IArchiveChunkNamer {
-	public string Prefix => string.Empty;
+	public string Prefix => "chunk-";
 
-	public string GetFileNameFor(int logicalChunkNumber) => $"{logicalChunkNumber}-{logicalChunkNumber}.renamed";
+	public string GetFileNameFor(int logicalChunkNumber) => $"{Prefix}{logicalChunkNumber}-{logicalChunkNumber}.renamed";
 }
 
 internal class FakeArchiveStorage : IArchiveStorageWriter, IArchiveStorageReader, IArchiveStorageFactory

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiverServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiverServiceTests.cs
@@ -309,6 +309,8 @@ internal class FakeUnmerger : IChunkUnmerger {
 }
 
 internal class FakeArchiveChunkNamer : IArchiveChunkNamer {
+	public string Prefix => string.Empty;
+
 	public string GetFileNameFor(int logicalChunkNumber) => $"{logicalChunkNumber}-{logicalChunkNumber}.renamed";
 }
 
@@ -331,6 +333,8 @@ internal class FakeArchiveStorage : IArchiveStorageWriter, IArchiveStorageReader
 		_checkpoint = existingCheckpoint;
 		Chunks = new List<string>(existingChunks);
 	}
+
+	public IArchiveChunkNamer ChunkNamer { get; } = new FakeArchiveChunkNamer();
 
 	public IArchiveStorageReader CreateReader() => this;
 	public IArchiveStorageWriter CreateWriter() => this;

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Naming/ArchiveChunkNamerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Naming/ArchiveChunkNamerTests.cs
@@ -24,6 +24,13 @@ public class ArchiveChunkNamerTests
 	}
 
 	[Fact]
+	public void exposes_chunk_prefix()
+	{
+		var sut = CreateSut();
+		Assert.Equal("chunk-", sut.Prefix);
+	}
+
+	[Fact]
 	public void throws_if_chunk_number_is_negative()
 	{
 		var sut = CreateSut();

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageReaderTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageReaderTests.cs
@@ -98,4 +98,18 @@ public abstract class ArchiveStorageReaderTests<T> : ArchiveStorageTestsBase<T>
 			Path.GetFileName(chunk2)
 		], archivedChunks);
 	}
+
+	[Fact]
+	public async Task listing_ignores_files_outside_the_chunk_prefix()
+	{
+		var sut = CreateReaderSut(StorageType);
+
+		var chunk = CreateLocalChunk(0, 0);
+		var writerSut = CreateWriterSut(StorageType);
+		await writerSut.StoreChunk(chunk, Path.GetFileName(chunk), CancellationToken.None);
+		await writerSut.StoreChunk(chunk, "other-000000.000000", CancellationToken.None);
+
+		var archivedChunks = sut.ListChunks(CancellationToken.None).ToEnumerable();
+		Assert.Equal([Path.GetFileName(chunk)], archivedChunks);
+	}
 }

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageTestsBase.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageTestsBase.cs
@@ -1,5 +1,6 @@
 using EventStore.Core.Services.Archive.Storage;
 using EventStore.Core.Services.Archive;
+using EventStore.Core.Services.Archive.Naming;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
 using System.IO;
 using System.Security.Cryptography;
@@ -22,6 +23,7 @@ public abstract class ArchiveStorageTestsBase<T> : DirectoryPerTest<T>
 	protected IArchiveStorageFactory CreateSutFactory(StorageType storageType)
 	{
 		var namingStrategy = new VersionedPatternFileNamingStrategy(ArchivePath, ChunkPrefix);
+		var chunkNamer = new ArchiveChunkNamer(namingStrategy);
 		var factory = new ArchiveStorageFactory(
 			new()
 			{
@@ -29,7 +31,7 @@ public abstract class ArchiveStorageTestsBase<T> : DirectoryPerTest<T>
 				FileSystem = new() { Path = ArchivePath },
 				S3 = new() { AwsCliProfileName = "default", Bucket = "archiver-unit-tests", Region = "eu-west-1", }
 			},
-			namingStrategy);
+			chunkNamer);
 		return factory;
 	}
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -55,6 +55,7 @@ using EventStore.Core.Caching;
 using EventStore.Core.Certificates;
 using EventStore.Core.Cluster;
 using EventStore.Core.Services.Archive;
+using EventStore.Core.Services.Archive.Naming;
 using EventStore.Core.Services.Storage.InMemory;
 using EventStore.Core.Services.PeriodicLogs;
 using EventStore.Core.Services.Transport.Http.NodeHttpClientFactory;
@@ -1357,7 +1358,9 @@ public class ClusterVNode<TStreamId> :
 			var chunkDeleter = IChunkDeleter<TStreamId, ILogRecord>.NoOp;
 			if (archiveOptions.Enabled) {
 				// todo: consider if we can/should reuse the same reader elsewhere
-				var archiveReader = new ArchiveStorageFactory(archiveOptions, _fileNamingStrategy).CreateReader();
+				var archiveReader = new ArchiveStorageFactory(
+					archiveOptions,
+					new ArchiveChunkNamer(_fileNamingStrategy)).CreateReader();
 				chunkDeleter = new ChunkDeleter<TStreamId, ILogRecord>(
 					logger: logger,
 					archiveCheckpoint: new AdvancingCheckpoint(archiveReader.GetCheckpoint),

--- a/src/EventStore.Core/Services/Archive/Naming/ArchiveChunkNamer.cs
+++ b/src/EventStore.Core/Services/Archive/Naming/ArchiveChunkNamer.cs
@@ -6,6 +6,8 @@ namespace EventStore.Core.Services.Archive.Naming;
 
 public class ArchiveChunkNamer(IVersionedFileNamingStrategy namingStrategy) : IArchiveChunkNamer
 {
+	public string Prefix => namingStrategy.Prefix;
+
 	public string GetFileNameFor(int logicalChunkNumber)
 	{
 		ArgumentOutOfRangeException.ThrowIfNegative(logicalChunkNumber);

--- a/src/EventStore.Core/Services/Archive/Naming/IArchiveChunkNamer.cs
+++ b/src/EventStore.Core/Services/Archive/Naming/IArchiveChunkNamer.cs
@@ -2,5 +2,6 @@ namespace EventStore.Core.Services.Archive.Naming;
 
 public interface IArchiveChunkNamer
 {
+	string Prefix { get; }
 	string GetFileNameFor(int logicalChunkNumber);
 }

--- a/src/EventStore.Core/Services/Archive/Storage/ArchiveStorageFactory.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/ArchiveStorageFactory.cs
@@ -1,11 +1,11 @@
 using System;
-using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Services.Archive.Naming;
 
 namespace EventStore.Core.Services.Archive.Storage;
 
 public class ArchiveStorageFactory(
 	ArchiveOptions options,
-	IVersionedFileNamingStrategy fileNamingStrategy) : IArchiveStorageFactory
+	IArchiveChunkNamer chunkNamer) : IArchiveStorageFactory
 {
 	private const string ArchiveCheckpointFile = "archive.chk";
 
@@ -14,9 +14,9 @@ public class ArchiveStorageFactory(
 		return options.StorageType switch
 		{
 			StorageType.Unspecified => throw new InvalidOperationException("Please specify an Archive StorageType"),
-			StorageType.FileSystem => new FileSystemReader(options.FileSystem, fileNamingStrategy.GetPrefixFor,
+			StorageType.FileSystem => new FileSystemReader(options.FileSystem, chunkNamer,
 				ArchiveCheckpointFile),
-			StorageType.S3 => new S3Reader(options.S3, fileNamingStrategy.GetPrefixFor, ArchiveCheckpointFile),
+			StorageType.S3 => new S3Reader(options.S3, chunkNamer, ArchiveCheckpointFile),
 			_ => throw new ArgumentOutOfRangeException(nameof(options.StorageType))
 		};
 	}
@@ -26,9 +26,8 @@ public class ArchiveStorageFactory(
 		return options.StorageType switch
 		{
 			StorageType.Unspecified => throw new InvalidOperationException("Please specify an Archive StorageType"),
-			StorageType.FileSystem => new FileSystemWriter(options.FileSystem, fileNamingStrategy.GetPrefixFor,
-				ArchiveCheckpointFile),
-			StorageType.S3 => new S3Writer(options.S3, fileNamingStrategy.GetPrefixFor, ArchiveCheckpointFile),
+			StorageType.FileSystem => new FileSystemWriter(options.FileSystem, ArchiveCheckpointFile),
+			StorageType.S3 => new S3Writer(options.S3, ArchiveCheckpointFile),
 			_ => throw new ArgumentOutOfRangeException(nameof(options.StorageType))
 		};
 	}

--- a/src/EventStore.Core/Services/Archive/Storage/FileSystemReader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/FileSystemReader.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNext.IO;
+using EventStore.Core.Services.Archive.Naming;
 using EventStore.Core.Services.Archive.Storage.Exceptions;
 using Microsoft.Win32.SafeHandles;
 using Serilog;
@@ -14,7 +15,7 @@ namespace EventStore.Core.Services.Archive.Storage;
 
 public class FileSystemReader(
 	FileSystemOptions options,
-	Func<int?, int?, string> getChunkPrefix,
+	IArchiveChunkNamer chunkNamer,
 	string archiveCheckpointFile)
 	: IArchiveStorageReader
 {
@@ -26,6 +27,8 @@ public class FileSystemReader(
 	{
 		Access = FileAccess.Read, Mode = FileMode.Open, Options = FileOptions.Asynchronous,
 	};
+
+	public IArchiveChunkNamer ChunkNamer { get; } = chunkNamer;
 
 	public ValueTask<long> GetCheckpoint(CancellationToken ct)
 	{
@@ -118,7 +121,7 @@ public class FileSystemReader(
 	public IAsyncEnumerable<string> ListChunks(CancellationToken ct)
 	{
 		return new DirectoryInfo(_archivePath)
-			.EnumerateFiles($"{getChunkPrefix(null, null)}*")
+			.EnumerateFiles($"{ChunkNamer.Prefix}*")
 			.Select(chunk => chunk.Name)
 			.Order()
 			.ToAsyncEnumerable();

--- a/src/EventStore.Core/Services/Archive/Storage/FileSystemWriter.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/FileSystemWriter.cs
@@ -11,14 +11,12 @@ namespace EventStore.Core.Services.Archive.Storage;
 
 public class FileSystemWriter(
 	FileSystemOptions options,
-	Func<int?, int?, string> getChunkPrefix,
 	string archiveCheckpointFile)
 	: IArchiveStorageWriter
 {
 	protected static readonly ILogger Log = Serilog.Log.ForContext<FileSystemWriter>();
 
 	private readonly string _archivePath = options.Path;
-	private readonly Func<int?, int?, string> _getChunkPrefix = getChunkPrefix;
 
 	public ValueTask<bool> SetCheckpoint(long checkpoint, CancellationToken ct)
 	{

--- a/src/EventStore.Core/Services/Archive/Storage/FluentReader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/FluentReader.cs
@@ -5,16 +5,18 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNext.Buffers;
+using EventStore.Core.Services.Archive.Naming;
 using EventStore.Core.Services.Archive.Storage.Exceptions;
 using FluentStorage.Blobs;
 using Serilog;
 
 namespace EventStore.Core.Services.Archive.Storage;
 
-public abstract class FluentReader(string archiveCheckpointFile)
+public abstract class FluentReader(IArchiveChunkNamer chunkNamer, string archiveCheckpointFile)
 {
 	protected abstract ILogger Log { get; }
 	protected abstract IBlobStorage BlobStorage { get; }
+	public IArchiveChunkNamer ChunkNamer { get; } = chunkNamer;
 
 	public async ValueTask<long> GetCheckpoint(CancellationToken ct)
 	{

--- a/src/EventStore.Core/Services/Archive/Storage/IArchiveStorageReader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/IArchiveStorageReader.cs
@@ -2,11 +2,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Core.Services.Archive.Naming;
 
 namespace EventStore.Core.Services.Archive.Storage;
 
 public interface IArchiveStorageReader
 {
+	public IArchiveChunkNamer ChunkNamer { get; }
 	public ValueTask<long> GetCheckpoint(CancellationToken ct);
 	public ValueTask<Stream> GetChunk(string chunkFile, long start, long end, CancellationToken ct);
 	public ValueTask<Stream> GetChunk(string chunkFile, CancellationToken ct);

--- a/src/EventStore.Core/Services/Archive/Storage/S3Reader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/S3Reader.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Amazon.S3;
 using Amazon.S3.Model;
 using EventStore.Common.Exceptions;
+using EventStore.Core.Services.Archive.Naming;
 using EventStore.Core.Services.Archive.Storage.Exceptions;
 using FluentStorage;
 using FluentStorage.AWS.Blobs;
@@ -19,14 +20,12 @@ public class S3Reader : FluentReader, IArchiveStorageReader
 {
 	private readonly S3Options _options;
 	private readonly IAwsS3BlobStorage _awsBlobStorage;
-	private readonly Func<int?, int?, string> _getChunkPrefix;
 
-	public S3Reader(S3Options options, Func<int?, int?, string> getChunkPrefix, string archiveCheckpointFile) : base(
-		archiveCheckpointFile)
+	public S3Reader(S3Options options, IArchiveChunkNamer chunkNamer, string archiveCheckpointFile) : base(
+		chunkNamer, archiveCheckpointFile)
 	{
 		AwsTraceLogging.Configure();
 		_options = options;
-		_getChunkPrefix = getChunkPrefix;
 
 		if (string.IsNullOrEmpty(options.Bucket))
 			throw new InvalidConfigurationException("Please specify an Archive S3 Bucket");
@@ -68,7 +67,7 @@ public class S3Reader : FluentReader, IArchiveStorageReader
 	public override async IAsyncEnumerable<string> ListChunks([EnumeratorCancellation] CancellationToken ct)
 	{
 		var listResponse = _awsBlobStorage.NativeBlobClient.Paginators.ListObjectsV2(
-			new ListObjectsV2Request { BucketName = _options.Bucket, Prefix = _getChunkPrefix(null, null) });
+			new ListObjectsV2Request { BucketName = _options.Bucket, Prefix = ChunkNamer.Prefix });
 
 		await foreach (var s3Object in listResponse.S3Objects.WithCancellation(ct))
 			yield return s3Object.Key;

--- a/src/EventStore.Core/Services/Archive/Storage/S3Writer.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/S3Writer.cs
@@ -1,4 +1,3 @@
-using System;
 using FluentStorage;
 using FluentStorage.Blobs;
 using Serilog;
@@ -7,7 +6,7 @@ namespace EventStore.Core.Services.Archive.Storage;
 
 public class S3Writer : FluentWriter, IArchiveStorageWriter
 {
-	public S3Writer(S3Options options, Func<int?, int?, string> getChunkPrefix, string archiveCheckpointFile) : base(
+	public S3Writer(S3Options options, string archiveCheckpointFile) : base(
 		archiveCheckpointFile)
 	{
 		AwsTraceLogging.Configure();

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -136,7 +136,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 
 	public ValueTask<TFChunk.TFChunk> CreateTempChunk(ChunkHeader chunkHeader, int fileSize, CancellationToken token)
 	{
-		var chunkFileName = FileSystem.NamingStrategy.GetTempFilename();
+		var chunkFileName = FileSystem.NamingStrategy.CreateTempFilename();
 		return TFChunk.TFChunk.CreateWithHeader(FileSystem, chunkFileName,
 			chunkHeader,
 			fileSize,
@@ -309,8 +309,8 @@ public class TFChunkManager : IThreadPoolWorkItem
 			}
 
 			var newFileName =
-				FileSystem.NamingStrategy.DetermineBestVersionFilenameFor(chunkHeader.ChunkStartNumber,
-					initialVersion: 1);
+				FileSystem.NamingStrategy.DetermineNewVersionFilenameForIndex(chunkHeader.ChunkStartNumber,
+					defaultVersion: 1);
 			Log.Information("File {oldFileName} will be moved to file {newFileName}", Path.GetFileName(oldFileName),
 				Path.GetFileName(newFileName));
 			try

--- a/src/EventStore.Core/TransactionLog/FileNamingStrategy/IVersionedFileNamingStrategy.cs
+++ b/src/EventStore.Core/TransactionLog/FileNamingStrategy/IVersionedFileNamingStrategy.cs
@@ -1,13 +1,13 @@
 namespace EventStore.Core.TransactionLog.FileNamingStrategy {
 	public interface IVersionedFileNamingStrategy {
+		string Prefix { get; }
 		string GetFilenameFor(int index, int version);
-		string DetermineBestVersionFilenameFor(int index, int initialVersion);
+		string DetermineNewVersionFilenameForIndex(int index, int defaultVersion);
 		string[] GetAllVersionsFor(int index);
 		string[] GetAllPresentFiles();
-		string GetTempFilename();
+		string CreateTempFilename();
 		string[] GetAllTempFiles();
 		int GetIndexFor(string fileName);
 		int GetVersionFor(string fileName);
-		string GetPrefixFor(int? index, int? version);
 	}
 }

--- a/src/EventStore.Core/TransactionLog/FileNamingStrategy/VersionedPatternFileNamingStrategy.cs
+++ b/src/EventStore.Core/TransactionLog/FileNamingStrategy/VersionedPatternFileNamingStrategy.cs
@@ -30,23 +30,26 @@ public class VersionedPatternFileNamingStrategy : IVersionedFileNamingStrategy
 		Ensure.Nonnegative(index, "index");
 		Ensure.Nonnegative(version, "version");
 
-		return Path.Combine(_path, string.Format("{0}{1:000000}.{2:000000}", _prefix, index, version));
+		return Path.Combine(_path, $"{_prefix}{index:000000}.{version:000000}");
 	}
 
-	public string DetermineBestVersionFilenameFor(int index, int initialVersion)
+	public string DetermineNewVersionFilenameForIndex(int index, int defaultVersion)
 	{
 		var allVersions = GetAllVersionsFor(index);
 		if (allVersions.Length == 0)
-			return GetFilenameFor(index, initialVersion);
-		int lastVersion;
-		if (!int.TryParse(allVersions[0].Substring(allVersions[0].LastIndexOf('.') + 1), out lastVersion))
-			throw new Exception(string.Format("Could not determine version from filename '{0}'.", allVersions[0]));
+			return GetFilenameFor(index, defaultVersion);
+
+		var lastFile = allVersions[0];
+		var lastVersionSpan = lastFile.AsSpan(lastFile.LastIndexOf('.') + 1);
+		if (!int.TryParse(lastVersionSpan, out var lastVersion))
+			throw new Exception($"Could not determine version from filename '{lastFile}'.");
+
 		return GetFilenameFor(index, lastVersion + 1);
 	}
 
 	public string[] GetAllVersionsFor(int index)
 	{
-		var versions = Directory.EnumerateFiles(_path, string.Format("{0}{1:000000}.*", _prefix, index))
+		var versions = Directory.EnumerateFiles(_path, $"{_prefix}{index:000000}.*")
 			.Where(x => _pattern.IsMatch(Path.GetFileName(x)))
 			.OrderByDescending(x => x, StringComparer.CurrentCultureIgnoreCase)
 			.ToArray();
@@ -84,15 +87,15 @@ public class VersionedPatternFileNamingStrategy : IVersionedFileNamingStrategy
 
 	public string[] GetAllPresentFiles()
 	{
-		var versions = Directory.EnumerateFiles(_path, string.Format("{0}*.*", _prefix))
+		var versions = Directory.EnumerateFiles(_path, $"{_prefix}*.*")
 			.Where(x => _pattern.IsMatch(Path.GetFileName(x)))
 			.ToArray();
 		return versions;
 	}
 
-	public string GetTempFilename()
+	public string CreateTempFilename()
 	{
-		return Path.Combine(_path, string.Format("{0}.tmp", Guid.NewGuid()));
+		return Path.Combine(_path, $"{Guid.NewGuid()}.tmp");
 	}
 
 	public string[] GetAllTempFiles()
@@ -100,14 +103,4 @@ public class VersionedPatternFileNamingStrategy : IVersionedFileNamingStrategy
 		return Directory.GetFiles(_path, "*.tmp");
 	}
 
-	public string GetPrefixFor(int? index, int? version)
-	{
-		if (index is null)
-			return _prefix;
-
-		if (version is null)
-			return $"{_prefix}{index:000000}.";
-
-		return $"{_prefix}{index:000000}.{version:000000}";
-	}
 }


### PR DESCRIPTION
- Storage is harder to finish safely while chunk prefix ownership lives behind a locator-shaped helper that accepts values current callers do not need.
- Archive listing should depend on the same chunk naming boundary that produces archive chunk names, so prefix filtering cannot drift from chunk naming.
- Closing the remaining storage tracker rows keeps Phase 6 complete without pulling in the larger optional archiver workstream.