### PR TITLE
fix(persistent-subscription): keep replayed retries from breaking retry order

### DIFF
--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/StreamBufferTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/StreamBufferTests.cs
@@ -243,6 +243,29 @@ public class StreamBufferTests
 		Assert.AreEqual(2, buffer.GetLowestRetry().sequenceNumber);
 	}
 
+	[Test]
+	public void can_add_retries_after_replayed_events()
+	{
+		var buffer = new StreamBuffer(10, 10, null, true);
+		var parkedEvent = BuildMessageAt(1);
+		buffer.AddRetry(OutstandingMessage.ForParkedEvent(Helper.BuildLinkEvent(
+			Guid.NewGuid(),
+			"$persistentsubscription-foo::group-parked",
+			0,
+			parkedEvent.ResolvedEvent)));
+
+		buffer.AddRetry(BuildMessageAt(4));
+		buffer.AddRetry(BuildMessageAt(2));
+		buffer.AddRetry(BuildMessageAt(3));
+
+		Assert.AreEqual(2, buffer.GetLowestRetry().sequenceNumber);
+		var messagePointers = buffer.Scan().ToArray();
+		Assert.AreEqual(GetEventIdFor(1), messagePointers[0].Message.ResolvedEvent.Event.EventId);
+		Assert.AreEqual(GetEventIdFor(2), messagePointers[1].Message.EventId);
+		Assert.AreEqual(GetEventIdFor(3), messagePointers[2].Message.EventId);
+		Assert.AreEqual(GetEventIdFor(4), messagePointers[3].Message.EventId);
+	}
+
 	private OutstandingMessage BuildMessageAt(int position, Guid? forcedEventId = null)
 	{
 		IPersistentSubscriptionStreamPosition previousEventPosition =

--- a/src/EventStore.Core/Services/PersistentSubscription/StreamBuffer.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/StreamBuffer.cs
@@ -74,7 +74,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 			while (currentNode != null) {
 				var currentEventPosition = currentNode.Value.EventPosition;
-				if (retryEventPosition.CompareTo(currentEventPosition) < 0) {
+				if (currentEventPosition is not null && retryEventPosition.CompareTo(currentEventPosition) < 0) {
 					_retry.AddBefore(currentNode, ev);
 					return;
 				}


### PR DESCRIPTION
- Keeps replayed parked events from disrupting retry ordering when normal retries are reinserted.
- Preserves stable retry-buffer behavior for subscriptions that revisit parked events.