### PR TITLE
fix(config): surface ignored plugin subsection

### DIFF
--- a/src/EventStore.Core.Tests/Configuration/ClusterVNodePluginConfigurationWarningTests.cs
+++ b/src/EventStore.Core.Tests/Configuration/ClusterVNodePluginConfigurationWarningTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Core.Tests.Services.Transport.Tcp;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace EventStore.Core.Tests.Configuration;
+
+[TestFixture]
+[NonParallelizable]
+public class ClusterVNodePluginConfigurationWarningTests
+{
+	private ILogger _previousLogger;
+	private CollectingSink _sink;
+
+	[SetUp]
+	public void SetUp()
+	{
+		_previousLogger = Log.Logger;
+		_sink = new CollectingSink();
+		Log.Logger = new LoggerConfiguration()
+			.MinimumLevel.Verbose()
+			.WriteTo.Sink(_sink)
+			.CreateLogger();
+	}
+
+	[TearDown]
+	public void TearDown()
+	{
+		Log.Logger = _previousLogger;
+	}
+
+	[Test]
+	public async Task logs_ignored_plugins_subsection_options()
+	{
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string>
+			{
+				["EventStore:Plugins:Authorization:DefaultPolicyType"] = "custom",
+				["EventStore:Plugins:Subsystem:Enabled"] = "true",
+			})
+			.Build();
+
+		await CreateNode(configuration);
+
+		var warnings = LoggedWarnings();
+		Assert.That(warnings, Has.Some.Contains("\"Plugins\" configuration subsection has been removed"));
+		Assert.That(warnings, Has.Some.Contains("EventStore:Plugins:Authorization:DefaultPolicyType"));
+		Assert.That(warnings, Has.Some.Contains("EventStore:Plugins:Subsystem:Enabled"));
+	}
+
+	[Test]
+	public async Task does_not_log_when_plugins_subsection_is_absent()
+	{
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string>
+			{
+				["EventStore:Authorization:DefaultPolicyType"] = "custom",
+			})
+			.Build();
+
+		await CreateNode(configuration);
+
+		var warnings = LoggedWarnings();
+		Assert.That(warnings, Has.None.Contains("\"Plugins\" configuration subsection has been removed"));
+		Assert.That(warnings, Has.None.Contains("EventStore:Plugins"));
+	}
+
+	private string[] LoggedWarnings() =>
+		_sink.Events
+			.Where(x => x.Level == LogEventLevel.Warning)
+			.Select(x => x.RenderMessage())
+			.ToArray();
+
+	private static async Task CreateNode(IConfiguration configuration)
+	{
+		var options = new ClusterVNodeOptions()
+			.ReduceMemoryUsageForTests()
+			.RunInMemory()
+			.Insecure();
+
+		var node = new ClusterVNode<string>(
+			options,
+			LogFormatHelper<LogFormat.V2, string>.LogFormatFactory,
+			configuration: configuration);
+
+		await node.Db.DisposeAsync();
+	}
+
+	private sealed class CollectingSink : ILogEventSink
+	{
+		public List<LogEvent> Events { get; } = [];
+
+		public void Emit(LogEvent logEvent) =>
+			Events.Add(logEvent);
+	}
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -248,6 +248,8 @@ public class ClusterVNode<TStreamId> :
 
 		configuration ??= new ConfigurationBuilder().Build();
 
+		LogPluginSubsectionWarnings(configuration);
+
 		_certificateProvider = certificateProvider;
 
 		ClusterVNodeOptionsValidator.Validate(options);
@@ -2214,6 +2216,26 @@ public class ClusterVNode<TStreamId> :
 		{
 			throw new InvalidConfigurationException("Aborting certificate loading due to verification errors.");
 		}
+	}
+
+	private static void LogPluginSubsectionWarnings(IConfiguration configuration)
+	{
+		var ignoredOptions = configuration.GetSection("EventStore:Plugins")
+			.AsEnumerable()
+			.Where(kvp => kvp.Value is not null)
+			.ToList();
+
+		if (ignoredOptions.Count == 0)
+			return;
+
+		var log = Serilog.Log.ForContext<ClusterVNode>();
+		log.Warning(
+			"The \"Plugins\" configuration subsection has been removed. " +
+			"The following settings will be ignored. " +
+			"Move them directly under the \"EventStore\" root.");
+
+		foreach (var kvp in ignoredOptions)
+			log.Warning("Ignoring option nested in \"Plugins\" subsection: {IgnoredOption}", kvp.Key);
 	}
 
 	public override string ToString() =>


### PR DESCRIPTION
- Operators need a clear signal when obsolete plugin-nested settings are ignored during startup.
- The migration tracker can now close the remaining plugin configuration warning gap without bundling unrelated UI, OTLP, or package-feed work.