### PR TITLE
chore(ui): remove stale ui submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/EventStore.UI"]
-	path = src/EventStore.UI
-	url = https://github.com/EventStore/EventStore.UI.git

--- a/build.cmd
+++ b/build.cmd
@@ -12,8 +12,7 @@ exit /B %errorlevel%
 :help
 
 echo Usage:
-echo build.cmd ^[-Version=0.0.0.0^] ^[-Configuration=Debug^|Release^] ^[-BuildUI=yes^|no^]
+echo build.cmd ^[-Version=0.0.0.0^] ^[-Configuration=Debug^|Release^]
 echo.
 echo Prerequisites:
 echo Building EventStore database requires .NET Core SDK 5.0.4
-echo Building the UI requires Node.js (v8.11.4+)

--- a/build.ps1
+++ b/build.ps1
@@ -5,9 +5,6 @@ Param(
     [Parameter(HelpMessage="Configuration (Debug, Release)")]
     [ValidateSet("Debug","Release")]
     [string]$Configuration = "Release",
-    [Parameter(HelpMessage="Build UI (yes,no)")]
-    [ValidateSet("yes","no")]
-    [string]$BuildUI = "no",
     [Parameter(HelpMessage="Run Tests (yes,no)")]
     [ValidateSet("yes","no")]
     [string]$RunTests = "no"
@@ -48,36 +45,13 @@ Function Start-Build{
     $libsDirectory = Join-Path $srcDirectory "libs"
     $eventStoreSolution = Join-Path $srcDirectory "EventStore.sln"
 
-    $uiSrcDirectory = Join-Path $srcDirectory "EventStore.UI\"
-    $uiDistDirectory = Join-Path $srcDirectory "EventStore.ClusterNode.Web\clusternode-web\"
-
     Write-Info "Build Configuration"
     Write-Info "-------------------"
 
     Write-Info "Version: $Version"
     Write-Info "Platform: $platform"
     Write-Info "Configuration: $Configuration"
-    Write-Info "Build UI: $BuildUI"
     Write-Info "Run Tests: $RunTests"
-
-    #Build Event Store UI
-    if ($BuildUI -eq "yes") {
-        #Build the UI    
-        if (Test-Path $uiDistDirectory) {
-            Remove-Item -Recurse -Force $uiDistDirectory
-        }
-        Push-Location $uiSrcDirectory
-            if(-Not (Test-Path (Join-Path $uiSrcDirectory "package.json"))) {
-                Exec { git submodule update --init ./ }
-            }
-            Exec { npm install bower@~1.8.14 -g }
-            Exec { bower install --allow-root }
-            Exec { npm install gulp-cli -g }
-            Exec { npm install }
-            Exec { gulp dist }
-            Exec { mv es-dist $uiDistDirectory }
-        Pop-Location
-    }
 
     #Build Event Store (Patch AssemblyInfo, Build, Revert AssemblyInfo)
     Remove-Item -Force -Recurse $binDirectory -ErrorAction SilentlyContinue > $null

--- a/build.sh
+++ b/build.sh
@@ -9,19 +9,16 @@ COPYRIGHT="Copyright 2021 Event Store Ltd. All rights reserved."
 # ------------ End of configuration -------------
 
 CONFIGURATION="Release"
-BUILD_UI="no"
 NET_FRAMEWORK="net8.0"
 
 function usage() {    
 cat <<EOF
 Usage:
-  $0 [<version=0.0.0.0>] [<configuration=Debug|Release>] [<build_ui=yes|no>]
+  $0 [<version=0.0.0.0>] [<configuration=Debug|Release>]
 
 version: EventStore build version. Versions must be complete four part identifiers valid for use on a .NET assembly.
 
 configuration: Build configuration. Valid configurations are: Debug, Release
-
-build_ui: Whether or not to build the EventStore UI. Building the UI requires an installation of Node.js (v8.11.4+)
 
 EOF
     exit 1
@@ -49,9 +46,8 @@ function checkParams() {
 
     version=$1
     configuration=$2
-    build_ui=$3
 
-    [[ $# -gt 3 ]] && usage
+    [[ $# -gt 2 ]] && usage
 
     if [[ "$version" == "" ]] ; then
         VERSIONSTRING="0.0.0.0"
@@ -74,18 +70,6 @@ function checkParams() {
         fi
     fi
 
-    if [[ "$build_ui" == "" ]]; then
-        BUILD_UI="no"
-        echo "Build UI defaulted to: $BUILD_UI"
-    else
-        if [[ "$build_ui" == "yes" || "$build_ui" == "no" ]]; then
-            BUILD_UI=$build_ui
-            echo "Build UI set to: $BUILD_UI"
-        else
-            echo "Invalid Build UI value: $build_ui"
-            usage
-        fi
-    fi
 }
 
 function revertVersionInfo() {
@@ -135,28 +119,6 @@ function patchVersionInfo {
     done
 }
 
-function buildUI {
-    if [[ "$BUILD_UI" != "yes" ]] ; then
-        echo "Skipping UI Build"
-        return
-    fi
-
-    rm -rf src/EventStore.ClusterNode.Web/clusternode-web/
-    pushd src/EventStore.UI
-
-    if [ ! -f ./package.json ]; then
-        git submodule update --init ./
-    fi
-
-    npm install bower@~1.8.14 -g
-    bower install --allow-root
-    npm install gulp-cli -g
-    npm install
-    gulp dist
-    mv es-dist ../EventStore.ClusterNode.Web/clusternode-web/
-    popd
-}
-
 function buildEventStore {
     patchVersionInfo
     rm -rf bin/
@@ -170,8 +132,7 @@ function exitWithError {
 }
 
 detectOS
-checkParams "$1" "$2" "$3"
+checkParams "$@"
 
 echo "Running from base directory: $BASE_DIR"
-buildUI
 buildEventStore


### PR DESCRIPTION
- The hosted management shell now owns local UI work, so the old generated-asset source submodule should not remain as a parallel build path.
- Keeping one UI source path avoids stale build switches and makes future UI changes reviewable in-tree.