### PR TITLE
fix(ui): preserve stream metadata inspection

### DIFF
--- a/src/EventStore.ClusterNode.Web/clusternode-web/js/legacy-dashboard-redirect.js
+++ b/src/EventStore.ClusterNode.Web/clusternode-web/js/legacy-dashboard-redirect.js
@@ -74,8 +74,10 @@
 				var action = (parts[1] || "").toLowerCase();
 				if (action === "addevent")
 					return "/ui/streams/append/" + encodeURIComponent(streamId);
-				if (action === "acl" || action === "metadata")
+				if (action === "acl")
 					return "/ui/streams/acl/" + encodeURIComponent(streamId);
+				if (action === "metadata")
+					return "/ui/streams/metadata/" + encodeURIComponent(streamId);
 
 				var direction = (parts[2] || "").toLowerCase();
 				if (parts.length >= 4 && isStreamDirection(direction))

--- a/src/EventStore.ClusterNode/Components/Pages/StreamAcl.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/StreamAcl.razor
@@ -66,6 +66,7 @@ else
 
 				<div class="mt-5 flex flex-wrap gap-2">
 					<button class="rounded-2xl bg-es-ink px-5 py-3 text-sm font-black text-white shadow-lg shadow-es-ink/15 transition hover:bg-es-green" type="submit">Save ACL</button>
+					<a class="rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@($"/ui/streams/metadata/{Uri.EscapeDataString(StreamId)}")">Inspect metadata</a>
 					<a class="rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@($"/ui/streams/{Uri.EscapeDataString(StreamId)}")">Cancel</a>
 				</div>
 			</EditForm>

--- a/src/EventStore.ClusterNode/Components/Pages/StreamAppend.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/StreamAppend.razor
@@ -3,6 +3,8 @@
 @using EventStore.ClusterNode.Components.Services
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Http
+@inject IHttpContextAccessor HttpContextAccessor
 @inject StreamBrowserService Streams
 
 <PageTitle>Add Event - EventStore UI</PageTitle>
@@ -89,7 +91,7 @@
 			_lastRequestedFromEvent == requestedFromEvent;
 		var hasSubmittedForm = !string.IsNullOrWhiteSpace(Input.StreamId) &&
 			(string.IsNullOrWhiteSpace(requestedStream) || string.Equals(Input.StreamId, requestedStream, StringComparison.OrdinalIgnoreCase));
-		if (hasSubmittedForm || sameRequest)
+		if (hasSubmittedForm && (IsFormPost || sameRequest))
 			return;
 
 		Input = NewInput(requestedStream);
@@ -110,6 +112,9 @@
 		_lastRequestedStreamId = requestedStream;
 		_lastRequestedFromEvent = requestedFromEvent;
 	}
+
+	private bool IsFormPost =>
+		string.Equals(HttpContextAccessor.HttpContext?.Request.Method, HttpMethods.Post, StringComparison.OrdinalIgnoreCase);
 
 	private async Task Append() {
 		try {

--- a/src/EventStore.ClusterNode/Components/Pages/StreamAppend.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/StreamAppend.razor
@@ -89,7 +89,7 @@
 			_lastRequestedFromEvent == requestedFromEvent;
 		var hasSubmittedForm = !string.IsNullOrWhiteSpace(Input.StreamId) &&
 			(string.IsNullOrWhiteSpace(requestedStream) || string.Equals(Input.StreamId, requestedStream, StringComparison.OrdinalIgnoreCase));
-		if (hasSubmittedForm && sameRequest)
+		if (hasSubmittedForm || sameRequest)
 			return;
 
 		Input = NewInput(requestedStream);

--- a/src/EventStore.ClusterNode/Components/Pages/StreamDetail.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/StreamDetail.razor
@@ -16,6 +16,7 @@
 		}
 		@if (CanEditMetadata)
 		{
+			<a class="rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@($"/ui/streams/metadata/{Uri.EscapeDataString(StreamId)}")">Metadata</a>
 			<a class="rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@($"/ui/streams/acl/{Uri.EscapeDataString(StreamId)}")">Edit ACL</a>
 		}
 		@if (CanDelete)

--- a/src/EventStore.ClusterNode/Components/Pages/StreamMetadata.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/StreamMetadata.razor
@@ -1,0 +1,74 @@
+@page "/ui/streams/metadata/{*StreamId}"
+@using EventStore.ClusterNode.Components.Services
+@inject StreamBrowserService Streams
+
+<PageTitle>Stream Metadata - EventStore UI</PageTitle>
+
+<section class="max-w-5xl">
+	<a class="text-sm font-bold text-es-green transition hover:text-es-forest" href="@BackHref">&lt;- Back to stream</a>
+	<p class="mt-6 text-sm font-black uppercase tracking-[0.28em] text-es-green">Stream metadata</p>
+	<h1 class="mt-4 break-words text-5xl font-black tracking-tight text-es-ink sm:text-6xl">@StreamId</h1>
+	<p class="mt-5 text-lg leading-8 text-es-muted">Inspect the metadata event that the legacy stream browser exposed, then jump into ACL editing only when you intend to change it.</p>
+	<div class="mt-6 flex flex-wrap gap-3">
+		<a class="rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@AclHref">Edit ACL</a>
+		<a class="rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@RawMetadataHref" target="_blank" rel="noopener noreferrer">Raw metadata</a>
+	</div>
+</section>
+
+<section class="mt-8">
+	@if (Page is null)
+	{
+		<div class="rounded-[1.75rem] border border-white/80 bg-white/80 p-6 text-es-muted shadow-[0_18px_60px_rgba(23,32,51,0.08)]">
+			Loading stream metadata...
+		</div>
+	}
+	else if (!Page.IsAvailable)
+	{
+		<div class="rounded-[1.75rem] border border-white/80 bg-white/80 p-6 text-es-muted shadow-[0_18px_60px_rgba(23,32,51,0.08)]">
+			@Page.Message
+		</div>
+	}
+	else if (!Page.HasMetadata)
+	{
+		<div class="rounded-[1.75rem] border border-white/80 bg-white/80 p-6 text-es-muted shadow-[0_18px_60px_rgba(23,32,51,0.08)]">
+			@Page.Message
+		</div>
+	}
+	else
+	{
+		<div class="mb-5 flex flex-wrap items-end justify-between gap-4">
+			<div>
+				<p class="text-sm font-black uppercase tracking-[0.24em] text-es-green">Metadata event</p>
+				<h2 class="mt-2 break-words text-3xl font-black tracking-tight text-es-ink">@Page.MetadataEvent.EventType</h2>
+			</div>
+			<div class="flex flex-wrap gap-3">
+				<a class="rounded-full bg-es-ink px-4 py-2 text-sm font-bold text-white transition hover:bg-es-green" href="@Page.MetadataEvent.RawHref" target="_blank" rel="noopener noreferrer">Raw event</a>
+			</div>
+		</div>
+
+		<StreamEventCard Event="Page.MetadataEvent" />
+		<div class="mt-5 grid gap-4 lg:grid-cols-2">
+			<JsonPanel Eyebrow="Data" Title="Stream metadata" Content="@Page.MetadataEvent.DataForDisplay" RawHref="@RawMetadataHref" />
+			<JsonPanel Eyebrow="Metadata" Title="Metadata event metadata" Content="@Page.MetadataEvent.MetadataForDisplay" />
+		</div>
+	}
+</section>
+
+@code {
+	[Parameter] public string StreamId { get; set; } = "";
+
+	private StreamMetadataPage Page { get; set; }
+	private string BackHref => $"/ui/streams/{Uri.EscapeDataString(StreamId)}";
+	private string AclHref => $"/ui/streams/acl/{Uri.EscapeDataString(StreamId)}";
+	private string RawMetadataHref => $"/streams/{Uri.EscapeDataString(StreamId)}/metadata";
+
+	protected override async Task OnParametersSetAsync() {
+		var requested = StreamId;
+		Page = null;
+		var page = await Streams.ReadMetadata(requested);
+		if (!string.Equals(StreamId, requested, StringComparison.Ordinal))
+			return;
+
+		Page = page;
+	}
+}

--- a/src/EventStore.ClusterNode/Components/Services/StreamBrowserService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/StreamBrowserService.cs
@@ -257,6 +257,25 @@ public sealed class StreamBrowserService(
 		return StreamAclPage.Success(streamId.Trim(), latestMetadata.EventNumber, rawMetadata, StreamAclInput.FromMetadata(streamId.Trim(), rawMetadata), "");
 	}
 
+	public async Task<StreamMetadataPage> ReadMetadata(
+		string streamId,
+		CancellationToken cancellationToken = default) {
+		var validation = ValidateUserStream(streamId);
+		if (!validation.Success)
+			return StreamMetadataPage.Unavailable(streamId, validation.Message);
+
+		streamId = streamId.Trim();
+		var metadata = await ReadStreamBackward(SystemStreams.MetastreamOf(streamId), count: 1, cancellationToken: cancellationToken);
+		if (!metadata.HasEvents && string.IsNullOrWhiteSpace(metadata.Message))
+			return StreamMetadataPage.Empty(streamId, "No stream metadata exists yet.");
+		if (!metadata.HasEvents && metadata.Message.Contains("was not found", StringComparison.OrdinalIgnoreCase))
+			return StreamMetadataPage.Empty(streamId, "No stream metadata exists yet.");
+		if (!metadata.HasEvents)
+			return StreamMetadataPage.Unavailable(streamId, metadata.Message);
+
+		return StreamMetadataPage.Success(streamId, metadata.Events[0]);
+	}
+
 	public async Task<StreamCommandResult> AppendEvent(
 		StreamAppendRequest request,
 		CancellationToken cancellationToken = default) {
@@ -647,6 +666,23 @@ public sealed record StreamAclPage(
 
 	public static StreamAclPage Unavailable(string streamId, string message) =>
 		new(streamId, ExpectedVersion.Any, "", null, message);
+}
+
+public sealed record StreamMetadataPage(
+	string StreamId,
+	StreamViewEvent MetadataEvent,
+	bool IsAvailable,
+	string Message) {
+	public bool HasMetadata => MetadataEvent is not null;
+
+	public static StreamMetadataPage Success(string streamId, StreamViewEvent metadataEvent) =>
+		new(streamId, metadataEvent, true, "");
+
+	public static StreamMetadataPage Empty(string streamId, string message) =>
+		new(streamId, null, true, message);
+
+	public static StreamMetadataPage Unavailable(string streamId, string message) =>
+		new(streamId, null, false, message);
 }
 
 public sealed record StreamAclInput(


### PR DESCRIPTION
- Operators need legacy stream metadata bookmarks to remain an inspection path, not unexpectedly land in a mutation-oriented ACL workflow.
- Separating metadata inspection from ACL editing reduces the chance of changing stream access while troubleshooting metadata state.