### PR TITLE
chore(ui): narrow credential cookie parsing

### DIFF
--- a/src/EventStore.ClusterNode/Components/Services/UiCredentialCookie.cs
+++ b/src/EventStore.ClusterNode/Components/Services/UiCredentialCookie.cs
@@ -17,20 +17,6 @@ public static class UiCredentialCookie {
 	public static void AppendBasic(HttpResponse response, UiCredentials credentials) =>
 		AppendBasicValue(response, credentials.BasicValue);
 
-	public static bool TryParseBasicCredentials(string raw, out UiCredentials credentials) {
-		credentials = new UiCredentials("", "");
-		if (!TryExtractBasicValue(SafeDecode(raw), out var value))
-			return false;
-
-		value = NormalizeBasicValue(value);
-		if (!IsHeaderSafe(value) ||
-		    !TryDecodeBasicValue(value, out var username, out var password))
-			return false;
-
-		credentials = new UiCredentials(username, password);
-		return true;
-	}
-
 	private static void AppendBasicValue(HttpResponse response, string value) =>
 		response.Cookies.Append(
 			BasicCookieName,
@@ -76,22 +62,15 @@ public static class UiCredentialCookie {
 		if (!TryExtractBasicValue(SafeDecode(raw), out value))
 			return false;
 
-		value = NormalizeBasicValue(value);
 		return IsHeaderSafe(value) && TryDecodeBasicValue(value, out _, out _);
 	}
 
 	private static bool TryExtractBasicValue(string raw, out string value) {
 		value = "";
-		var candidate = raw.StartsWith("j:", StringComparison.Ordinal) ? raw[2..] : raw;
-		if (!candidate.StartsWith("{", StringComparison.Ordinal)) {
-			value = candidate;
-			return true;
-		}
 
 		try {
-			using var document = JsonDocument.Parse(candidate);
-			if (!document.RootElement.TryGetProperty("credentials", out var credentials) &&
-			    !document.RootElement.TryGetProperty("Credentials", out credentials))
+			using var document = JsonDocument.Parse(raw);
+			if (!document.RootElement.TryGetProperty("credentials", out var credentials))
 				return false;
 
 			value = credentials.GetString() ?? "";
@@ -117,11 +96,6 @@ public static class UiCredentialCookie {
 			return false;
 		}
 	}
-
-	private static string NormalizeBasicValue(string value) =>
-		value.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase)
-			? value["Basic ".Length..].TrimStart()
-			: value;
 
 	private static bool IsHeaderSafe(string value) =>
 		!value.Any(x => x is '\r' or '\n');

--- a/src/EventStore.ClusterNode/ui-assets/js/ui-auth.js
+++ b/src/EventStore.ClusterNode/ui-assets/js/ui-auth.js
@@ -39,12 +39,12 @@
 			return "";
 
 		try {
-			var parsed = JSON.parse(raw.indexOf("j:") === 0 ? raw.substring(2) : raw);
+			var parsed = JSON.parse(raw);
 			var credentials = parsed && typeof parsed.credentials === "string" ? parsed.credentials : "";
 			if (!isHeaderSafe(credentials))
 				return "";
 
-			return /^Basic\s+/i.test(credentials) ? credentials : "Basic " + credentials;
+			return "Basic " + credentials;
 		} catch (_) {
 			return "";
 		}


### PR DESCRIPTION
- The Razor sign-in flow should only accept the cookie format it actively writes.
- Retired UI compatibility formats make authentication behavior harder to reason about.
- The management surface should keep security-adjacent parsing intentionally small.