### PR TITLE
chore(startup): modernize host bootstrap

### DIFF
--- a/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
+++ b/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<OutputType>Exe</OutputType>

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -232,9 +232,12 @@ internal static class Program
 #if DEBUG
 							x.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.StopHost;
 #endif
+						})
+						.Configure<ConsoleLifetimeOptions>(x =>
+						{
+							x.SuppressStatusMessages = true;
 						});
 
-					builder.WebHost.UseSetting(WebHostDefaults.SuppressStatusMessagesKey, "true");
 					builder.WebHost.ConfigureKestrel(server =>
 					{
 						server.Limits.Http2.KeepAlivePingDelay =

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -16,6 +16,7 @@ using EventStore.Core;
 using EventStore.Core.Certificates;
 using EventStore.Core.Configuration;
 using EventStore.Core.Services.Transport.Http;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
@@ -220,45 +221,42 @@ internal static class Program
 			{
 				try
 				{
-					await new HostBuilder()
-						.ConfigureHostConfiguration(builder =>
-							builder.AddEnvironmentVariables("DOTNET_").AddCommandLine(args))
-						.ConfigureAppConfiguration(builder => builder.AddConfiguration(configuration))
-						.ConfigureLogging(logging => logging.ClearProviders().AddSerilog())
-						.ConfigureServices(services => services
-							.Configure<KestrelServerOptions>(configuration.GetSection("Kestrel"))
-							.Configure<HostOptions>(x =>
-							{
-								x.ShutdownTimeout = ClusterVNode.ShutdownTimeout + TimeSpan.FromSeconds(1);
+					var builder = WebApplication.CreateBuilder(args);
+					builder.Configuration.AddConfiguration(configuration);
+					builder.Logging.ClearProviders().AddSerilog();
+					builder.Services
+						.Configure<KestrelServerOptions>(configuration.GetSection("Kestrel"))
+						.Configure<HostOptions>(x =>
+						{
+							x.ShutdownTimeout = ClusterVNode.ShutdownTimeout + TimeSpan.FromSeconds(1);
 #if DEBUG
-								x.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.StopHost;
+							x.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.StopHost;
 #endif
-							})
-						)
-						.ConfigureWebHostDefaults(builder => builder
-							.UseKestrel(server =>
-							{
-								server.Limits.Http2.KeepAlivePingDelay =
-									TimeSpan.FromMilliseconds(options.Grpc.KeepAliveInterval);
-								server.Limits.Http2.KeepAlivePingTimeout =
-									TimeSpan.FromMilliseconds(options.Grpc.KeepAliveTimeout);
+						});
 
-								server.Listen(options.Interface.NodeIp, options.Interface.NodePort, listenOptions =>
-									ConfigureHttpOptions(listenOptions, hostedService,
-										useHttps: !hostedService.Node.DisableHttps));
+					builder.WebHost.UseSetting(WebHostDefaults.SuppressStatusMessagesKey, "true");
+					builder.WebHost.ConfigureKestrel(server =>
+					{
+						server.Limits.Http2.KeepAlivePingDelay =
+							TimeSpan.FromMilliseconds(options.Grpc.KeepAliveInterval);
+						server.Limits.Http2.KeepAlivePingTimeout =
+							TimeSpan.FromMilliseconds(options.Grpc.KeepAliveTimeout);
 
-								if (hostedService.Node.EnableUnixSocket)
-									TryListenOnUnixSocket(hostedService, server);
-							})
-							.ConfigureServices(services => hostedService.Node.Startup.ConfigureServices(services))
-							.Configure(hostedService.Node.Startup.Configure)
-						)
-						// Order is important, configure IHostedService after the WebHost to make the sure
-						// ClusterVNodeHostedService and the subsystems are started after configuration is finished.
-						// Allows the subsystems to resolve dependencies out of the DI in Configure() before being started.
-						// Later it may be possible to use constructor injection instead if it fits with the bootstrapping strategy.
-						.ConfigureServices(services => services.AddSingleton<IHostedService>(hostedService))
-						.RunConsoleAsync(x => x.SuppressStatusMessages = true, cts.Token);
+						server.Listen(options.Interface.NodeIp, options.Interface.NodePort, listenOptions =>
+							ConfigureHttpOptions(listenOptions, hostedService,
+								useHttps: !hostedService.Node.DisableHttps));
+
+						if (hostedService.Node.EnableUnixSocket)
+							TryListenOnUnixSocket(hostedService, server);
+					});
+
+					hostedService.Node.Startup.ConfigureServicesOnly(builder.Services);
+					builder.Services.AddSingleton<IHostedService>(hostedService);
+
+					var app = builder.Build();
+					hostedService.Node.Startup.Configure(app);
+
+					await app.RunAsync(cts.Token);
 
 					exitCodeSource.TrySetResult(0);
 				}

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -222,7 +222,11 @@ internal static class Program
 				try
 				{
 					var builder = WebApplication.CreateBuilder(args);
-					builder.Configuration.AddConfiguration(configuration);
+					builder.Configuration.Sources.Clear();
+					builder.Configuration
+						.AddEnvironmentVariables("DOTNET_")
+						.AddCommandLine(args)
+						.AddConfiguration(configuration);
 					builder.Logging.ClearProviders().AddSerilog();
 					builder.Services
 						.Configure<KestrelServerOptions>(configuration.GetSection("Kestrel"))

--- a/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
+++ b/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
@@ -37,7 +37,7 @@ public abstract class specification_with_bare_vnode<TLogFormat, TStreamId> : IPu
 			certificateProvider: new OptionsCertificateProvider());
 
 		var builder = WebApplication.CreateBuilder();
-		_node.Startup.ConfigureServices(builder.Services);
+		_node.Startup.ConfigureServicesOnly(builder.Services);
 		var app = builder.Build();
 		_node.Startup.Configure(app);
 

--- a/src/EventStore.Core.Tests/Helpers/WebHostBuilderExtensions.cs
+++ b/src/EventStore.Core.Tests/Helpers/WebHostBuilderExtensions.cs
@@ -6,6 +6,13 @@ namespace EventStore.Core.Tests.Helpers;
 internal static class WebHostBuilderExtensions
 {
 	public static IWebHostBuilder UseStartup(this IWebHostBuilder builder, IStartup startup)
-		=> builder
+	{
+		if (startup is IInternalStartup internalStartup)
+			return builder
+				.ConfigureServices(internalStartup.ConfigureServicesOnly)
+				.Configure(startup.Configure);
+
+		return builder
 			.ConfigureServices(services => services.AddSingleton(startup));
+	}
 }

--- a/src/EventStore.Core.Tests/Http/HttpProtocols/clear_text_http_multiplexing_middleware.cs
+++ b/src/EventStore.Core.Tests/Http/HttpProtocols/clear_text_http_multiplexing_middleware.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using EventStore.Core.Services.Transport.Http;
+using EventStore.Core.Tests.Helpers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server.Features;

--- a/src/EventStore.Core.Tests/VerifyIntPtrSize.cs
+++ b/src/EventStore.Core.Tests/VerifyIntPtrSize.cs
@@ -18,6 +18,13 @@ public class VerifyIntPtrSize
 public static class WebHostBuilderExtensions
 {
 	public static IWebHostBuilder UseStartup(this IWebHostBuilder builder, IStartup startup)
-		=> builder
+	{
+		if (startup is IInternalStartup internalStartup)
+			return builder
+				.ConfigureServices(internalStartup.ConfigureServicesOnly)
+				.Configure(startup.Configure);
+
+		return builder
 			.ConfigureServices(services => services.AddSingleton(startup));
+	}
 }

--- a/src/EventStore.Core.Tests/VerifyIntPtrSize.cs
+++ b/src/EventStore.Core.Tests/VerifyIntPtrSize.cs
@@ -1,6 +1,4 @@
 using System;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests;
@@ -12,19 +10,5 @@ public class VerifyIntPtrSize
 	public void TestIntPtrSize()
 	{
 		Assert.AreEqual(8, IntPtr.Size);
-	}
-}
-
-public static class WebHostBuilderExtensions
-{
-	public static IWebHostBuilder UseStartup(this IWebHostBuilder builder, IStartup startup)
-	{
-		if (startup is IInternalStartup internalStartup)
-			return builder
-				.ConfigureServices(internalStartup.ConfigureServicesOnly)
-				.Configure(startup.Configure);
-
-		return builder
-			.ConfigureServices(services => services.AddSingleton(startup));
 	}
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -117,7 +117,7 @@ public abstract class ClusterVNode
 	abstract public IPublisher MainQueue { get; }
 	abstract public ISubscriber MainBus { get; }
 	abstract public QueueStatsManager QueueStatsManager { get; }
-	abstract public IStartup Startup { get; }
+	abstract public IInternalStartup Startup { get; }
 	abstract public IAuthenticationProvider AuthenticationProvider { get; }
 	abstract public IHttpService HttpService { get; }
 	abstract public VNodeInfo NodeInfo { get; }
@@ -157,7 +157,7 @@ public class ClusterVNode<TStreamId> :
 
 	public override QueueStatsManager QueueStatsManager => _queueStatsManager;
 
-	public override IStartup Startup => _startup;
+	public override IInternalStartup Startup => _startup;
 
 	public override IAuthenticationProvider AuthenticationProvider
 	{

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -37,7 +37,7 @@ using ServerFeatures = EventStore.Core.Services.Transport.Grpc.ServerFeatures;
 #nullable enable
 namespace EventStore.Core;
 
-public class ClusterVNodeStartup<TStreamId> : IStartup, IHandle<SystemMessage.SystemReady>,
+public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMessage.SystemReady>,
 	IHandle<SystemMessage.BecomeShuttingDown>
 {
 
@@ -191,6 +191,12 @@ public class ClusterVNodeStartup<TStreamId> : IStartup, IHandle<SystemMessage.Sy
 
 	public IServiceProvider ConfigureServices(IServiceCollection services)
 	{
+		ConfigureServicesOnly(services);
+		return services.BuildServiceProvider();
+	}
+
+	public void ConfigureServicesOnly(IServiceCollection services)
+	{
 		var metricsConfiguration = MetricsConfiguration.Get(_configuration);
 
 		services = services
@@ -297,8 +303,6 @@ public class ClusterVNodeStartup<TStreamId> : IStartup, IHandle<SystemMessage.Sy
 
 		foreach (var component in _plugableComponents)
 			component.ConfigureServices(services, _configuration);
-
-		return services.BuildServiceProvider();
 	}
 
 	public void Handle(SystemMessage.SystemReady _) => _ready = true;

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -189,11 +189,10 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 		});
 	}
 
-	public IServiceProvider ConfigureServices(IServiceCollection services)
-	{
-		ConfigureServicesOnly(services);
-		return services.BuildServiceProvider();
-	}
+	public IServiceProvider ConfigureServices(IServiceCollection services) =>
+		throw new NotSupportedException(
+			$"{nameof(ClusterVNodeStartup<TStreamId>)} is driven via {nameof(IInternalStartup)}.{nameof(ConfigureServicesOnly)} " +
+			$"and the host's service provider. Use {nameof(ConfigureServicesOnly)} instead.");
 
 	public void ConfigureServicesOnly(IServiceCollection services)
 	{

--- a/src/EventStore.Core/IInternalStartup.cs
+++ b/src/EventStore.Core/IInternalStartup.cs
@@ -1,0 +1,11 @@
+#nullable enable
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventStore.Core;
+
+public interface IInternalStartup : IStartup
+{
+	void ConfigureServicesOnly(IServiceCollection services);
+}

--- a/src/EventStore.Core/Services/Transport/Http/WebHostBuilderExtensions.cs
+++ b/src/EventStore.Core/Services/Transport/Http/WebHostBuilderExtensions.cs
@@ -4,7 +4,14 @@ using Microsoft.Extensions.DependencyInjection;
 namespace EventStore.Core.Services.Transport.Http {
 	internal static class WebHostBuilderExtensions {
 		public static IWebHostBuilder UseStartup(this IWebHostBuilder builder, IStartup startup)
-			=> builder
+		{
+			if (startup is IInternalStartup internalStartup)
+				return builder
+					.ConfigureServices(internalStartup.ConfigureServicesOnly)
+					.Configure(startup.Configure);
+
+			return builder
 				.ConfigureServices(services => services.AddSingleton(startup));
+		}
 	}
 }


### PR DESCRIPTION
- Keeping startup on the current ASP.NET host path reduces divergence between process lifetime, Kestrel, and application startup.
- Keeping service registration on the host-owned collection avoids extra provider construction during boot.