### PR TITLE
fix(archive): align catch-up startup checkpoints

### DIFF
--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_existing_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_existing_epochs.cs
@@ -127,6 +127,7 @@ public sealed class
 		Assert.That(_cache.Count == 10);
 		Assert.That(_cache.First.Value.EpochNumber == _epochs[20].EpochNumber);
 		Assert.That(_cache.Last.Value.EpochNumber == _epochs[29].EpochNumber);
+		Assert.That(_db.Config.EpochCheckpoint.Read() == _epochs[29].EpochPosition);
 
 	}
 
@@ -155,6 +156,7 @@ public sealed class
 		Assert.That(_cache.Count == 30);
 		Assert.That(_cache.First.Value.EpochNumber == _epochs[0].EpochNumber);
 		Assert.That(_cache.Last.Value.EpochNumber == _epochs[29].EpochNumber);
+		Assert.That(_db.Config.EpochCheckpoint.Read() == _epochs[29].EpochPosition);
 
 	}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_chasing_a_chunked_transaction_log.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_chasing_a_chunked_transaction_log.cs
@@ -80,6 +80,51 @@ public class when_chasing_a_chunked_transaction_log<TLogFormat, TStreamId> : Spe
 	}
 
 	[Test]
+	public async Task open_starts_from_the_latest_chaser_checkpoint()
+	{
+		var writerchk = new InMemoryCheckpoint(0);
+		var chaserchk = new InMemoryCheckpoint(Checkpoint.Chaser, 0);
+		await using var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, writerchk, chaserchk));
+		await db.Open();
+
+		var recordFactory = LogFormatHelper<TLogFormat, TStreamId>.RecordFactory;
+		var streamId = LogFormatHelper<TLogFormat, TStreamId>.StreamId;
+		var eventTypeId = LogFormatHelper<TLogFormat, TStreamId>.EventTypeId;
+		var recordToWrite = LogRecord.Prepare(
+			factory: recordFactory,
+			logPosition: 0,
+			correlationId: _correlationId,
+			eventId: _eventId,
+			transactionPos: 0,
+			transactionOffset: 0,
+			eventStreamId: streamId,
+			expectedVersion: 1234,
+			timeStamp: new DateTime(2012, 12, 21),
+			flags: PrepareFlags.None,
+			eventType: eventTypeId,
+			data: new byte[] { 1, 2, 3, 4, 5 },
+			metadata: new byte[] { 7, 17 });
+		var writer = new TFChunkWriter(db);
+		writer.Open();
+		Assert.IsTrue(await writer.Write(recordToWrite, CancellationToken.None) is (true, _));
+		await writer.DisposeAsync();
+
+		var endPosition = recordToWrite.GetSizeWithLengthPrefixAndSuffix();
+		writerchk.Write(endPosition);
+		writerchk.Flush();
+
+		var chaser = new TFChunkChaser(db, writerchk, chaserchk);
+		chaserchk.Write(endPosition);
+		chaserchk.Flush();
+		chaser.Open();
+
+		Assert.IsTrue(await chaser.TryReadNext(CancellationToken.None) is { LogRecord: null });
+		Assert.AreEqual(endPosition, chaserchk.Read());
+
+		chaser.Close();
+	}
+
+	[Test]
 	public async Task try_read_returns_record_when_writerchecksum_ahead()
 	{
 		var recordFactory = LogFormatHelper<TLogFormat, TStreamId>.RecordFactory;

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/ArchiveCatchupTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/ArchiveCatchupTests.cs
@@ -29,7 +29,8 @@ public class ArchiveCatchupTests : DirectoryPerTest<ArchiveCatchupTests>
 		public string[] DbChunks { get; init; }
 		public string[] ArchiveChunks { get; init; }
 		public ICheckpoint WriterCheckpoint { get; init; }
-		public ICheckpoint ReplicationCheckpoint { get; init; }
+		public ICheckpoint ChaserCheckpoint { get; init; }
+		public ICheckpoint EpochCheckpoint { get; init; }
 	}
 
 	private Sut CreateSut(
@@ -56,11 +57,13 @@ public class ArchiveCatchupTests : DirectoryPerTest<ArchiveCatchupTests>
 			onGetChunk);
 
 		var writerCheckpoint = new InMemoryCheckpoint(dbCheckpoint.Value);
-		var replicationCheckpoint = new InMemoryCheckpoint(dbCheckpoint.Value);
+		var chaserCheckpoint = new InMemoryCheckpoint(dbCheckpoint.Value);
+		var epochCheckpoint = new InMemoryCheckpoint(123);
 		var catchup = new ArchiveCatchup(
 			dbPath: DbPath,
 			writerCheckpoint: writerCheckpoint,
-			replicationCheckpoint: replicationCheckpoint,
+			chaserCheckpoint: chaserCheckpoint,
+			epochCheckpoint: epochCheckpoint,
 			chunkSize: ChunkSize,
 			fileNamingStrategy: new CustomNamingStrategy(),
 			archiveStorageFactory: archive
@@ -73,7 +76,8 @@ public class ArchiveCatchupTests : DirectoryPerTest<ArchiveCatchupTests>
 			DbChunks = dbChunks,
 			ArchiveChunks = archiveChunks,
 			WriterCheckpoint = writerCheckpoint,
-			ReplicationCheckpoint = replicationCheckpoint
+			ChaserCheckpoint = chaserCheckpoint,
+			EpochCheckpoint = epochCheckpoint
 		};
 	}
 
@@ -109,7 +113,8 @@ public class ArchiveCatchupTests : DirectoryPerTest<ArchiveCatchupTests>
 		Assert.Equal(0, sut.Archive.NumListings);
 		Assert.Empty(sut.Archive.ChunkGets);
 		Assert.Equal(dbCheckpoint, sut.WriterCheckpoint.Read());
-		Assert.Equal(dbCheckpoint, sut.ReplicationCheckpoint.Read());
+		Assert.Equal(dbCheckpoint, sut.ChaserCheckpoint.Read());
+		Assert.Equal(123, sut.EpochCheckpoint.Read());
 		Assert.Equal(archiveCheckpoint, await sut.Archive.GetCheckpoint(CancellationToken.None));
 	}
 
@@ -196,7 +201,8 @@ public class ArchiveCatchupTests : DirectoryPerTest<ArchiveCatchupTests>
 
 		Assert.Equal(2, sut.Archive.NumListings);
 		Assert.Equal(2000L, sut.WriterCheckpoint.Read());
-		Assert.Equal(2000L, sut.ReplicationCheckpoint.Read());
+		Assert.Equal(2000L, sut.ChaserCheckpoint.Read());
+		Assert.Equal(-1, sut.EpochCheckpoint.Read());
 
 		return;
 
@@ -225,11 +231,14 @@ public class ArchiveCatchupTests : DirectoryPerTest<ArchiveCatchupTests>
 		// moves the writer checkpoint
 		Assert.Equal(archiveCheckpoint, sut.WriterCheckpoint.Read());
 
-		// moves the replication checkpoint
-		Assert.Equal(archiveCheckpoint, sut.ReplicationCheckpoint.Read());
+		// moves the chaser checkpoint
+		Assert.Equal(archiveCheckpoint, sut.ChaserCheckpoint.Read());
 
 		// doesn't move the archive checkpoint
 		Assert.Equal(archiveCheckpoint, await sut.Archive.GetCheckpoint(CancellationToken.None));
+
+		// resets the epoch checkpoint
+		Assert.Equal(-1, sut.EpochCheckpoint.Read());
 
 		// backs up the expected chunks
 		Assert.Equal(expectedChunkBackups, ListBackedUpChunks());

--- a/src/EventStore.Core/Services/Archive/ArchiveCatchup/ArchiveCatchup.cs
+++ b/src/EventStore.Core/Services/Archive/ArchiveCatchup/ArchiveCatchup.cs
@@ -25,7 +25,8 @@ public class ArchiveCatchup : IClusterVNodeStartupTask
 {
 	private readonly string _dbPath;
 	private readonly ICheckpoint _writerCheckpoint;
-	private readonly ICheckpoint _replicationCheckpoint;
+	private readonly ICheckpoint _chaserCheckpoint;
+	private readonly ICheckpoint _epochCheckpoint;
 	private readonly int _chunkSize;
 	private readonly IVersionedFileNamingStrategy _fileNamingStrategy;
 	private readonly IArchiveStorageReader _archiveReader;
@@ -36,14 +37,16 @@ public class ArchiveCatchup : IClusterVNodeStartupTask
 	public ArchiveCatchup(
 		string dbPath,
 		ICheckpoint writerCheckpoint,
-		ICheckpoint replicationCheckpoint,
+		ICheckpoint chaserCheckpoint,
+		ICheckpoint epochCheckpoint,
 		int chunkSize,
 		IVersionedFileNamingStrategy fileNamingStrategy,
 		IArchiveStorageFactory archiveStorageFactory)
 	{
 		_dbPath = dbPath;
 		_writerCheckpoint = writerCheckpoint;
-		_replicationCheckpoint = replicationCheckpoint;
+		_chaserCheckpoint = chaserCheckpoint;
+		_epochCheckpoint = epochCheckpoint;
 		_chunkSize = chunkSize;
 		_fileNamingStrategy = fileNamingStrategy;
 		_archiveReader = archiveStorageFactory.CreateReader();
@@ -216,14 +219,18 @@ public class ArchiveCatchup : IClusterVNodeStartupTask
 		await using var headerStream = File.OpenRead(chunkPath);
 		var header = await ChunkHeader.FromStream(headerStream, ct);
 
+		_epochCheckpoint.Write(-1);
+		_epochCheckpoint.Flush();
+		Log.Debug("Reset {checkpoint} checkpoint to: 0x{position:X}", _epochCheckpoint.Name, -1);
+
+		_chaserCheckpoint.Write(header.ChunkEndPosition);
+		_chaserCheckpoint.Flush();
+		Log.Debug("Moved {checkpoint} checkpoint forward to: 0x{position:X}", _chaserCheckpoint.Name,
+			header.ChunkEndPosition);
+
 		_writerCheckpoint.Write(header.ChunkEndPosition);
 		_writerCheckpoint.Flush();
 		Log.Debug("Moved {checkpoint} checkpoint forward to: 0x{position:X}", _writerCheckpoint.Name,
-			header.ChunkEndPosition);
-
-		_replicationCheckpoint.Write(header.ChunkEndPosition);
-		_replicationCheckpoint.Flush();
-		Log.Debug("Moved {checkpoint} checkpoint forward to: 0x{position:X}", _replicationCheckpoint.Name,
 			header.ChunkEndPosition);
 	}
 }

--- a/src/EventStore.Core/Services/Archive/ArchivePlugableComponent.cs
+++ b/src/EventStore.Core/Services/Archive/ArchivePlugableComponent.cs
@@ -69,7 +69,8 @@ public class ArchivePlugableComponent(bool isArchiver) : IPlugableComponent
 		newStartupTasks.Add(new ArchiveCatchup.ArchiveCatchup(
 			dbPath: standardComponents.DbConfig.Path,
 			writerCheckpoint: standardComponents.DbConfig.WriterCheckpoint,
-			replicationCheckpoint: standardComponents.DbConfig.ReplicationCheckpoint,
+			chaserCheckpoint: standardComponents.DbConfig.ChaserCheckpoint,
+			epochCheckpoint: standardComponents.DbConfig.EpochCheckpoint,
 			chunkSize: standardComponents.DbConfig.ChunkSize,
 			serviceProvider.GetRequiredService<IVersionedFileNamingStrategy>(),
 			serviceProvider.GetRequiredService<IArchiveStorageFactory>()));

--- a/src/EventStore.Core/Services/Storage/EpochManager/EpochManager.cs
+++ b/src/EventStore.Core/Services/Storage/EpochManager/EpochManager.cs
@@ -153,6 +153,7 @@ public class EpochManager<TStreamId> : IEpochManager
 						    ((ISystemLogRecord)rec).SystemRecordType is not SystemRecordType.Epoch)
 							continue;
 						epochPos = rec.LogPosition;
+						await SetCheckpointAsync(epochPos, token);
 						break;
 					}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkChaser.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkChaser.cs
@@ -12,8 +12,10 @@ public class TFChunkChaser : ITransactionFileChaser
 		get { return _chaserCheckpoint; }
 	}
 
+	private readonly TFChunkDb _db;
+	private readonly IReadOnlyCheckpoint _writerCheckpoint;
 	private readonly ICheckpoint _chaserCheckpoint;
-	private readonly TFChunkReader _reader;
+	private TFChunkReader _reader;
 
 	public TFChunkChaser(TFChunkDb db, IReadOnlyCheckpoint writerCheckpoint, ICheckpoint chaserCheckpoint)
 	{
@@ -21,13 +23,14 @@ public class TFChunkChaser : ITransactionFileChaser
 		Ensure.NotNull(writerCheckpoint, "writerCheckpoint");
 		Ensure.NotNull(chaserCheckpoint, "chaserCheckpoint");
 
+		_db = db;
+		_writerCheckpoint = writerCheckpoint;
 		_chaserCheckpoint = chaserCheckpoint;
-		_reader = new TFChunkReader(db, writerCheckpoint, _chaserCheckpoint.Read());
 	}
 
 	public void Open()
 	{
-		// NOOP
+		_reader = new TFChunkReader(_db, _writerCheckpoint, _chaserCheckpoint.Read());
 	}
 
 	public async ValueTask<SeqReadResult> TryReadNext(CancellationToken token)


### PR DESCRIPTION
- archive catch-up needs startup checkpoints to reflect the downloaded log so recovery resumes from the right place after archived chunks are restored
- epoch discovery should remain stable after catch-up resets so repeated restarts do not depend on stale checkpoint state