### PR TITLE
feat(archive): keep archived chunk reads available after local cleanup

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
@@ -49,4 +49,17 @@ public class WhenOpeningTfchunkFromNonExistingFile : SpecificationWithFile
 
 		Assert.That(ex?.InnerException, Is.TypeOf<ChunkNotFoundException>());
 	}
+
+	[Test]
+	public void it_should_throw_when_metadata_file_is_too_small()
+	{
+		File.WriteAllBytes(Filename, new byte[ChunkHeader.Size]);
+		var fileSystem = new ChunkLocalFileSystem(
+			new VersionedPatternFileNamingStrategy(Path.GetDirectoryName(Filename)!, "chunk-"));
+
+		var ex = Assert.ThrowsAsync<CorruptDatabaseException>(async () =>
+			await fileSystem.ReadHeaderAsync(Filename, CancellationToken.None));
+
+		Assert.That(ex?.InnerException, Is.TypeOf<BadChunkInDatabaseException>());
+	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/with_file_system_with_archive.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/with_file_system_with_archive.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Services.Archive;
+using EventStore.Core.Services.Archive.Naming;
+using EventStore.Core.Services.Archive.Storage;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Transforms.Identity;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog;
+
+[TestFixture]
+public class with_file_system_with_archive : SpecificationWithDirectory
+{
+	private const string ChunkPrefix = "chunk-";
+	private const string ArchiveCheckpointFile = "archive.chk";
+	private const int ChunkSize = 4096;
+
+	private string ArchivePath => Path.Combine(PathName, "archive");
+	private string DbPath => Path.Combine(PathName, "db");
+
+	[SetUp]
+	public override async Task SetUp()
+	{
+		await base.SetUp();
+		Directory.CreateDirectory(ArchivePath);
+		Directory.CreateDirectory(DbPath);
+	}
+
+	[Test]
+	public async Task opens_remote_chunk_handles_for_archive_locators()
+	{
+		var sourcePath = Path.Combine(DbPath, "source");
+		var content = new byte[256];
+		new Random(17).NextBytes(content);
+		await File.WriteAllBytesAsync(sourcePath, content);
+
+		var dbNamingStrategy = new VersionedPatternFileNamingStrategy(DbPath, ChunkPrefix);
+		var archiveChunkNamer = new ArchiveChunkNamer(dbNamingStrategy);
+		var writer = new FileSystemWriter(new FileSystemOptions { Path = ArchivePath }, ArchiveCheckpointFile);
+		await writer.StoreChunk(sourcePath, archiveChunkNamer.GetFileNameFor(0), CancellationToken.None);
+
+		var sut = CreateSut();
+		using var handle = await sut.OpenForReadAsync("archived-chunk-0", ReadOptimizationHint.SequentialScan,
+			asyncIO: false, CancellationToken.None);
+		var slice = new byte[32];
+
+		Assert.That(handle.Length, Is.EqualTo(content.Length));
+		Assert.That(await handle.ReadAsync(slice, 64, CancellationToken.None), Is.EqualTo(slice.Length));
+		Assert.That(slice, Is.EqualTo(content.Skip(64).Take(slice.Length).ToArray()));
+	}
+
+	[Test]
+	public async Task opens_completed_remote_tfchunks_through_the_archive_file_system()
+	{
+		var sourcePath = Path.Combine(DbPath, "chunk-000000.000000");
+		var sourceChunk = await TFChunkHelper.CreateNewChunk(sourcePath, chunkSize: ChunkSize);
+		await sourceChunk.Complete(CancellationToken.None);
+		var expectedFileSize = sourceChunk.FileSize;
+		sourceChunk.Dispose();
+
+		var writer = new FileSystemWriter(new FileSystemOptions { Path = ArchivePath }, ArchiveCheckpointFile);
+		var dbNamingStrategy = new VersionedPatternFileNamingStrategy(DbPath, ChunkPrefix);
+		await writer.StoreChunk(sourcePath, new ArchiveChunkNamer(dbNamingStrategy).GetFileNameFor(0),
+			CancellationToken.None);
+
+		var sut = CreateSut();
+		using var remoteChunk = await TFChunk.FromCompletedFile(
+			sut,
+			"archived-chunk-0",
+			verifyHash: false,
+			unbufferedRead: false,
+			tracker: new TFChunkTracker.NoOp(),
+			getTransformFactory: static _ => new IdentityChunkTransformFactory(),
+			token: CancellationToken.None);
+
+		Assert.That(remoteChunk.IsRemote, Is.True);
+		Assert.That(remoteChunk.FileSize, Is.EqualTo(expectedFileSize));
+		Assert.That(remoteChunk.ChunkHeader.ChunkStartNumber, Is.EqualTo(0));
+		Assert.That(remoteChunk.ChunkHeader.ChunkEndNumber, Is.EqualTo(0));
+	}
+
+	[Test]
+	public async Task reads_remote_chunk_metadata_for_archive_locators()
+	{
+		var sourcePath = Path.Combine(DbPath, "chunk-000000.000000");
+		var sourceChunk = await TFChunkHelper.CreateNewChunk(sourcePath, chunkSize: ChunkSize);
+		await sourceChunk.Complete(CancellationToken.None);
+		sourceChunk.Dispose();
+
+		var writer = new FileSystemWriter(new FileSystemOptions { Path = ArchivePath }, ArchiveCheckpointFile);
+		var dbNamingStrategy = new VersionedPatternFileNamingStrategy(DbPath, ChunkPrefix);
+		await writer.StoreChunk(sourcePath, new ArchiveChunkNamer(dbNamingStrategy).GetFileNameFor(0),
+			CancellationToken.None);
+
+		var sut = CreateSut();
+		var header = await sut.ReadHeaderAsync("archived-chunk-0", CancellationToken.None);
+		var footer = await sut.ReadFooterAsync("archived-chunk-0", CancellationToken.None);
+
+		Assert.That(header.ChunkStartNumber, Is.EqualTo(0));
+		Assert.That(header.ChunkEndNumber, Is.EqualTo(0));
+		Assert.That(footer.IsCompleted, Is.True);
+	}
+
+	[Test]
+	public async Task enumerator_replaces_missing_local_chunks_that_are_already_in_archive()
+	{
+		var namingStrategy = new VersionedPatternFileNamingStrategy(DbPath, ChunkPrefix);
+		var localChunkEnumerator = new FakeChunkEnumerator(
+			new MissingVersion(namingStrategy.GetFilenameFor(0, 0), 0),
+			new LatestVersion(namingStrategy.GetFilenameFor(1, 0), 1, 1),
+			new MissingVersion(namingStrategy.GetFilenameFor(2, 0), 2));
+
+		var sut = new FileSystemWithArchive(
+			chunkSize: 1000,
+			locatorCodec: new PrefixingLocatorCodec(),
+			localFileSystem: new FakeChunkFileSystem(namingStrategy, localChunkEnumerator),
+			archive: new FakeArchiveReader(checkpoint: 2000, namingStrategy));
+
+		var results = new List<TFChunkInfo>();
+		await foreach (var chunkInfo in sut.CreateChunkEnumerator().EnumerateChunks(2, CancellationToken.None))
+		{
+			results.Add(chunkInfo);
+		}
+
+		Assert.That(results, Is.EqualTo(new TFChunkInfo[]
+		{
+			new LatestVersion("archived-chunk-0", 0, 0),
+			new LatestVersion(namingStrategy.GetFilenameFor(1, 0), 1, 1),
+			new MissingVersion(namingStrategy.GetFilenameFor(2, 0), 2),
+		}));
+	}
+
+	private FileSystemWithArchive CreateSut()
+	{
+		var dbNamingStrategy = new VersionedPatternFileNamingStrategy(DbPath, ChunkPrefix);
+		var archiveNamingStrategy = new VersionedPatternFileNamingStrategy(ArchivePath, ChunkPrefix);
+		return new FileSystemWithArchive(
+			ChunkSize,
+			new PrefixingLocatorCodec(),
+			new ChunkLocalFileSystem(dbNamingStrategy),
+			new FileSystemReader(
+				new FileSystemOptions { Path = ArchivePath },
+				new ArchiveChunkNamer(archiveNamingStrategy),
+				ArchiveCheckpointFile));
+	}
+
+	private sealed class FakeChunkFileSystem(IVersionedFileNamingStrategy namingStrategy, IChunkEnumerator chunkEnumerator)
+		: IChunkFileSystem
+	{
+		public IVersionedFileNamingStrategy NamingStrategy { get; } = namingStrategy;
+
+		public ValueTask<IChunkHandle> OpenForReadAsync(string fileName, ReadOptimizationHint readOptimizationHint,
+			bool asyncIO, CancellationToken token) =>
+			throw new NotImplementedException();
+
+		public ValueTask<ChunkHeader> ReadHeaderAsync(string fileName, CancellationToken token) =>
+			throw new NotImplementedException();
+
+		public ValueTask<ChunkFooter> ReadFooterAsync(string fileName, CancellationToken token) =>
+			throw new NotImplementedException();
+
+		public IChunkEnumerator CreateChunkEnumerator() => chunkEnumerator;
+	}
+
+	private sealed class FakeChunkEnumerator(params TFChunkInfo[] chunkInfos) : IChunkEnumerator
+	{
+		public async IAsyncEnumerable<TFChunkInfo> EnumerateChunks(int lastChunkNumber,
+			[EnumeratorCancellation] CancellationToken token)
+		{
+			foreach (var chunkInfo in chunkInfos)
+			{
+				token.ThrowIfCancellationRequested();
+				yield return chunkInfo;
+				await Task.Yield();
+			}
+		}
+	}
+
+	private sealed class FakeArchiveReader(long checkpoint, IVersionedFileNamingStrategy namingStrategy)
+		: IArchiveStorageReader
+	{
+		public IArchiveChunkNamer ChunkNamer { get; } = new ArchiveChunkNamer(namingStrategy);
+
+		public ValueTask<long> GetCheckpoint(CancellationToken ct) => ValueTask.FromResult(checkpoint);
+
+		public ValueTask<long> GetChunkLength(string chunkFile, CancellationToken ct) =>
+			throw new NotImplementedException();
+
+		public ValueTask<Stream> GetChunk(string chunkFile, long start, long end, CancellationToken ct) =>
+			throw new NotImplementedException();
+
+		public ValueTask<Stream> GetChunk(string chunkFile, CancellationToken ct) =>
+			throw new NotImplementedException();
+
+		public IAsyncEnumerable<string> ListChunks(CancellationToken ct) =>
+			throw new NotImplementedException();
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/FakeArchiveStorage.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/FakeArchiveStorage.cs
@@ -65,6 +65,11 @@ internal class FakeArchiveStorage : IArchiveStorageWriter, IArchiveStorageReader
 		return ValueTask.FromResult(_checkpoint);
 	}
 
+	public ValueTask<long> GetChunkLength(string chunkFile, CancellationToken ct)
+	{
+		return ValueTask.FromResult((long)(ChunkHeader.Size + _chunkSize));
+	}
+
 	private ChunkHeader CreateChunkHeader(int chunkStartNumber, int chunkEndNumber)
 	{
 		return new ChunkHeader(

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiverServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiverServiceTests.cs
@@ -352,6 +352,11 @@ internal class FakeArchiveStorage : IArchiveStorageWriter, IArchiveStorageReader
 		return ValueTask.FromResult(_checkpoint);
 	}
 
+	public ValueTask<long> GetChunkLength(string chunkFile, CancellationToken ct)
+	{
+		return ValueTask.FromException<long>(new NotImplementedException());
+	}
+
 	public ValueTask<bool> SetCheckpoint(long checkpoint, CancellationToken ct)
 	{
 		_checkpoint = checkpoint;

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -63,6 +63,7 @@ using EventStore.Core.Synchronization;
 using EventStore.Core.Telemetry;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.Transforms;
 using EventStore.Core.Transforms.Identity;
 using EventStore.Core.Util;
@@ -445,8 +446,23 @@ public class ClusterVNode<TStreamId> :
 					readerThreadsCount, isRunningInContainer);
 
 			_fileNamingStrategy = new VersionedPatternFileNamingStrategy(dbPath, "chunk-");
+			IChunkFileSystem chunkFileSystem = new ChunkLocalFileSystem(_fileNamingStrategy);
+			if (archiveOptions.Enabled)
+			{
+				var archiveReader = new ArchiveStorageFactory(
+					archiveOptions,
+					new ArchiveChunkNamer(_fileNamingStrategy))
+					.CreateReader();
+
+				chunkFileSystem = new FileSystemWithArchive(
+					options.Database.ChunkSize,
+					new PrefixingLocatorCodec(),
+					chunkFileSystem,
+					archiveReader);
+			}
+
 			return new TFChunkDbConfig(dbPath,
-				_fileNamingStrategy,
+				chunkFileSystem,
 				options.Database.ChunkSize,
 				cache,
 				writerChk,

--- a/src/EventStore.Core/Services/Archive/Storage/ArchivedChunkHandle.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/ArchivedChunkHandle.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
+
+namespace EventStore.Core.Services.Archive.Storage;
+
+internal sealed class ArchivedChunkHandle : IChunkHandle
+{
+	private readonly IArchiveStorageReader _reader;
+	private readonly string _chunkFile;
+
+	private ArchivedChunkHandle(IArchiveStorageReader reader, string chunkFile, long length)
+	{
+		_reader = reader;
+		_chunkFile = chunkFile;
+		Length = length;
+	}
+
+	public static async ValueTask<IChunkHandle> OpenForReadAsync(
+		IArchiveStorageReader reader,
+		int logicalChunkNumber,
+		CancellationToken token)
+	{
+		var chunkFile = reader.ChunkNamer.GetFileNameFor(logicalChunkNumber);
+		var length = await reader.GetChunkLength(chunkFile, token);
+		return new ArchivedChunkHandle(reader, chunkFile, length);
+	}
+
+	public long Length { get; set; }
+
+	public string Name => _chunkFile;
+
+	public FileAccess Access => FileAccess.Read;
+
+	public void Flush()
+	{
+	}
+
+	public Task FlushAsync(CancellationToken token) =>
+		token.IsCancellationRequested ? Task.FromCanceled(token) : Task.CompletedTask;
+
+	public ValueTask WriteAsync(ReadOnlyMemory<byte> data, long offset, CancellationToken token) =>
+		ValueTask.FromException(new NotSupportedException());
+
+	public async ValueTask<int> ReadAsync(Memory<byte> buffer, long offset, CancellationToken token)
+	{
+		await using var stream = await _reader.GetChunk(_chunkFile, offset, offset + buffer.Length, token);
+
+		var totalRead = 0;
+		while (totalRead < buffer.Length)
+		{
+			var bytesRead = await stream.ReadAsync(buffer[totalRead..], token);
+			if (bytesRead == 0)
+				break;
+
+			totalRead += bytesRead;
+		}
+
+		return totalRead;
+	}
+
+	public ValueTask SetReadOnlyAsync(bool value, CancellationToken token) =>
+		token.IsCancellationRequested ? ValueTask.FromCanceled(token) : ValueTask.CompletedTask;
+
+	public void Dispose()
+	{
+	}
+}

--- a/src/EventStore.Core/Services/Archive/Storage/Exceptions/ChunkDeletedException.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/Exceptions/ChunkDeletedException.cs
@@ -2,4 +2,15 @@ using System;
 
 namespace EventStore.Core.Services.Archive.Storage.Exceptions;
 
-public class ChunkDeletedException : Exception;
+public class ChunkDeletedException : Exception
+{
+	public ChunkDeletedException()
+		: base("Chunk has been deleted.")
+	{
+	}
+
+	public ChunkDeletedException(Exception innerException)
+		: base("Chunk has been deleted.", innerException)
+	{
+	}
+}

--- a/src/EventStore.Core/Services/Archive/Storage/FileSystemReader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/FileSystemReader.cs
@@ -72,6 +72,25 @@ public class FileSystemReader(
 		return task;
 	}
 
+	public ValueTask<long> GetChunkLength(string chunkFile, CancellationToken ct)
+	{
+		ct.ThrowIfCancellationRequested();
+
+		try
+		{
+			var chunkPath = Path.Combine(_archivePath, chunkFile);
+			return ValueTask.FromResult(new FileInfo(chunkPath).Length);
+		}
+		catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+		{
+			return ValueTask.FromException<long>(new ChunkDeletedException());
+		}
+		catch (Exception e)
+		{
+			return ValueTask.FromException<long>(e);
+		}
+	}
+
 	public ValueTask<Stream> GetChunk(string chunkFile, CancellationToken ct)
 	{
 		ValueTask<Stream> task;

--- a/src/EventStore.Core/Services/Archive/Storage/IArchiveStorageReader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/IArchiveStorageReader.cs
@@ -10,6 +10,7 @@ public interface IArchiveStorageReader
 {
 	public IArchiveChunkNamer ChunkNamer { get; }
 	public ValueTask<long> GetCheckpoint(CancellationToken ct);
+	public ValueTask<long> GetChunkLength(string chunkFile, CancellationToken ct);
 	public ValueTask<Stream> GetChunk(string chunkFile, long start, long end, CancellationToken ct);
 	public ValueTask<Stream> GetChunk(string chunkFile, CancellationToken ct);
 	public IAsyncEnumerable<string> ListChunks(CancellationToken ct);

--- a/src/EventStore.Core/Services/Archive/Storage/S3Reader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/S3Reader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -42,6 +43,22 @@ public class S3Reader : FluentReader, IArchiveStorageReader
 	protected override ILogger Log { get; } = Serilog.Log.ForContext<S3Reader>();
 
 	protected override IBlobStorage BlobStorage => _awsBlobStorage;
+
+	public async ValueTask<long> GetChunkLength(string chunkFile, CancellationToken ct)
+	{
+		try
+		{
+			var response = await _awsBlobStorage.NativeBlobClient.GetObjectMetadataAsync(
+				_options.Bucket,
+				chunkFile,
+				ct);
+			return response.ContentLength;
+		}
+		catch (AmazonS3Exception ex) when (ex.ErrorCode == "NoSuchKey" || ex.StatusCode == HttpStatusCode.NotFound)
+		{
+			throw new ChunkDeletedException();
+		}
+	}
 
 	public async ValueTask<Stream> GetChunk(string chunkFile, long start, long end, CancellationToken ct)
 	{

--- a/src/EventStore.Core/Services/Archive/Storage/S3Reader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/S3Reader.cs
@@ -56,7 +56,7 @@ public class S3Reader : FluentReader, IArchiveStorageReader
 		}
 		catch (AmazonS3Exception ex) when (ex.ErrorCode == "NoSuchKey" || ex.StatusCode == HttpStatusCode.NotFound)
 		{
-			throw new ChunkDeletedException();
+			throw new ChunkDeletedException(ex);
 		}
 	}
 
@@ -85,13 +85,13 @@ public class S3Reader : FluentReader, IArchiveStorageReader
 			var response = await client.GetObjectAsync(request, ct);
 			return response.ResponseStream;
 		}
-		catch (AmazonS3Exception ex)
+		catch (AmazonS3Exception ex) when (ex.ErrorCode == "NoSuchKey" || ex.StatusCode == HttpStatusCode.NotFound)
 		{
-			if (ex.ErrorCode == "NoSuchKey")
-				throw new ChunkDeletedException();
-			if (ex.ErrorCode == "InvalidRange")
-				return Stream.Null;
-			throw;
+			throw new ChunkDeletedException(ex);
+		}
+		catch (AmazonS3Exception ex) when (ex.ErrorCode == "InvalidRange")
+		{
+			return Stream.Null;
 		}
 	}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkFileReadHelper.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkFileReadHelper.cs
@@ -12,9 +12,10 @@ internal static class ChunkFileReadHelper
 {
 	public static SafeFileHandle OpenValidatedMetadataReadHandle(string fileName, out long length)
 	{
+		SafeFileHandle handle = null;
 		try
 		{
-			var handle = File.OpenHandle(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
+			handle = File.OpenHandle(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
 				FileOptions.Asynchronous);
 			length = RandomAccess.GetLength(handle);
 			ValidateMetadataLength(length, fileName);
@@ -22,8 +23,14 @@ internal static class ChunkFileReadHelper
 		}
 		catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
 		{
+			handle?.Dispose();
 			length = 0;
 			throw new CorruptDatabaseException(new ChunkNotFoundException(fileName));
+		}
+		catch
+		{
+			handle?.Dispose();
+			throw;
 		}
 	}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkFileReadHelper.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ChunkFileReadHelper.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Exceptions;
+using DotNext.Buffers;
 using Microsoft.Win32.SafeHandles;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
@@ -16,12 +17,8 @@ internal static class ChunkFileReadHelper
 			var handle = File.OpenHandle(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
 				FileOptions.Asynchronous);
 			length = RandomAccess.GetLength(handle);
-			if (length >= ChunkFooter.Size + ChunkHeader.Size)
-				return handle;
-
-			handle.Dispose();
-			throw new CorruptDatabaseException(new BadChunkInDatabaseException(
-				$"Chunk file '{fileName}' is bad. It does not have enough size for header and footer. File size is {length} bytes."));
+			ValidateMetadataLength(length, fileName);
+			return handle;
 		}
 		catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
 		{
@@ -45,5 +42,51 @@ internal static class ChunkFileReadHelper
 
 			totalRead += bytesRead;
 		}
+	}
+
+	public static async ValueTask ReadExactlyAsync(IChunkHandle handle, Memory<byte> buffer, long offset,
+		string fileName, CancellationToken token)
+	{
+		var totalRead = 0;
+		while (totalRead < buffer.Length)
+		{
+			var bytesRead = await handle.ReadAsync(buffer[totalRead..], offset + totalRead, token);
+			if (bytesRead == 0)
+			{
+				throw new CorruptDatabaseException(new BadChunkInDatabaseException(
+					$"Chunk file '{fileName}' was truncated while reading metadata."));
+			}
+
+			totalRead += bytesRead;
+		}
+	}
+
+	public static async ValueTask<ChunkHeader> ReadHeaderAsync(IChunkHandle handle, string fileName,
+		CancellationToken token)
+	{
+		ValidateMetadataLength(handle.Length, fileName);
+
+		using var buffer = Memory.AllocateExactly<byte>(ChunkHeader.Size);
+		await ReadExactlyAsync(handle, buffer.Memory, 0L, fileName, token);
+		return new(buffer.Span);
+	}
+
+	public static async ValueTask<ChunkFooter> ReadFooterAsync(IChunkHandle handle, string fileName,
+		CancellationToken token)
+	{
+		ValidateMetadataLength(handle.Length, fileName);
+
+		using var buffer = Memory.AllocateExactly<byte>(ChunkFooter.Size);
+		await ReadExactlyAsync(handle, buffer.Memory, handle.Length - ChunkFooter.Size, fileName, token);
+		return new(buffer.Span);
+	}
+
+	private static void ValidateMetadataLength(long length, string fileName)
+	{
+		if (length >= ChunkFooter.Size + ChunkHeader.Size)
+			return;
+
+		throw new CorruptDatabaseException(new BadChunkInDatabaseException(
+			$"Chunk file '{fileName}' is bad. It does not have enough size for header and footer. File size is {length} bytes."));
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/FileSystemWithArchive.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/FileSystemWithArchive.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Services.Archive.Storage;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+
+namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
+
+public sealed class FileSystemWithArchive : IChunkFileSystem
+{
+	private readonly int _chunkSize;
+	private readonly ILocatorCodec _locatorCodec;
+	private readonly IChunkFileSystem _localFileSystem;
+	private readonly IArchiveStorageReader _archive;
+
+	public FileSystemWithArchive(
+		int chunkSize,
+		ILocatorCodec locatorCodec,
+		IChunkFileSystem localFileSystem,
+		IArchiveStorageReader archive)
+	{
+		_chunkSize = chunkSize;
+		_locatorCodec = locatorCodec ?? throw new ArgumentNullException(nameof(locatorCodec));
+		_localFileSystem = localFileSystem ?? throw new ArgumentNullException(nameof(localFileSystem));
+		_archive = archive ?? throw new ArgumentNullException(nameof(archive));
+	}
+
+	public IVersionedFileNamingStrategy NamingStrategy => _localFileSystem.NamingStrategy;
+
+	public ValueTask<IChunkHandle> OpenForReadAsync(string fileName, ReadOptimizationHint readOptimizationHint,
+		bool asyncIO, CancellationToken token) =>
+		_locatorCodec.Decode(fileName, out var logicalChunkNumber, out var localFileName)
+			? ArchivedChunkHandle.OpenForReadAsync(_archive, logicalChunkNumber, token)
+			: _localFileSystem.OpenForReadAsync(localFileName, readOptimizationHint, asyncIO, token);
+
+	public async ValueTask<ChunkHeader> ReadHeaderAsync(string fileName, CancellationToken token)
+	{
+		if (!_locatorCodec.Decode(fileName, out var logicalChunkNumber, out var localFileName))
+			return await _localFileSystem.ReadHeaderAsync(localFileName, token);
+
+		using var handle = await ArchivedChunkHandle.OpenForReadAsync(_archive, logicalChunkNumber, token);
+		return await ChunkFileReadHelper.ReadHeaderAsync(handle, fileName, token);
+	}
+
+	public async ValueTask<ChunkFooter> ReadFooterAsync(string fileName, CancellationToken token)
+	{
+		if (!_locatorCodec.Decode(fileName, out var logicalChunkNumber, out var localFileName))
+			return await _localFileSystem.ReadFooterAsync(localFileName, token);
+
+		using var handle = await ArchivedChunkHandle.OpenForReadAsync(_archive, logicalChunkNumber, token);
+		return await ChunkFileReadHelper.ReadFooterAsync(handle, fileName, token);
+	}
+
+	public IChunkEnumerator CreateChunkEnumerator() =>
+		new ChunkEnumeratorWithArchive(_chunkSize, _locatorCodec, _localFileSystem.CreateChunkEnumerator(), _archive);
+
+	private sealed class ChunkEnumeratorWithArchive : IChunkEnumerator
+	{
+		private readonly int _chunkSize;
+		private readonly ILocatorCodec _locatorCodec;
+		private readonly IChunkEnumerator _localChunkEnumerator;
+		private readonly IArchiveStorageReader _archive;
+
+		public ChunkEnumeratorWithArchive(
+			int chunkSize,
+			ILocatorCodec locatorCodec,
+			IChunkEnumerator localChunkEnumerator,
+			IArchiveStorageReader archive)
+		{
+			_chunkSize = chunkSize;
+			_locatorCodec = locatorCodec;
+			_localChunkEnumerator = localChunkEnumerator;
+			_archive = archive;
+		}
+
+		public async IAsyncEnumerable<TFChunkInfo> EnumerateChunks(int lastChunkNumber,
+			[EnumeratorCancellation] CancellationToken token)
+		{
+			var firstChunkNotInArchive = (int)(await _archive.GetCheckpoint(token) / _chunkSize);
+
+			await foreach (var chunkInfo in _localChunkEnumerator.EnumerateChunks(lastChunkNumber, token)
+				               .WithCancellation(token))
+			{
+				if (chunkInfo is MissingVersion(_, var start) && start < firstChunkNotInArchive)
+				{
+					yield return new LatestVersion(_locatorCodec.EncodeRemote(start), start, start);
+					continue;
+				}
+
+				yield return chunkInfo;
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ILocatorCodec.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ILocatorCodec.cs
@@ -1,0 +1,8 @@
+namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
+
+public interface ILocatorCodec
+{
+	string EncodeRemote(int chunkNumber);
+
+	bool Decode(string locator, out int chunkNumber, out string fileName);
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/PrefixingLocatorCodec.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/PrefixingLocatorCodec.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
+
+public class PrefixingLocatorCodec : ILocatorCodec
+{
+	private const string RemotePrefix = "archived-chunk-";
+
+	public string EncodeRemote(int chunkNumber) => $"{RemotePrefix}{chunkNumber}";
+
+	public bool Decode(string locator, out int chunkNumber, out string fileName)
+	{
+		if (locator.StartsWith(RemotePrefix, StringComparison.Ordinal))
+		{
+			chunkNumber = int.Parse(locator.AsSpan(RemotePrefix.Length));
+			fileName = string.Empty;
+			return true;
+		}
+
+		chunkNumber = default;
+		fileName = locator;
+		return false;
+	}
+}


### PR DESCRIPTION
- keep completed chunks readable after archive storage takes over from local files
- unblock startup and verification paths that still need chunk metadata while archived chunks are in circulation
- close the missing local archive-read seam before local chunk removal work continues