### PR TITLE
chore(release): use version-only names

### DIFF
--- a/.github/workflows/build-container-debian-lts.yml
+++ b/.github/workflows/build-container-debian-lts.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - master
-      - release/oss-v*
+      - release/v*
     tags:
-      - oss-v*
+      - v*
     paths-ignore:
       - "docs/**"
       - "samples/**"

--- a/.github/workflows/build-container-ubuntu-lts.yml
+++ b/.github/workflows/build-container-ubuntu-lts.yml
@@ -9,9 +9,9 @@ on:
   push:
     branches:
       - master
-      - release/oss-v*
+      - release/v*
     tags:
-      - oss-v*
+      - v*
     paths-ignore:
       - "docs/**"
       - "samples/**"

--- a/.github/workflows/build-ubuntu-lts-arm64.yml
+++ b/.github/workflows/build-ubuntu-lts-arm64.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - master
-      - release/oss-v*
+      - release/v*
     tags:
-      - oss-v*
+      - v*
     paths-ignore:
       - "docs/**"
       - "samples/**"

--- a/.github/workflows/build-ubuntu-lts-x64.yml
+++ b/.github/workflows/build-ubuntu-lts-x64.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - master
-      - release/oss-v*
+      - release/v*
     tags:
-      - oss-v*
+      - v*
     paths-ignore:
       - "docs/**"
       - "samples/**"

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -10,9 +10,9 @@ on:
     branches:
       - master
       - main
-      - release/oss-v*
+      - release/v*
     tags:
-      - oss-v*
+      - v*
     paths-ignore:
       - "docs/**"
       - "samples/**"

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -15,5 +15,5 @@ jobs:
     - uses: FantasticFiasco/action-update-license-year@v2
       with:
         path: LICENSE.md
-        labels: 'cherry-pick:release/oss-v5,cherry-pick:release/oss-v20.10,cherry-pick:release/oss-v21.10'
+        labels: 'cherry-pick:release/v5,cherry-pick:release/v20.10,cherry-pick:release/v21.10'
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Development is done on the `master` branch.
 We attempt to do our best to ensure that the history remains clean and to do so, we generally ask contributors to squash their commits into a set or single logical commit.
 
-If you want to switch to a particular release, you can check out the release branch for that particular release. For example: `git checkout release/oss-v22.10`
+If you want to switch to a particular release, you can check out the release branch for that particular release. For example: `git checkout release/v22.10`
 
 - [Create an issue](https://github.com/TrogonStack/TrogonEventStore/issues)
 - [Documentation](https://developers.trogondb.com/)
@@ -11,7 +11,7 @@ If you want to switch to a particular release, you can check out the release bra
 
 ## Working with the Git
 
-We're using `master` as the main development branch. It contains all changes to the upcoming release. Older releases have dedicated feature branches with the format `release/oss-{version}`. E.g. `release/oss-v5`, `release/oss-v20.10`, `release/oss-v21.2`. Specific releases are tagged from the release branches commits. 
+We're using `master` as the main development branch. It contains all changes to the upcoming release. Older releases have dedicated feature branches with the format `release/v{version}`. E.g. `release/v5`, `release/v20.10`, `release/v21.2`. Specific releases are tagged from the release branches commits.
 
 We attempt to do our best to ensure that the history remains clean and to do so, we generally ask contributors to squash their commits into a set or single logical commit.
 
@@ -31,20 +31,20 @@ It's recommended to have documentation changes be put together with code changes
 
 We're supporting multiple versions of the documentation. Versions are kept in:
 - the main (`master`) branch: all changes that refer to the upcoming release should be put there. That includes both non-released changes and enhancements to documentation for existing features.
-- specific release branches - the last version and older release are kept there (e.g. `release/oss-v5`, `release/oss-v20.10`, `release/oss-v21.2`). We aim to keep the up to date documentation for the last LTS releases and all further. Read more on the release strategy: [link](https://www.trogondb.com/blog/eventstoredb-20.10-lts-has-been-released).
+- specific release branches - the last version and older release are kept there (e.g. `release/v5`, `release/v20.10`, `release/v21.2`). We aim to keep the up to date documentation for the last LTS releases and all further. Read more on the release strategy: [link](https://www.trogondb.com/blog/eventstoredb-20.10-lts-has-been-released).
 
 To update the specific database version's docs, it's recommended to create a feature branch based on the particular version release branch. For instance, if you want to change documentation in the `21.2` version, then you should:
-- checkout the latest `release/oss-v21.2`,
+- checkout the latest `release/v21.2`,
 - create a new branch and add your changes,
-- create pull request targeting the `release/oss-v21.2` branch.
+- create pull request targeting the `release/v21.2` branch.
 
 If you're unsure which branch to select, the safe choice is the main branch (`master`). 
 
-It's not needed to send multiple pull requests if your change should be reflected in multiple database versions documentation. Contributors reviewing the pull request should mark it with proper labels (e.g. as `cherry-pick:release/oss-v20.10`). We're using the [GitHub action](/.github/workflows/cherry-pick-pr-for-label.yml) based on the labels that should create pull requests with cherry-picks to the target branches. Action will inform about success or failure via the review comments to the initial pull request tagging the person that merged the pull request. It's recommended for contributors to monitor those notifications and make sure that cherry-picks succeeded. Read more in [action documentation](https://github.com/EventStore/Automations/tree/master/cherry-pick-pr-for-label).
+It's not needed to send multiple pull requests if your change should be reflected in multiple database versions documentation. Contributors reviewing the pull request should mark it with proper labels (e.g. as `cherry-pick:release/v20.10`). We're using the [GitHub action](/.github/workflows/cherry-pick-pr-for-label.yml) based on the labels that should create pull requests with cherry-picks to the target branches. Action will inform about success or failure via the review comments to the initial pull request tagging the person that merged the pull request. It's recommended for contributors to monitor those notifications and make sure that cherry-picks succeeded. Read more in [action documentation](https://github.com/EventStore/Automations/tree/master/cherry-pick-pr-for-label).
 
-Taking the previous example. You sent a pull request targeting the `release/oss-v21.2`. You'd like to have it also for the upcoming release and version `20.10`. Contributor should label your pull request with:
+Taking the previous example. You sent a pull request targeting the `release/v21.2`. You'd like to have it also for the upcoming release and version `20.10`. Contributor should label your pull request with:
 - `cherry-pick:master`,
-- `cherry-pick:release/oss-v20.10`.
+- `cherry-pick:release/v20.10`.
 
 _**Note:** Cherry-pick action requires changes to be rebased. If there is a merge commit, then cherry-pick will fail. It will also fail if there is a conflict with the target branch (so `target_branch` from label suffix). If those cases happen then, it's needed to do manual cherry-picks._
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,16 +18,15 @@ command line. For example:
 
 :::: code-group
 ::: code Linux
-```bash
 ```bash:no-line-numbers
 $ eventstored --version
-EventStoreDB version 24.6.0.0 (oss-v24.6.0-alpha-16-g8e06f9f77/8e06f9f77, 2023-10-24T22:05:57-05:00)
+EventStoreDB version 24.6.0.0 (v24.6.0-alpha-16-g8e06f9f77/8e06f9f77, 2023-10-24T22:05:57-05:00)
 ```
 :::
 ::: code Windows
-```
+```powershell:no-line-numbers
 > EventStore.ClusterNode.exe --version
-EventStoreDB version 24.6.0.0 (oss-v24.6.0-alpha-16-g8e06f9f77/8e06f9f77, 2023-10-24T22:05:57-05:00)
+EventStoreDB version 24.6.0.0 (v24.6.0-alpha-16-g8e06f9f77/8e06f9f77, 2023-10-24T22:05:57-05:00)
 ```
 :::
 ::::

--- a/docs/usage-telemetry.md
+++ b/docs/usage-telemetry.md
@@ -30,7 +30,7 @@ Here's an example of a full telemetry message from a single-node instance:
 ```json
 {
   "version": "23.10.0.0",
-  "tag": "oss-v23.10.0",
+  "tag": "v23.10.0",
   "uptime": "00:01:11.0115732",
   "cluster": {
     "leaderId": "81e9ca2a-8acc-41ed-b9d0-65a652b36801",

--- a/src/EventStore.Common/Utils/VersionInfo.cs
+++ b/src/EventStore.Common/Utils/VersionInfo.cs
@@ -41,13 +41,15 @@ public static class VersionInfo
 		if (properties.TryGetValue("version_suffix", out var versionSuffix))
 			VersionSuffix = versionSuffix;
 
+		BuildId = $"v{Version}";
+
 		if (properties.TryGetValue("commit_sha", out var commitSha))
 			CommitSha = commitSha;
 
 		if (properties.TryGetValue("timestamp", out var timestamp))
 			Timestamp = timestamp;
 
-		if (properties.TryGetValue("build_id", out var buildId))
+		if (properties.TryGetValue("build_id", out var buildId) && !string.IsNullOrWhiteSpace(buildId))
 			BuildId = buildId;
 
 		if (properties.TryGetValue("edition", out var edition))


### PR DESCRIPTION
- Every published release is OSS, so release branch and tag names do not need a separate OSS marker.