### PR TITLE
chore(http): reduce ES protocol literal drift

### DIFF
--- a/src/EventStore.Core.Tests/Http/Cluster/when_requesting_from_follower.cs
+++ b/src/EventStore.Core.Tests/Http/Cluster/when_requesting_from_follower.cs
@@ -6,8 +6,10 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using EventStore.Core.Data;
+using EventStore.Core.Services;
 using EventStore.Core.Tests.Helpers;
 using EventStore.Core.Tests.Integration;
+using EventStoreHttpContentType = EventStore.Transport.Http.ContentType;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Http.Cluster;
@@ -191,7 +193,7 @@ public class when_requesting_from_follower<TLogFormat, TStreamId> : specificatio
 	{
 		var uri = CreateUri(nodeEndpoint, path);
 		var request = CreateRequest(uri, HttpMethod.Get, requireLeader);
-		request.Headers.Add("Accept", "application/json");
+		request.Headers.Add("Accept", EventStoreHttpContentType.Json);
 		return GetRequestResponse(request);
 	}
 
@@ -207,11 +209,11 @@ public class when_requesting_from_follower<TLogFormat, TStreamId> : specificatio
 		var uri = CreateUri(nodeEndpoint, path);
 		var request = CreateRequest(uri, HttpMethod.Post, requireLeader);
 
-		request.Headers.Add("ES-EventType", "SomeType");
-		request.Headers.Add("ES-ExpectedVersion", ExpectedVersion.Any.ToString());
-		request.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
+		request.Headers.Add(SystemHeaders.EventType, "SomeType");
+		request.Headers.Add(SystemHeaders.ExpectedVersion, ExpectedVersion.Any.ToString());
+		request.Headers.Add(SystemHeaders.EventId, Guid.NewGuid().ToString());
 		var data = "{a : \"1\", b:\"3\", c:\"5\" }";
-		request.Content = new StringContent(data, Encoding.UTF8, "application/json");
+		request.Content = new StringContent(data, Encoding.UTF8, EventStoreHttpContentType.Json);
 
 		return GetRequestResponse(request);
 	}
@@ -222,7 +224,7 @@ public class when_requesting_from_follower<TLogFormat, TStreamId> : specificatio
 	private HttpRequestMessage CreateRequest(Uri uri, HttpMethod method, bool requireLeader)
 	{
 		var request = new HttpRequestMessage(method, uri);
-		request.Headers.Add("ES-RequireLeader", requireLeader ? "True" : "False");
+		request.Headers.Add(SystemHeaders.RequireLeader, requireLeader ? bool.TrueString : bool.FalseString);
 		request.Headers.Authorization = new AuthenticationHeaderValue("Basic",
 							GetAuthorizationHeader(DefaultData.AdminNetworkCredentials));
 		return request;

--- a/src/EventStore.Core.Tests/Http/HttpBehaviorSpecification.cs
+++ b/src/EventStore.Core.Tests/Http/HttpBehaviorSpecification.cs
@@ -15,6 +15,7 @@ using EventStore.ClientAPI.Transport.Http;
 using EventStore.Common.Utils;
 using EventStore.Core.Tests.ClientAPI.Helpers;
 using EventStore.Core.Tests.Helpers;
+using HttpTransportContentType = EventStore.Transport.Http.ContentType;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
@@ -278,14 +279,14 @@ public abstract class HttpBehaviorSpecification<TLogFormat, TStreamId> : Specifi
 	protected async Task<XDocument> GetAtomXml(Uri uri, NetworkCredential credentials = null, string extra = null)
 	{
 		credentials ??= _defaultCredentials;
-		await Get(uri.ToString(), extra, ContentType.Atom, credentials);
+		await Get(uri.ToString(), extra, HttpTransportContentType.Atom, credentials);
 		return XDocument.Parse(_lastResponseBody);
 	}
 
 	protected async Task<XDocument> GetXml(Uri uri, NetworkCredential credentials = null, string extra = null)
 	{
 		credentials ??= _defaultCredentials;
-		await Get(uri.ToString(), null, ContentType.Xml, credentials);
+		await Get(uri.ToString(), null, HttpTransportContentType.Xml, credentials);
 		return XDocument.Parse(_lastResponseBody);
 	}
 
@@ -346,7 +347,7 @@ public abstract class HttpBehaviorSpecification<TLogFormat, TStreamId> : Specifi
 		var request = CreateRequest(path, extra, "GET", null, credentials, headers);
 		if (setAcceptHeader)
 		{
-			request.Headers.Add("accept", accept ?? "application/json");
+			request.Headers.Add("accept", accept ?? HttpTransportContentType.Json);
 		}
 
 		_lastResponse = await GetRequestResponse(request);
@@ -412,10 +413,10 @@ public abstract class HttpBehaviorSpecification<TLogFormat, TStreamId> : Specifi
 		string path, string method, T body, NetworkCredential credentials = null, string extra = null)
 	{
 		credentials = credentials ?? _defaultCredentials;
-		var request = CreateRequest(path, extra, method, "application/vnd.eventstore.events+json", credentials);
+		var request = CreateRequest(path, extra, method, HttpTransportContentType.EventsJson, credentials);
 		request.Content = new ByteArrayContent(ToJsonBytes(body))
 		{
-			Headers = { ContentType = new MediaTypeHeaderValue("application/vnd.eventstore.events+json") }
+			Headers = { ContentType = new MediaTypeHeaderValue(HttpTransportContentType.EventsJson) }
 		};
 		return request;
 	}
@@ -424,10 +425,10 @@ public abstract class HttpBehaviorSpecification<TLogFormat, TStreamId> : Specifi
 		string path, string method, T body, NetworkCredential credentials = null, string extra = null)
 	{
 		credentials ??= _defaultCredentials;
-		var request = CreateRequest(path, extra, method, "application/json", credentials);
+		var request = CreateRequest(path, extra, method, HttpTransportContentType.Json, credentials);
 		request.Content = new ByteArrayContent(ToJsonBytes(body))
 		{
-			Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+			Headers = { ContentType = new MediaTypeHeaderValue(HttpTransportContentType.Json) }
 		};
 		return request;
 	}

--- a/src/EventStore.Core.Tests/Http/StreamSecurity/stream_access.cs
+++ b/src/EventStore.Core.Tests/Http/StreamSecurity/stream_access.cs
@@ -9,6 +9,7 @@ using EventStore.Core.Services;
 using EventStore.Core.Tests.Http.Users;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using EventStoreHttpContentType = EventStore.Transport.Http.ContentType;
 
 namespace EventStore.Core.Tests.Http.StreamSecurity
 {
@@ -69,13 +70,13 @@ namespace EventStore.Core.Tests.Http.StreamSecurity
 
 				var request = new HttpRequestMessage(HttpMethod.Post, uri)
 				{
-					Headers = { { "ES-TrustedAuth", "root; admin, other" } },
+					Headers = { { SystemHeaders.TrustedAuth, "root; admin, other" } },
 					Content = new ByteArrayContent(
 						new[] { new { EventId = Guid.NewGuid(), EventType = "event-type", Data = new { Some = "Data" } } }
 							.ToJsonBytes())
 					{
 						Headers = {
-							ContentType = MediaTypeHeaderValue.Parse("application/vnd.eventstore.events+json")
+							ContentType = MediaTypeHeaderValue.Parse(EventStoreHttpContentType.EventsJson)
 						}
 					}
 				};

--- a/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
@@ -32,49 +32,49 @@ namespace EventStore.Core.Tests.Http.Streams
 
 			public Task<HttpResponseMessage> PostEventWithExpectedVersion(long expectedVersion)
 			{
-				var request = CreateRequest(TestStream, "", "POST", "application/json");
-				request.Headers.Add("ES-EventType", "SomeType");
-				request.Headers.Add("ES-ExpectedVersion", expectedVersion.ToString());
-				request.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
+				var request = CreateRequest(TestStream, "", "POST", ContentType.Json);
+				request.Headers.Add(SystemHeaders.EventType, "SomeType");
+				request.Headers.Add(SystemHeaders.ExpectedVersion, expectedVersion.ToString());
+				request.Headers.Add(SystemHeaders.EventId, Guid.NewGuid().ToString());
 				var data = Encoding.UTF8.GetBytes("{a : \"1\", b:\"3\", c:\"5\" }");
 				request.Content = new ByteArrayContent(data)
 				{
-					Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+					Headers = { ContentType = new MediaTypeHeaderValue(ContentType.Json) }
 				};
 				return GetRequestResponse(request);
 			}
 
 			public Task<HttpResponseMessage> PostEvent(byte[] data)
 			{
-				var request = CreateRequest(TestStream, "", "POST", "application/json");
-				request.Headers.Add("ES-EventType", "SomeType");
-				request.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
+				var request = CreateRequest(TestStream, "", "POST", ContentType.Json);
+				request.Headers.Add(SystemHeaders.EventType, "SomeType");
+				request.Headers.Add(SystemHeaders.EventId, Guid.NewGuid().ToString());
 				request.Content = new ByteArrayContent(data)
 				{
-					Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+					Headers = { ContentType = new MediaTypeHeaderValue(ContentType.Json) }
 				};
 				return GetRequestResponse(request);
 			}
 
 			public Task TombstoneTestStream()
 			{
-				var deleteRequest = CreateRequest(TestStream, "", "DELETE", "application/json");
-				deleteRequest.Headers.Add("ES-ExpectedVersion", ExpectedVersion.Any.ToString());
-				deleteRequest.Headers.Add("ES-HardDelete", bool.TrueString);
+				var deleteRequest = CreateRequest(TestStream, "", "DELETE", ContentType.Json);
+				deleteRequest.Headers.Add(SystemHeaders.ExpectedVersion, ExpectedVersion.Any.ToString());
+				deleteRequest.Headers.Add(SystemHeaders.HardDelete, bool.TrueString);
 				return GetRequestResponse(deleteRequest);
 			}
 
 			public Task SoftDeleteTestStream()
 			{
-				var deleteRequest = CreateRequest(TestMetadataStream, "", "POST", "application/json");
-				deleteRequest.Headers.Add("ES-EventType", SystemEventTypes.StreamMetadata);
-				deleteRequest.Headers.Add("ES-ExpectedVersion", ExpectedVersion.Any.ToString());
-				deleteRequest.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
+				var deleteRequest = CreateRequest(TestMetadataStream, "", "POST", ContentType.Json);
+				deleteRequest.Headers.Add(SystemHeaders.EventType, SystemEventTypes.StreamMetadata);
+				deleteRequest.Headers.Add(SystemHeaders.ExpectedVersion, ExpectedVersion.Any.ToString());
+				deleteRequest.Headers.Add(SystemHeaders.EventId, Guid.NewGuid().ToString());
 				deleteRequest.Content = new ByteArrayContent(StreamMetadata
 					.Create(truncateBefore: long.MaxValue)
 					.AsJsonBytes())
 				{
-					Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+					Headers = { ContentType = new MediaTypeHeaderValue(ContentType.Json) }
 				};
 				return GetRequestResponse(deleteRequest);
 			}
@@ -490,14 +490,14 @@ namespace EventStore.Core.Tests.Http.Streams
 
 			protected override async Task Given()
 			{
-				var request = CreateRequest(TestMetadataStream, "", "POST", "application/json");
-				request.Headers.Add("ES-EventType", "$user-created");
-				request.Headers.Add("ES-ExpectedVersion", ExpectedVersion.Any.ToString());
-				request.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
+				var request = CreateRequest(TestMetadataStream, "", "POST", ContentType.Json);
+				request.Headers.Add(SystemHeaders.EventType, "$user-created");
+				request.Headers.Add(SystemHeaders.ExpectedVersion, ExpectedVersion.Any.ToString());
+				request.Headers.Add(SystemHeaders.EventId, Guid.NewGuid().ToString());
 				var data = Encoding.UTF8.GetBytes("{a : \"1\", b:\"3\", c:\"5\" }");
 				request.Content = new ByteArrayContent(data)
 				{
-					Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+					Headers = { ContentType = new MediaTypeHeaderValue(ContentType.Json) }
 				};
 				await GetRequestResponse(request);
 			}

--- a/src/EventStore.Core.Tests/Http/Streams/description_document.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/description_document.cs
@@ -59,7 +59,7 @@ public class when_getting_a_stream_with_description_document_media_type<TLogForm
 
 	protected override async Task When()
 	{
-		_descriptionDocument = await GetJson<JObject>(TestStream, "application/vnd.eventstore.streamdesc+json", null);
+		_descriptionDocument = await GetJson<JObject>(TestStream, ContentType.DescriptionDocJson, null);
 	}
 
 	[Test]
@@ -89,7 +89,7 @@ public class when_getting_description_document<TLogFormat, TStreamId> : with_adm
 
 	protected override async Task When()
 	{
-		_descriptionDocument = await GetJson<JObject>(TestStream, "application/vnd.eventstore.streamdesc+json", null);
+		_descriptionDocument = await GetJson<JObject>(TestStream, ContentType.DescriptionDocJson, null);
 		_links = _descriptionDocument != null ? _descriptionDocument["_links"].ToList() : new List<JToken>();
 	}
 
@@ -118,7 +118,7 @@ public class when_getting_description_document<TLogFormat, TStreamId> : with_adm
 		var supportedContentTypes = _descriptionDocument["_links"]["self"]["supportedContentTypes"].Values<string>()
 			.ToArray();
 		Assert.AreEqual(1, supportedContentTypes.Length);
-		Assert.AreEqual("application/vnd.eventstore.streamdesc+json", supportedContentTypes[0]);
+		Assert.AreEqual(ContentType.DescriptionDocJson, supportedContentTypes[0]);
 	}
 
 	[Test]
@@ -135,7 +135,7 @@ public class when_getting_description_document<TLogFormat, TStreamId> : with_adm
 			.Values<string>().ToArray();
 		Assert.AreEqual(2, supportedContentTypes.Length);
 		Assert.Contains("application/atom+xml", supportedContentTypes);
-		Assert.Contains("application/vnd.eventstore.atom+json", supportedContentTypes);
+		Assert.Contains(ContentType.AtomJson, supportedContentTypes);
 	}
 }
 
@@ -162,7 +162,7 @@ public class when_getting_description_document_and_subscription_exists_for_strea
 
 	protected override async Task When()
 	{
-		_descriptionDocument = await GetJson<JObject>(TestStream, "application/vnd.eventstore.streamdesc+json", null);
+		_descriptionDocument = await GetJson<JObject>(TestStream, ContentType.DescriptionDocJson, null);
 		_links = _descriptionDocument != null ? _descriptionDocument["_links"].ToList() : new List<JToken>();
 		_subscriptions = _descriptionDocument["_links"]["streamSubscription"].Values<JToken>().ToArray();
 	}
@@ -197,7 +197,7 @@ public class when_getting_description_document_and_subscription_exists_for_strea
 	{
 		var supportedContentTypes = _subscriptions[0]["supportedContentTypes"].Values<string>().ToArray();
 		Assert.AreEqual(2, supportedContentTypes.Length);
-		Assert.Contains("application/vnd.eventstore.competingatom+xml", supportedContentTypes);
-		Assert.Contains("application/vnd.eventstore.competingatom+json", supportedContentTypes);
+		Assert.Contains(ContentType.Competing, supportedContentTypes);
+		Assert.Contains(ContentType.CompetingJson, supportedContentTypes);
 	}
 }


### PR DESCRIPTION
- Keeps the ES-only HTTP contract sourced from shared constants instead of scattered literals.
- Reduces the chance of future protocol drift in HTTP tests and helpers.