### PR TITLE
fix(archive): avoid redundant archive work

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/DirectoryPerTest.cs
+++ b/src/EventStore.Core.XUnit.Tests/DirectoryPerTest.cs
@@ -7,12 +7,12 @@ public class DirectoryPerTest<T> : IAsyncLifetime
 {
 	protected DirectoryFixture<T> Fixture { get; private set; } = new();
 
-	public async Task InitializeAsync()
+	public virtual async Task InitializeAsync()
 	{
 		await Fixture.InitializeAsync();
 	}
 
-	public async Task DisposeAsync()
+	public virtual async Task DisposeAsync()
 	{
 		await Fixture.DisposeAsync();
 	}

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/ArchiveCatchupTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiveCatchup/ArchiveCatchupTests.cs
@@ -219,6 +219,21 @@ public class ArchiveCatchupTests : DirectoryPerTest<ArchiveCatchupTests>
 		}
 	}
 
+	[Fact]
+	public async Task propagates_cancellation_while_fetching_chunk()
+	{
+		var cancellation = new OperationCanceledException();
+		var sut = CreateSut(
+			dbCheckpoint: 0L,
+			archiveCheckpoint: 1000L,
+			archiveChunks: ["chunk-0.0"],
+			onGetChunk: _ => throw cancellation);
+
+		var ex = await Assert.ThrowsAsync<OperationCanceledException>(() => sut.Catchup.Run());
+
+		Assert.Same(cancellation, ex);
+	}
+
 	private async Task VerifyCatchUp(Sut sut, long dbCheckpoint, long archiveCheckpoint, string[] expectedChunkGets,
 		string[] expectedChunkBackups)
 	{

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiverServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/ArchiverServiceTests.cs
@@ -148,6 +148,32 @@ public class ArchiverServiceTests {
 	}
 
 	[Fact]
+	public async Task doesnt_archive_a_remote_existing_chunk() {
+		var (sut, archive) = CreateSut();
+
+		var chunkInfo = GetChunkInfo(0, 0, complete: true, remote: true);
+		sut.Handle(new SystemMessage.ChunkLoaded(chunkInfo));
+		sut.Handle(new ReplicationTrackingMessage.ReplicatedTo(chunkInfo.ChunkEndPosition));
+
+		await WaitFor(archive, numStores: 0);
+
+		Assert.Equal([], archive.Chunks);
+	}
+
+	[Fact]
+	public async Task doesnt_archive_a_remote_completed_chunk() {
+		var (sut, archive) = CreateSut();
+
+		var chunkInfo = GetChunkInfo(0, 0, complete: true, remote: true);
+		sut.Handle(new ReplicationTrackingMessage.ReplicatedTo(chunkInfo.ChunkEndPosition));
+		sut.Handle(new SystemMessage.ChunkCompleted(chunkInfo));
+
+		await WaitFor(archive, numStores: 0);
+
+		Assert.Equal([], archive.Chunks);
+	}
+
+	[Fact]
 	public async Task archives_chunks_in_order() {
 		var (sut, archive) = CreateSut(chunkStorageDelay: TimeSpan.FromMilliseconds(100));
 

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/FileSystemArchiveLoggingTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/FileSystemArchiveLoggingTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using EventStore.Core.Services.Archive;
 using EventStore.Core.Services.Archive.Naming;
 using EventStore.Core.Services.Archive.Storage;
@@ -13,7 +14,7 @@ using Xunit;
 namespace EventStore.Core.XUnit.Tests.Services.Archive.Storage;
 
 [Collection("SerilogLoggingTests")]
-public class FileSystemArchiveLoggingTests : DirectoryPerTest<FileSystemArchiveLoggingTests>, IDisposable
+public class FileSystemArchiveLoggingTests : DirectoryPerTest<FileSystemArchiveLoggingTests>
 {
 	private readonly ILogger _previousLogger = Log.Logger;
 	private readonly CollectingSink _sink = new();
@@ -55,9 +56,16 @@ public class FileSystemArchiveLoggingTests : DirectoryPerTest<FileSystemArchiveL
 			x => x.RenderMessage().Contains(Path.GetFullPath(archivePath), StringComparison.Ordinal));
 	}
 
-	public void Dispose()
+	public override async Task DisposeAsync()
 	{
-		Log.Logger = _previousLogger;
+		try
+		{
+			Log.Logger = _previousLogger;
+		}
+		finally
+		{
+			await base.DisposeAsync();
+		}
 	}
 
 	private static IArchiveChunkNamer CreateChunkNamer(string archivePath)

--- a/src/EventStore.Core/Services/Archive/ArchiveCatchup/ArchiveCatchup.cs
+++ b/src/EventStore.Core/Services/Archive/ArchiveCatchup/ArchiveCatchup.cs
@@ -138,6 +138,10 @@ public class ArchiveCatchup : IClusterVNodeStartupTask
 			{
 				return await _archiveReader.GetCheckpoint(ct);
 			}
+			catch (OperationCanceledException)
+			{
+				throw;
+			}
 			catch (Exception ex)
 			{
 				Log.Error(ex, "Failed to get archive checkpoint. Retrying in: {interval}", RetryInterval);
@@ -205,6 +209,10 @@ public class ArchiveCatchup : IClusterVNodeStartupTask
 				"Failed to fetch {chunk} from the archive as it was deleted. This can happen if the archive is being scavenged.",
 				chunkFile);
 			return false;
+		}
+		catch (OperationCanceledException)
+		{
+			throw;
 		}
 		catch (Exception ex)
 		{

--- a/src/EventStore.Core/Services/Archive/Archiver/ArchiverService.cs
+++ b/src/EventStore.Core/Services/Archive/Archiver/ArchiverService.cs
@@ -77,7 +77,7 @@ public class ArchiverService :
 
 	public void Handle(SystemMessage.ChunkLoaded message)
 	{
-		if (!message.ChunkInfo.IsCompleted)
+		if (!message.ChunkInfo.IsCompleted || message.ChunkInfo.IsRemote)
 			return;
 
 		_existingChunks[Path.GetFileName(message.ChunkInfo.ChunkLocator)!] = message.ChunkInfo;
@@ -86,6 +86,9 @@ public class ArchiverService :
 	public void Handle(SystemMessage.ChunkCompleted message)
 	{
 		var chunkInfo = message.ChunkInfo;
+		if (chunkInfo.IsRemote)
+			return;
+
 		if (chunkInfo.ChunkEndPosition > _replicationPosition)
 		{
 			_uncommittedChunks.Enqueue(chunkInfo);


### PR DESCRIPTION
- Archived chunks should stay outside archival work once they are already represented remotely.
- Shutdown and cancellation need to interrupt archive catch-up promptly instead of looking like transient storage failures.
- Archive logging tests should restore process-wide logger state without leaking per-test directories.