### PR TITLE
fix(archive): surface archive state during startup and scavenging

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/OptionsFormatterTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/OptionsFormatterTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests;
+
+[Collection("SerilogLoggingTests")]
+public class OptionsFormatterTests : IDisposable
+{
+	private readonly ILogger _previousLogger = Log.Logger;
+	private readonly CollectingSink _sink = new();
+
+	public OptionsFormatterTests()
+	{
+		Log.Logger = new LoggerConfiguration()
+			.MinimumLevel.Verbose()
+			.WriteTo.Sink(_sink)
+			.CreateLogger();
+	}
+
+	[Fact]
+	public void logs_named_configuration_as_json()
+	{
+		OptionsFormatter.LogConfig("Archive", new SampleOptions
+		{
+			Mode = SampleMode.FileSystem,
+			Path = "/tmp/archive",
+		});
+
+		var logEvent = Assert.Single(_sink.Events);
+		var message = logEvent.RenderMessage();
+		Assert.Contains("Archive Configuration:", message, StringComparison.Ordinal);
+		Assert.Contains("\"Mode\": \"FileSystem\"", message, StringComparison.Ordinal);
+		Assert.DoesNotContain("\"Ignored\"", message, StringComparison.Ordinal);
+	}
+
+	public void Dispose()
+	{
+		Log.Logger = _previousLogger;
+	}
+
+	private sealed class CollectingSink : ILogEventSink
+	{
+		public List<LogEvent> Events { get; } = [];
+
+		public void Emit(LogEvent logEvent) =>
+			Events.Add(logEvent);
+	}
+
+	private sealed class SampleOptions
+	{
+		public SampleMode Mode { get; init; }
+		public string Path { get; init; } = "";
+		public string Ignored { get; init; }
+	}
+
+	private enum SampleMode
+	{
+		FileSystem,
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/OptionsFormatterTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/OptionsFormatterTests.cs
@@ -37,6 +37,31 @@ public class OptionsFormatterTests : IDisposable
 		Assert.DoesNotContain("\"Ignored\"", message, StringComparison.Ordinal);
 	}
 
+	[Fact]
+	public void redacts_sensitive_values()
+	{
+		OptionsFormatter.LogConfig("Archive", new SampleOptions
+		{
+			Mode = SampleMode.FileSystem,
+			Path = "/tmp/archive",
+			Password = "secret-password",
+			Nested = new NestedOptions
+			{
+				AccessKey = "abc123",
+				ApiToken = "token-value",
+			}
+		});
+
+		var logEvent = Assert.Single(_sink.Events);
+		var message = logEvent.RenderMessage();
+		Assert.DoesNotContain("secret-password", message, StringComparison.Ordinal);
+		Assert.DoesNotContain("abc123", message, StringComparison.Ordinal);
+		Assert.DoesNotContain("token-value", message, StringComparison.Ordinal);
+		Assert.Contains("\"Password\": \"***REDACTED***\"", message, StringComparison.Ordinal);
+		Assert.Contains("\"AccessKey\": \"***REDACTED***\"", message, StringComparison.Ordinal);
+		Assert.Contains("\"ApiToken\": \"***REDACTED***\"", message, StringComparison.Ordinal);
+	}
+
 	public void Dispose()
 	{
 		Log.Logger = _previousLogger;
@@ -55,6 +80,14 @@ public class OptionsFormatterTests : IDisposable
 		public SampleMode Mode { get; init; }
 		public string Path { get; init; } = "";
 		public string Ignored { get; init; }
+		public string Password { get; init; }
+		public NestedOptions Nested { get; init; }
+	}
+
+	private sealed class NestedOptions
+	{
+		public string AccessKey { get; init; }
+		public string ApiToken { get; init; }
 	}
 
 	private enum SampleMode

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/ChunkDeleterTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/ChunkDeleterTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.Index.Hashers;
@@ -7,6 +8,9 @@ using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.TransactionLog.Scavenging;
 using EventStore.Core.TransactionLog.Scavenging.InMemory;
 using EventStore.Core.TransactionLog.Scavenging.Stages;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
 using Xunit;
 
 namespace EventStore.Core.XUnit.Tests.Scavenge;
@@ -30,11 +34,11 @@ public class ChunkDeleterTests
 		int retainDays,
 		long retainBytes,
 		Func<long> readArchiveCheckpoint,
-		int maxAttempts = 1)
+		int maxAttempts = 1,
+		ILogger logger = null)
 	{
-
 		var sut = new ChunkDeleter<string, ILogRecord>(
-			logger: Serilog.Log.Logger,
+			logger: logger ?? Serilog.Log.Logger,
 			archiveCheckpoint: new AdvancingCheckpoint(_ => new(readArchiveCheckpoint())),
 			retainPeriod: TimeSpan.FromDays(retainDays),
 			retainBytes: retainBytes,
@@ -120,6 +124,68 @@ public class ChunkDeleterTests
 			Assert.False(deleted);
 		else
 			throw new InvalidOperationException();
+	}
+
+	[Fact]
+	public async Task logs_when_retained_by_logical_bytes()
+	{
+		var sink = new CollectingSink();
+		var logger = new LoggerConfiguration()
+			.MinimumLevel.Verbose()
+			.WriteTo.Sink(sink)
+			.CreateLogger();
+		var minDateInChunk = new DateTime(2024, 1, 1);
+		var maxDateInChunk = new DateTime(2024, 12, 1);
+		_backend.ChunkTimeStampRanges[0] = new(minDateInChunk, maxDateInChunk);
+		var chunk = new FakeChunk(chunkStartNumber: 0, chunkEndNumber: 1, chunkSize: 1_000);
+		var sut = GenSut(
+			retainDays: 10,
+			retainBytes: 1001,
+			readArchiveCheckpoint: () => chunk.ChunkEndPosition,
+			logger: logger);
+
+		var deleted = await sut.DeleteIfNotRetained(
+			scavengePoint: GenScavengePoint(
+				position: chunk.ChunkEndPosition + 1001,
+				effectiveNow: maxDateInChunk + TimeSpan.FromDays(10.1)),
+			concurrentState: _scavengeState,
+			physicalChunk: chunk,
+			CancellationToken.None);
+
+		Assert.False(deleted);
+		Assert.Contains(sink.Events.Select(x => x.RenderMessage()),
+			x => x.Contains("logical bytes retention window", StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public async Task logs_when_retained_by_period()
+	{
+		var sink = new CollectingSink();
+		var logger = new LoggerConfiguration()
+			.MinimumLevel.Verbose()
+			.WriteTo.Sink(sink)
+			.CreateLogger();
+		var minDateInChunk = new DateTime(2024, 1, 1);
+		var maxDateInChunk = new DateTime(2024, 12, 1);
+		_backend.ChunkTimeStampRanges[0] = new(minDateInChunk, maxDateInChunk);
+		var chunk = new FakeChunk(chunkStartNumber: 0, chunkEndNumber: 1, chunkSize: 1_000);
+		var sut = GenSut(
+			retainDays: 11,
+			retainBytes: 1000,
+			readArchiveCheckpoint: () => chunk.ChunkEndPosition,
+			logger: logger);
+
+		var deleted = await sut.DeleteIfNotRetained(
+			scavengePoint: GenScavengePoint(
+				position: chunk.ChunkEndPosition + 1001,
+				effectiveNow: maxDateInChunk + TimeSpan.FromDays(10.1)),
+			concurrentState: _scavengeState,
+			physicalChunk: chunk,
+			CancellationToken.None);
+
+		Assert.False(deleted);
+		Assert.Contains(sink.Events.Select(x => x.RenderMessage()),
+			x => x.Contains("retention period window", StringComparison.Ordinal));
 	}
 
 	[Fact]
@@ -245,5 +311,13 @@ public class ChunkDeleterTests
 		{
 			throw new NotImplementedException();
 		}
+	}
+
+	private sealed class CollectingSink : ILogEventSink
+	{
+		public List<LogEvent> Events { get; } = [];
+
+		public void Emit(LogEvent logEvent) =>
+			Events.Add(logEvent);
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/SerilogLoggingTestsCollection.cs
+++ b/src/EventStore.Core.XUnit.Tests/SerilogLoggingTestsCollection.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests;
+
+[CollectionDefinition("SerilogLoggingTests", DisableParallelization = true)]
+public class SerilogLoggingTestsCollection;

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/FileSystemArchiveLoggingTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/FileSystemArchiveLoggingTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using EventStore.Core.Services.Archive;
+using EventStore.Core.Services.Archive.Naming;
+using EventStore.Core.Services.Archive.Storage;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.Archive.Storage;
+
+[Collection("SerilogLoggingTests")]
+public class FileSystemArchiveLoggingTests : DirectoryPerTest<FileSystemArchiveLoggingTests>, IDisposable
+{
+	private readonly ILogger _previousLogger = Log.Logger;
+	private readonly CollectingSink _sink = new();
+
+	public FileSystemArchiveLoggingTests()
+	{
+		Log.Logger = new LoggerConfiguration()
+			.MinimumLevel.Verbose()
+			.WriteTo.Sink(_sink)
+			.CreateLogger();
+	}
+
+	[Fact]
+	public void reader_logs_the_resolved_archive_path()
+	{
+		var archivePath = Path.Combine(Fixture.Directory, "nested", "..", "archive-reader");
+		Directory.CreateDirectory(Path.GetFullPath(archivePath));
+
+		_ = new FileSystemReader(
+			new FileSystemOptions { Path = archivePath },
+			CreateChunkNamer(Path.GetFullPath(archivePath)),
+			"archive.chk");
+
+		Assert.Contains(_sink.Events,
+			x => x.RenderMessage().Contains(Path.GetFullPath(archivePath), StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public void writer_logs_the_resolved_archive_path()
+	{
+		var archivePath = Path.Combine(Fixture.Directory, "nested", "..", "archive-writer");
+		Directory.CreateDirectory(Path.GetFullPath(archivePath));
+
+		_ = new FileSystemWriter(
+			new FileSystemOptions { Path = archivePath },
+			"archive.chk");
+
+		Assert.Contains(_sink.Events,
+			x => x.RenderMessage().Contains(Path.GetFullPath(archivePath), StringComparison.Ordinal));
+	}
+
+	public void Dispose()
+	{
+		Log.Logger = _previousLogger;
+	}
+
+	private static IArchiveChunkNamer CreateChunkNamer(string archivePath)
+	{
+		var namingStrategy = new VersionedPatternFileNamingStrategy(archivePath, "chunk-");
+		return new ArchiveChunkNamer(namingStrategy);
+	}
+
+	private sealed class CollectingSink : ILogEventSink
+	{
+		public List<LogEvent> Events { get; } = [];
+
+		public void Emit(LogEvent logEvent) =>
+			Events.Add(logEvent);
+	}
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -279,6 +279,7 @@ public class ClusterVNode<TStreamId> :
 #endif
 
 		var archiveOptions = configuration.GetSection("EventStore:Archive").Get<ArchiveOptions>() ?? new();
+		OptionsFormatter.LogConfig("Archive", archiveOptions);
 		archiveOptions.Validate();
 
 		var disableInternalTcpTls = options.Application.Insecure;

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -279,8 +279,8 @@ public class ClusterVNode<TStreamId> :
 #endif
 
 		var archiveOptions = configuration.GetSection("EventStore:Archive").Get<ArchiveOptions>() ?? new();
-		OptionsFormatter.LogConfig("Archive", archiveOptions);
 		archiveOptions.Validate();
+		OptionsFormatter.LogConfig("Archive", archiveOptions);
 
 		var disableInternalTcpTls = options.Application.Insecure;
 		var disableExternalTcpTls = options.Application.Insecure;

--- a/src/EventStore.Core/MetricsBootstrapper.cs
+++ b/src/EventStore.Core/MetricsBootstrapper.cs
@@ -10,9 +10,6 @@ using EventStore.Core.Metrics;
 using EventStore.Core.Services.VNode;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Scavenging;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Serilog;
 using Conf = EventStore.Common.Configuration.MetricsConfiguration;
 
 namespace EventStore.Core;
@@ -63,14 +60,13 @@ public class GossipTrackers {
 
 public static class MetricsBootstrapper {
 	public const string LogicalChunkReadDistributionName = "eventstore-logical-chunk-read-distribution";
-	private static readonly ILogger Log = Serilog.Log.ForContext(typeof(MetricsBootstrapper));
 
 	public static void Bootstrap(
 		Conf conf,
 		TFChunkDbConfig dbConfig,
 		Trackers trackers) {
 
-		LogConfig(conf);
+		OptionsFormatter.LogConfig("Metrics", conf);
 
 		MessageLabelConfigurator.ConfigureMessageLabels(
 			conf.MessageTypes, InMemoryBus.KnownMessageTypes);
@@ -329,19 +325,5 @@ public static class MetricsBootstrapper {
 			{ Conf.ProcessTracker.DiskReadOps, "read" },
 			{ Conf.ProcessTracker.DiskWrittenOps, "written" },
 		});
-	}
-
-	private static void LogConfig(Conf conf) {
-		var jsonSerializerSettings = new JsonSerializerSettings {
-			NullValueHandling = NullValueHandling.Ignore,
-		};
-		jsonSerializerSettings.Converters.Add(new StringEnumConverter());
-
-		var confJson = JsonConvert.SerializeObject(
-			conf,
-			Formatting.Indented,
-			jsonSerializerSettings);
-
-		Log.Information("Metrics Configuration: " + confJson);
 	}
 }

--- a/src/EventStore.Core/OptionsFormatter.cs
+++ b/src/EventStore.Core/OptionsFormatter.cs
@@ -1,0 +1,27 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace EventStore.Core;
+
+public static class OptionsFormatter
+{
+	private static readonly JsonSerializerSettings SerializerSettings = CreateSerializerSettings();
+
+	public static void LogConfig(string name, object options)
+	{
+		var configJson = JsonConvert.SerializeObject(options, Formatting.Indented, SerializerSettings);
+		Serilog.Log.ForContext(typeof(OptionsFormatter))
+			.Information("{name:l} Configuration:{newline:l}{configJson:l}", name, Environment.NewLine, configJson);
+	}
+
+	private static JsonSerializerSettings CreateSerializerSettings()
+	{
+		var serializerSettings = new JsonSerializerSettings
+		{
+			NullValueHandling = NullValueHandling.Ignore,
+		};
+		serializerSettings.Converters.Add(new StringEnumConverter());
+		return serializerSettings;
+	}
+}

--- a/src/EventStore.Core/OptionsFormatter.cs
+++ b/src/EventStore.Core/OptionsFormatter.cs
@@ -1,18 +1,76 @@
 using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
 
 namespace EventStore.Core;
 
 public static class OptionsFormatter
 {
 	private static readonly JsonSerializerSettings SerializerSettings = CreateSerializerSettings();
+	private const string RedactedValue = "***REDACTED***";
+	private static readonly string[] SensitivePropertyNames = [
+		"password",
+		"secret",
+		"token",
+		"apikey",
+		"api_key",
+		"accesskey",
+		"access_key",
+		"secretkey",
+		"secret_key",
+		"credential",
+		"credentials",
+		"connectionstring",
+		"connection_string",
+	];
 
 	public static void LogConfig(string name, object options)
 	{
-		var configJson = JsonConvert.SerializeObject(options, Formatting.Indented, SerializerSettings);
+		var configJson = FormatOptions(options);
 		Serilog.Log.ForContext(typeof(OptionsFormatter))
 			.Information("{name:l} Configuration:{newline:l}{configJson:l}", name, Environment.NewLine, configJson);
+	}
+
+	private static string FormatOptions(object options)
+	{
+		var serializer = JsonSerializer.Create(SerializerSettings);
+		var config = JToken.FromObject(options, serializer);
+		RedactSensitiveValues(config);
+		return config.ToString(Formatting.Indented);
+	}
+
+	private static void RedactSensitiveValues(JToken token)
+	{
+		switch (token)
+		{
+			case JObject obj:
+				foreach (var property in obj.Properties())
+				{
+					if (IsSensitive(property.Name))
+					{
+						property.Value = RedactedValue;
+						continue;
+					}
+
+					RedactSensitiveValues(property.Value);
+				}
+
+				break;
+			case JArray array:
+				foreach (var item in array)
+					RedactSensitiveValues(item);
+				break;
+		}
+	}
+
+	private static bool IsSensitive(string propertyName)
+	{
+		foreach (var sensitivePropertyName in SensitivePropertyNames)
+			if (propertyName.Contains(sensitivePropertyName, StringComparison.OrdinalIgnoreCase))
+				return true;
+
+		return false;
 	}
 
 	private static JsonSerializerSettings CreateSerializerSettings()

--- a/src/EventStore.Core/Services/Archive/Storage/FileSystemReader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/FileSystemReader.cs
@@ -21,7 +21,7 @@ public class FileSystemReader(
 {
 	protected static readonly ILogger Log = Serilog.Log.ForContext<FileSystemReader>();
 
-	private readonly string _archivePath = options.Path;
+	private readonly string _archivePath = ResolveArchivePath(options.Path);
 
 	private readonly FileStreamOptions _fileStreamOptions = new()
 	{
@@ -29,6 +29,14 @@ public class FileSystemReader(
 	};
 
 	public IArchiveChunkNamer ChunkNamer { get; } = chunkNamer;
+
+	private static string ResolveArchivePath(string path)
+	{
+		var fullPath = Path.GetFullPath(path);
+		Serilog.Log.ForContext<FileSystemReader>()
+			.Information("Using file system archive storage at {archivePath}", fullPath);
+		return fullPath;
+	}
 
 	public ValueTask<long> GetCheckpoint(CancellationToken ct)
 	{

--- a/src/EventStore.Core/Services/Archive/Storage/FileSystemWriter.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/FileSystemWriter.cs
@@ -16,7 +16,15 @@ public class FileSystemWriter(
 {
 	protected static readonly ILogger Log = Serilog.Log.ForContext<FileSystemWriter>();
 
-	private readonly string _archivePath = options.Path;
+	private readonly string _archivePath = ResolveArchivePath(options.Path);
+
+	private static string ResolveArchivePath(string path)
+	{
+		var fullPath = Path.GetFullPath(path);
+		Serilog.Log.ForContext<FileSystemWriter>()
+			.Information("Using file system archive storage at {archivePath}", fullPath);
+		return fullPath;
+	}
 
 	public ValueTask<bool> SetCheckpoint(long checkpoint, CancellationToken ct)
 	{

--- a/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkDeleter.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkDeleter.cs
@@ -47,11 +47,17 @@ public class ChunkDeleter<TStreamId, TRecord> : IChunkDeleter<TStreamId, TRecord
 
 		if (!ShouldDeleteForBytes(scavengePoint, physicalChunk))
 		{
+			_logger.Debug(
+				"SCAVENGING: Keeping physical chunk {physicalChunk} because it is still within the logical bytes retention window.",
+				physicalChunk.Name);
 			return false;
 		}
 
 		if (!ShouldDeleteForPeriod(scavengePoint, concurrentState, physicalChunk))
 		{
+			_logger.Debug(
+				"SCAVENGING: Keeping physical chunk {physicalChunk} because it is still within the retention period window.",
+				physicalChunk.Name);
 			return false;
 		}
 


### PR DESCRIPTION
- archive-enabled nodes need enough startup and scavenging visibility to explain why chunks are being kept or removed and which storage path is actually in use
- shared configuration formatting keeps archive diagnostics consistent with other runtime settings without duplicating logging behavior