### PR TITLE
feat(metrics): improve observability interoperability

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -60,6 +60,7 @@
     <PackageVersion Include="NUnit" Version="3.14.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="ObjectLayoutInspector" Version="0.1.4" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="Quickenshtein" Version="1.5.1" />

--- a/src/EventStore.ClusterNode/metricsconfig.json
+++ b/src/EventStore.ClusterNode/metricsconfig.json
@@ -2,7 +2,8 @@
 	// must be 0, 1, 5, 10 or a multiple of 15
 	"ExpectedScrapeIntervalSeconds": 15,
 
-	// Endpoint, protocol, headers, and timeouts use the standard OTEL_* environment variables.
+	// Exporter options, including export interval, use the OTEL_* variables
+	// supported by the OpenTelemetry .NET metrics exporter.
 	"Otlp": {
 		"Enabled": false
 	},

--- a/src/EventStore.ClusterNode/metricsconfig.json
+++ b/src/EventStore.ClusterNode/metricsconfig.json
@@ -2,6 +2,11 @@
 	// must be 0, 1, 5, 10 or a multiple of 15
 	"ExpectedScrapeIntervalSeconds": 15,
 
+	// Endpoint, protocol, headers, and timeouts use the standard OTEL_* environment variables.
+	"Otlp": {
+		"Enabled": false
+	},
+
 	"Meters": [
 		"EventStore.Core",
 		"EventStore.Projections.Core"

--- a/src/EventStore.Common/Configuration/MetricsConfiguration.cs
+++ b/src/EventStore.Common/Configuration/MetricsConfiguration.cs
@@ -135,6 +135,11 @@ public class MetricsConfiguration
 		public string Label { get; set; } = "";
 	}
 
+	public class OtlpExporterConfiguration
+	{
+		public bool Enabled { get; set; }
+	}
+
 	public string[] Meters { get; set; } = Array.Empty<string>();
 
 	public Dictionary<StatusTracker, bool> Statuses { get; set; } = new();
@@ -169,6 +174,8 @@ public class MetricsConfiguration
 
 	// must be 0, 1, 5, 10 or a multiple of 15
 	public int ExpectedScrapeIntervalSeconds { get; set; }
+
+	public OtlpExporterConfiguration Otlp { get; set; } = new();
 
 	public Dictionary<QueueTracker, bool> Queues { get; set; } = new();
 

--- a/src/EventStore.Core.XUnit.Tests/Metrics/OtlpMetricsConfigurationTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/OtlpMetricsConfigurationTests.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using EventStore.Common.Configuration;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Metrics;
+
+public class OtlpMetricsConfigurationTests
+{
+	[Fact]
+	public void IsDisabledByDefault()
+	{
+		var configuration = new ConfigurationBuilder().Build();
+
+		var metrics = MetricsConfiguration.Get(configuration);
+
+		metrics.Otlp.Enabled.Should().BeFalse();
+	}
+
+	[Fact]
+	public void BindsOtlpSettings()
+	{
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string>
+			{
+				["EventStore:Metrics:Otlp:Enabled"] = "true",
+			})
+			.Build();
+
+		var metrics = MetricsConfiguration.Get(configuration);
+
+		metrics.Otlp.Enabled.Should().BeTrue();
+	}
+}

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using EventStore.Common.Configuration;
+using EventStore.Common.Exceptions;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
@@ -22,6 +23,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry;
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using MidFunc = System.Func<
@@ -229,58 +231,8 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 			.AddSingleton(new Redaction(_mainQueue, _authorizationProvider))
 			.AddSingleton<ServerFeatures>()
 
-			// OpenTelemetry
 			.AddOpenTelemetry()
-			.WithMetrics(meterOptions => meterOptions
-				.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("eventstore"))
-				.AddMeter(metricsConfiguration.Meters)
-				.AddView(i =>
-				{
-					if (i.Name == MetricsBootstrapper.LogicalChunkReadDistributionName)
-						// 20 buckets, 0, 1, 2, 4, 8, ...
-						return new ExplicitBucketHistogramConfiguration
-						{
-							Boundaries =
-							[
-								0,
-								.. Enumerable.Range(0, count: 19).Select(x => 1 << x)
-							]
-						};
-					else if (i.Name.StartsWith("eventstore-") &&
-					         i.Name.EndsWith("-latency-seconds"))
-						return new ExplicitBucketHistogramConfiguration
-						{
-							Boundaries =
-							[
-								0.001, //    1 ms
-								0.005, //    5 ms
-								0.01, //   10 ms
-								0.05, //   50 ms
-								0.1, //  100 ms
-								0.5, //  500 ms
-								1, // 1000 ms
-								5, // 5000 ms
-							]
-						};
-					else if (i.Name.StartsWith("eventstore-") &&
-					         i.Name.EndsWith("-seconds"))
-						return new ExplicitBucketHistogramConfiguration
-						{
-							Boundaries =
-							[
-								0.000_001, // 1 microsecond
-								0.000_01,
-								0.000_1,
-								0.001, // 1 millisecond
-								0.01,
-								0.1,
-								1, // 1 second
-								10,
-							]
-						};
-					return default;
-				})
-				.AddPrometheusExporter(options => options.ScrapeResponseCacheDurationMilliseconds = 1000))
+			.WithMetrics(meterOptions => ConfigureMetrics(meterOptions, metricsConfiguration))
 			.Services
 
 			// gRPC
@@ -302,6 +254,134 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 
 		foreach (var component in _plugableComponents)
 			component.ConfigureServices(services, _configuration);
+	}
+
+	private static void ConfigureMetrics(MeterProviderBuilder meterOptions, MetricsConfiguration metricsConfiguration)
+	{
+		meterOptions
+			.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("eventstore"))
+			.AddMeter(metricsConfiguration.Meters)
+			.AddView(i =>
+			{
+				if (i.Name == MetricsBootstrapper.LogicalChunkReadDistributionName)
+					// 20 buckets, 0, 1, 2, 4, 8, ...
+					return new ExplicitBucketHistogramConfiguration
+					{
+						Boundaries =
+						[
+							0,
+							.. Enumerable.Range(0, count: 19).Select(x => 1 << x)
+						]
+					};
+				else if (i.Name.StartsWith("eventstore-") &&
+				         i.Name.EndsWith("-latency-seconds"))
+					return new ExplicitBucketHistogramConfiguration
+					{
+						Boundaries =
+						[
+							0.001, //    1 ms
+							0.005, //    5 ms
+							0.01, //   10 ms
+							0.05, //   50 ms
+							0.1, //  100 ms
+							0.5, //  500 ms
+							1, // 1000 ms
+							5, // 5000 ms
+						]
+					};
+				else if (i.Name.StartsWith("eventstore-") &&
+				         i.Name.EndsWith("-seconds"))
+					return new ExplicitBucketHistogramConfiguration
+					{
+						Boundaries =
+						[
+							0.000_001, // 1 microsecond
+							0.000_01,
+							0.000_1,
+							0.001, // 1 millisecond
+							0.01,
+							0.1,
+							1, // 1 second
+							10,
+						]
+					};
+				return default;
+			})
+			.AddPrometheusExporter(options => options.ScrapeResponseCacheDurationMilliseconds = 1000);
+
+		ConfigureOtlpMetrics(meterOptions, metricsConfiguration);
+	}
+
+	private static void ConfigureOtlpMetrics(
+		MeterProviderBuilder meterOptions,
+		MetricsConfiguration metricsConfiguration)
+	{
+		var options = metricsConfiguration.Otlp;
+		if (!options.Enabled && !OtlpMetricExporterSelected())
+			return;
+
+		meterOptions.AddOtlpExporter((exporterOptions, readerOptions) =>
+		{
+			ApplyMetricSpecificOtlpEnvironmentVariables(exporterOptions);
+
+			if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(OtelMetricExportInterval)) &&
+			    metricsConfiguration.ExpectedScrapeIntervalSeconds > 0)
+				readerOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds =
+					checked(metricsConfiguration.ExpectedScrapeIntervalSeconds * 1000);
+		});
+	}
+
+	private const string OtelMetricsExporter = "OTEL_METRICS_EXPORTER";
+	private const string OtelMetricExportInterval = "OTEL_METRIC_EXPORT_INTERVAL";
+	private const string OtelExporterOtlpMetricsEndpoint = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT";
+	private const string OtelExporterOtlpMetricsHeaders = "OTEL_EXPORTER_OTLP_METRICS_HEADERS";
+	private const string OtelExporterOtlpMetricsTimeout = "OTEL_EXPORTER_OTLP_METRICS_TIMEOUT";
+	private const string OtelExporterOtlpMetricsProtocol = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL";
+
+	private static bool OtlpMetricExporterSelected()
+	{
+		var exporters = Environment.GetEnvironmentVariable(OtelMetricsExporter);
+		return exporters?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+			.Any(exporter => exporter.Equals("otlp", StringComparison.OrdinalIgnoreCase)) ?? false;
+	}
+
+	private static void ApplyMetricSpecificOtlpEnvironmentVariables(OtlpExporterOptions exporterOptions)
+	{
+		var endpoint = Environment.GetEnvironmentVariable(OtelExporterOtlpMetricsEndpoint);
+		if (!string.IsNullOrWhiteSpace(endpoint))
+		{
+			if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var endpointUri))
+				throw new InvalidConfigurationException(
+					$"{OtelExporterOtlpMetricsEndpoint} must be an absolute URI.");
+
+			exporterOptions.Endpoint = endpointUri;
+		}
+
+		var headers = Environment.GetEnvironmentVariable(OtelExporterOtlpMetricsHeaders);
+		if (!string.IsNullOrWhiteSpace(headers))
+			exporterOptions.Headers = headers;
+
+		var timeout = Environment.GetEnvironmentVariable(OtelExporterOtlpMetricsTimeout);
+		if (!string.IsNullOrWhiteSpace(timeout))
+		{
+			if (!int.TryParse(timeout, out var timeoutMilliseconds) || timeoutMilliseconds <= 0)
+				throw new InvalidConfigurationException(
+					$"{OtelExporterOtlpMetricsTimeout} must be greater than zero.");
+
+			exporterOptions.TimeoutMilliseconds = timeoutMilliseconds;
+		}
+
+		var protocol = Environment.GetEnvironmentVariable(OtelExporterOtlpMetricsProtocol);
+		if (!string.IsNullOrWhiteSpace(protocol))
+		{
+			exporterOptions.Protocol = protocol.Trim().ToLowerInvariant() switch
+			{
+				"grpc" => OtlpExportProtocol.Grpc,
+				"http/protobuf" => OtlpExportProtocol.HttpProtobuf,
+				_ => throw new InvalidConfigurationException(
+					$"{OtelExporterOtlpMetricsProtocol} must be 'grpc' or 'http/protobuf'.")
+			};
+		}
 	}
 
 	public void Handle(SystemMessage.SystemReady _) => _ready = true;

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using EventStore.Common.Configuration;
-using EventStore.Common.Exceptions;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
@@ -23,7 +22,6 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry;
-using OpenTelemetry.Exporter;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using MidFunc = System.Func<
@@ -317,71 +315,10 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 		MetricsConfiguration metricsConfiguration)
 	{
 		var options = metricsConfiguration.Otlp;
-		if (!options.Enabled && !OtlpMetricExporterSelected())
+		if (!options.Enabled)
 			return;
 
-		meterOptions.AddOtlpExporter((exporterOptions, readerOptions) =>
-		{
-			ApplyMetricSpecificOtlpEnvironmentVariables(exporterOptions);
-
-			if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(OtelMetricExportInterval)) &&
-			    metricsConfiguration.ExpectedScrapeIntervalSeconds > 0)
-				readerOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds =
-					checked(metricsConfiguration.ExpectedScrapeIntervalSeconds * 1000);
-		});
-	}
-
-	private const string OtelMetricsExporter = "OTEL_METRICS_EXPORTER";
-	private const string OtelMetricExportInterval = "OTEL_METRIC_EXPORT_INTERVAL";
-	private const string OtelExporterOtlpMetricsEndpoint = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT";
-	private const string OtelExporterOtlpMetricsHeaders = "OTEL_EXPORTER_OTLP_METRICS_HEADERS";
-	private const string OtelExporterOtlpMetricsTimeout = "OTEL_EXPORTER_OTLP_METRICS_TIMEOUT";
-	private const string OtelExporterOtlpMetricsProtocol = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL";
-
-	private static bool OtlpMetricExporterSelected()
-	{
-		var exporters = Environment.GetEnvironmentVariable(OtelMetricsExporter);
-		return exporters?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-			.Any(exporter => exporter.Equals("otlp", StringComparison.OrdinalIgnoreCase)) ?? false;
-	}
-
-	private static void ApplyMetricSpecificOtlpEnvironmentVariables(OtlpExporterOptions exporterOptions)
-	{
-		var endpoint = Environment.GetEnvironmentVariable(OtelExporterOtlpMetricsEndpoint);
-		if (!string.IsNullOrWhiteSpace(endpoint))
-		{
-			if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var endpointUri))
-				throw new InvalidConfigurationException(
-					$"{OtelExporterOtlpMetricsEndpoint} must be an absolute URI.");
-
-			exporterOptions.Endpoint = endpointUri;
-		}
-
-		var headers = Environment.GetEnvironmentVariable(OtelExporterOtlpMetricsHeaders);
-		if (!string.IsNullOrWhiteSpace(headers))
-			exporterOptions.Headers = headers;
-
-		var timeout = Environment.GetEnvironmentVariable(OtelExporterOtlpMetricsTimeout);
-		if (!string.IsNullOrWhiteSpace(timeout))
-		{
-			if (!int.TryParse(timeout, out var timeoutMilliseconds) || timeoutMilliseconds <= 0)
-				throw new InvalidConfigurationException(
-					$"{OtelExporterOtlpMetricsTimeout} must be greater than zero.");
-
-			exporterOptions.TimeoutMilliseconds = timeoutMilliseconds;
-		}
-
-		var protocol = Environment.GetEnvironmentVariable(OtelExporterOtlpMetricsProtocol);
-		if (!string.IsNullOrWhiteSpace(protocol))
-		{
-			exporterOptions.Protocol = protocol.Trim().ToLowerInvariant() switch
-			{
-				"grpc" => OtlpExportProtocol.Grpc,
-				"http/protobuf" => OtlpExportProtocol.HttpProtobuf,
-				_ => throw new InvalidConfigurationException(
-					$"{OtelExporterOtlpMetricsProtocol} must be 'grpc' or 'http/protobuf'.")
-			};
-		}
+		meterOptions.AddOtlpExporter();
 	}
 
 	public void Handle(SystemMessage.SystemReady _) => _ready = true;

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -18,6 +18,7 @@
 		<PackageReference Include="librdkafka.redist" />
 		<PackageReference Include="Microsoft.FASTER.Core" />
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
 		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" />
 		<PackageReference Include="Quickenshtein" />


### PR DESCRIPTION
- Operators should be able to export runtime metrics into standard OpenTelemetry pipelines without maintaining a separate extension surface.
- The server should remain quiet by default while still respecting established OTEL environment variable conventions when metrics export is intentionally enabled.
- Keeping this built in reduces deployment friction for observability-first environments while preserving the existing Prometheus path.