### PR TITLE
chore(ui): keep detail flows in razor workspace

### DIFF
--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionConfig.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionConfig.razor
@@ -96,7 +96,6 @@
 		<StatusBadge Label="Stopped projections" Tone="warn" />
 		<h2 class="mt-4 text-2xl font-black tracking-tight text-es-ink">Config writes can be refused while running</h2>
 		<p class="mt-3 text-sm leading-6 text-es-muted">The projection subsystem protects some configuration changes until a projection is stopped or faulted. If a save is rejected, stop the projection and retry.</p>
-		<a class="mt-5 inline-flex rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@RawConfigHref" target="_blank" rel="noopener noreferrer">Open raw config</a>
 	</article>
 </section>
 
@@ -109,7 +108,6 @@
 	private ProjectionConfigPage Page { get; set; }
 	private ProjectionCommandResult Result { get; set; }
 	private string DetailHref => $"/ui/projections/{Uri.EscapeDataString(Name)}";
-	private string RawConfigHref => $"/projection/{Uri.EscapeDataString(Name)}/config";
 
 	protected override async Task OnParametersSetAsync() {
 		var hasSubmittedForm = string.Equals(Input.Name, Name, StringComparison.OrdinalIgnoreCase);

--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionDebug.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionDebug.razor
@@ -8,7 +8,7 @@
 	<a class="text-sm font-bold text-es-green transition hover:text-es-forest" href="@DetailHref">Back to projection</a>
 	<p class="mt-6 text-sm font-black uppercase tracking-[0.28em] text-es-green">Projection debug</p>
 	<h1 class="mt-4 break-words text-5xl font-black tracking-tight text-es-ink sm:text-6xl">@Name</h1>
-	<p class="mt-5 text-lg leading-8 text-es-muted">Inspect projection source, state, result, and raw debug endpoints while keeping lifecycle commands close.</p>
+	<p class="mt-5 text-lg leading-8 text-es-muted">Inspect projection source and state while keeping lifecycle commands close.</p>
 </section>
 
 @if (CommandResult is not null)
@@ -87,15 +87,6 @@
 			}
 		</article>
 
-		<article class="rounded-[2rem] border border-white/80 bg-white/85 p-6 shadow-[0_20px_70px_rgba(23,32,51,0.09)]">
-			<StatusBadge Label="Raw debug" Tone="muted" />
-			<h2 class="mt-4 text-xl font-black tracking-tight text-es-ink">Endpoint handoffs</h2>
-			<div class="mt-5 flex flex-wrap gap-2">
-				<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@RawStateHref" target="_blank" rel="noopener noreferrer">State</a>
-				<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@RawResultHref" target="_blank" rel="noopener noreferrer">Result</a>
-				<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@RawStatsHref" target="_blank" rel="noopener noreferrer">Stats</a>
-			</div>
-		</article>
 	</aside>
 </section>
 
@@ -115,9 +106,6 @@
 	private string DetailHref => $"/ui/projections/{Uri.EscapeDataString(LinkName)}";
 	private string EditHref => $"/ui/projections/edit/{Uri.EscapeDataString(LinkName)}";
 	private string QueryHref => $"/ui/query?location={Uri.EscapeDataString(LinkName)}";
-	private string RawStateHref => $"/projection/{Uri.EscapeDataString(LinkName)}/state";
-	private string RawResultHref => $"/projection/{Uri.EscapeDataString(LinkName)}/result";
-	private string RawStatsHref => $"/projection/{Uri.EscapeDataString(LinkName)}/statistics";
 
 	protected override async Task OnParametersSetAsync() {
 		try {

--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionDetail.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionDetail.razor
@@ -169,17 +169,12 @@
 			</aside>
 		</section>
 
-		<section class="mt-6 grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-			<SurfaceCard Eyebrow="Raw" Title="Statistics" Description="Open the projection statistics payload returned by the node." Href="@projection.RawStatisticsHref" LinkText="Open statistics" Target="_blank" />
-			<SurfaceCard Eyebrow="Raw" Title="State" Description="Inspect the projection state payload when the projection exposes one." Href="@projection.RawStateHref" LinkText="Open state" Target="_blank" />
-			<SurfaceCard Eyebrow="Raw" Title="Result" Description="Inspect the projection result payload when the projection exposes one." Href="@projection.RawResultHref" LinkText="Open result" Target="_blank" />
-			<SurfaceCard Eyebrow="Raw" Title="Query" Description="Review the projection query and configuration response." Href="@projection.RawQueryHref" LinkText="Open query" Target="_blank" />
-			<SurfaceCard Eyebrow="Raw" Title="Config" Description="Review the projection configuration response." Href="@projection.RawConfigHref" LinkText="Open config" Target="_blank" />
-			@if (!string.IsNullOrWhiteSpace(projection.ResultStreamHref))
-			{
+		@if (!string.IsNullOrWhiteSpace(projection.ResultStreamHref))
+		{
+			<section class="mt-6 max-w-xl">
 				<SurfaceCard Eyebrow="Stream" Title="Result stream" Description="Inspect the stream that receives this projection output." Href="@projection.ResultStreamHref" LinkText="Open stream" />
-			}
-		</section>
+			</section>
+		}
 	}
 </section>
 

--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionEdit.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionEdit.razor
@@ -71,11 +71,6 @@
 				<p class="mt-4 rounded-2xl border @(ResetResult.Success ? "border-es-green/25 bg-es-green/10 text-es-forest" : "border-red-200 bg-red-50 text-red-800") p-4 text-sm font-bold">@ResetResult.Message</p>
 			}
 		</article>
-		<article class="rounded-[2rem] border border-white/80 bg-white/85 p-6 shadow-[0_20px_70px_rgba(23,32,51,0.09)]">
-			<StatusBadge Label="Raw" Tone="muted" />
-			<h2 class="mt-4 text-2xl font-black tracking-tight text-es-ink">Need the raw query response?</h2>
-			<a class="mt-5 inline-flex rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@RawQueryHref" target="_blank" rel="noopener noreferrer">Open raw query</a>
-		</article>
 	</aside>
 </section>
 
@@ -92,7 +87,6 @@
 	private ProjectionCommandResult SaveResult { get; set; }
 	private ProjectionCommandResult ResetResult { get; set; }
 	private string DetailHref => $"/ui/projections/{Uri.EscapeDataString(Name)}";
-	private string RawQueryHref => $"/projection/{Uri.EscapeDataString(Name)}/query?config=yes";
 
 	protected override async Task OnParametersSetAsync() {
 		var hasSubmittedForm = string.Equals(Input.Name, Name, StringComparison.OrdinalIgnoreCase);

--- a/src/EventStore.ClusterNode/Components/Pages/Query.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Query.razor
@@ -13,7 +13,7 @@
 	<div>
 		<p class="text-sm font-black uppercase tracking-[0.28em] text-es-green">Query</p>
 		<h1 class="mt-4 text-5xl font-black tracking-tight text-es-ink sm:text-6xl">Run transient projection queries with the guardrails visible.</h1>
-		<p class="mt-5 text-lg leading-8 text-es-muted">Submit JavaScript projection queries, inspect the created transient projection, and keep state/result endpoints one click away for troubleshooting.</p>
+		<p class="mt-5 text-lg leading-8 text-es-muted">Submit JavaScript projection queries and inspect the created transient projection inside the Razor workspace.</p>
 	</div>
 	<div class="rounded-[2rem] border border-white/80 bg-white/85 p-6 shadow-[0_20px_70px_rgba(23,32,51,0.09)]">
 		<p class="text-sm font-black uppercase tracking-[0.22em] text-es-green">Execution model</p>
@@ -66,7 +66,7 @@
 					<StatusBadge Label="Transient projection" Tone="muted" />
 				</div>
 				<h2 class="mt-4 break-words font-mono text-xl font-black tracking-tight text-es-ink">@Result.ProjectionName</h2>
-				<p class="mt-3 text-sm leading-6 text-es-muted">The projection may still be processing. Use state/result links to inspect the latest server-side view.</p>
+				<p class="mt-3 text-sm leading-6 text-es-muted">The projection may still be processing. Open its detail or debug page to inspect the latest server-side view.</p>
 				<div class="mt-5 flex flex-wrap gap-2">
 					<a class="rounded-full bg-es-ink px-4 py-2 text-sm font-bold text-white transition hover:bg-es-green" href="@Result.ProjectionHref">Projection detail</a>
 					<EditForm Model="StopInput" FormName="query-stop" OnValidSubmit="StopProjection">
@@ -75,9 +75,6 @@
 						<button class="rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-bold text-amber-900 transition hover:bg-amber-100" type="submit">Break</button>
 					</EditForm>
 					<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@Result.DebugHref">Debug</a>
-					<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@Result.RawStateHref" target="_blank" rel="noopener noreferrer">State</a>
-					<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@Result.RawResultHref" target="_blank" rel="noopener noreferrer">Result</a>
-					<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@Result.RawStatisticsHref" target="_blank" rel="noopener noreferrer">Stats</a>
 				</div>
 			</article>
 		}

--- a/src/EventStore.ClusterNode/Components/Pages/ScavengeDetail.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ScavengeDetail.razor
@@ -21,7 +21,7 @@
 			<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="/ui/operations">Operations</a>
 			@if (Page?.IsAvailable == true)
 			{
-				<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@Page.RawStreamHref">Raw stream</a>
+				<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@Page.StreamHref">Scavenge stream</a>
 			}
 		</div>
 	</div>

--- a/src/EventStore.ClusterNode/Components/Pages/StreamAcl.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/StreamAcl.razor
@@ -72,7 +72,7 @@ else
 			</EditForm>
 		</article>
 
-		<JsonPanel Eyebrow="Metadata" Title="Current stream metadata" Content="@Page.RawMetadata" RawHref="@($"/streams/{Uri.EscapeDataString(StreamId)}/metadata")" />
+		<JsonPanel Eyebrow="Metadata" Title="Current stream metadata" Content="@Page.RawMetadata" />
 	</section>
 }
 

--- a/src/EventStore.ClusterNode/Components/Pages/StreamDetail.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/StreamDetail.razor
@@ -24,7 +24,6 @@
 			<a class="rounded-2xl border border-red-200 bg-red-50 px-5 py-3 text-sm font-black text-red-800 transition hover:border-red-300 hover:bg-red-100" href="@($"/ui/streams/delete/{Uri.EscapeDataString(StreamId)}")">Delete</a>
 		}
 		<a class="rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@($"/ui/query?initStreamId={Uri.EscapeDataString(StreamId)}")">Query</a>
-		<a class="rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@($"/streams/{Uri.EscapeDataString(StreamId)}")" target="_blank" rel="noopener noreferrer">Raw stream</a>
 	</div>
 </section>
 

--- a/src/EventStore.ClusterNode/Components/Pages/StreamEventDetail.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/StreamEventDetail.razor
@@ -38,13 +38,12 @@
 				}
 				<a class="rounded-full border border-es-ink/10 px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green hover:text-es-forest" href="@Page.NextHref">Next</a>
 				<a class="rounded-full bg-es-ink px-4 py-2 text-sm font-bold text-white transition hover:bg-es-green" href="@Page.Event.AppendLikeHref">Add New Like This</a>
-				<a class="rounded-full border border-es-ink/10 px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green hover:text-es-forest" href="@Page.Event.RawHref" target="_blank" rel="noopener noreferrer">Raw event</a>
 			</div>
 		</div>
 
 		<StreamEventCard Event="Page.Event" />
 		<div class="mt-5 grid gap-4 lg:grid-cols-2">
-			<JsonPanel Eyebrow="Data" Title="@($"{Page.Event.EventType} data")" Content="@Page.Event.DataForDisplay" RawHref="@Page.Event.RawHref" />
+			<JsonPanel Eyebrow="Data" Title="@($"{Page.Event.EventType} data")" Content="@Page.Event.DataForDisplay" />
 			<JsonPanel Eyebrow="Metadata" Title="Event metadata" Content="@Page.Event.MetadataForDisplay" />
 			@if (Page.Event.HasLinkMetadata)
 			{

--- a/src/EventStore.ClusterNode/Components/Pages/StreamMetadata.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/StreamMetadata.razor
@@ -11,7 +11,6 @@
 	<p class="mt-5 text-lg leading-8 text-es-muted">Inspect the metadata event, then jump into ACL editing only when you intend to change it.</p>
 	<div class="mt-6 flex flex-wrap gap-3">
 		<a class="rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@AclHref">Edit ACL</a>
-		<a class="rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@RawMetadataHref" target="_blank" rel="noopener noreferrer">Raw metadata</a>
 	</div>
 </section>
 
@@ -41,14 +40,11 @@
 				<p class="text-sm font-black uppercase tracking-[0.24em] text-es-green">Metadata event</p>
 				<h2 class="mt-2 break-words text-3xl font-black tracking-tight text-es-ink">@Page.MetadataEvent.EventType</h2>
 			</div>
-			<div class="flex flex-wrap gap-3">
-				<a class="rounded-full bg-es-ink px-4 py-2 text-sm font-bold text-white transition hover:bg-es-green" href="@Page.MetadataEvent.RawHref" target="_blank" rel="noopener noreferrer">Raw event</a>
-			</div>
 		</div>
 
 		<StreamEventCard Event="Page.MetadataEvent" />
 		<div class="mt-5 grid gap-4 lg:grid-cols-2">
-			<JsonPanel Eyebrow="Data" Title="Stream metadata" Content="@Page.MetadataEvent.DataForDisplay" RawHref="@RawMetadataHref" />
+			<JsonPanel Eyebrow="Data" Title="Stream metadata" Content="@Page.MetadataEvent.DataForDisplay" />
 			<JsonPanel Eyebrow="Metadata" Title="Metadata event metadata" Content="@Page.MetadataEvent.MetadataForDisplay" />
 		</div>
 	}
@@ -60,7 +56,6 @@
 	private StreamMetadataPage Page { get; set; }
 	private string BackHref => $"/ui/streams/{Uri.EscapeDataString(StreamId)}";
 	private string AclHref => $"/ui/streams/acl/{Uri.EscapeDataString(StreamId)}";
-	private string RawMetadataHref => $"/streams/{Uri.EscapeDataString(StreamId)}/metadata";
 
 	protected override async Task OnParametersSetAsync() {
 		var requested = StreamId;

--- a/src/EventStore.ClusterNode/Components/Pages/SubscriptionDetail.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SubscriptionDetail.razor
@@ -90,7 +90,6 @@ else
 					<a class="rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@subscription.UiParkedHref">View parked</a>
 					<a class="rounded-2xl border border-red-200 bg-red-50 px-5 py-3 text-sm font-black text-red-800 transition hover:bg-red-100" href="@subscription.UiDeleteHref">Delete</a>
 				</div>
-				<a class="mt-4 inline-flex text-sm font-bold text-es-green transition hover:text-es-forest" href="@subscription.DetailHref" target="_blank" rel="noopener noreferrer">Raw details</a>
 			</article>
 
 			<article class="rounded-[2rem] border border-white/80 bg-white/85 p-6 shadow-[0_20px_70px_rgba(23,32,51,0.09)]">

--- a/src/EventStore.ClusterNode/Components/Pages/SubscriptionParked.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SubscriptionParked.razor
@@ -43,7 +43,7 @@ else
 				{
 					<a class="rounded-full border border-es-ink/10 px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green hover:text-es-forest" href="@newerHref">Previous</a>
 				}
-				<a class="rounded-full border border-es-ink/10 px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green hover:text-es-forest" href="/streams/@Uri.EscapeDataString(ParkedStreamName(subscription.StreamId, subscription.GroupName))" target="_blank" rel="noopener noreferrer">Raw parked stream</a>
+				<a class="rounded-full border border-es-ink/10 px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green hover:text-es-forest" href="/ui/streams/@Uri.EscapeDataString(ParkedStreamName(subscription.StreamId, subscription.GroupName))">Open parked stream</a>
 			</div>
 		</article>
 
@@ -87,7 +87,7 @@ else
 				{
 					<StreamEventCard Event="ev" />
 					<div class="grid gap-4 lg:grid-cols-2">
-						<JsonPanel Eyebrow="Data" Title="@($"{ev.EventType} data")" Content="@ev.DataForDisplay" RawHref="@ev.RawHref" />
+						<JsonPanel Eyebrow="Data" Title="@($"{ev.EventType} data")" Content="@ev.DataForDisplay" />
 						<JsonPanel Eyebrow="Metadata" Title="Event metadata" Content="@ev.MetadataForDisplay" />
 						@if (ev.HasLinkMetadata)
 						{

--- a/src/EventStore.ClusterNode/Components/Pages/UserCommandConfirm.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/UserCommandConfirm.razor
@@ -67,7 +67,6 @@ else
 					<p class="mt-2 font-mono text-xs text-es-ink">@Page.User.UpdatedLabel</p>
 				</div>
 			</div>
-			<a class="mt-5 inline-flex rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@Page.User.RawHref" target="_blank" rel="noopener noreferrer">Raw user</a>
 		</article>
 	</section>
 }

--- a/src/EventStore.ClusterNode/Components/Pages/UserDetail.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/UserDetail.razor
@@ -45,7 +45,6 @@
 				<div class="flex flex-wrap gap-2">
 					<a class="rounded-full bg-es-ink px-4 py-2 text-sm font-bold text-white transition hover:bg-es-green" href="@user.EditHref">Edit</a>
 					<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@user.ResetPasswordHref">Reset password</a>
-					<a class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@user.RawHref" target="_blank" rel="noopener noreferrer">Raw user</a>
 					@if (user.Disabled)
 					{
 						<a class="rounded-full border border-es-green/30 bg-es-green/10 px-4 py-2 text-sm font-bold text-es-forest transition hover:bg-es-green hover:text-white" href="@user.EnableHref">Enable</a>
@@ -70,26 +69,6 @@
 				<div class="rounded-2xl border border-es-ink/10 bg-es-ink/5 p-4 md:col-span-2">
 					<p class="text-xs font-black uppercase tracking-[0.18em] text-es-muted">Groups</p>
 					<p class="mt-2 break-words text-es-ink">@user.GroupsLabel</p>
-				</div>
-			</div>
-
-			<div class="mt-6 rounded-2xl border border-es-ink/10 bg-white/70 p-4">
-				<p class="text-xs font-black uppercase tracking-[0.18em] text-es-muted">API links</p>
-				<div class="mt-3 grid gap-2">
-					@foreach (var link in user.ApiLinks)
-					{
-						@if (link.IsGet)
-						{
-							<a class="break-all rounded-2xl border border-es-ink/10 bg-es-ink/5 px-3 py-2 font-mono text-xs font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="@link.Href" target="_blank" rel="noopener noreferrer">@link.Method @link.Rel: @link.Href</a>
-						}
-						else
-						{
-							<div class="break-all rounded-2xl border border-es-ink/10 bg-es-ink/5 px-3 py-2 font-mono text-xs font-bold text-es-muted">
-								<span class="mr-2 rounded-full bg-es-ink px-2 py-1 text-[0.65rem] uppercase tracking-[0.18em] text-white">@link.Method</span>
-								@link.Rel: @link.Href
-							</div>
-						}
-					}
 				</div>
 			</div>
 		</article>

--- a/src/EventStore.ClusterNode/Components/Services/AdminOperationsService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/AdminOperationsService.cs
@@ -473,7 +473,7 @@ public sealed record ScavengeDetailPage(
 		? $"/ui/operations/scavenges/{Uri.EscapeDataString(ScavengeId)}"
 		: $"/ui/operations/scavenges/{Uri.EscapeDataString(ScavengeId)}?page={Page - 1}&from={NewerFrom}";
 	public string LatestHref => $"/ui/operations/scavenges/{Uri.EscapeDataString(ScavengeId)}";
-	public string RawStreamHref => $"/ui/streams/{Uri.EscapeDataString(SystemStreams.ScavengesStream + "-" + ScavengeId)}";
+	public string StreamHref => $"/ui/streams/{Uri.EscapeDataString(SystemStreams.ScavengesStream + "-" + ScavengeId)}";
 
 	public static ScavengeDetailPage Success(
 		string scavengeId,

--- a/src/EventStore.ClusterNode/Components/Services/ProjectionBrowserService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/ProjectionBrowserService.cs
@@ -826,11 +826,6 @@ public sealed record ProjectionView(
 	public string ConfigHref => $"/ui/projections/config/{Uri.EscapeDataString(Name)}";
 	public string DeleteHref => $"/ui/projections/delete/{Uri.EscapeDataString(Name)}";
 	public string DebugHref => $"/ui/projections/debug/{Uri.EscapeDataString(Name)}";
-	public string RawStatisticsHref => $"/projection/{Uri.EscapeDataString(Name)}/statistics";
-	public string RawStateHref => $"/projection/{Uri.EscapeDataString(Name)}/state";
-	public string RawResultHref => $"/projection/{Uri.EscapeDataString(Name)}/result";
-	public string RawQueryHref => $"/projection/{Uri.EscapeDataString(Name)}/query?config=yes";
-	public string RawConfigHref => $"/projection/{Uri.EscapeDataString(Name)}/config";
 	public string ResultStreamHref => string.IsNullOrWhiteSpace(ResultStreamName)
 		? ""
 		: $"/ui/streams/{Uri.EscapeDataString(ResultStreamName)}";

--- a/src/EventStore.ClusterNode/Components/Services/QueryBrowserService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/QueryBrowserService.cs
@@ -74,9 +74,6 @@ public sealed record QueryRunPage(
 	public bool HasProjection => !string.IsNullOrWhiteSpace(ProjectionName);
 	public string ProjectionHref => HasProjection ? $"/ui/projections/{Uri.EscapeDataString(ProjectionName)}" : "";
 	public string DebugHref => HasProjection ? $"/ui/projections/debug/{Uri.EscapeDataString(ProjectionName)}" : "";
-	public string RawStateHref => HasProjection ? $"/projection/{Uri.EscapeDataString(ProjectionName)}/state" : "";
-	public string RawResultHref => HasProjection ? $"/projection/{Uri.EscapeDataString(ProjectionName)}/result" : "";
-	public string RawStatisticsHref => HasProjection ? $"/projection/{Uri.EscapeDataString(ProjectionName)}/statistics" : "";
 
 	public static QueryRunPage Success(string query, string projectionName) => new(query, projectionName, "");
 	public static QueryRunPage Unavailable(string query, string message) => new(query, "", message);

--- a/src/EventStore.ClusterNode/Components/Services/StreamBrowserService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/StreamBrowserService.cs
@@ -767,7 +767,6 @@ public sealed record StreamViewEvent(
 	public bool HasLinkMetadata => !string.IsNullOrWhiteSpace(LinkMetadata);
 	public string DetailHref => $"/ui/streams/event/{EventNumber}/{Uri.EscapeDataString(StreamId)}";
 	public string AppendLikeHref => $"/ui/streams/append/{Uri.EscapeDataString(StreamId)}?fromEvent={EventNumber}";
-	public string RawHref => $"/streams/{Uri.EscapeDataString(StreamId)}/{EventNumber}?embed=tryharder";
 
 	private static string FormatBody(string value, bool preferJson) {
 		if (string.IsNullOrWhiteSpace(value))

--- a/src/EventStore.ClusterNode/Components/Services/SubscriptionBrowserService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/SubscriptionBrowserService.cs
@@ -684,10 +684,6 @@ public sealed record SubscriptionView(
 			return $"{behind.Value} behind / {seconds:0.##}s";
 		}
 	}
-	public string DetailHref =>
-		$"/subscriptions/{Uri.EscapeDataString(StreamId)}/{Uri.EscapeDataString(GroupName)}/info";
-	public string ParkedHref =>
-		$"/subscriptions/{Uri.EscapeDataString(StreamId)}/{Uri.EscapeDataString(GroupName)}/parked";
 	public string UiDetailHref =>
 		$"/ui/subscriptions/{Uri.EscapeDataString(StreamId)}/{Uri.EscapeDataString(GroupName)}";
 	public string UiEditHref =>

--- a/src/EventStore.ClusterNode/Components/Services/UserBrowserService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/UserBrowserService.cs
@@ -425,15 +425,6 @@ public sealed record UserView(
 	public string DisableHref => $"/ui/users/{Uri.EscapeDataString(LoginName)}/disable";
 	public string DeleteHref => $"/ui/users/{Uri.EscapeDataString(LoginName)}/delete";
 	public string ResetPasswordHref => $"/ui/users/{Uri.EscapeDataString(LoginName)}/reset";
-	public string RawHref => $"/users/{Uri.EscapeDataString(LoginName)}";
-	public IReadOnlyList<UserLinkView> ApiLinks => [
-		new("self", RawHref, "GET"),
-		new("reset-password", $"{RawHref}/command/reset-password", "POST"),
-		new("change-password", $"{RawHref}/command/change-password", "POST"),
-		new("edit", RawHref, "PUT"),
-		new("delete", RawHref, "DELETE"),
-		new(Disabled ? "enable" : "disable", $"{RawHref}/command/{(Disabled ? "enable" : "disable")}", "POST")
-	];
 
 	public static UserView From(UserManagementMessage.UserData source) =>
 		new(
@@ -442,11 +433,4 @@ public sealed record UserView(
 			source.Groups ?? Array.Empty<string>(),
 			source.Disabled,
 			source.DateLastUpdated);
-}
-
-public sealed record UserLinkView(
-	string Rel,
-	string Href,
-	string Method) {
-	public bool IsGet => string.Equals(Method, "GET", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/EventStore.ClusterNode/Components/Shared/JsonPanel.razor
+++ b/src/EventStore.ClusterNode/Components/Shared/JsonPanel.razor
@@ -4,10 +4,6 @@
 			<p class="text-xs font-black uppercase tracking-[0.24em] text-es-green">@Eyebrow</p>
 			<h3 class="mt-1 text-lg font-black tracking-tight">@Title</h3>
 		</div>
-		@if (!string.IsNullOrWhiteSpace(RawHref))
-		{
-			<a class="rounded-full border border-white/20 px-3 py-1 text-xs font-bold text-white/80 hover:border-es-green hover:text-white" href="@RawHref" target="_blank" rel="noopener noreferrer">Raw</a>
-		}
 	</div>
 	@if (string.IsNullOrWhiteSpace(Content))
 	{
@@ -23,5 +19,4 @@
 	[Parameter] public string Eyebrow { get; set; } = "JSON";
 	[Parameter] public string Title { get; set; } = "Payload";
 	[Parameter] public string Content { get; set; } = "";
-	[Parameter] public string RawHref { get; set; } = "";
 }

--- a/src/EventStore.ClusterNode/Components/Shared/StreamEventCard.razor
+++ b/src/EventStore.ClusterNode/Components/Shared/StreamEventCard.razor
@@ -29,7 +29,6 @@
 	</dl>
 	<div class="mt-5 flex flex-wrap gap-3">
 		<a class="rounded-full bg-es-ink px-4 py-2 text-sm font-bold text-white transition hover:bg-es-green" href="@Event.DetailHref">Inspect</a>
-		<a class="rounded-full border border-es-ink/10 px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green hover:text-es-forest" href="@Event.RawHref" target="_blank" rel="noopener noreferrer">Raw event</a>
 	</div>
 </article>
 

--- a/src/EventStore.ClusterNode/Components/Shared/StreamEventsSection.razor
+++ b/src/EventStore.ClusterNode/Components/Shared/StreamEventsSection.razor
@@ -21,7 +21,6 @@ else
 			{
 				<a class="rounded-full bg-es-ink px-4 py-2 text-sm font-bold text-white transition hover:bg-es-green" href="@Page.NextPageHref">@Page.NextPageLabel</a>
 			}
-			<a class="rounded-full border border-es-ink/10 px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green hover:text-es-forest" href="/streams/@Uri.EscapeDataString(Page.StreamId)" target="_blank" rel="noopener noreferrer">Raw stream</a>
 		</div>
 	</div>
 	<div class="grid gap-5">
@@ -29,7 +28,7 @@ else
 		{
 			<StreamEventCard Event="ev" />
 			<div class="grid gap-4 lg:grid-cols-2">
-				<JsonPanel Eyebrow="Data" Title="@($"{ev.EventType} data")" Content="@ev.DataForDisplay" RawHref="@ev.RawHref" />
+				<JsonPanel Eyebrow="Data" Title="@($"{ev.EventType} data")" Content="@ev.DataForDisplay" />
 				<JsonPanel Eyebrow="Metadata" Title="Event metadata" Content="@ev.MetadataForDisplay" />
 				@if (ev.HasLinkMetadata)
 				{


### PR DESCRIPTION
- Routine operator paths should stay anchored in the replacement workspace now that Razor renders the detail data directly.
- Removing raw endpoint exits keeps the breaking UI transition deliberate instead of preserving old escape hatches.