### PR TITLE
chore(ui): keep routine paths in razor workspace

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -42,6 +42,7 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable
 	private readonly ExclusiveDbLock _dbLock;
 	private readonly ClusterNodeMutex _clusterNodeMutex;
 
+	public ClusterVNodeOptions Options => _options;
 	public ClusterVNode Node { get; }
 	public IReadOnlyList<NodeSubsystems> EnabledNodeSubsystems { get; private set; } = Array.Empty<NodeSubsystems>();
 	public bool SupportsScavenge =>

--- a/src/EventStore.ClusterNode/Components/Layout/MainLayout.razor
+++ b/src/EventStore.ClusterNode/Components/Layout/MainLayout.razor
@@ -9,10 +9,7 @@
 					<p class="text-xs font-black uppercase tracking-[0.24em] text-es-green">Management workspace</p>
 					<h1 class="mt-1 text-2xl font-black tracking-tight text-es-ink">EventStore dashboard</h1>
 				</div>
-				<div class="flex flex-wrap gap-2">
-					<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink shadow-inner shadow-es-ink/5 hover:border-es-green hover:text-es-forest" href="/stats?format=json" target="_blank" rel="noopener noreferrer">Stats JSON</a>
-					<a class="rounded-full bg-es-ink px-4 py-2 text-sm font-bold text-white shadow-lg shadow-es-ink/15 hover:bg-es-green hover:text-white" href="/ui/navigator">Navigator</a>
-				</div>
+				<a class="rounded-full bg-es-ink px-4 py-2 text-sm font-bold text-white shadow-lg shadow-es-ink/15 hover:bg-es-green hover:text-white" href="/ui/navigator">Navigator</a>
 			</header>
 			<main class="min-w-0 p-4 sm:p-5 lg:p-6">
 				@Body

--- a/src/EventStore.ClusterNode/Components/Pages/Cluster.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Cluster.razor
@@ -16,7 +16,6 @@
 		<div class="flex flex-wrap gap-2">
 			<span class="rounded-full border border-es-green/20 bg-es-green/10 px-4 py-2 text-sm font-bold text-es-forest" data-cluster-status-label>Connecting gossip...</span>
 			<span class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-muted" data-cluster-updated>Waiting for first update</span>
-			<a class="rounded-full bg-es-ink px-4 py-2 text-sm font-bold text-white hover:bg-es-green hover:text-white" href="/gossip?format=json" target="_blank" rel="noopener noreferrer">Raw gossip</a>
 		</div>
 	</div>
 
@@ -194,7 +193,6 @@
 					<p class="text-xs font-black uppercase tracking-[0.22em] text-es-green">Node probes</p>
 					<h2 class="mt-2 text-2xl font-black tracking-tight text-es-ink">Quick checks</h2>
 				</div>
-				<a class="text-sm font-black text-es-green hover:text-es-forest" href="/stats?format=json" target="_blank" rel="noopener noreferrer">Raw stats</a>
 			</div>
 			<div class="mt-5 grid gap-2">
 				@foreach (var probe in Probes)
@@ -210,7 +208,6 @@
 							<p class="text-xs font-black uppercase tracking-[0.2em] text-es-green">@SelectedProbe.Title</p>
 							<p class="mt-1 text-sm text-es-muted">@SelectedProbe.Description</p>
 						</div>
-						<a class="rounded-full border border-es-ink/10 px-3 py-1.5 text-xs font-bold text-es-ink hover:border-es-green hover:text-es-forest" href="@SelectedProbe.Href" target="_blank" rel="noopener noreferrer">Open raw</a>
 					</div>
 					<iframe class="h-64 w-full bg-white" src="@SelectedProbe.Href" title="@($"{SelectedProbe.Title} response")"></iframe>
 				</div>
@@ -219,8 +216,8 @@
 
 		<div class="rounded-[2rem] bg-es-green p-5 text-white shadow-[0_20px_70px_rgba(107,163,0,0.20)]">
 			<p class="text-xs font-black uppercase tracking-[0.22em] text-white/70">Operator flow</p>
-			<h2 class="mt-3 text-2xl font-black tracking-tight">One dashboard, raw endpoints nearby.</h2>
-			<p class="mt-3 text-sm leading-6 text-white/80">The new surface makes routine checks readable while keeping the low-level HTTP endpoints available when you need exact payloads.</p>
+			<h2 class="mt-3 text-2xl font-black tracking-tight">One dashboard for routine operations.</h2>
+			<p class="mt-3 text-sm leading-6 text-white/80">The replacement surface keeps live membership, workload, and follow-up actions in the same workspace.</p>
 		</div>
 	</aside>
 </section>
@@ -229,7 +226,7 @@
 	<SurfaceCard Eyebrow="Explore" Title="Navigator" Description="Jump into streams, subscriptions, projections, user management, and browser tools from one place." Href="/ui/navigator" LinkText="Open" />
 	<SurfaceCard Eyebrow="Run" Title="Operations" Description="Reach privileged actions for scavenging, shutdown, reload, and node-level workflows." Href="/ui/operations" LinkText="Open" />
 	<SurfaceCard Eyebrow="Watch" Title="Observability" Description="Inspect queues, replication, TCP, metrics, and health through a curated operator map." Href="/ui/observability" LinkText="Open" />
-	<SurfaceCard Eyebrow="Review" Title="Configuration" Description="Find runtime information, loaded options, and subsystem metadata without memorizing endpoints." Href="/ui/configuration" LinkText="Open" />
+	<SurfaceCard Eyebrow="Review" Title="Configuration" Description="Find runtime information, loaded options, and subsystem metadata inside the workspace." Href="/ui/configuration" LinkText="Open" />
 </section>
 </div>
 

--- a/src/EventStore.ClusterNode/Components/Pages/Configuration.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Configuration.razor
@@ -1,18 +1,162 @@
 @page "/ui/configuration"
+@inject ConfigurationBrowserService ConfigurationBrowser
 
 <PageTitle>Configuration - EventStore UI</PageTitle>
 
-<section class="max-w-4xl">
-	<p class="text-sm font-black uppercase tracking-[0.28em] text-es-green">Configuration</p>
-	<h1 class="mt-4 text-5xl font-black tracking-tight text-es-ink sm:text-6xl">Runtime context without guesswork.</h1>
-	<p class="mt-5 text-lg leading-8 text-es-muted">The configuration workspace gathers read-only node metadata, loaded options, and subsystem details in one place.</p>
-</section>
+@if (!string.IsNullOrWhiteSpace(LoadError))
+{
+	<section class="rounded-[1.75rem] border border-red-200 bg-red-50 p-6 text-red-800 shadow-[0_18px_60px_rgba(23,32,51,0.08)]">
+		@LoadError
+	</section>
+}
+else if (Page is null)
+{
+	<section class="rounded-[1.75rem] border border-white/80 bg-white/80 p-6 text-es-muted shadow-[0_18px_60px_rgba(23,32,51,0.08)]">
+		Loading configuration...
+	</section>
+}
+else
+{
+	<section class="grid gap-8 lg:grid-cols-[0.95fr_1.05fr] lg:items-start">
+		<div>
+			<p class="text-sm font-black uppercase tracking-[0.28em] text-es-green">Configuration</p>
+			<h1 class="mt-4 text-5xl font-black tracking-tight text-es-ink sm:text-6xl">Runtime context without guesswork.</h1>
+			<p class="mt-5 text-lg leading-8 text-es-muted">Read node metadata, feature flags, subsystem availability, and loaded options directly in the Razor workspace.</p>
+		</div>
+		<div class="grid gap-3 rounded-[2rem] border border-white/80 bg-white/85 p-6 shadow-[0_20px_70px_rgba(23,32,51,0.09)] sm:grid-cols-2">
+			<MetricCard Label="Version" Value="@Page.Version" />
+			@if (Page.CanInspectRuntimeDetails)
+			{
+				<MetricCard Label="Node HTTP" Value="@Page.NodeEndpoint" Tone="muted" />
+				<MetricCard Label="Database" Value="@Page.DatabaseLogFormat" Tone="muted" />
+				<MetricCard Label="Security" Value="@Page.SecurityMode" Tone="@Page.SecurityTone" />
+			}
+			else
+			{
+				<div class="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-amber-900 sm:col-span-2">
+					<p class="text-xs font-black uppercase tracking-[0.18em]">Restricted</p>
+					<p class="mt-2 text-sm font-bold">@Page.OptionsMessage</p>
+				</div>
+			}
+		</div>
+	</section>
 
-<section class="mt-8 grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-	<SurfaceCard Eyebrow="Node" Title="Node information" Description="Read version, state, feature, and authentication metadata from the node." Href="/info" LinkText="Open info" Target="_blank" />
-	<SurfaceCard Eyebrow="Node" Title="Loaded options" Description="Inspect the options that were loaded and their configuration sources." Href="/info/options" LinkText="Open options" Target="_blank" />
-	<SurfaceCard Eyebrow="Cluster" Title="Gossip" Description="Review the node's current gossip view of the cluster." Href="/gossip" LinkText="Open gossip" Target="_blank" />
-	<SurfaceCard Eyebrow="Features" Title="Subsystems" Description="Inspect the subsystems enabled for the hosted node." Href="/sys/subsystems" LinkText="Open subsystems" Target="_blank" />
-	<SurfaceCard Eyebrow="UI" Title="Navigator" Description="Jump across the Razor management workspace from a single route index." Href="/ui/navigator" LinkText="Open navigator" />
-	<SurfaceCard Eyebrow="API" Title="HTTP API root" Description="Open the root HTTP surface for link discovery and API navigation." Href="/" LinkText="Open root" Target="_blank" />
-</section>
+	<section class="mt-8 grid gap-5 xl:grid-cols-[0.7fr_1.3fr]">
+		<div class="grid gap-5">
+			<article class="rounded-[2rem] border border-white/80 bg-white/85 p-6 shadow-[0_20px_70px_rgba(23,32,51,0.09)]">
+				<p class="text-sm font-black uppercase tracking-[0.22em] text-es-green">Features</p>
+				<div class="mt-5 grid gap-3">
+					@foreach (var feature in Page.Features)
+					{
+						<div class="flex items-center justify-between gap-3 rounded-2xl border border-es-ink/10 bg-white/70 px-4 py-3">
+							<span class="font-bold text-es-ink">@feature.Name</span>
+							<StatusBadge Label="@feature.Status" Tone="@feature.Tone" />
+						</div>
+					}
+				</div>
+			</article>
+
+			<article class="rounded-[2rem] border border-white/80 bg-white/85 p-6 shadow-[0_20px_70px_rgba(23,32,51,0.09)]">
+				<p class="text-sm font-black uppercase tracking-[0.22em] text-es-green">Subsystems</p>
+				@if (!Page.HasSubsystems)
+				{
+					<p class="mt-5 rounded-2xl border border-es-ink/10 bg-es-ink/5 p-4 text-sm font-bold text-es-muted">No optional subsystems are enabled.</p>
+				}
+				else
+				{
+					<div class="mt-5 grid gap-3">
+						@foreach (var subsystem in Page.Subsystems)
+						{
+							<div class="flex items-center justify-between gap-3 rounded-2xl border border-es-ink/10 bg-white/70 px-4 py-3">
+								<span class="font-bold text-es-ink">@subsystem.Name</span>
+								<StatusBadge Label="Enabled" Tone="good" />
+							</div>
+						}
+					</div>
+				}
+			</article>
+
+			@if (Page.CanInspectRuntimeDetails)
+			{
+				<article class="rounded-[2rem] border border-white/80 bg-white/85 p-6 shadow-[0_20px_70px_rgba(23,32,51,0.09)]">
+					<p class="text-sm font-black uppercase tracking-[0.22em] text-es-green">Authentication</p>
+					<div class="mt-5 grid gap-3 text-sm">
+						<p class="rounded-2xl border border-es-ink/10 bg-white/70 px-4 py-3"><span class="font-black text-es-ink">Authentication:</span> <span class="text-es-muted">@Page.AuthenticationType</span></p>
+						<p class="rounded-2xl border border-es-ink/10 bg-white/70 px-4 py-3"><span class="font-black text-es-ink">Authorization:</span> <span class="text-es-muted">@Page.AuthorizationType</span></p>
+						<p class="rounded-2xl border border-es-ink/10 bg-white/70 px-4 py-3"><span class="font-black text-es-ink">Database path:</span> <span class="break-all font-mono text-es-muted">@Page.DatabasePath</span></p>
+					</div>
+				</article>
+			}
+		</div>
+
+		<article class="overflow-hidden rounded-[2rem] border border-white/80 bg-white/85 shadow-[0_20px_70px_rgba(23,32,51,0.09)]">
+			<div class="border-b border-es-ink/10 px-5 py-5">
+				<p class="text-sm font-black uppercase tracking-[0.22em] text-es-green">Loaded options</p>
+				<h2 class="mt-2 text-3xl font-black tracking-tight text-es-ink">Effective node settings</h2>
+				<p class="mt-2 text-sm text-es-muted">Sensitive values are masked before display.</p>
+			</div>
+
+			@if (!Page.HasLoadedOptions)
+			{
+				<p class="m-5 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm font-bold text-amber-900">@Page.OptionsMessage</p>
+			}
+			else
+			{
+				<div class="overflow-x-auto">
+					<table class="min-w-full divide-y divide-es-ink/10 text-left text-sm">
+						<thead class="bg-es-ink/5 text-xs font-black uppercase tracking-[0.18em] text-es-muted">
+							<tr>
+								<th class="px-5 py-4">Option</th>
+								<th class="px-5 py-4">Value</th>
+								<th class="px-5 py-4">Source</th>
+							</tr>
+						</thead>
+						<tbody class="divide-y divide-es-ink/10">
+							@foreach (var option in Page.LoadedOptions)
+							{
+								<tr class="align-top">
+									<td class="px-5 py-4">
+										<p class="font-black text-es-ink">@option.Name</p>
+										<p class="mt-1 text-xs font-black uppercase tracking-[0.16em] text-es-green">@option.Group</p>
+										@if (!string.IsNullOrWhiteSpace(option.Description))
+										{
+											<p class="mt-2 max-w-md text-sm leading-6 text-es-muted">@option.Description</p>
+										}
+										@if (!string.IsNullOrWhiteSpace(option.DeprecationMessage))
+										{
+											<p class="mt-2 max-w-md rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-bold leading-5 text-amber-900">@option.DeprecationMessage</p>
+										}
+									</td>
+									<td class="max-w-sm break-all px-5 py-4 font-mono text-xs text-es-ink">@option.Value</td>
+									<td class="px-5 py-4"><StatusBadge Label="@option.Source" Tone="@option.SourceTone" /></td>
+								</tr>
+							}
+						</tbody>
+					</table>
+				</div>
+			}
+		</article>
+	</section>
+}
+
+@code {
+	private ConfigurationPage Page { get; set; }
+	private string LoadError { get; set; } = "";
+
+	protected override async Task OnInitializedAsync() {
+		try
+		{
+			await Task.Yield();
+			Page = ConfigurationBrowser.Read();
+			LoadError = "";
+		}
+		catch (OperationCanceledException)
+		{
+			LoadError = "Loading configuration was canceled.";
+		}
+		catch (Exception ex)
+		{
+			LoadError = $"Failed to load configuration: {UiMessages.Friendly(ex)}";
+		}
+	}
+}

--- a/src/EventStore.ClusterNode/Components/Pages/Navigator.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Navigator.razor
@@ -5,7 +5,7 @@
 <section class="max-w-4xl">
 	<p class="text-sm font-black uppercase tracking-[0.28em] text-es-green">Navigator</p>
 	<h1 class="mt-4 text-5xl font-black tracking-tight text-es-ink sm:text-6xl">One front door for the management workflows.</h1>
-	<p class="mt-5 text-lg leading-8 text-es-muted">This page keeps the new UI honest by linking to the node surfaces that already exist today.</p>
+	<p class="mt-5 text-lg leading-8 text-es-muted">This page keeps the replacement UI centered on the workflows operators use most.</p>
 </section>
 
 <section class="mt-8 grid gap-5 md:grid-cols-2 xl:grid-cols-3">
@@ -15,5 +15,5 @@
 	<SurfaceCard Eyebrow="Processing" Title="Projections" Description="Inspect projection status, progress, and diagnostics in the native workspace." Href="/ui/projections" LinkText="Open projections" />
 	<SurfaceCard Eyebrow="Consumers" Title="Subscriptions" Description="Review persistent subscription groups, parked messages, and consumer progress." Href="/ui/subscriptions" LinkText="Open subscriptions" />
 	<SurfaceCard Eyebrow="Security" Title="Users" Description="Inspect accounts, groups, and the current authenticated request." Href="/ui/users" LinkText="Open users" />
-	<SurfaceCard Eyebrow="API" Title="HTTP root" Description="Inspect the HTTP API root and discover links exposed by the node." Href="/" LinkText="Open root" Target="_blank" />
+	<SurfaceCard Eyebrow="Control" Title="Operations" Description="Run privileged node workflows from the guarded operations surface." Href="/ui/operations" LinkText="Open operations" />
 </section>

--- a/src/EventStore.ClusterNode/Components/Pages/Observability.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Observability.razor
@@ -37,7 +37,6 @@
 		<div class="flex flex-wrap gap-2">
 			<span class="rounded-full border border-es-green/20 bg-es-green/10 px-4 py-2 text-sm font-bold text-es-forest" data-queue-status>Connecting live stats...</span>
 			<span class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-muted" data-queue-updated>Waiting for first update</span>
-			<a class="rounded-full bg-es-ink px-4 py-2 text-sm font-bold text-white hover:bg-es-green hover:text-white" href="/stats?format=json" target="_blank" rel="noopener noreferrer">Open raw stats</a>
 		</div>
 	</div>
 
@@ -99,7 +98,6 @@
 			<span class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-muted" data-tcp-page-status>No pages</span>
 			<button type="button" class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-green disabled:cursor-not-allowed disabled:opacity-40" data-tcp-page="previous" disabled>Previous</button>
 			<button type="button" class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-green disabled:cursor-not-allowed disabled:opacity-40" data-tcp-page="next" disabled>Next</button>
-			<a class="rounded-full bg-es-ink px-4 py-2 text-sm font-bold text-white hover:bg-es-green hover:text-white" href="/stats/tcp?format=json" target="_blank" rel="noopener noreferrer">Open raw TCP</a>
 		</div>
 	</div>
 
@@ -130,14 +128,6 @@
 	</div>
 </section>
 
-<section class="mt-8 grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-	<SurfaceCard Eyebrow="Health" Title="Health check" Description="Check whether the node health endpoint is responding." Href="/health/live" LinkText="Open health" Target="_blank" />
-	<SurfaceCard Eyebrow="Health" Title="Ping" Description="Use the simplest HTTP probe for process availability." Href="/ping" LinkText="Open ping" Target="_blank" />
-	<SurfaceCard Eyebrow="Stats" Title="Grouped stats" Description="Inspect grouped runtime statistics collected by the node." Href="/stats" LinkText="Open stats" Target="_blank" />
-	<SurfaceCard Eyebrow="Stats" Title="Replication stats" Description="Review replication-specific statistics for diagnosing cluster movement." Href="/stats/replication" LinkText="Open replication" Target="_blank" />
-	<SurfaceCard Eyebrow="Stats" Title="TCP stats" Description="Inspect TCP connection statistics when troubleshooting network behavior." Href="/stats/tcp" LinkText="Open TCP stats" Target="_blank" />
-	<SurfaceCard Eyebrow="Metrics" Title="Metrics endpoint" Description="Open the metrics endpoint used by external monitoring systems." Href="/metrics" LinkText="Open metrics" Target="_blank" />
-</section>
 </div>
 
 @code {

--- a/src/EventStore.ClusterNode/Components/Pages/Operations.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Operations.razor
@@ -67,7 +67,6 @@ else
 
 			<div class="mt-5 flex flex-wrap gap-2">
 				<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="/ui/configuration">Configuration</a>
-				<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="/sys/subsystems" target="_blank" rel="noopener noreferrer">Raw subsystems</a>
 			</div>
 		</article>
 
@@ -179,8 +178,6 @@ else
 			<p class="mt-5 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm leading-6 text-amber-900">If scavenge progress stops updating, the status stream may not be writable. Check the node logs before assuming the job is idle.</p>
 			<div class="mt-5 flex flex-wrap gap-2">
 				<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="/ui/streams/$scavenges">Scavenge history stream</a>
-				<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="/admin/scavenge/current" target="_blank" rel="noopener noreferrer">Raw current</a>
-				<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="/admin/scavenge/last" target="_blank" rel="noopener noreferrer">Raw last</a>
 			</div>
 		</article>
 	</section>

--- a/src/EventStore.ClusterNode/Components/Pages/Projections.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Projections.razor
@@ -8,7 +8,7 @@
 	<div>
 		<p class="text-sm font-black uppercase tracking-[0.28em] text-es-green">Projections</p>
 		<h1 class="mt-4 text-5xl font-black tracking-tight text-es-ink sm:text-6xl">Manage projection health without leaving the workspace.</h1>
-		<p class="mt-5 text-lg leading-8 text-es-muted">Create, edit, reset, start, stop, debug, and delete projections from the Razor shell while keeping raw diagnostics nearby.</p>
+		<p class="mt-5 text-lg leading-8 text-es-muted">Create, edit, reset, start, stop, debug, and delete projections from the Razor shell.</p>
 		<div class="mt-6 flex flex-wrap gap-2">
 			<a class="rounded-2xl bg-es-ink px-5 py-3 text-sm font-black text-white shadow-lg shadow-es-ink/15 transition hover:bg-es-green" href="/ui/projections/new">New projection</a>
 			<a class="rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="/ui/projections/standard">New standard projection</a>

--- a/src/EventStore.ClusterNode/Components/Pages/Streams.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Streams.razor
@@ -8,7 +8,7 @@
 	<div>
 		<p class="text-sm font-black uppercase tracking-[0.28em] text-es-green">Streams</p>
 		<h1 class="mt-4 text-5xl font-black tracking-tight text-es-ink sm:text-6xl">Browse and operate on streams from the Razor workspace.</h1>
-		<p class="mt-5 text-lg leading-8 text-es-muted">Open a stream by id, inspect recent created and changed streams, append events, and keep raw endpoint access nearby for troubleshooting.</p>
+		<p class="mt-5 text-lg leading-8 text-es-muted">Open a stream by id, inspect recent created and changed streams, and append events from the Razor workspace.</p>
 	</div>
 	<form class="rounded-[2rem] border border-white/80 bg-white/85 p-6 shadow-[0_20px_70px_rgba(23,32,51,0.09)]" method="get" action="/ui/streams">
 		<label class="text-sm font-black uppercase tracking-[0.22em] text-es-green" for="streamId">Stream id</label>
@@ -18,7 +18,6 @@
 		</div>
 		<div class="mt-4 flex flex-wrap gap-2">
 			<a class="rounded-2xl border border-es-ink/10 bg-white px-4 py-2 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="/ui/streams/append">Add Event</a>
-			<a class="rounded-2xl border border-es-ink/10 bg-white px-4 py-2 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="/streams/$all/head/100?embed=rich" target="_blank" rel="noopener noreferrer">Raw $all feed</a>
 		</div>
 	</form>
 </section>

--- a/src/EventStore.ClusterNode/Components/Pages/Users.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Users.razor
@@ -10,7 +10,6 @@
 		<p class="mt-5 text-lg leading-8 text-es-muted">Create users, adjust roles, reset passwords, and inspect the currently authenticated principal.</p>
 		<div class="mt-6 flex flex-wrap gap-2">
 			<a class="rounded-full bg-es-ink px-4 py-2 text-sm font-bold text-white shadow-lg shadow-es-ink/15 transition hover:bg-es-green" href="/ui/users/new">New user</a>
-			<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="/users/" target="_blank" rel="noopener noreferrer">Raw users</a>
 		</div>
 	</div>
 	<div class="grid gap-3 rounded-[2rem] border border-white/80 bg-white/85 p-6 shadow-[0_20px_70px_rgba(23,32,51,0.09)] sm:grid-cols-2">
@@ -92,7 +91,6 @@
 										{
 											<a class="rounded-full border border-amber-200 bg-amber-50 px-3 py-1.5 text-xs font-bold text-amber-900 transition hover:bg-amber-100" href="@user.DisableHref">Disable</a>
 										}
-										<a class="rounded-full border border-es-ink/10 bg-white px-3 py-1.5 text-xs font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@user.RawHref" target="_blank" rel="noopener noreferrer">Raw</a>
 									</div>
 								</td>
 							</tr>

--- a/src/EventStore.ClusterNode/Components/Services/ConfigurationBrowserService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/ConfigurationBrowserService.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using EventStore.Common.Options;
+using EventStore.Common.Utils;
+using EventStore.Core;
+using EventStore.Core.Data;
+using EventStore.Core.Services;
+using EventStore.Core.Util;
+using Microsoft.AspNetCore.Http;
+
+namespace EventStore.ClusterNode.Components.Services;
+
+public sealed class ConfigurationBrowserService(
+	ClusterVNodeHostedService hostedService,
+	IHttpContextAccessor httpContextAccessor) {
+	public ConfigurationPage Read() {
+		var options = hostedService.Options;
+		var features = new[] {
+			new ConfigurationFeature("Projections", options.Projection.RunProjections != ProjectionType.None || options.DevMode.Dev),
+			new ConfigurationFeature("User management", options.Auth.AuthenticationType == Opts.AuthenticationTypeDefault && !options.Application.Insecure),
+			new ConfigurationFeature("AtomPub over HTTP", options.Interface.EnableAtomPubOverHttp || options.DevMode.Dev)
+		};
+
+		var subsystems = hostedService.EnabledNodeSubsystems
+			.Select(x => new ConfigurationSubsystem(x.ToString()))
+			.OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+			.ToArray();
+
+		var canInspectRuntimeDetails = options.Application.Insecure || CanInspectRuntimeDetails(httpContextAccessor.HttpContext?.User);
+		var loadedOptions = canInspectRuntimeDetails
+			? options.LoadedOptions.Values
+				.OrderBy(x => x.Metadata.SectionMetadata.Sequence)
+				.ThenBy(x => x.Metadata.Sequence)
+				.Select(ConfigurationOption.From)
+				.ToArray()
+			: Array.Empty<ConfigurationOption>();
+
+		return new ConfigurationPage(
+			VersionInfo.Version,
+			canInspectRuntimeDetails ? new IPEndPoint(options.Interface.NodeIp, options.Interface.NodePort).ToString() : "",
+			canInspectRuntimeDetails ? options.Database.Db : "",
+			canInspectRuntimeDetails ? options.Database.DbLogFormat.ToString() : "",
+			canInspectRuntimeDetails ? options.Auth.AuthenticationType : "",
+			canInspectRuntimeDetails ? options.Auth.AuthorizationType : "",
+			options.Application.Insecure,
+			canInspectRuntimeDetails,
+			features,
+			subsystems,
+			loadedOptions,
+			canInspectRuntimeDetails ? "" : "Runtime configuration details are visible to operations and admin users.");
+	}
+
+	private static bool CanInspectRuntimeDetails(System.Security.Claims.ClaimsPrincipal user) =>
+		user?.LegacyRoleCheck(SystemRoles.Operations) == true ||
+		user?.LegacyRoleCheck(SystemRoles.Admins) == true;
+}
+
+public sealed record ConfigurationPage(
+	string Version,
+	string NodeEndpoint,
+	string DatabasePath,
+	string DatabaseLogFormat,
+	string AuthenticationType,
+	string AuthorizationType,
+	bool IsInsecure,
+	bool CanInspectRuntimeDetails,
+	IReadOnlyList<ConfigurationFeature> Features,
+	IReadOnlyList<ConfigurationSubsystem> Subsystems,
+	IReadOnlyList<ConfigurationOption> LoadedOptions,
+	string OptionsMessage) {
+	public string SecurityMode => IsInsecure ? "Insecure" : "Secure";
+	public string SecurityTone => IsInsecure ? "warn" : "good";
+	public bool HasSubsystems => Subsystems.Count > 0;
+	public bool HasLoadedOptions => LoadedOptions.Count > 0;
+}
+
+public sealed record ConfigurationFeature(string Name, bool Enabled) {
+	public string Status => Enabled ? "Enabled" : "Disabled";
+	public string Tone => Enabled ? "good" : "muted";
+}
+
+public sealed record ConfigurationSubsystem(string Name);
+
+public sealed record ConfigurationOption(
+	string Group,
+	string Name,
+	string Value,
+	string Source,
+	string Description,
+	string DeprecationMessage,
+	bool IsDefault) {
+	public string SourceTone => IsDefault ? "muted" : "good";
+
+	public static ConfigurationOption From(LoadedOption option) =>
+		new(
+			GroupLabel(option.Metadata.SectionMetadata),
+			option.Metadata.Name,
+			option.DisplayValue,
+			option.SourceDisplayName,
+			option.Metadata.Description,
+			option.Metadata.DeprecationMessage ?? "",
+			option.IsDefault);
+
+	private static string GroupLabel(SectionMetadata section) {
+		var name = section.SectionName;
+		return name.EndsWith("Options", StringComparison.Ordinal)
+			? name[..^"Options".Length]
+			: name;
+	}
+}

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -275,6 +275,7 @@ internal static class Program
 					builder.Services.AddScoped<UserBrowserService>();
 					builder.Services.AddScoped<SecurityBrowserService>();
 					builder.Services.AddScoped<AdminOperationsService>();
+					builder.Services.AddScoped<ConfigurationBrowserService>();
 					builder.Services.AddSingleton(hostedService);
 					builder.Services.AddSingleton<IHostedService>(hostedService);
 


### PR DESCRIPTION
- The replacement UI should keep routine operator flows inside Razor instead of sending people back to low-level endpoints.
- Configuration needs to be inspectable from the new workspace so removing shortcut links does not reduce operational visibility.
- Top-level navigation should reinforce the new surface as the primary workflow, not the old HTTP API as an escape hatch.