### PR TITLE
feat(archive): let scavenges retire local chunks

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Scavenge/ChunkDeleterTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/ChunkDeleterTests.cs
@@ -275,6 +275,32 @@ public class ChunkDeleterTests
 	}
 
 	[Fact]
+	public async Task when_switch_in_is_rejected()
+	{
+		var minDateInChunk = new DateTime(2024, 1, 1);
+		var maxDateInChunk = new DateTime(2024, 12, 1);
+		_backend.ChunkTimeStampRanges[1] = new(minDateInChunk, maxDateInChunk);
+		var chunk = new FakeChunk(chunkStartNumber: 1, chunkEndNumber: 2, chunkSize: 1_000);
+
+		var sut = GenSut(
+			retainDays: 10,
+			retainBytes: 1000,
+			readArchiveCheckpoint: () => chunk.ChunkEndPosition);
+		_chunkManager.ShouldSucceed = false;
+
+		var deleted = await sut.DeleteIfNotRetained(
+			scavengePoint: GenScavengePoint(
+				position: chunk.ChunkEndPosition + 1001,
+				effectiveNow: maxDateInChunk + TimeSpan.FromDays(10.1)),
+			concurrentState: _scavengeState,
+			physicalChunk: chunk,
+			CancellationToken.None);
+
+		Assert.False(deleted);
+		Assert.Equal(new[] { "archived-chunk-1", "archived-chunk-2" }, _chunkManager.InterceptedLocators);
+	}
+
+	[Fact]
 	public async Task when_chunk_has_no_prepares()
 	{
 		// chunk 1 contains records with positions 1000-2000
@@ -303,15 +329,19 @@ public class ChunkDeleterTests
 	sealed class FakeChunkManager : IChunkManagerForChunkDeleter
 	{
 		public IReadOnlyList<string> InterceptedLocators { get; private set; } = [];
+		public bool ShouldSucceed { get; set; } = true;
 
-		public void Reset() =>
+		public void Reset()
+		{
 			InterceptedLocators = [];
+			ShouldSucceed = true;
+		}
 
 		public ValueTask<bool> SwitchInChunks(IReadOnlyList<string> locators, CancellationToken token)
 		{
 			token.ThrowIfCancellationRequested();
 			InterceptedLocators = locators.ToArray();
-			return ValueTask.FromResult(true);
+			return ValueTask.FromResult(ShouldSucceed);
 		}
 	}
 

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/ChunkDeleterTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/ChunkDeleterTests.cs
@@ -256,6 +256,35 @@ public class ChunkDeleterTests
 	}
 
 	[Fact]
+	public async Task when_archive_presence_check_is_cancelled()
+	{
+		var minDateInChunk = new DateTime(2024, 1, 1);
+		var maxDateInChunk = new DateTime(2024, 12, 1);
+		_backend.ChunkTimeStampRanges[1] = new(minDateInChunk, maxDateInChunk);
+		var chunk = new FakeChunk(chunkStartNumber: 1, chunkEndNumber: 1, chunkSize: 1_000);
+		using var cts = new CancellationTokenSource();
+		var cancellation = new OperationCanceledException(cts.Token);
+
+		var sut = GenSut(
+			retainDays: 10,
+			retainBytes: 1000,
+			readArchiveCheckpoint: () => throw cancellation,
+			maxAttempts: 3);
+
+		var ex = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+			await sut.DeleteIfNotRetained(
+				scavengePoint: GenScavengePoint(
+					position: chunk.ChunkEndPosition + 1001,
+					effectiveNow: maxDateInChunk + TimeSpan.FromDays(10.1)),
+				concurrentState: _scavengeState,
+				physicalChunk: chunk,
+				CancellationToken.None));
+
+		Assert.Same(cancellation, ex);
+		Assert.Empty(_chunkManager.InterceptedLocators);
+	}
+
+	[Fact]
 	public async Task when_chunk_is_remote()
 	{
 		var chunk = new FakeChunk(chunkStartNumber: 1, chunkEndNumber: 1, isRemote: true);

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/ChunkDeleterTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/ChunkDeleterTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.Index.Hashers;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.TransactionLog.Scavenging;
 using EventStore.Core.TransactionLog.Scavenging.InMemory;
@@ -19,6 +20,7 @@ public class ChunkDeleterTests
 {
 	readonly IScavengeStateBackend<string> _backend;
 	readonly ScavengeStateForChunkWorker<string> _scavengeState;
+	readonly FakeChunkManager _chunkManager = new();
 
 	public ChunkDeleterTests()
 	{
@@ -30,16 +32,19 @@ public class ChunkDeleterTests
 			onDispose: () => { });
 	}
 
-	static ChunkDeleter<string, ILogRecord> GenSut(
+	ChunkDeleter<string, ILogRecord> GenSut(
 		int retainDays,
 		long retainBytes,
 		Func<long> readArchiveCheckpoint,
 		int maxAttempts = 1,
 		ILogger logger = null)
 	{
+		_chunkManager.Reset();
 		var sut = new ChunkDeleter<string, ILogRecord>(
 			logger: logger ?? Serilog.Log.Logger,
 			archiveCheckpoint: new AdvancingCheckpoint(_ => new(readArchiveCheckpoint())),
+			chunkManager: _chunkManager,
+			locatorCodec: new PrefixingLocatorCodec(),
 			retainPeriod: TimeSpan.FromDays(retainDays),
 			retainBytes: retainBytes,
 			maxAttempts: maxAttempts,
@@ -61,12 +66,11 @@ public class ChunkDeleterTests
 	{
 		Deleted,
 		Retained,
-		ExceptionNotPresent,
 	}
 
 	[Theory]
 	[InlineData(1000, 10, true, ExpectedOutcome.Deleted, "can be deleted")]
-	[InlineData(1000, 10, false, ExpectedOutcome.ExceptionNotPresent, "exception when not present in archive")]
+	[InlineData(1000, 10, false, ExpectedOutcome.Retained, "retain because it is not yet in archive")]
 	[InlineData(1000, 11, true, ExpectedOutcome.Retained, "retain because of retention period (in archive)")]
 	[InlineData(1000, 11, false, ExpectedOutcome.Retained, "retain because of retention period (not in archive)")]
 	[InlineData(1001, 10, true, ExpectedOutcome.Retained, "retain because of retention bytes (in archive)")]
@@ -84,10 +88,10 @@ public class ChunkDeleterTests
 		_ = name;
 		var minDateInChunk = new DateTime(2024, 1, 1);
 		var maxDateInChunk = new DateTime(2024, 12, 1);
-		_backend.ChunkTimeStampRanges[0] = new(minDateInChunk, maxDateInChunk);
+		_backend.ChunkTimeStampRanges[1] = new(minDateInChunk, maxDateInChunk);
 
-		// chunk 1 contains records with positions 1000-2000
-		var chunk = new FakeChunk(chunkStartNumber: 0, chunkEndNumber: 1, chunkSize: 1_000);
+		// chunk 1-2 contains records with positions 1000-3000
+		var chunk = new FakeChunk(chunkStartNumber: 1, chunkEndNumber: 2, chunkSize: 1_000);
 
 		var sut = GenSut(
 			retainDays: retainDays,
@@ -110,18 +114,17 @@ public class ChunkDeleterTests
 			return deleted;
 		};
 
-		if (expectedOutcome == ExpectedOutcome.ExceptionNotPresent)
-		{
-			var ex = await Assert.ThrowsAsync<Exception>(when);
-			Assert.Contains("Chunk 1 is not yet present in the archive", ex.Message);
-			return;
-		}
-
 		var deleted = await when();
 		if (expectedOutcome == ExpectedOutcome.Deleted)
+		{
 			Assert.True(deleted);
+			Assert.Equal(new[] { "archived-chunk-1", "archived-chunk-2" }, _chunkManager.InterceptedLocators);
+		}
 		else if (expectedOutcome == ExpectedOutcome.Retained)
+		{
 			Assert.False(deleted);
+			Assert.Empty(_chunkManager.InterceptedLocators);
+		}
 		else
 			throw new InvalidOperationException();
 	}
@@ -193,10 +196,10 @@ public class ChunkDeleterTests
 	{
 		var minDateInChunk = new DateTime(2024, 1, 1);
 		var maxDateInChunk = new DateTime(2024, 12, 1);
-		_backend.ChunkTimeStampRanges[0] = new(minDateInChunk, maxDateInChunk);
+		_backend.ChunkTimeStampRanges[1] = new(minDateInChunk, maxDateInChunk);
 
-		// chunk 0-1 contains records with positions 1000-2000
-		var chunk = new FakeChunk(chunkStartNumber: 0, chunkEndNumber: 1, chunkSize: 1_000);
+		// chunk 1-2 contains records with positions 1000-3000
+		var chunk = new FakeChunk(chunkStartNumber: 1, chunkEndNumber: 2, chunkSize: 1_000);
 
 		var attempts = 0;
 
@@ -211,19 +214,17 @@ public class ChunkDeleterTests
 			},
 			maxAttempts: 3);
 
-		var ex = await Assert.ThrowsAsync<Exception>(async () =>
-			await sut.DeleteIfNotRetained(
-				scavengePoint: GenScavengePoint(
-					// scavenging > 1000 bytes after the end of the chunk
-					position: chunk.ChunkEndPosition + 1001,
-					// scavenging > 10 days after the last record in the chunk
-					effectiveNow: maxDateInChunk + TimeSpan.FromDays(10.1)),
-				concurrentState: _scavengeState,
-				physicalChunk: chunk,
-				CancellationToken.None));
+		var deleted = await sut.DeleteIfNotRetained(
+			scavengePoint: GenScavengePoint(
+				position: chunk.ChunkEndPosition + 1001,
+				effectiveNow: maxDateInChunk + TimeSpan.FromDays(10.1)),
+			concurrentState: _scavengeState,
+			physicalChunk: chunk,
+			CancellationToken.None);
 
-		Assert.Contains("Chunk 1 is not yet present in the archive", ex.Message);
+		Assert.False(deleted);
 		Assert.Equal(3, attempts);
+		Assert.Empty(_chunkManager.InterceptedLocators);
 	}
 
 	[Fact]
@@ -239,20 +240,38 @@ public class ChunkDeleterTests
 		var sut = GenSut(
 			retainDays: 10,
 			retainBytes: 1000,
-			readArchiveCheckpoint: () => throw new Exception("something happened"));
+			readArchiveCheckpoint: () => throw new Exception("something happened"),
+			maxAttempts: 3);
 
-		var ex = await Assert.ThrowsAsync<Exception>(async () =>
-			await sut.DeleteIfNotRetained(
-				scavengePoint: GenScavengePoint(
-					// scavenging > 1000 bytes after the end of the chunk
-					position: chunk.ChunkEndPosition + 1001,
-					// scavenging > 10 days after the last record in the chunk
-					effectiveNow: maxDateInChunk + TimeSpan.FromDays(10.1)),
-				concurrentState: _scavengeState,
-				physicalChunk: chunk,
-				CancellationToken.None));
+		var deleted = await sut.DeleteIfNotRetained(
+			scavengePoint: GenScavengePoint(
+				position: chunk.ChunkEndPosition + 1001,
+				effectiveNow: maxDateInChunk + TimeSpan.FromDays(10.1)),
+			concurrentState: _scavengeState,
+			physicalChunk: chunk,
+			CancellationToken.None);
 
-		Assert.Contains("something happened", ex.Message);
+		Assert.False(deleted);
+		Assert.Empty(_chunkManager.InterceptedLocators);
+	}
+
+	[Fact]
+	public async Task when_chunk_is_remote()
+	{
+		var chunk = new FakeChunk(chunkStartNumber: 1, chunkEndNumber: 1, isRemote: true);
+		var sut = GenSut(
+			retainDays: 0,
+			retainBytes: 0,
+			readArchiveCheckpoint: () => chunk.ChunkEndPosition);
+
+		var deleted = await sut.DeleteIfNotRetained(
+			scavengePoint: GenScavengePoint(position: chunk.ChunkEndPosition + 1001, effectiveNow: DateTime.UtcNow),
+			concurrentState: _scavengeState,
+			physicalChunk: chunk,
+			CancellationToken.None);
+
+		Assert.False(deleted);
+		Assert.Empty(_chunkManager.InterceptedLocators);
 	}
 
 	[Fact]
@@ -281,10 +300,26 @@ public class ChunkDeleterTests
 		Assert.True(deleted);
 	}
 
+	sealed class FakeChunkManager : IChunkManagerForChunkDeleter
+	{
+		public IReadOnlyList<string> InterceptedLocators { get; private set; } = [];
+
+		public void Reset() =>
+			InterceptedLocators = [];
+
+		public ValueTask<bool> SwitchInChunks(IReadOnlyList<string> locators, CancellationToken token)
+		{
+			token.ThrowIfCancellationRequested();
+			InterceptedLocators = locators.ToArray();
+			return ValueTask.FromResult(true);
+		}
+	}
+
 	class FakeChunk(
 		int chunkStartNumber,
 		int chunkEndNumber,
-		int chunkSize = 1_000)
+		int chunkSize = 1_000,
+		bool isRemote = false)
 
 		: IChunkReaderForExecutor<string, ILogRecord>
 	{
@@ -298,7 +333,7 @@ public class ChunkDeleterTests
 
 		public bool IsReadOnly => throw new NotImplementedException();
 
-		public bool IsRemote => throw new NotImplementedException();
+		public bool IsRemote => isRemote;
 
 		public long ChunkStartPosition => chunkStartNumber * chunkSize;
 

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
@@ -494,6 +494,8 @@ public class Scenario<TLogFormat, TStreamId> : Scenario
 				buffer: new(checkpointPeriod),
 				throttle: throttle);
 
+			var locatorCodec = new PrefixingLocatorCodec();
+
 			IChunkExecutor<TStreamId> chunkExecutor = new ChunkExecutor<TStreamId, ILogRecord>(
 				logger: logger,
 				metastreamLookup: chunkExecutorMetastreamLookup,
@@ -501,6 +503,10 @@ public class Scenario<TLogFormat, TStreamId> : Scenario
 					new ChunkDeleter<TStreamId, ILogRecord>(
 						logger: logger,
 						archiveCheckpoint: new AdvancingCheckpoint(_ => new(_archiveCheckpoint)),
+						chunkManager: new TracingChunkManagerForChunkDeleter(
+							dbResult.RemoteChunks,
+							locatorCodec),
+						locatorCodec: locatorCodec,
 						retainPeriod: TimeSpan.FromDays(_retainDays),
 						retainBytes: _retainBytes),
 					Tracer),

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/TracingChunkManagerForChunkDeleter.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/TracingChunkManagerForChunkDeleter.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using EventStore.Core.TransactionLog.Scavenging;
+
+namespace EventStore.Core.XUnit.Tests.Scavenge;
+
+public class TracingChunkManagerForChunkDeleter(
+	HashSet<int> remoteChunks,
+	ILocatorCodec locatorCodec) : IChunkManagerForChunkDeleter
+{
+	public ValueTask<bool> SwitchInChunks(IReadOnlyList<string> locators, CancellationToken token)
+	{
+		token.ThrowIfCancellationRequested();
+
+		foreach (var locator in locators)
+		{
+			if (!locatorCodec.Decode(locator, out var chunkNumber, out _))
+				return ValueTask.FromResult(false);
+
+			remoteChunks.Add(chunkNumber);
+		}
+
+		return ValueTask.FromResult(true);
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkManagerArchiveSwitchTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkManagerArchiveSwitchTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Services.Archive;
+using EventStore.Core.Services.Archive.Naming;
+using EventStore.Core.Services.Archive.Storage;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Transforms;
+using EventStore.Core.Transforms.Identity;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.TransactionLog.Chunks;
+
+public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
+{
+	private const string ArchiveCheckpointFile = "archive.chk";
+	private const int ChunkSize = 4096;
+
+	private readonly DirectoryFixture<TFChunkManagerArchiveSwitchTests> _fixture = new();
+	private readonly string _dbPath;
+	private readonly string _archivePath;
+	private readonly ChunkLocalFileSystem _localFileSystem;
+	private readonly ILocatorCodec _locatorCodec = new PrefixingLocatorCodec();
+	private readonly FileSystemWriter _archiveWriter;
+	private readonly ArchiveChunkNamer _archiveChunkNamer;
+	private readonly TFChunkManager _sut;
+
+	public TFChunkManagerArchiveSwitchTests()
+	{
+		_dbPath = Path.Combine(_fixture.Directory, "db");
+		_archivePath = Path.Combine(_fixture.Directory, "archive");
+		Directory.CreateDirectory(_dbPath);
+		Directory.CreateDirectory(_archivePath);
+
+		var dbNamingStrategy = new VersionedPatternFileNamingStrategy(_dbPath, "chunk-");
+		_localFileSystem = new ChunkLocalFileSystem(dbNamingStrategy);
+		_archiveChunkNamer = new ArchiveChunkNamer(new VersionedPatternFileNamingStrategy(_archivePath, "chunk-"));
+		_archiveWriter = new FileSystemWriter(new FileSystemOptions { Path = _archivePath }, ArchiveCheckpointFile);
+
+		var config = new TFChunkDbConfig(
+			path: _dbPath,
+			chunkFileSystem: new FileSystemWithArchive(
+				ChunkSize,
+				_locatorCodec,
+				_localFileSystem,
+				new FileSystemReader(
+					new FileSystemOptions { Path = _archivePath },
+					_archiveChunkNamer,
+					ArchiveCheckpointFile)),
+			chunkSize: ChunkSize,
+			maxChunksCacheSize: 0,
+			writerCheckpoint: new InMemoryCheckpoint(0),
+			chaserCheckpoint: new InMemoryCheckpoint(0),
+			epochCheckpoint: new InMemoryCheckpoint(-1),
+			proposalCheckpoint: new InMemoryCheckpoint(-1),
+			truncateCheckpoint: new InMemoryCheckpoint(-1),
+			replicationCheckpoint: new InMemoryCheckpoint(-1),
+			indexCheckpoint: new InMemoryCheckpoint(-1),
+			streamExistenceFilterCheckpoint: new InMemoryCheckpoint(-1));
+
+		_sut = new TFChunkManager(config, new TFChunkTracker.NoOp(), DbTransformManager.Default);
+	}
+
+	public Task InitializeAsync() =>
+		_fixture.InitializeAsync();
+
+	public async Task DisposeAsync()
+	{
+		await _sut.TryClose(CancellationToken.None);
+		await _fixture.DisposeAsync();
+	}
+
+	[Fact]
+	public async Task switches_in_archived_chunks_for_a_precise_range()
+	{
+		var chunk0 = await AddLocalChunk(0, 0);
+		var chunk45 = await AddLocalChunk(4, 5);
+		await AddLocalChunk(1, 3);
+		await StoreArchivedChunk(1);
+		await StoreArchivedChunk(2);
+		await StoreArchivedChunk(3);
+
+		var switched = await _sut.SwitchInCompletedChunks([
+			_locatorCodec.EncodeRemote(1),
+			_locatorCodec.EncodeRemote(2),
+			_locatorCodec.EncodeRemote(3),
+		], CancellationToken.None);
+
+		Assert.True(switched);
+		Assert.Equal(new[]
+		{
+			chunk0.ChunkLocator,
+			_locatorCodec.EncodeRemote(1),
+			_locatorCodec.EncodeRemote(2),
+			_locatorCodec.EncodeRemote(3),
+			chunk45.ChunkLocator,
+			chunk45.ChunkLocator,
+		}, ActualChunks);
+	}
+
+	[Fact]
+	public async Task rejects_misaligned_archive_ranges_without_mutating_chunks()
+	{
+		var chunk0 = await AddLocalChunk(0, 0);
+		var chunk13 = await AddLocalChunk(1, 3);
+		var chunk45 = await AddLocalChunk(4, 5);
+		await StoreArchivedChunk(2);
+		await StoreArchivedChunk(3);
+
+		var switched = await _sut.SwitchInCompletedChunks([
+			_locatorCodec.EncodeRemote(2),
+			_locatorCodec.EncodeRemote(3),
+		], CancellationToken.None);
+
+		Assert.False(switched);
+		Assert.Equal(new[]
+		{
+			chunk0.ChunkLocator,
+			chunk13.ChunkLocator,
+			chunk13.ChunkLocator,
+			chunk13.ChunkLocator,
+			chunk45.ChunkLocator,
+			chunk45.ChunkLocator,
+		}, ActualChunks);
+	}
+
+	private string[] ActualChunks =>
+		Enumerable.Range(0, _sut.ChunksCount)
+			.Select(chunkNum => _sut.GetChunk(chunkNum).ChunkLocator)
+			.ToArray();
+
+	private async ValueTask<TFChunk> AddLocalChunk(int start, int end)
+	{
+		var fileName = _localFileSystem.NamingStrategy.GetFilenameFor(start, 0);
+		var chunk = await TFChunk.CreateNew(
+			fileSystem: _localFileSystem,
+			filename: fileName,
+			chunkDataSize: ChunkSize,
+			chunkStartNumber: start,
+			chunkEndNumber: end,
+			isScavenged: true,
+			inMem: false,
+			unbuffered: false,
+			writethrough: false,
+			reduceFileCachePressure: false,
+			asyncIO: false,
+			tracker: new TFChunkTracker.NoOp(),
+			transformFactory: new IdentityChunkTransformFactory(),
+			token: CancellationToken.None);
+		await chunk.CompleteScavenge([], CancellationToken.None);
+		await _sut.AddChunk(chunk, CancellationToken.None);
+		return chunk;
+	}
+
+	private async ValueTask StoreArchivedChunk(int chunkNumber)
+	{
+		var sourcePath = Path.Combine(_dbPath, $"archive-source-{chunkNumber}.tmp");
+		var sourceChunk = await TFChunk.CreateNew(
+			fileSystem: _localFileSystem,
+			filename: sourcePath,
+			chunkDataSize: ChunkSize,
+			chunkStartNumber: chunkNumber,
+			chunkEndNumber: chunkNumber,
+			isScavenged: true,
+			inMem: false,
+			unbuffered: false,
+			writethrough: false,
+			reduceFileCachePressure: false,
+			asyncIO: false,
+			tracker: new TFChunkTracker.NoOp(),
+			transformFactory: new IdentityChunkTransformFactory(),
+			token: CancellationToken.None);
+		await sourceChunk.CompleteScavenge([], CancellationToken.None);
+		sourceChunk.Dispose();
+
+		await _archiveWriter.StoreChunk(
+			sourcePath,
+			_archiveChunkNamer.GetFileNameFor(chunkNumber),
+			CancellationToken.None);
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkManagerArchiveSwitchTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkManagerArchiveSwitchTests.cs
@@ -12,6 +12,7 @@ using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.Transforms;
 using EventStore.Core.Transforms.Identity;
+using EventStore.Plugins.Transforms;
 using Xunit;
 
 namespace EventStore.Core.XUnit.Tests.TransactionLog.Chunks;
@@ -129,6 +130,33 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 		}, ActualChunks);
 	}
 
+	[Fact]
+	public async Task switch_chunk_throws_when_the_replacement_range_is_rejected()
+	{
+		var chunk0 = await AddLocalChunk(0, 0);
+		var chunk13 = await AddLocalChunk(1, 3);
+		var chunk45 = await AddLocalChunk(4, 5);
+		using var newChunk = await CreateCompletedTempChunk(2, 3);
+
+		var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+			await _sut.SwitchChunk(
+				newChunk,
+				verifyHash: false,
+				removeChunksWithGreaterNumbers: false,
+				CancellationToken.None));
+
+		Assert.Equal("Failed to switch in chunk #2-3.", ex.Message);
+		Assert.Equal(new[]
+		{
+			chunk0.ChunkLocator,
+			chunk13.ChunkLocator,
+			chunk13.ChunkLocator,
+			chunk13.ChunkLocator,
+			chunk45.ChunkLocator,
+			chunk45.ChunkLocator,
+		}, ActualChunks);
+	}
+
 	private string[] ActualChunks =>
 		Enumerable.Range(0, _sut.ChunksCount)
 			.Select(chunkNum => _sut.GetChunk(chunkNum).ChunkLocator)
@@ -154,6 +182,24 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 			token: CancellationToken.None);
 		await chunk.CompleteScavenge([], CancellationToken.None);
 		await _sut.AddChunk(chunk, CancellationToken.None);
+		return chunk;
+	}
+
+	private async ValueTask<TFChunk> CreateCompletedTempChunk(int start, int end)
+	{
+		var chunk = await _sut.CreateTempChunk(
+			new ChunkHeader(
+				version: (byte)TFChunk.ChunkVersions.Transformed,
+				minCompatibleVersion: (byte)TFChunk.ChunkVersions.Transformed,
+				chunkSize: ChunkSize,
+				chunkStartNumber: start,
+				chunkEndNumber: end,
+				isScavenged: true,
+				chunkId: Guid.NewGuid(),
+				transformType: TransformType.Identity),
+			fileSize: ChunkSize,
+			CancellationToken.None);
+		await chunk.CompleteScavenge([], CancellationToken.None);
 		return chunk;
 	}
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -446,6 +446,7 @@ public class ClusterVNode<TStreamId> :
 					readerThreadsCount, isRunningInContainer);
 
 			_fileNamingStrategy = new VersionedPatternFileNamingStrategy(dbPath, "chunk-");
+			var locatorCodec = new PrefixingLocatorCodec();
 			IChunkFileSystem chunkFileSystem = new ChunkLocalFileSystem(_fileNamingStrategy);
 			if (archiveOptions.Enabled)
 			{
@@ -456,7 +457,7 @@ public class ClusterVNode<TStreamId> :
 
 				chunkFileSystem = new FileSystemWithArchive(
 					options.Database.ChunkSize,
-					new PrefixingLocatorCodec(),
+					locatorCodec,
 					chunkFileSystem,
 					archiveReader);
 			}
@@ -1372,6 +1373,8 @@ public class ClusterVNode<TStreamId> :
 				buffer: calculatorBuffer,
 				throttle: throttle);
 
+			var chunkManager = new ChunkManagerForExecutor<TStreamId>(logger, Db.Manager, Db.Config,
+				Db.TransformManager);
 			var chunkDeleter = IChunkDeleter<TStreamId, ILogRecord>.NoOp;
 			if (archiveOptions.Enabled) {
 				// todo: consider if we can/should reuse the same reader elsewhere
@@ -1381,6 +1384,8 @@ public class ClusterVNode<TStreamId> :
 				chunkDeleter = new ChunkDeleter<TStreamId, ILogRecord>(
 					logger: logger,
 					archiveCheckpoint: new AdvancingCheckpoint(archiveReader.GetCheckpoint),
+					chunkManager: new ChunkManagerForChunkDeleter(Db.Manager),
+					locatorCodec: new PrefixingLocatorCodec(),
 					retainPeriod: TimeSpan.FromDays(archiveOptions.RetainAtLeast.Days),
 					retainBytes: archiveOptions.RetainAtLeast.LogicalBytes);
 			}
@@ -1389,7 +1394,7 @@ public class ClusterVNode<TStreamId> :
 				logger,
 				logFormat.Metastreams,
 				chunkDeleter,
-				new ChunkManagerForExecutor<TStreamId>(logger, Db.Manager, Db.Config, Db.TransformManager),
+				chunkManager,
 				chunkSize: Db.Config.ChunkSize,
 				unsafeIgnoreHardDeletes: options.Database.UnsafeIgnoreHardDelete,
 				cancellationCheckPeriod: cancellationCheckPeriod,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -278,6 +279,40 @@ public class TFChunkManager : IThreadPoolWorkItem
 			TriggerBackgroundCaching();
 	}
 
+	public async ValueTask<bool> SwitchInCompletedChunks(IReadOnlyList<string> locators, CancellationToken token)
+	{
+		Ensure.NotNull(locators, nameof(locators));
+		var getFactoryForExistingChunk = _transformManager.GetFactoryForExistingChunk;
+		var newChunks = new TFChunk.TFChunk[locators.Count];
+		try
+		{
+			for (var i = 0; i < locators.Count; i++)
+			{
+				newChunks[i] = await TFChunk.TFChunk.FromCompletedFile(
+					fileSystem: FileSystem,
+					filename: locators[i],
+					verifyHash: false,
+					unbufferedRead: _config.Unbuffered,
+					tracker: _tracker,
+					getTransformFactory: getFactoryForExistingChunk,
+					reduceFileCachePressure: _config.ReduceFileCachePressure,
+					asyncIO: _config.AsyncIO,
+					token: token);
+			}
+		}
+		catch
+		{
+			for (var i = 0; i < newChunks.Length; i++)
+			{
+				newChunks[i]?.Dispose();
+			}
+
+			throw;
+		}
+
+		return await SwitchInChunks(newChunks, removeChunksAfter: null, token);
+	}
+
 	public async ValueTask<TFChunk.TFChunk> SwitchChunk(TFChunk.TFChunk chunk, bool verifyHash,
 		bool removeChunksWithGreaterNumbers,
 		CancellationToken token)
@@ -329,23 +364,45 @@ public class TFChunkManager : IThreadPoolWorkItem
 				_config.ReduceFileCachePressure, _config.AsyncIO, token: token);
 		}
 
+		await SwitchInChunks([newChunk],
+			removeChunksWithGreaterNumbers ? chunkHeader.ChunkEndNumber : null,
+			token);
+		return newChunk;
+	}
+
+	private async ValueTask<bool> SwitchInChunks(IReadOnlyList<TFChunk.TFChunk> newChunks, int? removeChunksAfter,
+		CancellationToken token)
+	{
+		Ensure.NotNull(newChunks, nameof(newChunks));
+		var ret = true;
+
 		bool triggerCaching;
 		await _chunksLocker.AcquireAsync(token);
 		try
 		{
-			if (!ReplaceChunksWith(newChunk, "Old"))
+			if (ReplaceChunksWith(newChunks, "Old"))
 			{
-				Log.Information("Chunk {chunk} will be not switched, marking for remove...", newChunk);
-				newChunk.MarkForDeletion();
+				foreach (var newChunk in newChunks)
+				{
+					OnChunkSwitched?.Invoke(newChunk.ChunkInfo);
+				}
 			}
 			else
-				OnChunkSwitched?.Invoke(newChunk.ChunkInfo);
+			{
+				foreach (var newChunk in newChunks)
+				{
+					Log.Information("Chunk {chunk} will be not switched, marking for remove...", newChunk);
+					newChunk.MarkForDeletion();
+				}
 
-			if (removeChunksWithGreaterNumbers)
+				ret = false;
+			}
+
+			if (removeChunksAfter.HasValue)
 			{
 				var oldChunksCount = _chunksCount;
-				_chunksCount = newChunk.ChunkHeader.ChunkEndNumber + 1;
-				RemoveChunks(chunkHeader.ChunkEndNumber + 1, oldChunksCount - 1, "Excessive");
+				_chunksCount = newChunks[^1].ChunkHeader.ChunkEndNumber + 1;
+				RemoveChunks(removeChunksAfter.Value + 1, oldChunksCount - 1, "Excessive");
 				if (_chunks[_chunksCount] is not null)
 					throw new Exception(string.Format("Excessive chunk #{0} found after raw replication switch.",
 						_chunksCount));
@@ -358,18 +415,37 @@ public class TFChunkManager : IThreadPoolWorkItem
 			_chunksLocker.Release();
 		}
 
-		// trigger caching out of lock to avoid lock contention
 		if (triggerCaching)
 			TriggerBackgroundCaching();
-		return newChunk;
+
+		return ret;
 	}
 
-	private bool ReplaceChunksWith(TFChunk.TFChunk newChunk, string chunkExplanation)
+	private bool ReplaceChunksWith(IReadOnlyList<TFChunk.TFChunk> newChunks, string chunkExplanation)
 	{
 		Debug.Assert(_chunksLocker.IsLockHeld);
 
-		var chunkStartNumber = newChunk.ChunkHeader.ChunkStartNumber;
-		var chunkEndNumber = newChunk.ChunkHeader.ChunkEndNumber;
+		if (newChunks.Count is 0)
+			return true;
+
+		var chunkStartNumber = newChunks[0].ChunkHeader.ChunkStartNumber;
+		var chunkEndNumber = newChunks[^1].ChunkHeader.ChunkEndNumber;
+
+		var expectedStart = chunkStartNumber;
+		foreach (var newChunk in newChunks)
+		{
+			if (newChunk.ChunkHeader.ChunkStartNumber != expectedStart)
+			{
+				Log.Error(
+					"Cannot replace chunks because new chunks are not contiguous. ExpectedChunkNumber {Expected}. ActualChunkNumber {Actual}",
+					expectedStart,
+					newChunk.ChunkHeader.ChunkStartNumber);
+				return false;
+			}
+
+			expectedStart = newChunk.ChunkHeader.ChunkEndNumber + 1;
+		}
+
 		for (int i = chunkStartNumber; i <= chunkEndNumber;)
 		{
 			var chunk = _chunks[i];
@@ -389,9 +465,13 @@ public class TFChunkManager : IThreadPoolWorkItem
 		}
 
 		TFChunk.TFChunk previousRemovedChunk = null;
+		var newChunkIndex = 0;
 		for (int i = chunkStartNumber; i <= chunkEndNumber; i += 1)
 		{
-			var oldChunk = Interlocked.Exchange(ref _chunks[i], newChunk);
+			while (!Covers(newChunks[newChunkIndex], i))
+				newChunkIndex++;
+
+			var oldChunk = Interlocked.Exchange(ref _chunks[i], newChunks[newChunkIndex]);
 			if (!ReferenceEquals(previousRemovedChunk, oldChunk))
 			{
 				// Once we've swapped all entries for the previousRemovedChunk we can safely delete it.
@@ -415,6 +495,10 @@ public class TFChunkManager : IThreadPoolWorkItem
 		}
 
 		return true;
+
+		static bool Covers(TFChunk.TFChunk chunk, int chunkNumber) =>
+			chunk.ChunkHeader.ChunkStartNumber <= chunkNumber &&
+			chunk.ChunkHeader.ChunkEndNumber >= chunkNumber;
 	}
 
 	private void RemoveChunks(int chunkStartNumber, int chunkEndNumber, string chunkExplanation)

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -284,6 +284,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 		Ensure.NotNull(locators, nameof(locators));
 		var getFactoryForExistingChunk = _transformManager.GetFactoryForExistingChunk;
 		var newChunks = new TFChunk.TFChunk[locators.Count];
+		var ownsNewChunks = true;
 		try
 		{
 			for (var i = 0; i < locators.Count; i++)
@@ -299,18 +300,17 @@ public class TFChunkManager : IThreadPoolWorkItem
 					asyncIO: _config.AsyncIO,
 					token: token);
 			}
+
+			return await SwitchInChunks(newChunks, removeChunksAfter: null, token,
+				onOwnershipTransferred: () => ownsNewChunks = false);
 		}
 		catch
 		{
-			for (var i = 0; i < newChunks.Length; i++)
-			{
-				newChunks[i]?.Dispose();
-			}
+			if (ownsNewChunks)
+				DisposeChunks(newChunks);
 
 			throw;
 		}
-
-		return await SwitchInChunks(newChunks, removeChunksAfter: null, token);
 	}
 
 	public async ValueTask<TFChunk.TFChunk> SwitchChunk(TFChunk.TFChunk chunk, bool verifyHash,
@@ -376,7 +376,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 	}
 
 	private async ValueTask<bool> SwitchInChunks(IReadOnlyList<TFChunk.TFChunk> newChunks, int? removeChunksAfter,
-		CancellationToken token)
+		CancellationToken token, Action onOwnershipTransferred = null)
 	{
 		Ensure.NotNull(newChunks, nameof(newChunks));
 		var ret = true;
@@ -387,6 +387,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 		{
 			if (ReplaceChunksWith(newChunks, "Old"))
 			{
+				onOwnershipTransferred?.Invoke();
 				foreach (var newChunk in newChunks)
 				{
 					OnChunkSwitched?.Invoke(newChunk.ChunkInfo);
@@ -424,6 +425,14 @@ public class TFChunkManager : IThreadPoolWorkItem
 			TriggerBackgroundCaching();
 
 		return ret;
+	}
+
+	private static void DisposeChunks(IReadOnlyList<TFChunk.TFChunk> chunks)
+	{
+		for (var i = 0; i < chunks.Count; i++)
+		{
+			chunks[i]?.Dispose();
+		}
 	}
 
 	private bool ReplaceChunksWith(IReadOnlyList<TFChunk.TFChunk> newChunks, string chunkExplanation)

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -364,9 +364,14 @@ public class TFChunkManager : IThreadPoolWorkItem
 				_config.ReduceFileCachePressure, _config.AsyncIO, token: token);
 		}
 
-		await SwitchInChunks([newChunk],
+		if (!await SwitchInChunks([newChunk],
 			removeChunksWithGreaterNumbers ? chunkHeader.ChunkEndNumber : null,
-			token);
+			token))
+		{
+			throw new InvalidOperationException(
+				$"Failed to switch in chunk #{chunkHeader.ChunkStartNumber}-{chunkHeader.ChunkEndNumber}.");
+		}
+
 		return newChunk;
 	}
 

--- a/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkManagerForChunkDeleter.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkManagerForChunkDeleter.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.TransactionLog.Chunks;
+
+namespace EventStore.Core.TransactionLog.Scavenging;
+
+public class ChunkManagerForChunkDeleter(TFChunkManager manager) : IChunkManagerForChunkDeleter
+{
+	public ValueTask<bool> SwitchInChunks(IReadOnlyList<string> locators, CancellationToken token) =>
+		manager.SwitchInCompletedChunks(locators, token);
+}

--- a/src/EventStore.Core/TransactionLog/Scavenging/Interfaces/IChunkManagerForChunkExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Interfaces/IChunkManagerForChunkExecutor.cs
@@ -11,6 +11,10 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 		IChunkReaderForExecutor<TStreamId, TRecord> GetChunkReaderFor(long position);
 	}
 
+	public interface IChunkManagerForChunkDeleter {
+		ValueTask<bool> SwitchInChunks(IReadOnlyList<string> locators, CancellationToken token);
+	}
+
 	public interface IChunkWriterForExecutor<TStreamId, TRecord> {
 		string LocalFileName { get; }
 

--- a/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkDeleter.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkDeleter.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using Serilog;
 
 namespace EventStore.Core.TransactionLog.Scavenging.Stages;
@@ -11,6 +12,8 @@ public class ChunkDeleter<TStreamId, TRecord> : IChunkDeleter<TStreamId, TRecord
 {
 	private readonly ILogger _logger;
 	private readonly AdvancingCheckpoint _archiveCheckpoint;
+	private readonly IChunkManagerForChunkDeleter _chunkManager;
+	private readonly ILocatorCodec _locatorCodec;
 	private readonly TimeSpan _retainPeriod;
 	private readonly long _retainBytes;
 	private readonly int _maxAttempts;
@@ -19,6 +22,8 @@ public class ChunkDeleter<TStreamId, TRecord> : IChunkDeleter<TStreamId, TRecord
 	public ChunkDeleter(
 		ILogger logger,
 		AdvancingCheckpoint archiveCheckpoint,
+		IChunkManagerForChunkDeleter chunkManager,
+		ILocatorCodec locatorCodec,
 		TimeSpan retainPeriod,
 		long retainBytes,
 		int maxAttempts = 10,
@@ -27,6 +32,8 @@ public class ChunkDeleter<TStreamId, TRecord> : IChunkDeleter<TStreamId, TRecord
 
 		_logger = logger;
 		_archiveCheckpoint = archiveCheckpoint;
+		_chunkManager = chunkManager;
+		_locatorCodec = locatorCodec;
 		_retainPeriod = retainPeriod;
 		_retainBytes = retainBytes;
 		_maxAttempts = maxAttempts;
@@ -44,6 +51,8 @@ public class ChunkDeleter<TStreamId, TRecord> : IChunkDeleter<TStreamId, TRecord
 		IChunkReaderForExecutor<TStreamId, TRecord> physicalChunk,
 		CancellationToken ct)
 	{
+		if (physicalChunk.IsRemote)
+			return false;
 
 		if (!ShouldDeleteForBytes(scavengePoint, physicalChunk))
 		{
@@ -61,21 +70,18 @@ public class ChunkDeleter<TStreamId, TRecord> : IChunkDeleter<TStreamId, TRecord
 			return false;
 		}
 
-		await EnsurePresentInArchive(physicalChunk, ct);
-		await DeletePhysicalChunk(physicalChunk, ct);
+		if (!await IsConfirmedPresentInArchive(physicalChunk, ct))
+			return false;
+
+		await SwitchOutPhysicalChunk(physicalChunk, ct);
 		return true;
 	}
 
-	// ideally we want the scavenge to have the same results when run on
-	// different nodes so we do not skip over deleting this chunk if it is not in
-	// the archive, we stop the scavenge instead.
-	private async ValueTask EnsurePresentInArchive(
+	private async ValueTask<bool> IsConfirmedPresentInArchive(
 		IChunkReaderForExecutor<TStreamId, TRecord> physicalChunk,
 		CancellationToken ct)
 	{
-
 		var logicalChunkNumber = physicalChunk.ChunkEndNumber;
-		var lastError = default(Exception);
 
 		for (var attempt = 0; attempt < _maxAttempts; attempt++)
 		{
@@ -86,28 +92,24 @@ public class ChunkDeleter<TStreamId, TRecord> : IChunkDeleter<TStreamId, TRecord
 			{
 				var isPresent = await _archiveCheckpoint.IsGreaterThanOrEqualTo(physicalChunk.ChunkEndPosition, ct);
 				if (isPresent)
+					return true;
+
+				if (attempt == _maxAttempts - 1)
 				{
-					return;
-				}
-				else
-				{
-					lastError = new Exception(
-						$"Chunk {logicalChunkNumber} is not yet present in the archive. Check that the Archiver node is functioning correctly and re-run the scavenge to continue.");
 					_logger.Warning(
-						"Logical chunk {LogicalChunkNumber} is not yet present in the archive. Attempt {Attempt}/{MaxAttempts}",
-						logicalChunkNumber, attempt + 1, _maxAttempts);
+						"Logical chunk {LogicalChunkNumber} is not yet present in the archive.",
+						logicalChunkNumber);
 				}
 			}
 			catch (Exception ex)
 			{
-				lastError = ex;
 				_logger.Warning(ex,
 					"Unable to determine existence of logical chunk {LogicalChunkNumber} in the archive. Attempt {Attempt}/{MaxAttempts}",
 					logicalChunkNumber, attempt + 1, _maxAttempts);
 			}
 		}
 
-		throw lastError ?? new Exception("unknown error");
+		return false;
 	}
 
 	private bool ShouldDeleteForBytes(
@@ -147,23 +149,32 @@ public class ChunkDeleter<TStreamId, TRecord> : IChunkDeleter<TStreamId, TRecord
 		return true;
 	}
 
-	private ValueTask DeletePhysicalChunk(
+	private async ValueTask SwitchOutPhysicalChunk(
 		IChunkReaderForExecutor<TStreamId, TRecord> physicalChunk,
 		CancellationToken ct)
 	{
-
-		// todo: actually delete the file in cooperation with the chunk manager
-		// so that readers are allowed to complete and chunk manager knows that
-		// the chunk has gone and must direct readers to the archive
+		var chunkStartNumber = physicalChunk.ChunkStartNumber;
+		var chunkEndNumber = physicalChunk.ChunkEndNumber;
 		_logger.Debug(
 			"SCAVENGING: Deleting physical chunk: {oldChunkName} " +
 			"{chunkStartNumber} => {chunkEndNumber} ({chunkStartPosition} => {chunkEndPosition})",
 			physicalChunk.Name,
-			physicalChunk.ChunkStartNumber, physicalChunk.ChunkEndNumber,
+			chunkStartNumber, chunkEndNumber,
 			physicalChunk.ChunkStartPosition, physicalChunk.ChunkEndPosition);
 
-		return ct.IsCancellationRequested
-			? ValueTask.FromCanceled(ct)
-			: ValueTask.CompletedTask;
+		var locators = new string[chunkEndNumber - chunkStartNumber + 1];
+		for (var i = 0; i < locators.Length; i++)
+		{
+			locators[i] = _locatorCodec.EncodeRemote(chunkStartNumber + i);
+		}
+
+		if (await _chunkManager.SwitchInChunks(locators, ct))
+			return;
+
+		_logger.Warning(
+			"SCAVENGING: Did not delete physical chunk: {oldChunkName} {chunkStartNumber} => {chunkEndNumber}. This will be retried next scavenge.",
+			physicalChunk.Name,
+			chunkStartNumber,
+			chunkEndNumber);
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkDeleter.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkDeleter.cs
@@ -100,6 +100,10 @@ public class ChunkDeleter<TStreamId, TRecord> : IChunkDeleter<TStreamId, TRecord
 						logicalChunkNumber);
 				}
 			}
+			catch (OperationCanceledException)
+			{
+				throw;
+			}
 			catch (Exception ex)
 			{
 				_logger.Warning(ex,

--- a/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkDeleter.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkDeleter.cs
@@ -73,8 +73,7 @@ public class ChunkDeleter<TStreamId, TRecord> : IChunkDeleter<TStreamId, TRecord
 		if (!await IsConfirmedPresentInArchive(physicalChunk, ct))
 			return false;
 
-		await SwitchOutPhysicalChunk(physicalChunk, ct);
-		return true;
+		return await SwitchOutPhysicalChunk(physicalChunk, ct);
 	}
 
 	private async ValueTask<bool> IsConfirmedPresentInArchive(
@@ -149,7 +148,7 @@ public class ChunkDeleter<TStreamId, TRecord> : IChunkDeleter<TStreamId, TRecord
 		return true;
 	}
 
-	private async ValueTask SwitchOutPhysicalChunk(
+	private async ValueTask<bool> SwitchOutPhysicalChunk(
 		IChunkReaderForExecutor<TStreamId, TRecord> physicalChunk,
 		CancellationToken ct)
 	{
@@ -169,12 +168,13 @@ public class ChunkDeleter<TStreamId, TRecord> : IChunkDeleter<TStreamId, TRecord
 		}
 
 		if (await _chunkManager.SwitchInChunks(locators, ct))
-			return;
+			return true;
 
 		_logger.Warning(
 			"SCAVENGING: Did not delete physical chunk: {oldChunkName} {chunkStartNumber} => {chunkEndNumber}. This will be retried next scavenge.",
 			physicalChunk.Name,
 			chunkStartNumber,
 			chunkEndNumber);
+		return false;
 	}
 }


### PR DESCRIPTION
- let archive-backed scavenges reclaim local storage once completed chunks stay readable through archive locators
- keep retention scavenges moving when archive presence cannot be confirmed instead of aborting the whole run