### PR TITLE
feat(ui): replace legacy security page

### DIFF
--- a/src/EventStore.ClusterNode.Web/EventStore.ClusterNode.Web.csproj
+++ b/src/EventStore.ClusterNode.Web/EventStore.ClusterNode.Web.csproj
@@ -47,6 +47,9 @@
 		<None Include="clusternode-web\js\queue-dashboard.js">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
+		<None Include="clusternode-web\js\ui-auth.js">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 		<None Include="clusternode-web\js\requirejs.min.js">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>

--- a/src/EventStore.ClusterNode.Web/clusternode-web/js/legacy-dashboard-redirect.js
+++ b/src/EventStore.ClusterNode.Web/clusternode-web/js/legacy-dashboard-redirect.js
@@ -257,14 +257,17 @@
 		}
 	}
 
-	async function redirectLegacyRoutes() {
+	function redirectLegacyRoutes() {
 		var hash = window.location.hash || "";
 		for (var i = 0; i < legacyRoutes.length; i++) {
 			if (!legacyRoutes[i].pattern.test(hash))
 				continue;
 
-			await copyLegacyCredentialsCookie();
-			window.location.replace(legacyRoutes[i].target(hash));
+			var target = legacyRoutes[i].target(hash);
+			if (submitLegacyCredentials(target))
+				return;
+
+			window.location.replace(target);
 			return;
 		}
 	}
@@ -281,19 +284,28 @@
 		return "";
 	}
 
-	async function copyLegacyCredentialsCookie() {
+	function submitLegacyCredentials(returnUrl) {
 		var value = readCookie("es-creds");
-		if (!value || !window.fetch)
-			return;
+		if (!value)
+			return false;
 
-		try {
-			await window.fetch("/ui/security/migrate-credentials", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ credentials: value })
-			});
-		} catch (_) {
-		}
+		var form = document.createElement("form");
+		form.method = "post";
+		form.action = "/ui/security/migrate-credentials";
+		form.style.display = "none";
+		appendHidden(form, "credentials", value);
+		appendHidden(form, "returnUrl", returnUrl);
+		(document.body || document.documentElement).appendChild(form);
+		form.submit();
+		return true;
+	}
+
+	function appendHidden(form, name, value) {
+		var input = document.createElement("input");
+		input.type = "hidden";
+		input.name = name;
+		input.value = value;
+		form.appendChild(input);
 	}
 
 	function watchLegacyShell() {

--- a/src/EventStore.ClusterNode.Web/clusternode-web/js/legacy-dashboard-redirect.js
+++ b/src/EventStore.ClusterNode.Web/clusternode-web/js/legacy-dashboard-redirect.js
@@ -264,7 +264,7 @@
 				continue;
 
 			var target = legacyRoutes[i].target(hash);
-			if (submitLegacyCredentials(target))
+			if (shouldMigrateLegacyCredentials(target) && submitLegacyCredentials(target))
 				return;
 
 			window.location.replace(target);
@@ -301,6 +301,10 @@
 		(document.body || document.documentElement).appendChild(form);
 		form.submit();
 		return true;
+	}
+
+	function shouldMigrateLegacyCredentials(target) {
+		return !/^\/ui\/signout(?:[/?#]|$)/i.test(target || "");
 	}
 
 	function createMigrationToken() {

--- a/src/EventStore.ClusterNode.Web/clusternode-web/js/legacy-dashboard-redirect.js
+++ b/src/EventStore.ClusterNode.Web/clusternode-web/js/legacy-dashboard-redirect.js
@@ -25,6 +25,18 @@
 			}
 		},
 		{
+			pattern: /^#\/signin(?:[/?].*)?$/i,
+			target: function () {
+				return "/ui/signin";
+			}
+		},
+		{
+			pattern: /^#\/signout(?:[/?].*)?$/i,
+			target: function () {
+				return "/ui/signout";
+			}
+		},
+		{
 			pattern: /^#\/subscriptions(?:[/?].*)?$/i,
 			target: function (hash) {
 				var path = hash.replace(/^#\/subscriptions\/?/i, "").split(/[?#]/)[0].replace(/\/$/, "");
@@ -177,7 +189,9 @@
 		{ selector: 'a[ui-sref="users.list"]', text: "Users" },
 		{ selector: 'a[ui-sref="subscriptions.list"]', text: "Persistent Subscriptions" },
 		{ selector: 'a[ui-sref="projections.list"]', text: "Projections" },
-		{ selector: 'a[ui-sref="query"]', text: "Query" }
+		{ selector: 'a[ui-sref="query"]', text: "Query" },
+		{ selector: 'a[ui-sref="signout"]', text: "Log Out" },
+		{ selector: 'a[ui-sref="signout"]', text: "Disconnect" }
 	];
 
 	function safeDecode(value) {
@@ -249,9 +263,31 @@
 			if (!legacyRoutes[i].pattern.test(hash))
 				continue;
 
+			copyLegacyCredentialsCookie();
 			window.location.replace(legacyRoutes[i].target(hash));
 			return;
 		}
+	}
+
+	function readCookie(name) {
+		var prefix = name + "=";
+		var parts = document.cookie ? document.cookie.split(";") : [];
+		for (var i = 0; i < parts.length; i++) {
+			var part = parts[i].trim();
+			if (part.indexOf(prefix) === 0)
+				return part.substring(prefix.length);
+		}
+
+		return "";
+	}
+
+	function copyLegacyCredentialsCookie() {
+		var value = readCookie("es-creds");
+		if (!value)
+			return;
+
+		var secure = window.location.protocol === "https:" ? "; secure" : "";
+		document.cookie = "es-creds=" + value + "; path=/; SameSite=Lax" + secure;
 	}
 
 	function watchLegacyShell() {

--- a/src/EventStore.ClusterNode.Web/clusternode-web/js/legacy-dashboard-redirect.js
+++ b/src/EventStore.ClusterNode.Web/clusternode-web/js/legacy-dashboard-redirect.js
@@ -293,11 +293,33 @@
 		form.method = "post";
 		form.action = "/ui/security/migrate-credentials";
 		form.style.display = "none";
+		var migrationToken = createMigrationToken();
+		writeMigrationToken(migrationToken);
 		appendHidden(form, "credentials", value);
 		appendHidden(form, "returnUrl", returnUrl);
+		appendHidden(form, "migrationToken", migrationToken);
 		(document.body || document.documentElement).appendChild(form);
 		form.submit();
 		return true;
+	}
+
+	function createMigrationToken() {
+		if (window.crypto && window.crypto.getRandomValues) {
+			var bytes = new Uint8Array(16);
+			window.crypto.getRandomValues(bytes);
+			var token = "";
+			for (var i = 0; i < bytes.length; i++)
+				token += ("0" + bytes[i].toString(16)).slice(-2);
+
+			return token;
+		}
+
+		return String(Date.now()) + String(Math.random()).slice(2);
+	}
+
+	function writeMigrationToken(token) {
+		var secure = window.location.protocol === "https:" ? "; secure" : "";
+		document.cookie = "es-ui-migration-token=" + token + "; path=/; max-age=120; SameSite=Lax" + secure;
 	}
 
 	function appendHidden(form, name, value) {

--- a/src/EventStore.ClusterNode.Web/clusternode-web/js/legacy-dashboard-redirect.js
+++ b/src/EventStore.ClusterNode.Web/clusternode-web/js/legacy-dashboard-redirect.js
@@ -314,7 +314,16 @@
 			return token;
 		}
 
-		return String(Date.now()) + String(Math.random()).slice(2);
+		var fallback = String(Date.now());
+		while (fallback.length < 32) {
+			var chunk = Math.floor(Math.random() * 0x100000000).toString(16);
+			while (chunk.length < 8)
+				chunk = "0" + chunk;
+
+			fallback += chunk;
+		}
+
+		return fallback;
 	}
 
 	function writeMigrationToken(token) {

--- a/src/EventStore.ClusterNode.Web/clusternode-web/js/legacy-dashboard-redirect.js
+++ b/src/EventStore.ClusterNode.Web/clusternode-web/js/legacy-dashboard-redirect.js
@@ -257,13 +257,13 @@
 		}
 	}
 
-	function redirectLegacyRoutes() {
+	async function redirectLegacyRoutes() {
 		var hash = window.location.hash || "";
 		for (var i = 0; i < legacyRoutes.length; i++) {
 			if (!legacyRoutes[i].pattern.test(hash))
 				continue;
 
-			copyLegacyCredentialsCookie();
+			await copyLegacyCredentialsCookie();
 			window.location.replace(legacyRoutes[i].target(hash));
 			return;
 		}
@@ -281,13 +281,19 @@
 		return "";
 	}
 
-	function copyLegacyCredentialsCookie() {
+	async function copyLegacyCredentialsCookie() {
 		var value = readCookie("es-creds");
-		if (!value)
+		if (!value || !window.fetch)
 			return;
 
-		var secure = window.location.protocol === "https:" ? "; secure" : "";
-		document.cookie = "es-creds=" + value + "; path=/; SameSite=Lax" + secure;
+		try {
+			await window.fetch("/ui/security/migrate-credentials", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ credentials: value })
+			});
+		} catch (_) {
+		}
 	}
 
 	function watchLegacyShell() {

--- a/src/EventStore.ClusterNode.Web/clusternode-web/js/ui-auth.js
+++ b/src/EventStore.ClusterNode.Web/clusternode-web/js/ui-auth.js
@@ -25,32 +25,9 @@
 		}
 	}
 
-	function readBasicCredentials() {
-		var raw = safeDecode(readCookie("es-creds"));
-		if (!raw)
-			return "";
-
-		if (raw.indexOf("j:") === 0)
-			raw = raw.substring(2);
-
-		if (raw.charAt(0) !== "{")
-			return raw;
-
-		try {
-			var parsed = JSON.parse(raw);
-			return parsed ? (parsed.credentials || parsed.Credentials || "") : "";
-		} catch (_) {
-			return "";
-		}
-	}
-
 	function readAuthorization() {
 		var token = safeDecode(readCookie("oauth_id_token"));
-		if (token)
-			return "Bearer " + token;
-
-		var credentials = readBasicCredentials();
-		return credentials ? "Basic " + credentials : "";
+		return token ? "Bearer " + token : "";
 	}
 
 	function sameOrigin(input) {
@@ -78,7 +55,8 @@
 	}
 
 	function clearCookie(name) {
-		document.cookie = name + "=; max-age=0; path=/; SameSite=Lax";
+		var secure = window.location.protocol === "https:" ? "; secure" : "";
+		document.cookie = name + "=; max-age=0; path=/; SameSite=Lax" + secure;
 	}
 
 	function clearAuthCookies() {

--- a/src/EventStore.ClusterNode.Web/clusternode-web/js/ui-auth.js
+++ b/src/EventStore.ClusterNode.Web/clusternode-web/js/ui-auth.js
@@ -25,9 +25,13 @@
 		}
 	}
 
+	function isHeaderSafe(value) {
+		return value && !/[\r\n]/.test(value);
+	}
+
 	function readAuthorization() {
 		var token = safeDecode(readCookie("oauth_id_token"));
-		if (token)
+		if (isHeaderSafe(token))
 			return "Bearer " + token;
 
 		var raw = safeDecode(readCookie("es-creds"));
@@ -37,7 +41,7 @@
 		try {
 			var parsed = JSON.parse(raw.indexOf("j:") === 0 ? raw.substring(2) : raw);
 			var credentials = parsed && typeof parsed.credentials === "string" ? parsed.credentials : "";
-			if (!credentials || /[\r\n]/.test(credentials))
+			if (!isHeaderSafe(credentials))
 				return "";
 
 			return /^Basic\s+/i.test(credentials) ? credentials : "Basic " + credentials;
@@ -75,7 +79,7 @@
 		document.cookie = name + "=; max-age=0; path=/; SameSite=Lax" + secure;
 	}
 
-	function clearAuthCookies() {
+	function clearReadableAuthCookies() {
 		clearCookie("es-creds");
 		clearCookie("oauth_id_token");
 	}
@@ -134,7 +138,7 @@
 
 	document.addEventListener("DOMContentLoaded", function () {
 		if (document.querySelector("[data-ui-clear-auth]"))
-			clearAuthCookies();
+			clearReadableAuthCookies();
 
 		if (window.location.pathname !== "/ui/signin")
 			return;
@@ -164,7 +168,6 @@
 	});
 
 	window.EventStoreUiAuth = {
-		clear: clearAuthCookies,
 		readAuthorization: readAuthorization
 	};
 }());

--- a/src/EventStore.ClusterNode.Web/clusternode-web/js/ui-auth.js
+++ b/src/EventStore.ClusterNode.Web/clusternode-web/js/ui-auth.js
@@ -120,11 +120,22 @@
 		if (document.querySelector("[data-ui-clear-auth]"))
 			clearAuthCookies();
 
+		if (window.location.pathname !== "/ui/signin")
+			return;
+
 		var returnUrl = sessionStorage.getItem("eventstore-ui-return-url");
-		if (returnUrl && readAuthorization() && window.location.pathname === "/ui/signin") {
+		if (!readAuthorization())
+			return;
+
+		if (returnUrl) {
 			sessionStorage.removeItem("eventstore-ui-return-url");
 			window.location.href = returnUrl;
+			return;
 		}
+
+		var query = new URLSearchParams(window.location.search);
+		if (query.has("code") || query.has("state"))
+			window.location.href = "/ui";
 	});
 
 	document.addEventListener("click", function (event) {

--- a/src/EventStore.ClusterNode.Web/clusternode-web/js/ui-auth.js
+++ b/src/EventStore.ClusterNode.Web/clusternode-web/js/ui-auth.js
@@ -1,0 +1,165 @@
+(function () {
+	"use strict";
+
+	var originalFetch = window.fetch;
+
+	function readCookie(name) {
+		var prefix = name + "=";
+		var parts = document.cookie ? document.cookie.split(";") : [];
+		for (var i = 0; i < parts.length; i++) {
+			var part = parts[i].trim();
+			if (part.indexOf(prefix) !== 0)
+				continue;
+
+			return part.substring(prefix.length);
+		}
+
+		return "";
+	}
+
+	function safeDecode(value) {
+		try {
+			return decodeURIComponent(value);
+		} catch (_) {
+			return value;
+		}
+	}
+
+	function readBasicCredentials() {
+		var raw = safeDecode(readCookie("es-creds"));
+		if (!raw)
+			return "";
+
+		if (raw.indexOf("j:") === 0)
+			raw = raw.substring(2);
+
+		if (raw.charAt(0) !== "{")
+			return raw;
+
+		try {
+			var parsed = JSON.parse(raw);
+			return parsed ? (parsed.credentials || parsed.Credentials || "") : "";
+		} catch (_) {
+			return "";
+		}
+	}
+
+	function readAuthorization() {
+		var token = safeDecode(readCookie("oauth_id_token"));
+		if (token)
+			return "Bearer " + token;
+
+		var credentials = readBasicCredentials();
+		return credentials ? "Basic " + credentials : "";
+	}
+
+	function sameOrigin(input) {
+		var url = new URL(input instanceof Request ? input.url : input, window.location.href);
+		return url.origin === window.location.origin;
+	}
+
+	function addAuthorization(input, init) {
+		var authorization = readAuthorization();
+		if (!authorization || !sameOrigin(input))
+			return init;
+
+		var options = init ? Object.assign({}, init) : {};
+		var headers = new Headers(options.headers || (input instanceof Request ? input.headers : undefined));
+		if (!headers.has("Authorization"))
+			headers.set("Authorization", authorization);
+		options.headers = headers;
+		return options;
+	}
+
+	if (originalFetch) {
+		window.fetch = function (input, init) {
+			return originalFetch(input, addAuthorization(input, init));
+		};
+	}
+
+	function clearCookie(name) {
+		document.cookie = name + "=; max-age=0; path=/; SameSite=Lax";
+	}
+
+	function clearAuthCookies() {
+		clearCookie("es-creds");
+		clearCookie("oauth_id_token");
+	}
+
+	function setStatus(message) {
+		var status = document.querySelector("[data-ui-oauth-status]");
+		if (!status)
+			return;
+
+		status.textContent = message;
+		status.classList.remove("hidden");
+	}
+
+	async function beginOAuthSignIn(button) {
+		try {
+			var infoResponse = await originalFetch("/info?format=json", {
+				headers: { "Accept": "application/json" }
+			});
+			if (!infoResponse.ok)
+				throw new Error("Info endpoint returned " + infoResponse.status + " " + infoResponse.statusText);
+
+			var info = await infoResponse.json();
+			var authentication = info.authentication || info.Authentication || {};
+			var properties = authentication.properties || authentication.Properties || {};
+			if ((authentication.type || authentication.Type || "").toLowerCase() !== "oauth")
+				throw new Error("The configured provider is not an OAuth browser flow.");
+
+			var baseUrl = window.location.protocol + "//" + window.location.host;
+			var challengeResponse = await originalFetch(baseUrl + properties.code_challenge_uri);
+			if (!challengeResponse.ok)
+				throw new Error("Code challenge endpoint returned " + challengeResponse.status + " " + challengeResponse.statusText);
+
+			var challenge = await challengeResponse.json();
+			var state = btoa(JSON.stringify({
+				code_challenge_correlation_id: challenge.code_challenge_correlation_id
+			}));
+			var redirectUri = encodeURIComponent(baseUrl + properties.redirect_uri);
+			var target = properties.authorization_endpoint +
+				"?response_type=" + encodeURIComponent(properties.response_type) +
+				"&client_id=" + encodeURIComponent(properties.client_id) +
+				"&redirect_uri=" + redirectUri +
+				"&scope=" + encodeURIComponent(properties.scope) +
+				"&code_challenge=" + encodeURIComponent(challenge.code_challenge) +
+				"&code_challenge_method=" + encodeURIComponent(challenge.code_challenge_method) +
+				"&state=" + encodeURIComponent(state);
+
+			var returnUrl = button.getAttribute("data-ui-oauth-return");
+			if (returnUrl)
+				sessionStorage.setItem("eventstore-ui-return-url", returnUrl);
+
+			window.location.href = target;
+		} catch (error) {
+			setStatus(error && error.message ? error.message : "Unable to start the browser sign-in flow.");
+		}
+	}
+
+	document.addEventListener("DOMContentLoaded", function () {
+		if (document.querySelector("[data-ui-clear-auth]"))
+			clearAuthCookies();
+
+		var returnUrl = sessionStorage.getItem("eventstore-ui-return-url");
+		if (returnUrl && readAuthorization() && window.location.pathname === "/ui/signin") {
+			sessionStorage.removeItem("eventstore-ui-return-url");
+			window.location.href = returnUrl;
+		}
+	});
+
+	document.addEventListener("click", function (event) {
+		var button = event.target.closest("[data-ui-oauth-signin]");
+		if (!button)
+			return;
+
+		event.preventDefault();
+		beginOAuthSignIn(button);
+	});
+
+	window.EventStoreUiAuth = {
+		clear: clearAuthCookies,
+		readAuthorization: readAuthorization
+	};
+}());

--- a/src/EventStore.ClusterNode.Web/clusternode-web/js/ui-auth.js
+++ b/src/EventStore.ClusterNode.Web/clusternode-web/js/ui-auth.js
@@ -27,7 +27,23 @@
 
 	function readAuthorization() {
 		var token = safeDecode(readCookie("oauth_id_token"));
-		return token ? "Bearer " + token : "";
+		if (token)
+			return "Bearer " + token;
+
+		var raw = safeDecode(readCookie("es-creds"));
+		if (!raw)
+			return "";
+
+		try {
+			var parsed = JSON.parse(raw.indexOf("j:") === 0 ? raw.substring(2) : raw);
+			var credentials = parsed && typeof parsed.credentials === "string" ? parsed.credentials : "";
+			if (!credentials || /[\r\n]/.test(credentials))
+				return "";
+
+			return /^Basic\s+/i.test(credentials) ? credentials : "Basic " + credentials;
+		} catch (_) {
+			return "";
+		}
 	}
 
 	function sameOrigin(input) {

--- a/src/EventStore.ClusterNode/Components/App.razor
+++ b/src/EventStore.ClusterNode/Components/App.razor
@@ -10,6 +10,7 @@
 </head>
 <body>
 	<Routes />
+	<script src="/web/js/ui-auth.js"></script>
 	<script src="/web/js/cluster-status.js"></script>
 	<script src="/web/js/queue-dashboard.js"></script>
 	<script src="/web/js/admin-operations.js"></script>

--- a/src/EventStore.ClusterNode/Components/Layout/AuthLayout.razor
+++ b/src/EventStore.ClusterNode/Components/Layout/AuthLayout.razor
@@ -1,0 +1,7 @@
+@inherits LayoutComponentBase
+
+<div class="min-h-screen bg-[radial-gradient(circle_at_top_left,_rgba(107,163,0,0.16),_transparent_28rem),linear-gradient(135deg,_#f8faf5_0%,_#edf4e6_42%,_#fbfcf7_100%)] text-es-ink">
+	<main class="mx-auto flex min-h-screen w-full max-w-6xl items-center justify-center p-4">
+		@Body
+	</main>
+</div>

--- a/src/EventStore.ClusterNode/Components/Layout/NavMenu.razor
+++ b/src/EventStore.ClusterNode/Components/Layout/NavMenu.razor
@@ -1,3 +1,5 @@
+@inject IHttpContextAccessor HttpContextAccessor
+
 <aside class="lg:sticky lg:top-4 lg:h-[calc(100vh-2rem)] lg:w-72 lg:shrink-0">
 	<div class="flex h-full flex-col rounded-[2rem] border border-white/80 bg-white/85 p-4 shadow-[0_18px_70px_rgba(23,32,51,0.10)] backdrop-blur">
 		<a class="group flex items-center gap-3 rounded-2xl px-2 py-2 hover:bg-es-ink/5" href="/ui" aria-label="EventStore UI home">
@@ -32,6 +34,14 @@
 				<div class="mt-2 grid gap-1">
 					<NavLink href="/ui/users" class="@LinkClass" ActiveClass="@ActiveClass">Users</NavLink>
 					<NavLink href="/ui/operations" class="@LinkClass" ActiveClass="@ActiveClass">Operations</NavLink>
+					@if (IsAnonymous)
+					{
+						<NavLink href="/ui/signin" class="@LinkClass" ActiveClass="@ActiveClass">Sign in</NavLink>
+					}
+					else
+					{
+						<NavLink href="/ui/signout" class="@LinkClass" ActiveClass="@ActiveClass">Sign out</NavLink>
+					}
 				</div>
 			</div>
 		</nav>
@@ -42,4 +52,5 @@
 @code {
 	private const string LinkClass = "rounded-2xl px-3 py-2.5 transition hover:bg-es-ink/5 hover:text-es-forest";
 	private const string ActiveClass = "bg-es-ink text-white shadow-lg shadow-es-ink/15 hover:bg-es-ink hover:text-white";
+	private bool IsAnonymous => !SecurityBrowserService.IsSignedIn(HttpContextAccessor.HttpContext?.User);
 }

--- a/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
@@ -24,7 +24,13 @@
 	</article>
 
 	<article class="rounded-[2rem] border border-white/80 bg-white/95 p-7 shadow-[0_24px_90px_rgba(23,32,51,0.12)] backdrop-blur">
-		@if (Authentication.IsInsecure)
+		@if (!AuthenticationAvailable)
+		{
+			<StatusBadge Label="Authentication unavailable" Tone="bad" />
+			<h2 class="mt-4 text-3xl font-black tracking-tight text-es-ink">Sign-in is temporarily unavailable.</h2>
+			<p class="mt-3 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm font-bold text-red-800">@Message</p>
+		}
+		else if (Authentication.IsInsecure)
 		{
 			<StatusBadge Label="Insecure mode" Tone="warn" />
 			<h2 class="mt-4 text-3xl font-black tracking-tight text-es-ink">Authentication is disabled.</h2>
@@ -79,12 +85,21 @@
 	[SupplyParameterFromForm(FormName = "ui-signin")]
 	private SignInInput Input { get; set; } = new();
 
-	private SecurityAuthenticationInfo Authentication { get; set; }
+	private SecurityAuthenticationInfo Authentication { get; set; } = SecurityAuthenticationInfo.Unavailable();
+	private bool AuthenticationAvailable { get; set; } = true;
 	private string Message { get; set; } = "";
 	private string Destination => SecurityBrowserService.NormalizeReturnUrl(ReturnUrl);
 
 	protected override void OnParametersSet() {
-		Authentication = Security.AuthenticationInfo();
+		try {
+			Authentication = Security.AuthenticationInfo();
+			AuthenticationAvailable = true;
+		} catch (Exception ex) {
+			Authentication = SecurityAuthenticationInfo.Unavailable();
+			AuthenticationAvailable = false;
+			Message = $"Unable to load authentication information: {UserInterfaceMessages.Friendly(ex)}";
+		}
+
 		var context = HttpContextAccessor.HttpContext;
 		if (string.Equals(context?.Request.Method, HttpMethods.Get, StringComparison.OrdinalIgnoreCase) &&
 		    SecurityBrowserService.IsSignedIn(context.User) &&

--- a/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
@@ -87,9 +87,15 @@
 		Authentication = Security.AuthenticationInfo();
 		var context = HttpContextAccessor.HttpContext;
 		if (string.Equals(context?.Request.Method, HttpMethods.Get, StringComparison.OrdinalIgnoreCase) &&
-		    SecurityBrowserService.IsSignedIn(context.User))
+		    SecurityBrowserService.IsSignedIn(context.User) &&
+		    !IsOAuthCallback(context.Request))
 			Navigation.NavigateTo(Destination);
 	}
+
+	private static bool IsOAuthCallback(HttpRequest request) =>
+		request.Query.ContainsKey("code") ||
+		request.Query.ContainsKey("state") ||
+		request.Query.ContainsKey("error");
 
 	private async Task SignInUser() {
 		try {

--- a/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
@@ -1,0 +1,127 @@
+@page "/ui/signin"
+@layout AuthLayout
+@inject SecurityBrowserService Security
+@inject IHttpContextAccessor HttpContextAccessor
+@inject NavigationManager Navigation
+@using System.ComponentModel.DataAnnotations
+@using Microsoft.AspNetCore.Components.Forms
+
+<PageTitle>Sign in - EventStore UI</PageTitle>
+
+<section class="grid w-full gap-5 lg:grid-cols-[0.9fr_1.1fr]">
+	<article class="rounded-[2rem] border border-white/80 bg-white/90 p-7 shadow-[0_24px_90px_rgba(23,32,51,0.12)] backdrop-blur">
+		<a class="inline-flex items-center gap-3 rounded-2xl px-2 py-2 hover:bg-es-ink/5" href="/ui" aria-label="EventStore UI home">
+			<span class="flex size-10 items-center justify-center rounded-2xl bg-es-ink text-base font-black tracking-tight text-white shadow-lg shadow-es-ink/15">ES</span>
+			<span>
+				<span class="block text-xs font-bold uppercase tracking-[0.24em] text-es-green">EventStore</span>
+				<span class="block text-lg font-black tracking-tight text-es-ink">Operations UI</span>
+			</span>
+		</a>
+
+		<p class="mt-10 text-xs font-black uppercase tracking-[0.28em] text-es-green">Secure session</p>
+		<h1 class="mt-4 text-5xl font-black tracking-tight text-es-ink sm:text-6xl">Sign in to manage this node.</h1>
+		<p class="mt-5 text-lg leading-8 text-es-muted">Use the same node authentication provider as the legacy Admin UI while keeping the new Razor surface outside Angular.</p>
+	</article>
+
+	<article class="rounded-[2rem] border border-white/80 bg-white/95 p-7 shadow-[0_24px_90px_rgba(23,32,51,0.12)] backdrop-blur">
+		@if (Authentication.IsInsecure)
+		{
+			<StatusBadge Label="Insecure mode" Tone="warn" />
+			<h2 class="mt-4 text-3xl font-black tracking-tight text-es-ink">Authentication is disabled.</h2>
+			<p class="mt-3 text-sm leading-6 text-es-muted">This node is running with insecure access, so there is no credential exchange to perform.</p>
+			<a class="mt-6 inline-flex rounded-2xl bg-es-ink px-5 py-3 text-sm font-black text-white shadow-lg shadow-es-ink/15 transition hover:bg-es-green" href="@Destination">Continue to UI</a>
+		}
+		else if (!Authentication.SupportsBasic)
+		{
+			<StatusBadge Label="@Authentication.TypeLabel" Tone="warn" />
+			<h2 class="mt-4 text-3xl font-black tracking-tight text-es-ink">Continue with the configured provider.</h2>
+			<p class="mt-3 text-sm leading-6 text-es-muted">This node does not advertise Basic authentication, so sign-in is delegated to the configured browser authentication flow.</p>
+			<button class="mt-6 rounded-2xl bg-es-ink px-5 py-3 text-sm font-black text-white shadow-lg shadow-es-ink/15 transition hover:bg-es-green" type="button" data-ui-oauth-signin data-ui-oauth-return="@Destination">Continue</button>
+			<p class="mt-4 hidden rounded-2xl border border-red-200 bg-red-50 p-4 text-sm font-bold text-red-800" data-ui-oauth-status></p>
+		}
+		else
+		{
+			<EditForm Model="Input" FormName="ui-signin" OnValidSubmit="SignInUser">
+				<AntiforgeryToken />
+				<DataAnnotationsValidator />
+
+				<div class="grid gap-4">
+					<label class="text-sm font-bold text-es-muted">
+						Username
+						<InputText autocomplete="username" autofocus class="mt-2 w-full rounded-2xl border border-es-ink/10 bg-white px-4 py-3 text-es-ink outline-none transition focus:border-es-green focus:ring-4 focus:ring-es-green/15" @bind-Value="Input.Username" />
+						<ValidationMessage For="() => Input.Username" />
+					</label>
+					<label class="text-sm font-bold text-es-muted">
+						Password
+						<InputText autocomplete="current-password" type="password" class="mt-2 w-full rounded-2xl border border-es-ink/10 bg-white px-4 py-3 text-es-ink outline-none transition focus:border-es-green focus:ring-4 focus:ring-es-green/15" @bind-Value="Input.Password" />
+						<ValidationMessage For="() => Input.Password" />
+					</label>
+				</div>
+
+				@if (!string.IsNullOrWhiteSpace(Message))
+				{
+					<p class="mt-5 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm font-bold text-red-800">@Message</p>
+				}
+
+				<div class="mt-6 flex flex-wrap gap-2">
+					<button class="rounded-2xl bg-es-ink px-5 py-3 text-sm font-black text-white shadow-lg shadow-es-ink/15 transition hover:bg-es-green" type="submit">Sign in</button>
+					<a class="rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="/web/index.html#/signin">Legacy sign-in</a>
+				</div>
+			</EditForm>
+		}
+	</article>
+</section>
+
+@code {
+	[SupplyParameterFromQuery(Name = "returnUrl")]
+	private string ReturnUrl { get; set; } = "";
+
+	[SupplyParameterFromForm(FormName = "ui-signin")]
+	private SignInInput Input { get; set; } = new();
+
+	private SecurityAuthenticationInfo Authentication { get; set; }
+	private string Message { get; set; } = "";
+	private string Destination => SecurityBrowserService.NormalizeReturnUrl(ReturnUrl);
+
+	protected override void OnParametersSet() {
+		Authentication = Security.AuthenticationInfo();
+		var context = HttpContextAccessor.HttpContext;
+		if (string.Equals(context?.Request.Method, HttpMethods.Get, StringComparison.OrdinalIgnoreCase) &&
+		    SecurityBrowserService.IsSignedIn(context.User))
+			Navigation.NavigateTo(Destination);
+	}
+
+	private async Task SignInUser() {
+		try {
+			var result = await Security.Validate(Input.Username, Input.Password);
+			if (!result.Success) {
+				Message = result.Message;
+				return;
+			}
+
+			var context = HttpContextAccessor.HttpContext;
+			if (context is null) {
+				Message = "The sign-in response is no longer available.";
+				return;
+			}
+
+			UiCredentialCookie.AppendBasic(context.Response, new UiCredentials(Input.Username.Trim(), Input.Password));
+		} catch (OperationCanceledException) {
+			Message = "Sign-in was canceled.";
+			return;
+		} catch (Exception ex) {
+			Message = $"Failed to sign in: {UserInterfaceMessages.Friendly(ex)}";
+			return;
+		}
+
+		Navigation.NavigateTo(Destination);
+	}
+
+	private sealed class SignInInput {
+		[Required(ErrorMessage = "Enter a username.")]
+		public string Username { get; set; } = "";
+
+		[Required(ErrorMessage = "Enter a password.")]
+		public string Password { get; set; } = "";
+	}
+}

--- a/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
@@ -105,6 +105,7 @@
 				return;
 			}
 
+			UiCredentialCookie.DeleteOAuthToken(context.Response);
 			UiCredentialCookie.AppendBasic(context.Response, new UiCredentials(Input.Username.Trim(), Input.Password));
 		} catch (OperationCanceledException) {
 			Message = "Sign-in was canceled.";

--- a/src/EventStore.ClusterNode/Components/Pages/SignOut.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SignOut.razor
@@ -1,0 +1,26 @@
+@page "/ui/signout"
+@layout AuthLayout
+@inject IHttpContextAccessor HttpContextAccessor
+
+<PageTitle>Signed out - EventStore UI</PageTitle>
+
+<section class="w-full max-w-2xl rounded-[2rem] border border-white/80 bg-white/95 p-8 text-center shadow-[0_24px_90px_rgba(23,32,51,0.12)] backdrop-blur" data-ui-clear-auth>
+	<p class="text-xs font-black uppercase tracking-[0.28em] text-es-green">Session cleared</p>
+	<h1 class="mt-4 text-5xl font-black tracking-tight text-es-ink sm:text-6xl">You have been signed out.</h1>
+	<p class="mt-5 text-lg leading-8 text-es-muted">Stored browser credentials for the management UI have been removed.</p>
+	<div class="mt-7 flex flex-wrap justify-center gap-2">
+		<a class="rounded-2xl bg-es-ink px-5 py-3 text-sm font-black text-white shadow-lg shadow-es-ink/15 transition hover:bg-es-green" href="/ui/signin">Sign in again</a>
+		<a class="rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="/ui">Return to UI</a>
+	</div>
+</section>
+
+@code {
+	protected override void OnInitialized() {
+		var context = HttpContextAccessor.HttpContext;
+		if (context is null)
+			return;
+
+		UiCredentialCookie.Delete(context.Response);
+		UiCredentialCookie.DeleteOAuthToken(context.Response);
+	}
+}

--- a/src/EventStore.ClusterNode/Components/Services/SecurityBrowserService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/SecurityBrowserService.cs
@@ -9,6 +9,8 @@ using Microsoft.AspNetCore.Http;
 namespace EventStore.ClusterNode.Components.Services;
 
 public sealed class SecurityBrowserService(IAuthenticationProvider authenticationProvider) {
+	private static readonly Uri LocalBaseUri = new("http://localhost", UriKind.Absolute);
+
 	public SecurityAuthenticationInfo AuthenticationInfo() {
 		var schemes = authenticationProvider.GetSupportedAuthenticationSchemes() ?? [];
 		return new SecurityAuthenticationInfo(
@@ -40,18 +42,24 @@ public sealed class SecurityBrowserService(IAuthenticationProvider authenticatio
 		if (string.IsNullOrWhiteSpace(returnUrl))
 			return "/ui";
 
-		if (!Uri.TryCreate(returnUrl, UriKind.Relative, out _))
+		if (!returnUrl.StartsWith("/", StringComparison.Ordinal) ||
+		    returnUrl.StartsWith("//", StringComparison.Ordinal) ||
+		    returnUrl.IndexOf('\\') >= 0 ||
+		    !Uri.TryCreate(returnUrl, UriKind.Relative, out var relative))
 			return "/ui";
 
-		return returnUrl.StartsWith("/ui", StringComparison.OrdinalIgnoreCase)
-			? returnUrl
+		var normalized = new Uri(LocalBaseUri, relative);
+		return IsUiPath(normalized.AbsolutePath)
+			? $"{normalized.PathAndQuery}{normalized.Fragment}"
 			: "/ui";
 	}
 
 	public static bool IsSignedIn(ClaimsPrincipal principal) =>
-		principal != null &&
-		principal.Claims.Any() &&
-		principal.Claims.All(x => x.Type != ClaimTypes.Anonymous);
+		principal?.Identity?.IsAuthenticated == true;
+
+	private static bool IsUiPath(string path) =>
+		path.Equals("/ui", StringComparison.OrdinalIgnoreCase) ||
+		path.StartsWith("/ui/", StringComparison.OrdinalIgnoreCase);
 }
 
 public sealed record SecurityAuthenticationInfo(string Type, bool SupportsBasic, bool IsInsecure) {

--- a/src/EventStore.ClusterNode/Components/Services/SecurityBrowserService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/SecurityBrowserService.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authentication;
+using EventStore.Transport.Http;
+using Microsoft.AspNetCore.Http;
+
+namespace EventStore.ClusterNode.Components.Services;
+
+public sealed class SecurityBrowserService(IAuthenticationProvider authenticationProvider) {
+	public SecurityAuthenticationInfo AuthenticationInfo() {
+		var schemes = authenticationProvider.GetSupportedAuthenticationSchemes() ?? [];
+		return new SecurityAuthenticationInfo(
+			authenticationProvider.Name,
+			schemes.Any(x => string.Equals(x, "Basic", StringComparison.OrdinalIgnoreCase)),
+			schemes.Any(x => string.Equals(x, "Insecure", StringComparison.OrdinalIgnoreCase)));
+	}
+
+	public async Task<SecurityCommandResult> Validate(string username, string password) {
+		if (string.IsNullOrWhiteSpace(username))
+			return SecurityCommandResult.Failure("Enter a username.");
+		if (string.IsNullOrWhiteSpace(password))
+			return SecurityCommandResult.Failure("Enter a password.");
+
+		var context = new DefaultHttpContext();
+		var request = new HttpAuthenticationRequest(context, username.Trim(), password);
+		authenticationProvider.Authenticate(request);
+		var (status, _) = await request.AuthenticateAsync();
+
+		return status switch {
+			HttpAuthenticationRequestStatus.Authenticated => SecurityCommandResult.Succeeded(),
+			HttpAuthenticationRequestStatus.NotReady => SecurityCommandResult.Failure("The authentication provider is not ready yet."),
+			HttpAuthenticationRequestStatus.Error => SecurityCommandResult.Failure("The authentication provider failed while checking credentials."),
+			_ => SecurityCommandResult.Failure("Incorrect user credentials supplied.")
+		};
+	}
+
+	public static string NormalizeReturnUrl(string returnUrl) {
+		if (string.IsNullOrWhiteSpace(returnUrl))
+			return "/ui";
+
+		if (!Uri.TryCreate(returnUrl, UriKind.Relative, out _))
+			return "/ui";
+
+		return returnUrl.StartsWith("/ui", StringComparison.OrdinalIgnoreCase)
+			? returnUrl
+			: "/ui";
+	}
+
+	public static bool IsSignedIn(ClaimsPrincipal principal) =>
+		principal != null &&
+		principal.Claims.Any() &&
+		principal.Claims.All(x => x.Type != ClaimTypes.Anonymous);
+}
+
+public sealed record SecurityAuthenticationInfo(string Type, bool SupportsBasic, bool IsInsecure) {
+	public string TypeLabel => string.IsNullOrWhiteSpace(Type) ? "External authentication" : Type;
+}
+
+public sealed record SecurityCommandResult(bool Success, string Message) {
+	public static SecurityCommandResult Succeeded() => new(true, "");
+	public static SecurityCommandResult Failure(string message) => new(false, message);
+}

--- a/src/EventStore.ClusterNode/Components/Services/SecurityBrowserService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/SecurityBrowserService.cs
@@ -63,6 +63,8 @@ public sealed class SecurityBrowserService(IAuthenticationProvider authenticatio
 }
 
 public sealed record SecurityAuthenticationInfo(string Type, bool SupportsBasic, bool IsInsecure) {
+	public static SecurityAuthenticationInfo Unavailable() => new("Unavailable", SupportsBasic: false, IsInsecure: false);
+
 	public string TypeLabel => string.IsNullOrWhiteSpace(Type) ? "External authentication" : Type;
 }
 

--- a/src/EventStore.ClusterNode/Components/Services/SecurityEndpoints.cs
+++ b/src/EventStore.ClusterNode/Components/Services/SecurityEndpoints.cs
@@ -52,9 +52,7 @@ internal static class SecurityEndpoints {
 					: Results.Unauthorized();
 
 			UiCredentialCookie.AppendBasic(context.Response, credentials);
-			return string.IsNullOrWhiteSpace(request.ReturnUrl)
-				? Results.NoContent()
-				: Results.Redirect(request.ReturnUrl);
+			return RedirectToReturnUrlOrNoContent(request.ReturnUrl);
 		});
 
 		return app;
@@ -85,7 +83,15 @@ internal static class SecurityEndpoints {
 	private static IResult ClearLegacyCredentialsAndRedirect(HttpContext context, string returnUrl) {
 		UiCredentialCookie.Delete(context.Response);
 		DeleteMigrationToken(context.Response);
-		return Results.Redirect(string.IsNullOrWhiteSpace(returnUrl) ? "/ui" : returnUrl);
+		var normalizedReturnUrl = NormalizeOptionalReturnUrl(returnUrl);
+		return Results.Redirect(string.IsNullOrWhiteSpace(normalizedReturnUrl) ? "/ui" : normalizedReturnUrl);
+	}
+
+	private static IResult RedirectToReturnUrlOrNoContent(string returnUrl) {
+		var normalizedReturnUrl = NormalizeOptionalReturnUrl(returnUrl);
+		return string.IsNullOrWhiteSpace(normalizedReturnUrl)
+			? Results.NoContent()
+			: Results.Redirect(normalizedReturnUrl);
 	}
 
 	private static string NormalizeOptionalReturnUrl(string returnUrl) =>

--- a/src/EventStore.ClusterNode/Components/Services/SecurityEndpoints.cs
+++ b/src/EventStore.ClusterNode/Components/Services/SecurityEndpoints.cs
@@ -9,7 +9,7 @@ namespace EventStore.ClusterNode.Components.Services;
 
 internal static class SecurityEndpoints {
 	public static IEndpointRouteBuilder MapSecurityEndpoints(this IEndpointRouteBuilder app) {
-		app.MapPost("/ui/security/migrate-credentials", async (HttpContext context) => {
+		app.MapPost("/ui/security/migrate-credentials", async (HttpContext context, SecurityBrowserService security) => {
 			SecurityCredentialMigrationRequest request;
 			try {
 				request = await context.Request.ReadFromJsonAsync<SecurityCredentialMigrationRequest>(
@@ -21,10 +21,24 @@ internal static class SecurityEndpoints {
 			if (request is null || string.IsNullOrWhiteSpace(request.Credentials))
 				return Results.BadRequest();
 
-			return UiCredentialCookie.TryAppendBasicValue(context.Response, request.Credentials)
-				? Results.NoContent()
-				: Results.BadRequest();
-		}).AllowAnonymous();
+			if (!UiCredentialCookie.TryParseBasicCredentials(request.Credentials, out var credentials))
+				return Results.BadRequest();
+
+			SecurityCommandResult validation;
+			try {
+				validation = await security.Validate(credentials.Username, credentials.Password);
+			} catch (OperationCanceledException) {
+				throw;
+			} catch (Exception) {
+				return Results.Unauthorized();
+			}
+
+			if (!validation.Success)
+				return Results.Unauthorized();
+
+			UiCredentialCookie.AppendBasic(context.Response, credentials);
+			return Results.NoContent();
+		});
 
 		return app;
 	}

--- a/src/EventStore.ClusterNode/Components/Services/SecurityEndpoints.cs
+++ b/src/EventStore.ClusterNode/Components/Services/SecurityEndpoints.cs
@@ -10,7 +10,10 @@ namespace EventStore.ClusterNode.Components.Services;
 internal static class SecurityEndpoints {
 	public static IEndpointRouteBuilder MapSecurityEndpoints(this IEndpointRouteBuilder app) {
 		app.MapPost("/ui/security/migrate-credentials", async (HttpContext context, SecurityBrowserService security) => {
-			SecurityCredentialMigrationRequest request;
+			if (!IsSameOrigin(context.Request))
+				return Results.StatusCode(StatusCodes.Status403Forbidden);
+
+			SecurityCredentialMigration request;
 			try {
 				request = await ReadMigrationRequest(context);
 			} catch (Exception ex) when (ex is BadHttpRequestException or JsonException) {
@@ -21,7 +24,9 @@ internal static class SecurityEndpoints {
 				return Results.BadRequest();
 
 			if (!UiCredentialCookie.TryParseBasicCredentials(request.Credentials, out var credentials))
-				return Results.BadRequest();
+				return request.UsesRedirect
+					? ClearLegacyCredentialsAndRedirect(context, request.ReturnUrl)
+					: Results.BadRequest();
 
 			SecurityCommandResult validation;
 			try {
@@ -29,11 +34,15 @@ internal static class SecurityEndpoints {
 			} catch (OperationCanceledException) {
 				throw;
 			} catch (Exception) {
-				return Results.Unauthorized();
+				return request.UsesRedirect
+					? ClearLegacyCredentialsAndRedirect(context, request.ReturnUrl)
+					: Results.Unauthorized();
 			}
 
 			if (!validation.Success)
-				return Results.Unauthorized();
+				return request.UsesRedirect
+					? ClearLegacyCredentialsAndRedirect(context, request.ReturnUrl)
+					: Results.Unauthorized();
 
 			UiCredentialCookie.AppendBasic(context.Response, credentials);
 			return string.IsNullOrWhiteSpace(request.ReturnUrl)
@@ -44,12 +53,13 @@ internal static class SecurityEndpoints {
 		return app;
 	}
 
-	private static async Task<SecurityCredentialMigrationRequest> ReadMigrationRequest(HttpContext context) {
+	private static async Task<SecurityCredentialMigration> ReadMigrationRequest(HttpContext context) {
 		if (context.Request.HasFormContentType) {
 			var form = await context.Request.ReadFormAsync(context.RequestAborted);
-			return new SecurityCredentialMigrationRequest(
+			return new SecurityCredentialMigration(
 				form["credentials"].ToString(),
-				SecurityBrowserService.NormalizeReturnUrl(form["returnUrl"].ToString()));
+				NormalizeOptionalReturnUrl(form["returnUrl"].ToString()),
+				UsesRedirect: true);
 		}
 
 		var request = await context.Request.ReadFromJsonAsync<SecurityCredentialMigrationRequest>(
@@ -57,12 +67,48 @@ internal static class SecurityEndpoints {
 
 		return request is null
 			? null
-			: request with {
-				ReturnUrl = string.IsNullOrWhiteSpace(request.ReturnUrl)
-					? ""
-					: SecurityBrowserService.NormalizeReturnUrl(request.ReturnUrl)
-			};
+			: new SecurityCredentialMigration(
+				request.Credentials,
+				NormalizeOptionalReturnUrl(request.ReturnUrl),
+				UsesRedirect: false);
 	}
+
+	private static IResult ClearLegacyCredentialsAndRedirect(HttpContext context, string returnUrl) {
+		UiCredentialCookie.Delete(context.Response);
+		return Results.Redirect(string.IsNullOrWhiteSpace(returnUrl) ? "/ui" : returnUrl);
+	}
+
+	private static string NormalizeOptionalReturnUrl(string returnUrl) =>
+		string.IsNullOrWhiteSpace(returnUrl)
+			? ""
+			: SecurityBrowserService.NormalizeReturnUrl(returnUrl);
+
+	private static bool IsSameOrigin(HttpRequest request) {
+		if (!TryReadOrigin(request, out var origin))
+			return false;
+
+		var expectedPort = request.Host.Port ?? DefaultPort(request.Scheme);
+		return string.Equals(origin.Scheme, request.Scheme, StringComparison.OrdinalIgnoreCase) &&
+		       string.Equals(origin.Host, request.Host.Host, StringComparison.OrdinalIgnoreCase) &&
+		       origin.Port == expectedPort;
+	}
+
+	private static bool TryReadOrigin(HttpRequest request, out Uri origin) {
+		if (request.Headers.TryGetValue("Origin", out var originHeader) &&
+		    Uri.TryCreate(originHeader.ToString(), UriKind.Absolute, out origin))
+			return true;
+
+		if (request.Headers.TryGetValue("Referer", out var refererHeader) &&
+		    Uri.TryCreate(refererHeader.ToString(), UriKind.Absolute, out origin))
+			return true;
+
+		origin = null;
+		return false;
+	}
+
+	private static int DefaultPort(string scheme) =>
+		string.Equals(scheme, "https", StringComparison.OrdinalIgnoreCase) ? 443 : 80;
 }
 
 internal sealed record SecurityCredentialMigrationRequest(string Credentials, string ReturnUrl = "");
+internal sealed record SecurityCredentialMigration(string Credentials, string ReturnUrl, bool UsesRedirect);

--- a/src/EventStore.ClusterNode/Components/Services/SecurityEndpoints.cs
+++ b/src/EventStore.ClusterNode/Components/Services/SecurityEndpoints.cs
@@ -12,8 +12,7 @@ internal static class SecurityEndpoints {
 		app.MapPost("/ui/security/migrate-credentials", async (HttpContext context, SecurityBrowserService security) => {
 			SecurityCredentialMigrationRequest request;
 			try {
-				request = await context.Request.ReadFromJsonAsync<SecurityCredentialMigrationRequest>(
-					cancellationToken: context.RequestAborted);
+				request = await ReadMigrationRequest(context);
 			} catch (Exception ex) when (ex is BadHttpRequestException or JsonException) {
 				return Results.BadRequest();
 			}
@@ -37,11 +36,33 @@ internal static class SecurityEndpoints {
 				return Results.Unauthorized();
 
 			UiCredentialCookie.AppendBasic(context.Response, credentials);
-			return Results.NoContent();
+			return string.IsNullOrWhiteSpace(request.ReturnUrl)
+				? Results.NoContent()
+				: Results.Redirect(request.ReturnUrl);
 		});
 
 		return app;
 	}
+
+	private static async Task<SecurityCredentialMigrationRequest> ReadMigrationRequest(HttpContext context) {
+		if (context.Request.HasFormContentType) {
+			var form = await context.Request.ReadFormAsync(context.RequestAborted);
+			return new SecurityCredentialMigrationRequest(
+				form["credentials"].ToString(),
+				SecurityBrowserService.NormalizeReturnUrl(form["returnUrl"].ToString()));
+		}
+
+		var request = await context.Request.ReadFromJsonAsync<SecurityCredentialMigrationRequest>(
+			cancellationToken: context.RequestAborted);
+
+		return request is null
+			? null
+			: request with {
+				ReturnUrl = string.IsNullOrWhiteSpace(request.ReturnUrl)
+					? ""
+					: SecurityBrowserService.NormalizeReturnUrl(request.ReturnUrl)
+			};
+	}
 }
 
-internal sealed record SecurityCredentialMigrationRequest(string Credentials);
+internal sealed record SecurityCredentialMigrationRequest(string Credentials, string ReturnUrl = "");

--- a/src/EventStore.ClusterNode/Components/Services/SecurityEndpoints.cs
+++ b/src/EventStore.ClusterNode/Components/Services/SecurityEndpoints.cs
@@ -63,7 +63,7 @@ internal static class SecurityEndpoints {
 			var form = await context.Request.ReadFormAsync(context.RequestAborted);
 			return new SecurityCredentialMigration(
 				form["credentials"].ToString(),
-				NormalizeOptionalReturnUrl(form["returnUrl"].ToString()),
+				form["returnUrl"].ToString(),
 				form["migrationToken"].ToString(),
 				UsesRedirect: true);
 		}
@@ -75,7 +75,7 @@ internal static class SecurityEndpoints {
 			? null
 			: new SecurityCredentialMigration(
 				request.Credentials ?? "",
-				NormalizeOptionalReturnUrl(request.ReturnUrl),
+				request.ReturnUrl ?? "",
 				request.MigrationToken ?? "",
 				UsesRedirect: false);
 	}

--- a/src/EventStore.ClusterNode/Components/Services/SecurityEndpoints.cs
+++ b/src/EventStore.ClusterNode/Components/Services/SecurityEndpoints.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace EventStore.ClusterNode.Components.Services;
+
+internal static class SecurityEndpoints {
+	public static IEndpointRouteBuilder MapSecurityEndpoints(this IEndpointRouteBuilder app) {
+		app.MapPost("/ui/security/migrate-credentials", async (HttpContext context) => {
+			SecurityCredentialMigrationRequest request;
+			try {
+				request = await context.Request.ReadFromJsonAsync<SecurityCredentialMigrationRequest>(
+					cancellationToken: context.RequestAborted);
+			} catch (Exception ex) when (ex is BadHttpRequestException or JsonException) {
+				return Results.BadRequest();
+			}
+
+			if (request is null || string.IsNullOrWhiteSpace(request.Credentials))
+				return Results.BadRequest();
+
+			return UiCredentialCookie.TryAppendBasicValue(context.Response, request.Credentials)
+				? Results.NoContent()
+				: Results.BadRequest();
+		}).AllowAnonymous();
+
+		return app;
+	}
+}
+
+internal sealed record SecurityCredentialMigrationRequest(string Credentials);

--- a/src/EventStore.ClusterNode/Components/Services/SecurityEndpoints.cs
+++ b/src/EventStore.ClusterNode/Components/Services/SecurityEndpoints.cs
@@ -8,11 +8,10 @@ using Microsoft.AspNetCore.Routing;
 namespace EventStore.ClusterNode.Components.Services;
 
 internal static class SecurityEndpoints {
+	private const string MigrationTokenCookieName = "es-ui-migration-token";
+
 	public static IEndpointRouteBuilder MapSecurityEndpoints(this IEndpointRouteBuilder app) {
 		app.MapPost("/ui/security/migrate-credentials", async (HttpContext context, SecurityBrowserService security) => {
-			if (!IsSameOrigin(context.Request))
-				return Results.StatusCode(StatusCodes.Status403Forbidden);
-
 			SecurityCredentialMigration request;
 			try {
 				request = await ReadMigrationRequest(context);
@@ -20,7 +19,15 @@ internal static class SecurityEndpoints {
 				return Results.BadRequest();
 			}
 
-			if (request is null || string.IsNullOrWhiteSpace(request.Credentials))
+			if (request is null)
+				return Results.BadRequest();
+
+			if (!IsSameOrigin(context.Request) && !HasValidMigrationToken(context, request))
+				return Results.StatusCode(StatusCodes.Status403Forbidden);
+
+			DeleteMigrationToken(context.Response);
+
+			if (string.IsNullOrWhiteSpace(request.Credentials))
 				return Results.BadRequest();
 
 			if (!UiCredentialCookie.TryParseBasicCredentials(request.Credentials, out var credentials))
@@ -59,6 +66,7 @@ internal static class SecurityEndpoints {
 			return new SecurityCredentialMigration(
 				form["credentials"].ToString(),
 				NormalizeOptionalReturnUrl(form["returnUrl"].ToString()),
+				form["migrationToken"].ToString(),
 				UsesRedirect: true);
 		}
 
@@ -68,13 +76,15 @@ internal static class SecurityEndpoints {
 		return request is null
 			? null
 			: new SecurityCredentialMigration(
-				request.Credentials,
+				request.Credentials ?? "",
 				NormalizeOptionalReturnUrl(request.ReturnUrl),
+				request.MigrationToken ?? "",
 				UsesRedirect: false);
 	}
 
 	private static IResult ClearLegacyCredentialsAndRedirect(HttpContext context, string returnUrl) {
 		UiCredentialCookie.Delete(context.Response);
+		DeleteMigrationToken(context.Response);
 		return Results.Redirect(string.IsNullOrWhiteSpace(returnUrl) ? "/ui" : returnUrl);
 	}
 
@@ -108,7 +118,22 @@ internal static class SecurityEndpoints {
 
 	private static int DefaultPort(string scheme) =>
 		string.Equals(scheme, "https", StringComparison.OrdinalIgnoreCase) ? 443 : 80;
+
+	private static bool HasValidMigrationToken(HttpContext context, SecurityCredentialMigration request) =>
+		request.UsesRedirect &&
+		request.MigrationToken.Length >= 16 &&
+		context.Request.Cookies.TryGetValue(MigrationTokenCookieName, out var cookieToken) &&
+		string.Equals(cookieToken, request.MigrationToken, StringComparison.Ordinal);
+
+	private static void DeleteMigrationToken(HttpResponse response) =>
+		response.Cookies.Delete(MigrationTokenCookieName, new CookieOptions {
+			HttpOnly = false,
+			IsEssential = true,
+			Path = "/",
+			SameSite = SameSiteMode.Lax,
+			Secure = response.HttpContext.Request.IsHttps
+		});
 }
 
-internal sealed record SecurityCredentialMigrationRequest(string Credentials, string ReturnUrl = "");
-internal sealed record SecurityCredentialMigration(string Credentials, string ReturnUrl, bool UsesRedirect);
+internal sealed record SecurityCredentialMigrationRequest(string Credentials, string ReturnUrl = "", string MigrationToken = "");
+internal sealed record SecurityCredentialMigration(string Credentials, string ReturnUrl, string MigrationToken, bool UsesRedirect);

--- a/src/EventStore.ClusterNode/Components/Services/SecurityEndpoints.cs
+++ b/src/EventStore.ClusterNode/Components/Services/SecurityEndpoints.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -129,7 +131,12 @@ internal static class SecurityEndpoints {
 		request.UsesRedirect &&
 		request.MigrationToken.Length >= 16 &&
 		context.Request.Cookies.TryGetValue(MigrationTokenCookieName, out var cookieToken) &&
-		string.Equals(cookieToken, request.MigrationToken, StringComparison.Ordinal);
+		FixedTimeEquals(cookieToken, request.MigrationToken);
+
+	private static bool FixedTimeEquals(string left, string right) =>
+		CryptographicOperations.FixedTimeEquals(
+			SHA256.HashData(Encoding.UTF8.GetBytes(left)),
+			SHA256.HashData(Encoding.UTF8.GetBytes(right)));
 
 	private static void DeleteMigrationToken(HttpResponse response) =>
 		response.Cookies.Delete(MigrationTokenCookieName, new CookieOptions {

--- a/src/EventStore.ClusterNode/Components/Services/UiCredentialCookie.cs
+++ b/src/EventStore.ClusterNode/Components/Services/UiCredentialCookie.cs
@@ -19,8 +19,11 @@ public static class UiCredentialCookie {
 
 	public static bool TryParseBasicCredentials(string raw, out UiCredentials credentials) {
 		credentials = new UiCredentials("", "");
-		if (!TryExtractBasicValue(SafeDecode(raw), out var value) ||
-		    !IsHeaderSafe(value) ||
+		if (!TryExtractBasicValue(SafeDecode(raw), out var value))
+			return false;
+
+		value = NormalizeBasicValue(value);
+		if (!IsHeaderSafe(value) ||
 		    !TryDecodeBasicValue(value, out var username, out var password))
 			return false;
 
@@ -73,6 +76,7 @@ public static class UiCredentialCookie {
 		if (!TryExtractBasicValue(SafeDecode(raw), out value))
 			return false;
 
+		value = NormalizeBasicValue(value);
 		return IsHeaderSafe(value) && TryDecodeBasicValue(value, out _, out _);
 	}
 
@@ -113,6 +117,11 @@ public static class UiCredentialCookie {
 			return false;
 		}
 	}
+
+	private static string NormalizeBasicValue(string value) =>
+		value.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase)
+			? value["Basic ".Length..].TrimStart()
+			: value;
 
 	private static bool IsHeaderSafe(string value) =>
 		!value.Any(x => x is '\r' or '\n');

--- a/src/EventStore.ClusterNode/Components/Services/UiCredentialCookie.cs
+++ b/src/EventStore.ClusterNode/Components/Services/UiCredentialCookie.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+
+namespace EventStore.ClusterNode.Components.Services;
+
+public sealed record UiCredentials(string Username, string Password) {
+	public string BasicValue => Convert.ToBase64String(Encoding.UTF8.GetBytes($"{Username}:{Password}"));
+}
+
+public static class UiCredentialCookie {
+	public const string BasicCookieName = "es-creds";
+	public const string OAuthCookieName = "oauth_id_token";
+
+	public static void AppendBasic(HttpResponse response, UiCredentials credentials) =>
+		response.Cookies.Append(
+			BasicCookieName,
+			JsonSerializer.Serialize(new { credentials = credentials.BasicValue }),
+			Options(response.HttpContext.Request.IsHttps));
+
+	public static void Delete(HttpResponse response) =>
+		response.Cookies.Delete(BasicCookieName, Options(response.HttpContext.Request.IsHttps));
+
+	public static void DeleteOAuthToken(HttpResponse response) =>
+		response.Cookies.Delete(OAuthCookieName, Options(response.HttpContext.Request.IsHttps));
+
+	public static bool TryReadAuthorization(HttpRequest request, out string scheme, out string value) {
+		if (TryReadBearer(request, out value)) {
+			scheme = "Bearer";
+			return true;
+		}
+
+		if (TryReadBasic(request, out value)) {
+			scheme = "Basic";
+			return true;
+		}
+
+		scheme = "";
+		value = "";
+		return false;
+	}
+
+	private static bool TryReadBearer(HttpRequest request, out string value) {
+		value = "";
+		if (!request.Cookies.TryGetValue(OAuthCookieName, out var token) || string.IsNullOrWhiteSpace(token))
+			return false;
+
+		value = SafeDecode(token);
+		return IsHeaderSafe(value);
+	}
+
+	private static bool TryReadBasic(HttpRequest request, out string value) {
+		value = "";
+		if (!request.Cookies.TryGetValue(BasicCookieName, out var raw) || string.IsNullOrWhiteSpace(raw))
+			return false;
+
+		if (!TryExtractBasicValue(SafeDecode(raw), out value))
+			return false;
+
+		return IsHeaderSafe(value) && IsValidBasicValue(value);
+	}
+
+	private static bool TryExtractBasicValue(string raw, out string value) {
+		value = "";
+		var candidate = raw.StartsWith("j:", StringComparison.Ordinal) ? raw[2..] : raw;
+		if (!candidate.StartsWith("{", StringComparison.Ordinal)) {
+			value = candidate;
+			return true;
+		}
+
+		try {
+			using var document = JsonDocument.Parse(candidate);
+			if (!document.RootElement.TryGetProperty("credentials", out var credentials) &&
+			    !document.RootElement.TryGetProperty("Credentials", out credentials))
+				return false;
+
+			value = credentials.GetString() ?? "";
+			return !string.IsNullOrWhiteSpace(value);
+		} catch (JsonException) {
+			return false;
+		}
+	}
+
+	private static bool IsValidBasicValue(string value) {
+		try {
+			var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(value));
+			return decoded.Contains(':', StringComparison.Ordinal);
+		} catch (FormatException) {
+			return false;
+		}
+	}
+
+	private static bool IsHeaderSafe(string value) =>
+		!value.Any(x => x is '\r' or '\n');
+
+	private static string SafeDecode(string value) {
+		try {
+			return Uri.UnescapeDataString(value);
+		} catch (UriFormatException) {
+			return value;
+		}
+	}
+
+	private static CookieOptions Options(bool secure) => new() {
+		HttpOnly = true,
+		IsEssential = true,
+		Path = "/",
+		SameSite = SameSiteMode.Lax,
+		Secure = secure
+	};
+}

--- a/src/EventStore.ClusterNode/Components/Services/UiCredentialCookie.cs
+++ b/src/EventStore.ClusterNode/Components/Services/UiCredentialCookie.cs
@@ -15,9 +15,20 @@ public static class UiCredentialCookie {
 	public const string OAuthCookieName = "oauth_id_token";
 
 	public static void AppendBasic(HttpResponse response, UiCredentials credentials) =>
+		AppendBasicValue(response, credentials.BasicValue);
+
+	public static bool TryAppendBasicValue(HttpResponse response, string raw) {
+		if (!TryExtractBasicValue(SafeDecode(raw), out var value) || !IsHeaderSafe(value) || !IsValidBasicValue(value))
+			return false;
+
+		AppendBasicValue(response, value);
+		return true;
+	}
+
+	private static void AppendBasicValue(HttpResponse response, string value) =>
 		response.Cookies.Append(
 			BasicCookieName,
-			JsonSerializer.Serialize(new { credentials = credentials.BasicValue }),
+			JsonSerializer.Serialize(new { credentials = value }),
 			Options(response.HttpContext.Request.IsHttps));
 
 	public static void Delete(HttpResponse response) =>

--- a/src/EventStore.ClusterNode/Components/Services/UiCredentialCookie.cs
+++ b/src/EventStore.ClusterNode/Components/Services/UiCredentialCookie.cs
@@ -17,11 +17,14 @@ public static class UiCredentialCookie {
 	public static void AppendBasic(HttpResponse response, UiCredentials credentials) =>
 		AppendBasicValue(response, credentials.BasicValue);
 
-	public static bool TryAppendBasicValue(HttpResponse response, string raw) {
-		if (!TryExtractBasicValue(SafeDecode(raw), out var value) || !IsHeaderSafe(value) || !IsValidBasicValue(value))
+	public static bool TryParseBasicCredentials(string raw, out UiCredentials credentials) {
+		credentials = new UiCredentials("", "");
+		if (!TryExtractBasicValue(SafeDecode(raw), out var value) ||
+		    !IsHeaderSafe(value) ||
+		    !TryDecodeBasicValue(value, out var username, out var password))
 			return false;
 
-		AppendBasicValue(response, value);
+		credentials = new UiCredentials(username, password);
 		return true;
 	}
 
@@ -70,7 +73,7 @@ public static class UiCredentialCookie {
 		if (!TryExtractBasicValue(SafeDecode(raw), out value))
 			return false;
 
-		return IsHeaderSafe(value) && IsValidBasicValue(value);
+		return IsHeaderSafe(value) && TryDecodeBasicValue(value, out _, out _);
 	}
 
 	private static bool TryExtractBasicValue(string raw, out string value) {
@@ -94,10 +97,18 @@ public static class UiCredentialCookie {
 		}
 	}
 
-	private static bool IsValidBasicValue(string value) {
+	private static bool TryDecodeBasicValue(string value, out string username, out string password) {
+		username = "";
+		password = "";
 		try {
 			var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(value));
-			return decoded.Contains(':', StringComparison.Ordinal);
+			var separator = decoded.IndexOf(':', StringComparison.Ordinal);
+			if (separator < 0)
+				return false;
+
+			username = decoded[..separator];
+			password = decoded[(separator + 1)..];
+			return true;
 		} catch (FormatException) {
 			return false;
 		}

--- a/src/EventStore.ClusterNode/Components/Services/UiCredentialsMiddleware.cs
+++ b/src/EventStore.ClusterNode/Components/Services/UiCredentialsMiddleware.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+
+namespace EventStore.ClusterNode.Components.Services;
+
+public sealed class UiCredentialsMiddleware(RequestDelegate next) {
+	public Task InvokeAsync(HttpContext context) {
+		if (!context.Request.Headers.ContainsKey(HeaderNames.Authorization) &&
+		    UiCredentialCookie.TryReadAuthorization(context.Request, out var scheme, out var value))
+			context.Request.Headers.Authorization = $"{scheme} {value}";
+
+		return next(context);
+	}
+}

--- a/src/EventStore.ClusterNode/Components/_Imports.razor
+++ b/src/EventStore.ClusterNode/Components/_Imports.razor
@@ -5,3 +5,4 @@
 @using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Http

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -272,11 +272,13 @@ internal static class Program
 					builder.Services.AddScoped<StreamBrowserService>();
 					builder.Services.AddScoped<SubscriptionBrowserService>();
 					builder.Services.AddScoped<UserBrowserService>();
+					builder.Services.AddScoped<SecurityBrowserService>();
 					builder.Services.AddScoped<AdminOperationsService>();
 					builder.Services.AddSingleton(hostedService);
 					builder.Services.AddSingleton<IHostedService>(hostedService);
 
 					var app = builder.Build();
+					app.UseMiddleware<UiCredentialsMiddleware>();
 					hostedService.Node.Startup.Configure(app);
 					app.MapAdminOperationsEndpoints();
 					app.MapRazorComponents<App>();

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -281,6 +281,7 @@ internal static class Program
 					app.UseMiddleware<UiCredentialsMiddleware>();
 					hostedService.Node.Startup.Configure(app);
 					app.MapAdminOperationsEndpoints();
+					app.MapSecurityEndpoints();
 					app.MapRazorComponents<App>();
 
 					await app.RunAsync(cts.Token);


### PR DESCRIPTION
- Operators need the remaining Angular-only authentication routes to land in the Razor management surface before the old shell can be retired.
- Browser credentials need to survive legacy redirects and server-rendered navigation without depending on Angular request state.
- Sign-out needs to leave operators on a useful confirmation page after credentials are cleared.