### PR TITLE
feat(ui): deprecate legacy web shell

### DIFF
--- a/src/EventStore.ClusterNode.Web/clusternode-web/js/legacy-dashboard-redirect.js
+++ b/src/EventStore.ClusterNode.Web/clusternode-web/js/legacy-dashboard-redirect.js
@@ -265,13 +265,24 @@
 			if (!legacyRoutes[i].pattern.test(hash))
 				continue;
 
-			var target = legacyRoutes[i].target(hash);
-			if (shouldMigrateLegacyCredentials(target) && submitLegacyCredentials(target))
-				return;
-
-			window.location.replace(target);
+			replaceWithTarget(legacyRoutes[i].target(hash));
 			return;
 		}
+
+		replaceWithTarget(isLegacyShellRoot(hash) ? "/ui" : "/ui/navigator");
+	}
+
+	function isLegacyShellRoot(hash) {
+		return !hash ||
+			hash === "#" ||
+			/^#\/?(?:[?].*)?$/i.test(hash);
+	}
+
+	function replaceWithTarget(target) {
+		if (shouldMigrateLegacyCredentials(target) && submitLegacyCredentials(target))
+			return;
+
+		window.location.replace(target);
 	}
 
 	function readCookie(name) {

--- a/src/EventStore.ClusterNode/Components/Layout/MainLayout.razor
+++ b/src/EventStore.ClusterNode/Components/Layout/MainLayout.razor
@@ -11,7 +11,7 @@
 				</div>
 				<div class="flex flex-wrap gap-2">
 					<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink shadow-inner shadow-es-ink/5 hover:border-es-green hover:text-es-forest" href="/stats?format=json" target="_blank" rel="noopener noreferrer">Stats JSON</a>
-					<a class="rounded-full bg-es-ink px-4 py-2 text-sm font-bold text-white shadow-lg shadow-es-ink/15 hover:bg-es-green hover:text-white" href="/web/index.html" target="_blank" rel="noopener noreferrer">Current UI</a>
+					<a class="rounded-full bg-es-ink px-4 py-2 text-sm font-bold text-white shadow-lg shadow-es-ink/15 hover:bg-es-green hover:text-white" href="/ui/navigator">Navigator</a>
 				</div>
 			</header>
 			<main class="min-w-0 p-4 sm:p-5 lg:p-6">

--- a/src/EventStore.ClusterNode/Components/Pages/Configuration.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Configuration.razor
@@ -13,6 +13,6 @@
 	<SurfaceCard Eyebrow="Node" Title="Loaded options" Description="Inspect the options that were loaded and their configuration sources." Href="/info/options" LinkText="Open options" Target="_blank" />
 	<SurfaceCard Eyebrow="Cluster" Title="Gossip" Description="Review the node's current gossip view of the cluster." Href="/gossip" LinkText="Open gossip" Target="_blank" />
 	<SurfaceCard Eyebrow="Features" Title="Subsystems" Description="Inspect the subsystems enabled for the hosted node." Href="/sys/subsystems" LinkText="Open subsystems" Target="_blank" />
-	<SurfaceCard Eyebrow="UI" Title="Current web UI" Description="Return to the existing browser tools for workflows not yet rebuilt here." Href="/web/index.html" LinkText="Open current UI" Target="_blank" />
+	<SurfaceCard Eyebrow="UI" Title="Navigator" Description="Jump across the Razor management workspace from a single route index." Href="/ui/navigator" LinkText="Open navigator" />
 	<SurfaceCard Eyebrow="API" Title="HTTP API root" Description="Open the root HTTP surface for link discovery and API navigation." Href="/" LinkText="Open root" Target="_blank" />
 </section>

--- a/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
@@ -71,7 +71,7 @@
 
 				<div class="mt-6 flex flex-wrap gap-2">
 					<button class="rounded-2xl bg-es-ink px-5 py-3 text-sm font-black text-white shadow-lg shadow-es-ink/15 transition hover:bg-es-green" type="submit">Sign in</button>
-					<a class="rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="/web/index.html#/signin">Legacy sign-in</a>
+					<a class="rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="/ui">Back to UI</a>
 				</div>
 			</EditForm>
 		}


### PR DESCRIPTION
- Operators need old `/web/index.html` entry points to land in the supported Razor workspace now that the replacement surfaces exist.
- Keeping deprecated shell links visible invites operators back into a UI path we are actively retiring.