### PR TITLE
fix(projections): classify compound metric statuses

### DIFF
--- a/src/EventStore.Projections.Core.XUnit.Tests/Metrics/ProjectionMetricsTests.cs
+++ b/src/EventStore.Projections.Core.XUnit.Tests/Metrics/ProjectionMetricsTests.cs
@@ -44,7 +44,7 @@ public class ProjectionMetricsTests
 	[Fact]
 	public void ObserveRunningWithCompoundStatus()
 	{
-		_sut.OnNewStats([ProjectionWithStatus("Running/Writing results")]);
+		_sut.OnNewStats([ProjectionWithState(ManagedProjectionState.Running, "Running/Writing results")]);
 
 		var measurements = _sut.ObserveRunning();
 		var measurement = Assert.Single(measurements);
@@ -70,12 +70,13 @@ public class ProjectionMetricsTests
 	}
 
 	[Theory]
-	[InlineData("Running/Writing results", 1, 0, 0)]
-	[InlineData("Faulted (Enabled)", 0, 1, 0)]
-	[InlineData("Stopped (Enabled)", 0, 0, 1)]
-	public void ObserveStatusWithCompoundStatus(string status, long running, long faulted, long stopped)
+	[InlineData(ManagedProjectionState.Running, "Running/Writing results", 1, 0, 0)]
+	[InlineData(ManagedProjectionState.Faulted, "Faulted (Enabled)", 0, 1, 0)]
+	[InlineData(ManagedProjectionState.Stopped, "Stopped (Enabled)", 0, 0, 1)]
+	public void ObserveStatusWithCompoundStatus(ManagedProjectionState state, string status, long running,
+		long faulted, long stopped)
 	{
-		_sut.OnNewStats([ProjectionWithStatus(status)]);
+		_sut.OnNewStats([ProjectionWithState(state, status)]);
 
 		var measurements = _sut.ObserveStatus();
 		Assert.Collection(measurements,
@@ -98,7 +99,7 @@ public class ProjectionMetricsTests
 				actualMeasurement.Tags.ToArray().Select(tag => (tag.Key, tag.Value as string)));
 		};
 
-	private static ProjectionStatistics ProjectionWithStatus(string status) =>
+	private static ProjectionStatistics ProjectionWithState(ManagedProjectionState state, string status) =>
 		new() {
 			Name = "TestProjection",
 			ProjectionId = 1234,
@@ -106,6 +107,7 @@ public class ProjectionMetricsTests
 			Version = -1,
 			Mode = ProjectionMode.Continuous,
 			Status = status,
+			LeaderStatus = state,
 			Progress = 75,
 			EventsProcessedAfterRestart = 50,
 		};

--- a/src/EventStore.Projections.Core.XUnit.Tests/Metrics/ProjectionMetricsTests.cs
+++ b/src/EventStore.Projections.Core.XUnit.Tests/Metrics/ProjectionMetricsTests.cs
@@ -42,6 +42,16 @@ public class ProjectionMetricsTests
 	}
 
 	[Fact]
+	public void ObserveRunningWithCompoundStatus()
+	{
+		_sut.OnNewStats([ProjectionWithStatus("Running/Writing results")]);
+
+		var measurements = _sut.ObserveRunning();
+		var measurement = Assert.Single(measurements);
+		AssertMeasurement(1L, ("projection", "TestProjection"))(measurement);
+	}
+
+	[Fact]
 	public void ObserveProgress()
 	{
 		var measurements = _sut.ObserveProgress();
@@ -59,6 +69,21 @@ public class ProjectionMetricsTests
 			AssertMeasurement(0L, ("projection", "TestProjection"), ("status", "Stopped")));
 	}
 
+	[Theory]
+	[InlineData("Running/Writing results", 1, 0, 0)]
+	[InlineData("Faulted (Enabled)", 0, 1, 0)]
+	[InlineData("Stopped (Enabled)", 0, 0, 1)]
+	public void ObserveStatusWithCompoundStatus(string status, long running, long faulted, long stopped)
+	{
+		_sut.OnNewStats([ProjectionWithStatus(status)]);
+
+		var measurements = _sut.ObserveStatus();
+		Assert.Collection(measurements,
+			AssertMeasurement(running, ("projection", "TestProjection"), ("status", "Running")),
+			AssertMeasurement(faulted, ("projection", "TestProjection"), ("status", "Faulted")),
+			AssertMeasurement(stopped, ("projection", "TestProjection"), ("status", "Stopped")));
+	}
+
 	static Action<Measurement<T>> AssertMeasurement<T>(
 		T expectedValue, params (string, string?)[] tags) where T : struct =>
 
@@ -71,5 +96,17 @@ public class ProjectionMetricsTests
 			Assert.Equal(
 				tags,
 				actualMeasurement.Tags.ToArray().Select(tag => (tag.Key, tag.Value as string)));
+		};
+
+	private static ProjectionStatistics ProjectionWithStatus(string status) =>
+		new() {
+			Name = "TestProjection",
+			ProjectionId = 1234,
+			Epoch = -1,
+			Version = -1,
+			Mode = ProjectionMode.Continuous,
+			Status = status,
+			Progress = 75,
+			EventsProcessedAfterRestart = 50,
 		};
 }

--- a/src/EventStore.Projections.Core/Metrics/ProjectionTracker.cs
+++ b/src/EventStore.Projections.Core/Metrics/ProjectionTracker.cs
@@ -1,8 +1,8 @@
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Linq;
 using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Management;
 
 namespace EventStore.Projections.Core.Metrics;
 
@@ -34,7 +34,7 @@ public class ProjectionTracker : IProjectionTracker
 	public IEnumerable<Measurement<long>> ObserveRunning() =>
 		_currentStats.Select(x =>
 		{
-			var projectionRunning = HasStatus(x.Status, "running")
+			var projectionRunning = x.LeaderStatus == ManagedProjectionState.Running
 				? 1
 				: 0;
 
@@ -52,15 +52,15 @@ public class ProjectionTracker : IProjectionTracker
 			var projectionFaulted = 0;
 			var projectionStopped = 0;
 
-			if (HasStatus(statistics.Status, "running"))
+			if (statistics.LeaderStatus == ManagedProjectionState.Running)
 			{
 				projectionRunning = 1;
 			}
-			else if (HasStatus(statistics.Status, "stopped"))
+			else if (statistics.LeaderStatus == ManagedProjectionState.Stopped)
 			{
 				projectionStopped = 1;
 			}
-			else if (HasStatus(statistics.Status, "faulted"))
+			else if (statistics.LeaderStatus == ManagedProjectionState.Faulted)
 			{
 				projectionFaulted = 1;
 			}
@@ -81,7 +81,4 @@ public class ProjectionTracker : IProjectionTracker
 			]);
 		}
 	}
-
-	private static bool HasStatus(string status, string expected) =>
-		status?.StartsWith(expected, StringComparison.OrdinalIgnoreCase) == true;
 }

--- a/src/EventStore.Projections.Core/Metrics/ProjectionTracker.cs
+++ b/src/EventStore.Projections.Core/Metrics/ProjectionTracker.cs
@@ -34,7 +34,7 @@ public class ProjectionTracker : IProjectionTracker
 	public IEnumerable<Measurement<long>> ObserveRunning() =>
 		_currentStats.Select(x =>
 		{
-			var projectionRunning = x.Status.Equals("running", StringComparison.CurrentCultureIgnoreCase)
+			var projectionRunning = HasStatus(x.Status, "running")
 				? 1
 				: 0;
 
@@ -52,17 +52,17 @@ public class ProjectionTracker : IProjectionTracker
 			var projectionFaulted = 0;
 			var projectionStopped = 0;
 
-			switch (statistics.Status.ToLower())
+			if (HasStatus(statistics.Status, "running"))
 			{
-				case "running":
-					projectionRunning = 1;
-					break;
-				case "stopped":
-					projectionStopped = 1;
-					break;
-				case "faulted":
-					projectionFaulted = 1;
-					break;
+				projectionRunning = 1;
+			}
+			else if (HasStatus(statistics.Status, "stopped"))
+			{
+				projectionStopped = 1;
+			}
+			else if (HasStatus(statistics.Status, "faulted"))
+			{
+				projectionFaulted = 1;
 			}
 
 			yield return new(projectionRunning, [
@@ -81,4 +81,7 @@ public class ProjectionTracker : IProjectionTracker
 			]);
 		}
 	}
+
+	private static bool HasStatus(string status, string expected) =>
+		status?.StartsWith(expected, StringComparison.OrdinalIgnoreCase) == true;
 }


### PR DESCRIPTION
- Prevents projection metrics from going quiet when status text includes operational suffixes.
- Keeps system projection failures visible to monitoring instead of requiring an exact status string.
- Narrows the change to metric classification so projection lifecycle behavior remains untouched.