### PR TITLE
chore(ui): retire obsolete web ui naming

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -378,7 +378,7 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable
 	{
 		if (!_options.Interface.DisableAdminUi)
 		{
-			Node.HttpService.SetupController(new ClusterWebUiController(Node.MainQueue,
+			Node.HttpService.SetupController(new NodeUiController(Node.MainQueue,
 				enabledNodeSubsystems));
 		}
 	}

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/NodeUiController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/NodeUiController.cs
@@ -8,12 +8,12 @@ using EventStore.Transport.Http.EntityManagement;
 using ILogger = Serilog.ILogger;
 
 namespace EventStore.Core.Services.Transport.Http.Controllers {
-	public class ClusterWebUiController : CommunicationController {
-		private static readonly ILogger Log = Serilog.Log.ForContext<ClusterWebUiController>();
+	public class NodeUiController : CommunicationController {
+		private static readonly ILogger Log = Serilog.Log.ForContext<NodeUiController>();
 
 		private readonly NodeSubsystems[] _enabledNodeSubsystems;
 
-		public ClusterWebUiController(IPublisher publisher, NodeSubsystems[] enabledNodeSubsystems)
+		public NodeUiController(IPublisher publisher, NodeSubsystems[] enabledNodeSubsystems)
 			: base(publisher) {
 			_enabledNodeSubsystems = enabledNodeSubsystems;
 		}


### PR DESCRIPTION
- The old controller name kept implying legacy shell ownership after Razor took over asset serving.
- Keeping endpoint names aligned with the current UI host lowers the chance of future cleanup work preserving dead assumptions.