### PR TITLE
fix(ui): keep management shell anchored

### DIFF
--- a/src/EventStore.ClusterNode/Components/Layout/MainLayout.razor
+++ b/src/EventStore.ClusterNode/Components/Layout/MainLayout.razor
@@ -9,7 +9,7 @@
 		<footer class="border-t border-es-ink/10 py-6 text-sm text-es-muted">
 			<div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
 				<span>EventStore management surface</span>
-				<a class="font-semibold text-es-green hover:text-es-forest" href="/web/index.html">Open current web UI</a>
+				<a class="font-semibold text-es-green hover:text-es-forest" href="/web/index.html" target="_blank" rel="noopener noreferrer">Open current web UI</a>
 			</div>
 		</footer>
 	</div>

--- a/src/EventStore.ClusterNode/Components/Pages/Cluster.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Cluster.razor
@@ -15,7 +15,7 @@
 			</p>
 			<div class="mt-10 flex flex-wrap gap-3">
 				<a class="rounded-full bg-es-green px-5 py-3 text-sm font-black text-white shadow-lg shadow-es-green/25 hover:bg-white hover:text-es-ink" href="/ui/navigator">Explore tools</a>
-				<a class="rounded-full border border-white/30 px-5 py-3 text-sm font-black text-white hover:border-white hover:bg-white/10" href="/web/index.html">Open current web UI</a>
+				<a class="rounded-full border border-white/30 px-5 py-3 text-sm font-black text-white hover:border-white hover:bg-white/10" href="/web/index.html" target="_blank" rel="noopener noreferrer">Open current web UI</a>
 			</div>
 		</div>
 	</div>
@@ -24,9 +24,9 @@
 		<div class="rounded-[2rem] border border-white/80 bg-white/80 p-6 shadow-[0_20px_70px_rgba(23,32,51,0.09)]">
 			<p class="text-sm font-black uppercase tracking-[0.24em] text-es-green">Node probes</p>
 			<div class="mt-5 grid gap-3">
-				<a class="rounded-2xl border border-es-ink/10 bg-white px-4 py-3 font-bold text-es-ink hover:border-es-green hover:text-es-forest" href="/ping">Ping</a>
-				<a class="rounded-2xl border border-es-ink/10 bg-white px-4 py-3 font-bold text-es-ink hover:border-es-green hover:text-es-forest" href="/info">Node info</a>
-				<a class="rounded-2xl border border-es-ink/10 bg-white px-4 py-3 font-bold text-es-ink hover:border-es-green hover:text-es-forest" href="/gossip">Gossip</a>
+				<a class="rounded-2xl border border-es-ink/10 bg-white px-4 py-3 font-bold text-es-ink hover:border-es-green hover:text-es-forest" href="/ping" target="_blank" rel="noopener noreferrer">Ping</a>
+				<a class="rounded-2xl border border-es-ink/10 bg-white px-4 py-3 font-bold text-es-ink hover:border-es-green hover:text-es-forest" href="/info" target="_blank" rel="noopener noreferrer">Node info</a>
+				<a class="rounded-2xl border border-es-ink/10 bg-white px-4 py-3 font-bold text-es-ink hover:border-es-green hover:text-es-forest" href="/gossip" target="_blank" rel="noopener noreferrer">Gossip</a>
 			</div>
 		</div>
 		<div class="rounded-[2rem] bg-es-green p-6 text-white shadow-[0_20px_70px_rgba(107,163,0,0.20)]">

--- a/src/EventStore.ClusterNode/Components/Pages/Configuration.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Configuration.razor
@@ -9,10 +9,10 @@
 </section>
 
 <section class="mt-8 grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-	<SurfaceCard Eyebrow="Node" Title="Node information" Description="Read version, state, feature, and authentication metadata from the node." Href="/info" LinkText="Open info" />
-	<SurfaceCard Eyebrow="Node" Title="Loaded options" Description="Inspect the options that were loaded and their configuration sources." Href="/info/options" LinkText="Open options" />
-	<SurfaceCard Eyebrow="Cluster" Title="Gossip" Description="Review the node's current gossip view of the cluster." Href="/gossip" LinkText="Open gossip" />
-	<SurfaceCard Eyebrow="Features" Title="Subsystems" Description="Inspect the subsystems enabled for the hosted node." Href="/sys/subsystems" LinkText="Open subsystems" />
-	<SurfaceCard Eyebrow="UI" Title="Current web UI" Description="Return to the existing browser tools for workflows not yet rebuilt here." Href="/web/index.html" LinkText="Open current UI" />
-	<SurfaceCard Eyebrow="API" Title="HTTP API root" Description="Open the root HTTP surface for link discovery and API navigation." Href="/" LinkText="Open root" />
+	<SurfaceCard Eyebrow="Node" Title="Node information" Description="Read version, state, feature, and authentication metadata from the node." Href="/info" LinkText="Open info" Target="_blank" />
+	<SurfaceCard Eyebrow="Node" Title="Loaded options" Description="Inspect the options that were loaded and their configuration sources." Href="/info/options" LinkText="Open options" Target="_blank" />
+	<SurfaceCard Eyebrow="Cluster" Title="Gossip" Description="Review the node's current gossip view of the cluster." Href="/gossip" LinkText="Open gossip" Target="_blank" />
+	<SurfaceCard Eyebrow="Features" Title="Subsystems" Description="Inspect the subsystems enabled for the hosted node." Href="/sys/subsystems" LinkText="Open subsystems" Target="_blank" />
+	<SurfaceCard Eyebrow="UI" Title="Current web UI" Description="Return to the existing browser tools for workflows not yet rebuilt here." Href="/web/index.html" LinkText="Open current UI" Target="_blank" />
+	<SurfaceCard Eyebrow="API" Title="HTTP API root" Description="Open the root HTTP surface for link discovery and API navigation." Href="/" LinkText="Open root" Target="_blank" />
 </section>

--- a/src/EventStore.ClusterNode/Components/Pages/Navigator.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Navigator.razor
@@ -9,10 +9,10 @@
 </section>
 
 <section class="mt-8 grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-	<SurfaceCard Eyebrow="Data" Title="Streams" Description="Browse streams, inspect events, and use the current stream tooling." Href="/web/index.html#/streams" LinkText="Open streams" />
-	<SurfaceCard Eyebrow="Data" Title="Stream browser" Description="Open the current browser entry point for stream reads and event inspection." Href="/web/index.html#/dashboard" LinkText="Open dashboard" />
-	<SurfaceCard Eyebrow="Processing" Title="Projections" Description="Manage projection definitions and projection runtime state through the current tools." Href="/web/index.html#/projections" LinkText="Open projections" />
-	<SurfaceCard Eyebrow="Consumers" Title="Subscriptions" Description="Review persistent subscription groups, parked messages, and consumer progress." Href="/web/index.html#/subscriptions" LinkText="Open subscriptions" />
-	<SurfaceCard Eyebrow="Security" Title="Users" Description="Reach the user administration surface for accounts and access workflows." Href="/web/index.html#/users" LinkText="Open users" />
-	<SurfaceCard Eyebrow="API" Title="HTTP root" Description="Inspect the HTTP API root and discover links exposed by the node." Href="/" LinkText="Open root" />
+	<SurfaceCard Eyebrow="Data" Title="Streams" Description="Browse streams, inspect events, and use the current stream tooling." Href="/web/index.html#/streams" LinkText="Open streams" Target="_blank" />
+	<SurfaceCard Eyebrow="Data" Title="Stream browser" Description="Open the current browser entry point for stream reads and event inspection." Href="/web/index.html#/dashboard" LinkText="Open dashboard" Target="_blank" />
+	<SurfaceCard Eyebrow="Processing" Title="Projections" Description="Manage projection definitions and projection runtime state through the current tools." Href="/web/index.html#/projections" LinkText="Open projections" Target="_blank" />
+	<SurfaceCard Eyebrow="Consumers" Title="Subscriptions" Description="Review persistent subscription groups, parked messages, and consumer progress." Href="/web/index.html#/subscriptions" LinkText="Open subscriptions" Target="_blank" />
+	<SurfaceCard Eyebrow="Security" Title="Users" Description="Reach the user administration surface for accounts and access workflows." Href="/web/index.html#/users" LinkText="Open users" Target="_blank" />
+	<SurfaceCard Eyebrow="API" Title="HTTP root" Description="Inspect the HTTP API root and discover links exposed by the node." Href="/" LinkText="Open root" Target="_blank" />
 </section>

--- a/src/EventStore.ClusterNode/Components/Pages/Observability.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Observability.razor
@@ -9,10 +9,10 @@
 </section>
 
 <section class="mt-8 grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-	<SurfaceCard Eyebrow="Health" Title="Health check" Description="Check whether the node health endpoint is responding." Href="/health/live" LinkText="Open health" />
-	<SurfaceCard Eyebrow="Health" Title="Ping" Description="Use the simplest HTTP probe for process availability." Href="/ping" LinkText="Open ping" />
-	<SurfaceCard Eyebrow="Stats" Title="Grouped stats" Description="Inspect grouped runtime statistics collected by the node." Href="/stats" LinkText="Open stats" />
-	<SurfaceCard Eyebrow="Stats" Title="Replication stats" Description="Review replication-specific statistics for diagnosing cluster movement." Href="/stats/replication" LinkText="Open replication" />
-	<SurfaceCard Eyebrow="Stats" Title="TCP stats" Description="Inspect TCP connection statistics when troubleshooting network behavior." Href="/stats/tcp" LinkText="Open TCP stats" />
-	<SurfaceCard Eyebrow="Metrics" Title="Metrics endpoint" Description="Open the metrics endpoint used by external monitoring systems." Href="/metrics" LinkText="Open metrics" />
+	<SurfaceCard Eyebrow="Health" Title="Health check" Description="Check whether the node health endpoint is responding." Href="/health/live" LinkText="Open health" Target="_blank" />
+	<SurfaceCard Eyebrow="Health" Title="Ping" Description="Use the simplest HTTP probe for process availability." Href="/ping" LinkText="Open ping" Target="_blank" />
+	<SurfaceCard Eyebrow="Stats" Title="Grouped stats" Description="Inspect grouped runtime statistics collected by the node." Href="/stats" LinkText="Open stats" Target="_blank" />
+	<SurfaceCard Eyebrow="Stats" Title="Replication stats" Description="Review replication-specific statistics for diagnosing cluster movement." Href="/stats/replication" LinkText="Open replication" Target="_blank" />
+	<SurfaceCard Eyebrow="Stats" Title="TCP stats" Description="Inspect TCP connection statistics when troubleshooting network behavior." Href="/stats/tcp" LinkText="Open TCP stats" Target="_blank" />
+	<SurfaceCard Eyebrow="Metrics" Title="Metrics endpoint" Description="Open the metrics endpoint used by external monitoring systems." Href="/metrics" LinkText="Open metrics" Target="_blank" />
 </section>


### PR DESCRIPTION
- Operators should not lose the hosted management workspace when they inspect raw node endpoints or compatibility tools.
- Keeping endpoint handoffs separate makes the hosted shell safer to use while deeper workflows are rebuilt in-tree.