### PR TITLE
fix(archive): keep chunk range reads consistent

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageReaderTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageReaderTests.cs
@@ -105,6 +105,22 @@ public abstract class ArchiveStorageReaderTests<T> : ArchiveStorageTestsBase<T>
 	}
 
 	[Fact]
+	public async Task reading_a_range_that_partially_overlaps_the_end_returns_available_bytes()
+	{
+		var sut = CreateReaderSut(StorageType);
+
+		var chunkPath = CreateLocalChunk(0, 0);
+		var chunkFile = Path.GetFileName(chunkPath);
+		await CreateWriterSut(StorageType).StoreChunk(chunkPath, chunkFile, CancellationToken.None);
+
+		var localContent = await File.ReadAllBytesAsync(chunkPath);
+		var start = localContent.Length - 25;
+		using var chunkStream = await sut.GetChunk(chunkFile, start, localContent.Length + 50, CancellationToken.None);
+
+		Assert.Equal(localContent[start..], chunkStream.ToByteArray());
+	}
+
+	[Fact]
 	public async Task reading_with_a_negative_start_throws_ArgumentOutOfRangeException()
 	{
 		var sut = CreateReaderSut(StorageType);

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageReaderTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageReaderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -53,6 +54,69 @@ public abstract class ArchiveStorageReaderTests<T> : ArchiveStorageTestsBase<T>
 
 		// then
 		Assert.Equal(localContent[start..end], chunkStreamContent);
+	}
+
+	[Fact]
+	public async Task can_read_chunk_subrange_without_including_the_end_position()
+	{
+		var sut = CreateReaderSut(StorageType);
+
+		var chunkPath = CreateLocalChunk(0, 0);
+		var chunkFile = Path.GetFileName(chunkPath);
+		await CreateWriterSut(StorageType).StoreChunk(chunkPath, chunkFile, CancellationToken.None);
+
+		var localContent = await File.ReadAllBytesAsync(chunkPath);
+
+		var start = localContent.Length / 4;
+		var end = start + (localContent.Length / 4);
+		using var chunkStream = await sut.GetChunk(chunkFile, start, end, CancellationToken.None);
+		var chunkStreamContent = chunkStream.ToByteArray();
+
+		Assert.Equal(localContent[start..end], chunkStreamContent);
+	}
+
+	[Fact]
+	public async Task can_read_empty_range()
+	{
+		var sut = CreateReaderSut(StorageType);
+
+		var chunkPath = CreateLocalChunk(0, 0);
+		var chunkFile = Path.GetFileName(chunkPath);
+		await CreateWriterSut(StorageType).StoreChunk(chunkPath, chunkFile, CancellationToken.None);
+
+		using var chunkStream = await sut.GetChunk(chunkFile, 10, 10, CancellationToken.None);
+		Assert.Empty(chunkStream.ToByteArray());
+	}
+
+	[Fact]
+	public async Task reading_beyond_the_end_returns_an_empty_stream()
+	{
+		var sut = CreateReaderSut(StorageType);
+
+		var chunkPath = CreateLocalChunk(0, 0);
+		var chunkFile = Path.GetFileName(chunkPath);
+		await CreateWriterSut(StorageType).StoreChunk(chunkPath, chunkFile, CancellationToken.None);
+
+		var localContent = await File.ReadAllBytesAsync(chunkPath);
+		var start = localContent.Length + 25;
+		using var chunkStream = await sut.GetChunk(chunkFile, start, start + 50, CancellationToken.None);
+
+		Assert.Empty(chunkStream.ToByteArray());
+	}
+
+	[Fact]
+	public async Task reading_with_a_negative_start_throws_ArgumentOutOfRangeException()
+	{
+		var sut = CreateReaderSut(StorageType);
+
+		var chunkPath = CreateLocalChunk(0, 0);
+		var chunkFile = Path.GetFileName(chunkPath);
+		await CreateWriterSut(StorageType).StoreChunk(chunkPath, chunkFile, CancellationToken.None);
+
+		await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+		{
+			using var _ = await sut.GetChunk(chunkFile, -1, 10, CancellationToken.None);
+		});
 	}
 
 	[Fact]

--- a/src/EventStore.Core/Services/Archive/Storage/FileSystemReader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/FileSystemReader.cs
@@ -110,8 +110,9 @@ public class FileSystemReader(
 					return ValueTask.FromResult<Stream>(Stream.Null);
 				}
 
+				var available = fileStream.Length - start;
 				var segment = new StreamSegment(fileStream, leaveOpen: false);
-				segment.Adjust(start, length);
+				segment.Adjust(start, Math.Min(length, available));
 				task = ValueTask.FromResult<Stream>(segment);
 
 			}

--- a/src/EventStore.Core/Services/Archive/Storage/FileSystemReader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/FileSystemReader.cs
@@ -86,7 +86,11 @@ public class FileSystemReader(
 
 	public ValueTask<Stream> GetChunk(string chunkFile, long start, long end, CancellationToken ct)
 	{
+		ArgumentOutOfRangeException.ThrowIfNegative(start);
+
 		var length = end - start;
+		if (length == 0)
+			return ValueTask.FromResult<Stream>(Stream.Null);
 
 		ValueTask<Stream> task;
 		if (length < 0)
@@ -100,6 +104,12 @@ public class FileSystemReader(
 			{
 				var chunkPath = Path.Combine(_archivePath, chunkFile);
 				var fileStream = File.Open(chunkPath, _fileStreamOptions);
+				if (start >= fileStream.Length)
+				{
+					fileStream.Dispose();
+					return ValueTask.FromResult<Stream>(Stream.Null);
+				}
+
 				var segment = new StreamSegment(fileStream, leaveOpen: false);
 				segment.Adjust(start, length);
 				task = ValueTask.FromResult<Stream>(segment);

--- a/src/EventStore.Core/Services/Archive/Storage/S3Reader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/S3Reader.cs
@@ -45,9 +45,21 @@ public class S3Reader : FluentReader, IArchiveStorageReader
 
 	public async ValueTask<Stream> GetChunk(string chunkFile, long start, long end, CancellationToken ct)
 	{
+		ArgumentOutOfRangeException.ThrowIfNegative(start);
+
+		var length = end - start;
+		if (length < 0)
+		{
+			throw new InvalidOperationException(
+				$"Attempted to read negative amount from chunk {chunkFile}. Start: {start}. End {end}");
+		}
+
+		if (length == 0)
+			return Stream.Null;
+
 		var request = new GetObjectRequest
 		{
-			BucketName = _options.Bucket, Key = chunkFile, ByteRange = new ByteRange(start, end),
+			BucketName = _options.Bucket, Key = chunkFile, ByteRange = new ByteRange(start, end - 1),
 		};
 
 		try
@@ -60,6 +72,8 @@ public class S3Reader : FluentReader, IArchiveStorageReader
 		{
 			if (ex.ErrorCode == "NoSuchKey")
 				throw new ChunkDeletedException();
+			if (ex.ErrorCode == "InvalidRange")
+				return Stream.Null;
 			throw;
 		}
 	}


### PR DESCRIPTION
- Keeps archive chunk reads aligned on one backend-independent range contract.
- Prevents empty or out-of-range archive reads from turning into storage-specific failures during catchup and related access paths.