### PR TITLE
chore(docs): refresh admin ui guidance

### DIFF
--- a/docs/admin-ui.md
+++ b/docs/admin-ui.md
@@ -4,108 +4,73 @@ title: Admin UI
 
 # Admin UI
 
-The EventStoreDB Admin UI is available at _SERVER_IP:2113_ and helps you interact with and manage a cluster in a visual way. This guide explains the tabs of the interface and what they do.
-
-::: tip
-The embedded EventStoreDB web interface is reaching its end of life. We are working on a replacement, and you can try using the Early Preview of [Event Store Navigator](https://learn.eventstore.com/event-store-navigator-preview) app instead. It doesn't have full feature parity with the embedded web UI, but it already has usability improvements compared to it.
-:::
+The EventStoreDB Admin UI is available at `http://SERVER_IP:2113/ui` and helps operators inspect and manage a node or cluster from the browser.
 
 ## Dashboard
 
-![Web admin interface dashboard](./images/wai-dashboard.png)
+The dashboard opens at `/ui` and combines the daily operational view in one place:
 
-The _Dashboard_ tab shows an overview of active queues with associated statistics in the top half. The _+_ icon indicates a queue group, click it to reveal the queues that are part of the group.
+- _Cluster status_: live gossip membership, node state, checkpoints, TCP and HTTP endpoints, replica status, and a copy-friendly snapshot.
+- _Queue pressure_: live queue length, throughput, processing time, and currently processed messages.
+- _Node probes_: inline Ping, Node info, and Gossip checks rendered inside the UI.
 
-The second half of the tab shows active connections to EventStoreDB and information about them.
+## Navigator
 
-Click the _Snapshot_ button in the top right to output a snapshot of all queue statistics at the time you clicked the button.
+The _Navigator_ page links to the main workspace areas: streams, queries, projections, subscriptions, users, operations, observability, and configuration.
 
-## Stream browser
+## Observability
 
-![Web admin interface stream browser tab](./images/wai-stream-browser.png)
+The _Observability_ page focuses on runtime diagnostics:
 
-The _Stream Browser_ tab gives an overview of recently created and changed streams, clicking on an individual stream shows details about the individual stream.
+- queue groups and individual queue rows
+- current and last processed messages
+- TCP connection statistics
+- snapshot output for copy-paste debugging
 
-### Event stream
+## Configuration
 
-![Web admin interface stream details](./images/wai-stream-details.png)
+The _Configuration_ page shows node version information, loaded configuration options, and optional subsystem status.
 
-Each stream shows pages of the events in a stream with an overview of the event. Click the _Name_ to see the EventId, and _JSON_ to see the event data. The buttons above change depending on what you are viewing in the interface. The _Back_ button takes you to the parent screen.
+## Streams
 
-The buttons on the top right when you are viewing an event stream are:
+The _Streams_ page lets you find recently created or changed streams and open a stream by name. Stream detail pages provide:
 
-- _Pause_: Stop showing events arriving into this stream.
-- _Resume_: Resume showing events arriving into this stream.
-- _Edit ACL_: Edit [the access control lists](security.md#access-control-lists) for a stream.
-- _Add Event_: [Add a new event](@clients/http-api/README.md#appending-events) to the stream.
-- _Delete_: [Delete a stream](@clients/http-api/README.md#deleting-a-stream) to the stream.
-- _Query_:
+- paged event browsing
+- event detail views with data and metadata
+- append, metadata, ACL, delete, and query actions
 
-The buttons on the left above the events when you are viewing an event stream are:
-
-- _self_: Takes you to the overview of the stream.
-- _first_: Takes you to the first page of events in a stream.
-- _previous_: Takes you to the previous page of events in a stream.
-- _metadata_: Shows the metadata of a stream.
-  - On the metadata screen, click _Add New Like This_ to add a new event to the stream.
-
-## Projections
-
-![Web admin interface projections tab](./images/wai-projections.png)
-
-The _Projections_ tab shows system and user created projections defined in EventStoreDB, the buttons above the list do the following:
-
-- _Disable All_: Disable all running projections.
-- _Enable All_: Enable all stopped projections.
-- _Include Queries_: Toggle displaying queries in the Projections table.
-- _New Projection_: [Create a user-defined projection](projections.md#user-defined-projections) with the Admin UI.
-
-Clicking an individual projection shows further details.
-
-![Web admin interface projection details](./images/wai-projection-details.jpg)
-
-On the left is the projection definition. On the right are the stats, results, and state of the projection. The buttons above the details do the following:
-
-- _Start_: Start a stopped projection.
-- _Stop_: Stop a running projection.
-- _Edit_: Edit the projection definition.
-- _Config_: [Set configuration options](projections.md#configuring-projections) for a projection.
-- _Debug_: Opens [the debugging interface](projections.md#debugging) to debug what effect a projection is having on events.
-- _Delete_: Delete a projection.
-- _Reset_: Reset a projection.
-- _Back_: Returns you to the parent screen.
+The stream browser depends on AtomPub over HTTP. Enable AtomPub if the stream browsing controls are unavailable.
 
 ## Query
 
-The _Query_ tab has a code editor field where you can create transient and short-lived projections for quick analysis of your event streams.
+The _Query_ page runs transient JavaScript projections for short-lived analysis and can stop the generated transient projection from the same page.
 
-![Web admin interface query details](./images/wai-query-details.png)
+## Projections
 
-## Persistent subscriptions
+The _Projections_ page shows user, system, and optionally transient projections. It supports creating projections, creating standard projections, bulk enable or disable, and opening a projection for inspection.
 
-The _Persistent Subscriptions_ tab shows an overview of [persistent subscriptions](persistent-subscriptions.md) configured on streams. The button above the list does the following:
+Projection detail pages provide source, status, config, state, result, debug, edit, reset, and delete workflows. Projection features are available when projections are enabled on the node.
 
-- _New Subscription_: Create a new subscription.
+## Subscriptions
 
-Clicking the _+_ icon next to a stream name reveals the subscription name and more buttons. The _Back_ button takes you to the parent screen.
-
-- _Edit_: Edit the subscription.
-- _Delete_: Delete the subscription.
-- _Detail_: Shows the subscription configuration options.
-- _Replay Parked Messages_: Replay events in subscription to return state.
-
-## Admin
-
-![Web admin interface projections tab](./images/wai-admin.png)
-
-The _Admin_ tab shows subsystems enabled (currently only [projections](projections.md)) on EventStoreDB and [scavenges](operations.md#scavenging) run. You can start a new scavenge operation by clicking the _Scavenge_ button, and shut EventStoreDB down by clicking the _Shutdown Server_ button.
+The _Subscriptions_ page lists persistent subscriptions by stream and group. Detail pages show connection state, lag, settings, parked messages, and replay/edit/delete actions.
 
 ## Users
 
-![Web admin interface projections tab](./images/wai-users.png)
+The _Users_ page shows the active request identity and user accounts. It supports creating users, editing user details, resetting passwords, and enabling, disabling, or deleting accounts.
 
-The _Users_ tab shows [the users defined in EventStoreDB](security.md#authentication), clicking an individual user shows a JSON representation of that user's details.
+## Operations
 
-## Log out
+The _Operations_ page provides privileged node actions:
 
-Logs you out of the Admin UI interface.
+- start and inspect scavenges
+- stop active scavenges
+- merge indexes
+- set node priority
+- reload trusted certificates
+- request node shutdown
+- inspect optional subsystem status
+
+## Sign in and sign out
+
+The UI supports the node authentication providers configured for the server. Use _Sign out_ to clear the UI credentials for the current browser session.


### PR DESCRIPTION
- Avoid steering operators toward a replacement story after the embedded Razor workspace became the primary admin surface.\n- Keep the Admin UI guide aligned with the current operational pages so readers do not rely on stale Angular-era navigation.