### PR TITLE
chore(ui): render node probes in razor

### DIFF
--- a/src/EventStore.ClusterNode/Components/Pages/Cluster.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Cluster.razor
@@ -1,6 +1,7 @@
 @page "/ui"
 @page "/ui/cluster"
 @inject QueueDashboardService QueueDashboard
+@inject NodeProbeService NodeProbes
 @using System.Globalization
 
 <PageTitle>EventStore Cluster</PageTitle>
@@ -200,16 +201,23 @@
 					<a class="@ProbeLinkClass(probe)" href="@($"/ui?probe={probe.Key}")">@probe.Title</a>
 				}
 			</div>
-			@if (SelectedProbe is not null)
+			@if (ProbeResult.HasProbe)
 			{
 				<div class="mt-4 overflow-hidden rounded-[1.5rem] border border-es-ink/10 bg-white shadow-inner shadow-es-ink/5">
 					<div class="flex flex-wrap items-center justify-between gap-3 border-b border-es-ink/10 px-4 py-3">
 						<div>
-							<p class="text-xs font-black uppercase tracking-[0.2em] text-es-green">@SelectedProbe.Title</p>
-							<p class="mt-1 text-sm text-es-muted">@SelectedProbe.Description</p>
+							<p class="text-xs font-black uppercase tracking-[0.2em] text-es-green">@ProbeResult.Probe.Title</p>
+							<p class="mt-1 text-sm text-es-muted">@ProbeResult.Probe.Description</p>
 						</div>
 					</div>
-					<iframe class="h-64 w-full bg-white" src="@SelectedProbe.Href" title="@($"{SelectedProbe.Title} response")"></iframe>
+					@if (ProbeResult.IsAvailable)
+					{
+						<pre class="max-h-72 overflow-auto bg-es-ink px-4 py-4 font-mono text-xs leading-5 text-white">@ProbeResult.Content</pre>
+					}
+					else
+					{
+						<p class="px-4 py-5 text-sm font-bold leading-6 text-es-muted">@ProbeResult.Message</p>
+					}
 				</div>
 			}
 		</div>
@@ -232,15 +240,12 @@
 
 @code {
 	private QueueDashboardPage Page { get; set; }
+	private NodeProbeRead ProbeResult { get; set; } = NodeProbeRead.Unselected();
 
 	[SupplyParameterFromQuery(Name = "probe")]
 	private string Probe { get; set; } = "";
 
-	private static readonly ProbeLink[] Probes = [
-		new("ping", "Ping", "/ping?format=json", "Process availability probe."),
-		new("info", "Node info", "/info?format=json", "Version, state, feature, and authentication metadata."),
-		new("gossip", "Gossip", "/gossip?format=json", "Current cluster membership view.")
-	];
+	private static readonly IReadOnlyList<NodeProbeDefinition> Probes = NodeProbeService.Probes;
 
 	private IReadOnlyList<QueueDashboardRow> SpotlightQueues =>
 		Page?.Queues
@@ -253,11 +258,11 @@
 	private long MaxPressure =>
 		Math.Max(1, SpotlightQueues.Select(x => x.LengthCurrentTryPeak + x.AvgItemsPerSecond).DefaultIfEmpty(1).Max());
 
-	private ProbeLink SelectedProbe =>
-		Probes.FirstOrDefault(x => string.Equals(x.Key, Probe, StringComparison.OrdinalIgnoreCase));
+	private NodeProbeDefinition SelectedProbe => NodeProbeService.Find(Probe);
 
 	protected override async Task OnParametersSetAsync() {
 		Page = null;
+		ProbeResult = NodeProbeRead.Unselected();
 
 		try
 		{
@@ -271,6 +276,27 @@
 		{
 			Page = QueueDashboardPage.Unavailable($"Failed to load queue statistics: {UiMessages.Friendly(ex)}");
 		}
+
+		await LoadProbe();
+	}
+
+	private async Task LoadProbe() {
+		var selectedProbe = SelectedProbe;
+		if (selectedProbe is null)
+			return;
+
+		try
+		{
+			ProbeResult = await NodeProbes.Read(selectedProbe.Key);
+		}
+		catch (OperationCanceledException)
+		{
+			throw;
+		}
+		catch (Exception ex)
+		{
+			ProbeResult = NodeProbeRead.Unavailable(selectedProbe, $"Failed to load probe: {UiMessages.Friendly(ex)}");
+		}
 	}
 
 	private string PressureStyle(QueueDashboardRow queue) {
@@ -279,14 +305,8 @@
 		return string.Format(CultureInfo.InvariantCulture, "width: {0:0.##}%", width);
 	}
 
-	private string ProbeLinkClass(ProbeLink probe) =>
+	private string ProbeLinkClass(NodeProbeDefinition probe) =>
 		string.Equals(probe.Key, Probe, StringComparison.OrdinalIgnoreCase)
 			? "rounded-2xl border border-es-green bg-es-green px-4 py-3 font-bold text-white shadow-lg shadow-es-green/20 hover:bg-es-forest hover:text-white focus:text-white"
 			: "rounded-2xl border border-es-ink/10 bg-white px-4 py-3 font-bold text-es-ink hover:border-es-green hover:text-es-forest";
-
-	private sealed record ProbeLink(
-		string Key,
-		string Title,
-		string Href,
-		string Description);
 }

--- a/src/EventStore.ClusterNode/Components/Services/NodeHttpRequestHelper.cs
+++ b/src/EventStore.ClusterNode/Components/Services/NodeHttpRequestHelper.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using EventStore.Common.Utils;
+using EventStore.Core;
+using Microsoft.AspNetCore.Http;
+
+namespace EventStore.ClusterNode.Components.Services;
+
+internal static class NodeHttpRequestHelper {
+	public static LocalHttpEndPoint GetLocalEndPoint(StandardComponents standardComponents) {
+		var endPoint = standardComponents.HttpServices
+			.SelectMany(x => x.EndPoints)
+			.FirstOrDefault();
+
+		if (endPoint is null)
+			throw new InvalidOperationException("Node HTTP endpoint is unavailable.");
+
+		return new LocalHttpEndPoint(LocalHostFor(endPoint), endPoint.GetPort());
+	}
+
+	public static Uri BuildUri(HttpRequest request, LocalHttpEndPoint endPoint, string path, string query) {
+		var normalizedPath = path.StartsWith('/') ? path : $"/{path}";
+		var builder = new UriBuilder(request.Scheme, endPoint.Host, endPoint.Port) {
+			Path = $"{request.PathBase}{normalizedPath}",
+			Query = query
+		};
+
+		return builder.Uri;
+	}
+
+	public static void CopyHeader(HttpRequest source, HttpRequestMessage target, string headerName) {
+		if (source.Headers.TryGetValue(headerName, out var value) && value.Count > 0)
+			target.Headers.TryAddWithoutValidation(headerName, value.ToArray());
+	}
+
+	private static string LocalHostFor(EndPoint endPoint) =>
+		endPoint switch {
+			IPEndPoint { Address: var address } when IPAddress.Any.Equals(address) => IPAddress.Loopback.ToString(),
+			IPEndPoint { Address: var address } when IPAddress.IPv6Any.Equals(address) => IPAddress.Loopback.ToString(),
+			IPEndPoint { Address: var address } => address.ToString(),
+			DnsEndPoint { Host: var host } when !string.IsNullOrWhiteSpace(host) => host,
+			_ => endPoint.GetHost()
+		};
+}
+
+internal readonly record struct LocalHttpEndPoint(string Host, int Port);

--- a/src/EventStore.ClusterNode/Components/Services/NodeHttpRequestHelper.cs
+++ b/src/EventStore.ClusterNode/Components/Services/NodeHttpRequestHelper.cs
@@ -10,7 +10,11 @@ namespace EventStore.ClusterNode.Components.Services;
 
 internal static class NodeHttpRequestHelper {
 	public static LocalHttpEndPoint GetLocalEndPoint(StandardComponents standardComponents) {
-		var endPoint = standardComponents.HttpServices
+		var httpServices = standardComponents.HttpServices;
+		if (httpServices is null || httpServices.Length == 0)
+			throw new InvalidOperationException("Node HTTP endpoint is unavailable.");
+
+		var endPoint = httpServices
 			.SelectMany(x => x.EndPoints)
 			.FirstOrDefault();
 

--- a/src/EventStore.ClusterNode/Components/Services/NodeProbeService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/NodeProbeService.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core;
+using EventStore.Core.Services.Transport.Http.NodeHttpClientFactory;
+using EventStore.Plugins.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+
+namespace EventStore.ClusterNode.Components.Services;
+
+public sealed class NodeProbeService : IDisposable {
+	private static readonly TimeSpan ReadTimeout = TimeSpan.FromSeconds(10);
+
+	public static readonly IReadOnlyList<NodeProbeDefinition> Probes = [
+		new(
+			"ping",
+			"Ping",
+			"/ping",
+			"Process availability probe.",
+			new Operation(Operations.Node.Ping)),
+		new(
+			"info",
+			"Node info",
+			"/info",
+			"Version, state, feature, and authentication metadata.",
+			new Operation(Operations.Node.Information.Read)),
+		new(
+			"gossip",
+			"Gossip",
+			"/gossip",
+			"Current cluster membership view.",
+			new Operation(Operations.Node.Gossip.ClientRead))
+	];
+
+	private static readonly JsonSerializerOptions IndentedJson = new() {
+		WriteIndented = true
+	};
+
+	private readonly IAuthorizationProvider _authorizationProvider;
+	private readonly IHttpContextAccessor _httpContextAccessor;
+	private readonly HttpClient _client;
+	private readonly LocalHttpEndPoint _nodeEndPoint;
+
+	public NodeProbeService(
+		IAuthorizationProvider authorizationProvider,
+		IHttpContextAccessor httpContextAccessor,
+		INodeHttpClientFactory nodeHttpClientFactory,
+		StandardComponents standardComponents) {
+		_authorizationProvider = authorizationProvider;
+		_httpContextAccessor = httpContextAccessor;
+		_nodeEndPoint = NodeHttpRequestHelper.GetLocalEndPoint(standardComponents);
+		_client = nodeHttpClientFactory.CreateHttpClient([_nodeEndPoint.Host]);
+	}
+
+	public async Task<NodeProbeRead> Read(string key, CancellationToken cancellationToken = default) {
+		var probe = Find(key);
+		if (probe is null)
+			return NodeProbeRead.Unselected();
+
+		if (!await HasAccess(probe.Operation, cancellationToken))
+			return NodeProbeRead.Unavailable(probe, $"{probe.Title} access was denied.");
+
+		try {
+			var context = _httpContextAccessor.HttpContext;
+			if (context is null)
+				return NodeProbeRead.Unavailable(probe, $"{probe.Title} is unavailable outside an HTTP request.");
+
+			using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+			timeout.CancelAfter(ReadTimeout);
+			using var request = new HttpRequestMessage(
+				HttpMethod.Get,
+				NodeHttpRequestHelper.BuildUri(context.Request, _nodeEndPoint, probe.Path, "format=json"));
+			NodeHttpRequestHelper.CopyHeader(context.Request, request, HeaderNames.Authorization);
+			NodeHttpRequestHelper.CopyHeader(context.Request, request, HeaderNames.Cookie);
+
+			using var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeout.Token);
+			if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+				return NodeProbeRead.Unavailable(probe, $"{probe.Title} access was denied.");
+
+			if (!response.IsSuccessStatusCode)
+				return NodeProbeRead.Unavailable(
+					probe,
+					$"{probe.Title} endpoint returned {(int)response.StatusCode} {response.ReasonPhrase}.");
+
+			var content = await response.Content.ReadAsStringAsync(timeout.Token);
+			return NodeProbeRead.Available(probe, FormatPayload(content));
+		} catch (TimeoutException) {
+			return NodeProbeRead.Unavailable(probe, $"Timed out reading {probe.Title.ToLowerInvariant()}.");
+		} catch (OperationCanceledException) {
+			if (cancellationToken.IsCancellationRequested)
+				throw;
+
+			return NodeProbeRead.Unavailable(probe, $"Timed out reading {probe.Title.ToLowerInvariant()}.");
+		} catch (Exception ex) {
+			return NodeProbeRead.Unavailable(probe, $"Unable to read {probe.Title.ToLowerInvariant()}: {UiMessages.Friendly(ex)}");
+		}
+	}
+
+	public void Dispose() =>
+		_client.Dispose();
+
+	public static NodeProbeDefinition Find(string key) =>
+		Probes.FirstOrDefault(x => string.Equals(x.Key, key, StringComparison.OrdinalIgnoreCase));
+
+	private ClaimsPrincipal CurrentUser =>
+		_httpContextAccessor.HttpContext?.User ?? new ClaimsPrincipal(new ClaimsIdentity());
+
+	private Task<bool> HasAccess(Operation operation, CancellationToken cancellationToken) =>
+		_authorizationProvider.CheckAccessAsync(CurrentUser, operation, cancellationToken).AsTask();
+
+	private static string FormatPayload(string content) {
+		if (string.IsNullOrWhiteSpace(content))
+			return "";
+
+		try {
+			using var document = JsonDocument.Parse(content);
+			return JsonSerializer.Serialize(document.RootElement, IndentedJson);
+		} catch (JsonException) {
+			return content;
+		}
+	}
+}
+
+public sealed record NodeProbeDefinition(
+	string Key,
+	string Title,
+	string Path,
+	string Description,
+	Operation Operation);
+
+public sealed record NodeProbeRead(
+	NodeProbeDefinition Probe,
+	string Content,
+	string Message) {
+	public bool HasProbe => Probe is not null;
+	public bool IsAvailable => string.IsNullOrWhiteSpace(Message);
+
+	public static NodeProbeRead Unselected() => new(null, "", "");
+
+	public static NodeProbeRead Available(NodeProbeDefinition probe, string content) =>
+		new(probe, content, "");
+
+	public static NodeProbeRead Unavailable(NodeProbeDefinition probe, string message) =>
+		new(probe, "", message);
+}

--- a/src/EventStore.ClusterNode/Components/Services/QueueDashboardService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/QueueDashboardService.cs
@@ -8,7 +8,6 @@ using System.Security.Claims;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using EventStore.Common.Utils;
 using EventStore.Core;
 using EventStore.Core.Services.Transport.Grpc;
 using EventStore.Core.Services.Transport.Http.NodeHttpClientFactory;
@@ -34,7 +33,7 @@ public sealed class QueueDashboardService : IDisposable {
 		StandardComponents standardComponents) {
 		_authorizationProvider = authorizationProvider;
 		_httpContextAccessor = httpContextAccessor;
-		_statsEndPoint = GetLocalStatsEndPoint(standardComponents);
+		_statsEndPoint = NodeHttpRequestHelper.GetLocalEndPoint(standardComponents);
 		_client = nodeHttpClientFactory.CreateHttpClient([_statsEndPoint.Host]);
 	}
 
@@ -49,9 +48,11 @@ public sealed class QueueDashboardService : IDisposable {
 
 			using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 			timeout.CancelAfter(ReadTimeout);
-			using var request = new HttpRequestMessage(HttpMethod.Get, BuildStatsUri(context.Request, _statsEndPoint));
-			CopyHeader(context.Request, request, HeaderNames.Authorization);
-			CopyHeader(context.Request, request, HeaderNames.Cookie);
+			using var request = new HttpRequestMessage(
+				HttpMethod.Get,
+				NodeHttpRequestHelper.BuildUri(context.Request, _statsEndPoint, "/stats", "format=json"));
+			NodeHttpRequestHelper.CopyHeader(context.Request, request, HeaderNames.Authorization);
+			NodeHttpRequestHelper.CopyHeader(context.Request, request, HeaderNames.Cookie);
 
 			using var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeout.Token);
 			if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
@@ -85,40 +86,6 @@ public sealed class QueueDashboardService : IDisposable {
 	private Task<bool> HasAccess(Operation operation, CancellationToken cancellationToken) =>
 		_authorizationProvider.CheckAccessAsync(CurrentUser, operation, cancellationToken).AsTask();
 
-	private static LocalHttpEndPoint GetLocalStatsEndPoint(StandardComponents standardComponents) {
-		var endPoint = standardComponents.HttpServices
-			.SelectMany(x => x.EndPoints)
-			.FirstOrDefault();
-
-		if (endPoint is null)
-			throw new InvalidOperationException("Node HTTP endpoint is unavailable.");
-
-		return new LocalHttpEndPoint(LocalHostFor(endPoint), endPoint.GetPort());
-	}
-
-	private static string LocalHostFor(EndPoint endPoint) =>
-		endPoint switch {
-			IPEndPoint { Address: var address } when IPAddress.Any.Equals(address) => IPAddress.Loopback.ToString(),
-			IPEndPoint { Address: var address } when IPAddress.IPv6Any.Equals(address) => IPAddress.Loopback.ToString(),
-			IPEndPoint { Address: var address } => address.ToString(),
-			DnsEndPoint { Host: var host } when !string.IsNullOrWhiteSpace(host) => host,
-			_ => endPoint.GetHost()
-		};
-
-	private static Uri BuildStatsUri(HttpRequest request, LocalHttpEndPoint statsEndPoint) {
-		var builder = new UriBuilder(request.Scheme, statsEndPoint.Host, statsEndPoint.Port) {
-			Path = $"{request.PathBase}/stats",
-			Query = "format=json"
-		};
-
-		return builder.Uri;
-	}
-
-	private static void CopyHeader(HttpRequest source, HttpRequestMessage target, string headerName) {
-		if (source.Headers.TryGetValue(headerName, out var value) && value.Count > 0)
-			target.Headers.TryAddWithoutValidation(headerName, value.ToArray());
-	}
-
 	private static QueueDashboardPage ParseQueueStats(JsonDocument document) {
 		if (!document.RootElement.TryGetProperty("es", out var es) ||
 		    !es.TryGetProperty("queue", out var queueStats) ||
@@ -135,8 +102,6 @@ public sealed class QueueDashboardService : IDisposable {
 		return QueueDashboardPage.Success(queues);
 	}
 }
-
-internal readonly record struct LocalHttpEndPoint(string Host, int Port);
 
 public sealed record QueueDashboardPage(
 	IReadOnlyList<QueueDashboardBlock> Blocks,

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -270,6 +270,7 @@ internal static class Program
 					builder.Services.AddScoped<ProjectionBrowserService>();
 					builder.Services.AddScoped<QueryBrowserService>();
 					builder.Services.AddSingleton<QueueDashboardService>();
+					builder.Services.AddSingleton<NodeProbeService>();
 					builder.Services.AddScoped<StreamBrowserService>();
 					builder.Services.AddScoped<SubscriptionBrowserService>();
 					builder.Services.AddScoped<UserBrowserService>();

--- a/src/EventStore.ClusterNode/ui-assets/js/cluster-status.js
+++ b/src/EventStore.ClusterNode/ui-assets/js/cluster-status.js
@@ -370,9 +370,10 @@
 	function appendActions(row, member) {
 		var cell = element("td", "px-5 py-4 text-right");
 		var wrap = element("div", "flex flex-wrap justify-end gap-2");
-		appendLink(wrap, "Ping", "//" + endpoint(member.httpHost, member.httpPort) + "/ping?format=json");
-		appendLink(wrap, "Open", "//" + endpoint(member.httpHost, member.httpPort));
-		appendLink(wrap, "Gossip", "//" + endpoint(member.httpHost, member.httpPort) + "/gossip?format=json");
+		var httpEndpoint = endpoint(member.httpHost, member.httpPort);
+		appendLink(wrap, "Ping", "//" + httpEndpoint + "/ui?probe=ping");
+		appendLink(wrap, "Open", "//" + httpEndpoint + "/ui");
+		appendLink(wrap, "Gossip", "//" + httpEndpoint + "/ui?probe=gossip");
 		cell.appendChild(wrap);
 		row.appendChild(cell);
 	}
@@ -535,8 +536,6 @@
 	function appendLink(parent, label, href) {
 		var link = element("a", "rounded-full border border-es-ink/10 px-3 py-1.5 text-xs font-bold text-es-ink hover:border-es-green hover:text-es-forest");
 		link.href = href;
-		link.target = "_blank";
-		link.rel = "noopener noreferrer";
 		link.textContent = label;
 		parent.appendChild(link);
 	}


### PR DESCRIPTION
- Keep routine node diagnostics inside the Razor workspace instead of embedding raw endpoint responses.\n- Preserve cluster follow-up checks without reopening the old raw endpoint navigation seam.