### PR TITLE
fix(persistent-subscriptions): prevent checkpoint drift and push stalls

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
+++ b/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
@@ -685,6 +685,12 @@ public abstract class TestFixtureWithExistingEvents<TLogFormat, TStreamId> : Tes
 			list.Add(BuildEvent(record.Value, message.ResolveLinkTos, record.Key.CommitPosition));
 		}
 
+		if (records.IsEmpty())
+		{
+			var lastPos = _all.Keys[^1];
+			next = new TFPos(lastPos.CommitPosition, lastPos.PreparePosition + 1);
+		}
+
 		var events = list.ToArray();
 		message.Envelope.ReplyWith(
 			new ClientMessage.FilteredReadAllEventsForwardCompleted(

--- a/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
+++ b/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
@@ -685,7 +685,7 @@ public abstract class TestFixtureWithExistingEvents<TLogFormat, TStreamId> : Tes
 			list.Add(BuildEvent(record.Value, message.ResolveLinkTos, record.Key.CommitPosition));
 		}
 
-		if (records.IsEmpty())
+		if (records.IsEmpty() && _all.Count > 0)
 		{
 			var lastPos = _all.Keys[^1];
 			next = new TFPos(lastPos.CommitPosition, lastPos.PreparePosition + 1);

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -2658,9 +2658,10 @@ public class CheckpointingWithSkippedEvents
 				.StartFromCurrent());
 		reader.Load(null);
 
-		var correlationId = Guid.NewGuid();
-		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", client1Envelope, 1, "foo", "bar");
-		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", client2Envelope, 1000, "foo", "bar");
+		var client1CorrelationId = Guid.NewGuid();
+		var client2CorrelationId = Guid.NewGuid();
+		sub.AddClient(client1CorrelationId, Guid.NewGuid(), "connection-1", client1Envelope, 1, "foo", "bar");
+		sub.AddClient(client2CorrelationId, Guid.NewGuid(), "connection-2", client2Envelope, 1000, "foo", "bar");
 
 		var message11 = WriteEventForStream1();
 		var message12 = WriteEventForStream1();
@@ -2678,19 +2679,19 @@ public class CheckpointingWithSkippedEvents
 		Assert.AreEqual(2, streamBuffer.BufferCount);
 		Assert.IsNull(checkpoint);
 
-		sub.AcknowledgeMessagesProcessed(correlationId, new[] { message11 });
+		sub.AcknowledgeMessagesProcessed(client1CorrelationId, new[] { message11 });
 		pushScheduler.Push(sub);
 		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(0), checkpoint);
 
-		sub.AcknowledgeMessagesProcessed(correlationId, new[] { message21, message22, message23 });
+		sub.AcknowledgeMessagesProcessed(client2CorrelationId, new[] { message21, message22, message23 });
 		pushScheduler.Push(sub);
 		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(0), checkpoint);
 
-		sub.AcknowledgeMessagesProcessed(correlationId, new[] { message12 });
+		sub.AcknowledgeMessagesProcessed(client1CorrelationId, new[] { message12 });
 		pushScheduler.Push(sub);
 		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(1), checkpoint);
 
-		sub.AcknowledgeMessagesProcessed(correlationId, new[] { message13 });
+		sub.AcknowledgeMessagesProcessed(client1CorrelationId, new[] { message13 });
 		pushScheduler.Push(sub);
 		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(5), checkpoint);
 
@@ -2737,8 +2738,8 @@ public class CheckpointingWithNoMoreCapacity
 				.StartFromCurrent());
 		reader.Load(null);
 
-		var correlationId = Guid.NewGuid();
-		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", clientEnvelope, 1, "foo", "bar");
+		var clientCorrelationId = Guid.NewGuid();
+		sub.AddClient(clientCorrelationId, Guid.NewGuid(), "connection-1", clientEnvelope, 1, "foo", "bar");
 
 		var message1 = WriteEvent();
 		var message2 = WriteEvent();
@@ -2747,12 +2748,12 @@ public class CheckpointingWithNoMoreCapacity
 		Assert.AreEqual(1, clientEnvelope.Replies.Count);
 		Assert.IsNull(checkpoint);
 
-		sub.AcknowledgeMessagesProcessed(correlationId, new[] { message1 });
+		sub.AcknowledgeMessagesProcessed(clientCorrelationId, new[] { message1 });
 		pushScheduler.Push(sub);
 		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(0), checkpoint);
 		Assert.AreEqual(2, clientEnvelope.Replies.Count);
 
-		sub.AcknowledgeMessagesProcessed(correlationId, new[] { message2 });
+		sub.AcknowledgeMessagesProcessed(clientCorrelationId, new[] { message2 });
 		pushScheduler.Push(sub);
 		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(1), checkpoint);
 

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -10,6 +10,7 @@ using EventStore.ClientAPI.Common;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Helpers;
+using EventStore.Core.Index.Hashes;
 using EventStore.Core.LogAbstraction;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
@@ -436,6 +437,37 @@ public class LiveTests
 		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope, 10, "foo", "bar");
 		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(0, _eventSource));
 		Assert.AreEqual(1, envelope.Replies.Count);
+	}
+
+	[Test]
+	public void live_subscription_coalesces_scheduled_pushes()
+	{
+		var envelope = new FakeEnvelope();
+		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
+		var sub = new Core.Services.PersistentSubscription.PersistentSubscription(
+			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
+				.WithEventLoader(new FakeStreamReader())
+				.WithCheckpointReader(reader)
+				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
+				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
+				.StartFromCurrent());
+		reader.Load(null);
+
+		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope, 10, "foo", "bar");
+		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(0, _eventSource));
+		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(1, _eventSource));
+		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(2, _eventSource));
+
+		Assert.AreEqual(1, pushScheduler.ScheduleCount);
+		Assert.AreEqual(0, envelope.Replies.Count);
+
+		pushScheduler.Push(sub);
+		Assert.AreEqual(3, envelope.Replies.Count);
+
+		sub.NotifyLiveSubscriptionMessage(Helper.GetFakeEventFor(3, _eventSource));
+		Assert.AreEqual(2, pushScheduler.ScheduleCount);
 	}
 
 	[Test]
@@ -2598,6 +2630,142 @@ public class DeadlockTest<TLogFormat, TStreamId> : SpecificationWithMiniNode<TLo
 	}
 }
 
+public class CheckpointingWithSkippedEvents
+{
+	[Test]
+	public void checkpointing_works_when_events_are_skipped_by_the_consumer_strategy()
+	{
+		var categoryVersion = 0;
+		var stream1Version = 0;
+		var stream2Version = 0;
+
+		IPersistentSubscriptionStreamPosition checkpoint = null;
+		var client1Envelope = new FakeEnvelope();
+		var client2Envelope = new FakeEnvelope();
+		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
+		const string subscriptionStream = "$ce-streamName";
+		var sub = new Core.Services.PersistentSubscription.PersistentSubscription(
+			PersistentSubscriptionToStreamParamsBuilder.CreateFor(subscriptionStream, "groupName")
+				.WithEventLoader(new FakeStreamReader())
+				.WithCheckpointReader(reader)
+				.WithCheckpointWriter(new FakeCheckpointWriter(x => checkpoint = x))
+				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
+				.MinimumToCheckPoint(1)
+				.MaximumToCheckPoint(1)
+				.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
+				.StartFromCurrent());
+		reader.Load(null);
+
+		var correlationId = Guid.NewGuid();
+		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", client1Envelope, 1, "foo", "bar");
+		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", client2Envelope, 1000, "foo", "bar");
+
+		var message11 = WriteEventForStream1();
+		var message12 = WriteEventForStream1();
+		var message13 = WriteEventForStream1();
+		pushScheduler.Push(sub);
+
+		var message21 = WriteEventForStream2();
+		var message22 = WriteEventForStream2();
+		var message23 = WriteEventForStream2();
+		pushScheduler.Push(sub);
+
+		Assert.AreEqual(1, client1Envelope.Replies.Count);
+		Assert.AreEqual(3, client2Envelope.Replies.Count);
+		Assert.True(sub.TryGetStreamBuffer(out var streamBuffer));
+		Assert.AreEqual(2, streamBuffer.BufferCount);
+		Assert.IsNull(checkpoint);
+
+		sub.AcknowledgeMessagesProcessed(correlationId, new[] { message11 });
+		pushScheduler.Push(sub);
+		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(0), checkpoint);
+
+		sub.AcknowledgeMessagesProcessed(correlationId, new[] { message21, message22, message23 });
+		pushScheduler.Push(sub);
+		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(0), checkpoint);
+
+		sub.AcknowledgeMessagesProcessed(correlationId, new[] { message12 });
+		pushScheduler.Push(sub);
+		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(1), checkpoint);
+
+		sub.AcknowledgeMessagesProcessed(correlationId, new[] { message13 });
+		pushScheduler.Push(sub);
+		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(5), checkpoint);
+
+		Guid WriteEventForStream1()
+		{
+			var id = Guid.NewGuid();
+			sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(id, subscriptionStream, categoryVersion++,
+				Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", stream1Version++), false));
+			return id;
+		}
+
+		Guid WriteEventForStream2()
+		{
+			var id = Guid.NewGuid();
+			sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(id, subscriptionStream, categoryVersion++,
+				Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", stream2Version++), false));
+			return id;
+		}
+	}
+}
+
+public class CheckpointingWithNoMoreCapacity
+{
+	[Test]
+	public void checkpoint_is_correct_when_message_hits_no_more_capacity_then_succeeds()
+	{
+		var version = 0;
+
+		IPersistentSubscriptionStreamPosition checkpoint = null;
+		var clientEnvelope = new FakeEnvelope();
+		var reader = new FakeCheckpointReader();
+		var pushScheduler = new FakePushScheduler();
+		const string subscriptionStream = "streamName";
+		var sub = new Core.Services.PersistentSubscription.PersistentSubscription(
+			PersistentSubscriptionToStreamParamsBuilder.CreateFor(subscriptionStream, "groupName")
+				.WithEventLoader(new FakeStreamReader())
+				.WithCheckpointReader(reader)
+				.WithCheckpointWriter(new FakeCheckpointWriter(x => checkpoint = x))
+				.WithMessageParker(new FakeMessageParker())
+				.WithPushScheduler(pushScheduler)
+				.MinimumToCheckPoint(1)
+				.MaximumToCheckPoint(1)
+				.PreferRoundRobin()
+				.StartFromCurrent());
+		reader.Load(null);
+
+		var correlationId = Guid.NewGuid();
+		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", clientEnvelope, 1, "foo", "bar");
+
+		var message1 = WriteEvent();
+		var message2 = WriteEvent();
+		pushScheduler.Push(sub);
+
+		Assert.AreEqual(1, clientEnvelope.Replies.Count);
+		Assert.IsNull(checkpoint);
+
+		sub.AcknowledgeMessagesProcessed(correlationId, new[] { message1 });
+		pushScheduler.Push(sub);
+		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(0), checkpoint);
+		Assert.AreEqual(2, clientEnvelope.Replies.Count);
+
+		sub.AcknowledgeMessagesProcessed(correlationId, new[] { message2 });
+		pushScheduler.Push(sub);
+		Assert.AreEqual(new PersistentSubscriptionSingleStreamPosition(1), checkpoint);
+
+		Guid WriteEvent()
+		{
+			var id = Guid.NewGuid();
+			sub.NotifyLiveSubscriptionMessage(
+				Helper.BuildFakeEvent(id, "type", subscriptionStream, version++));
+			return id;
+		}
+	}
+}
+
 public static class Helper
 {
 	public static PersistentSubscriptionParamsBuilder CreatePersistentSubscriptionBuilderFor(EventSource eventSource)
@@ -2831,5 +2999,25 @@ class FakeCheckpointWriter : IPersistentSubscriptionCheckpointWriter
 	public void BeginDelete(Action<IPersistentSubscriptionCheckpointWriter> completed)
 	{
 		_deleteAction?.Invoke();
+	}
+}
+
+class FakePushScheduler : IPersistentSubscriptionPushScheduler
+{
+	private bool _pushScheduled;
+
+	public int ScheduleCount { get; private set; }
+
+	public void SchedulePush()
+	{
+		ScheduleCount++;
+		_pushScheduled = true;
+	}
+
+	public void Push(Core.Services.PersistentSubscription.PersistentSubscription subscription)
+	{
+		Assert.True(_pushScheduled, "Push was not scheduled");
+		_pushScheduled = false;
+		subscription.PushToClientsFromSchedule();
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.Tests.cs
@@ -77,7 +77,7 @@ public partial class EnumeratorTests
 			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
 			var response = await sub.GetNext();
 			Assert.IsInstanceOf<Checkpoint>(response);
-			Assert.True(((Checkpoint)response).CheckpointPosition < Position.End);
+			Assert.AreEqual(Position.Start, ((Checkpoint)response).CheckpointPosition);
 			Assert.True(await sub.GetNext() is CaughtUp);
 		}
 	}
@@ -150,7 +150,8 @@ public partial class EnumeratorTests
 			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
 			var response = await sub.GetNext();
 			Assert.IsInstanceOf<Checkpoint>(response);
-			Assert.True(((Checkpoint)response).CheckpointPosition < Position.End);
+			Assert.AreEqual(new Position((ulong)_subscribeFrom.CommitPosition, (ulong)_subscribeFrom.PreparePosition),
+				((Checkpoint)response).CheckpointPosition);
 			Assert.True(await sub.GetNext() is CaughtUp);
 		}
 	}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1247,6 +1247,7 @@ public class ClusterVNode<TStreamId> :
 		_mainBus.Subscribe<MonitoringMessage.GetStreamPersistentSubscriptionStats>(perSubscrQueue);
 		_mainBus.Subscribe<MonitoringMessage.GetPersistentSubscriptionStats>(perSubscrQueue);
 		_mainBus.Subscribe<SubscriptionMessage.PersistentSubscriptionTimerTick>(perSubscrQueue);
+		_mainBus.Subscribe<SubscriptionMessage.PersistentSubscriptionPushToClients>(perSubscrQueue);
 		_mainBus.Subscribe<SubscriptionMessage.PersistentSubscriptionsRestart>(perSubscrQueue);
 
 		//TODO CC can have multiple threads working on subscription if partition
@@ -1279,6 +1280,7 @@ public class ClusterVNode<TStreamId> :
 		perSubscrBus.Subscribe<MonitoringMessage.GetPersistentSubscriptionStats>(persistentSubscription);
 		perSubscrBus.Subscribe<TelemetryMessage.Request>(persistentSubscription);
 		perSubscrBus.Subscribe<SubscriptionMessage.PersistentSubscriptionTimerTick>(persistentSubscription);
+		perSubscrBus.Subscribe<SubscriptionMessage.PersistentSubscriptionPushToClients>(persistentSubscription);
 		perSubscrBus.Subscribe<SubscriptionMessage.PersistentSubscriptionsRestart>(persistentSubscription);
 
 		// STORAGE SCAVENGER

--- a/src/EventStore.Core/Data/TFPos.cs
+++ b/src/EventStore.Core/Data/TFPos.cs
@@ -5,6 +5,7 @@ namespace EventStore.Core.Data {
 	public struct TFPos : IEquatable<TFPos>, IComparable<TFPos> {
 		public static readonly TFPos Invalid = new TFPos(-1, -1);
 		public static readonly TFPos HeadOfTf = new TFPos(-1, -1);
+		public static readonly TFPos FirstRecordOfTf = new TFPos(0, 0);
 
 		public readonly long CommitPosition;
 		public readonly long PreparePosition;

--- a/src/EventStore.Core/Messages/SubscriptionMessage.cs
+++ b/src/EventStore.Core/Messages/SubscriptionMessage.cs
@@ -46,7 +46,16 @@ namespace EventStore.Core.Messages {
 				CorrelationId = correlationId;
 			}
 		}
-		
+
+		[DerivedMessage(CoreMessage.Subscription)]
+		public partial class PersistentSubscriptionPushToClients : Message {
+			public string SubscriptionId { get; }
+
+			public PersistentSubscriptionPushToClients(string subscriptionId) {
+				SubscriptionId = subscriptionId;
+			}
+		}
+
 		[DerivedMessage(CoreMessage.Subscription)]
 		public partial class PersistentSubscriptionsRestart : Message {
 			public IEnvelope ReplyEnvelope { get; }

--- a/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionPushScheduler.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionPushScheduler.cs
@@ -1,0 +1,5 @@
+namespace EventStore.Core.Services.PersistentSubscription {
+	public interface IPersistentSubscriptionPushScheduler {
+		void SchedulePush();
+	}
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -246,7 +246,15 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			if (!shouldSchedule)
 				return;
 
-			_settings.PushScheduler.SchedulePush();
+			try {
+				_settings.PushScheduler.SchedulePush();
+			} catch {
+				lock (_lock) {
+					_pushScheduled = false;
+				}
+
+				throw;
+			}
 		}
 
 		public void PushToClientsFromSchedule() {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -47,6 +47,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		private IPersistentSubscriptionStreamPosition _lastKnownMessage;
 		private readonly object _lock = new object();
 		private bool _faulted;
+		private bool _pushScheduled;
 
 		public bool HasClients {
 			get { return _pushClients.Count > 0; }
@@ -222,35 +223,57 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 				_nextEventToPullFrom = newPosition;
 				TryReadingNewBatch();
-				TryPushingMessagesToClients();
+				SchedulePushToClients();
 			}
 		}
 
-		private void TryPushingMessagesToClients() {
+		private void SchedulePushToClients() {
+			if (_settings.PushScheduler == null) {
+				PushToClients();
+				return;
+			}
+
+			if (_pushScheduled)
+				return;
+
+			_pushScheduled = true;
+			_settings.PushScheduler.SchedulePush();
+		}
+
+		public void PushToClientsFromSchedule() {
+			lock (_lock) {
+				_pushScheduled = false;
+				PushToClients();
+			}
+		}
+
+		private void PushToClients() {
 			lock (_lock) {
 				if (!TryGetStreamBuffer(out var streamBuffer))
 					return;
 
 				foreach (StreamBuffer.OutstandingMessagePointer messagePointer in streamBuffer.Scan()) {
-					//optimistically assume that the message will be pushed
-					//if it is, then we will increment the next sequence number if a new one was assigned
-					//if it is not, then we will not increment the next sequence number
 					(OutstandingMessage message, bool newSequenceNumberAssigned) =
 						OutstandingMessage.ForPushedEvent(messagePointer.Message, _nextSequenceNumber, _lastKnownMessage);
 					ConsumerPushResult result =
 						_pushClients.PushMessageToClient(message);
+
+					if (newSequenceNumberAssigned && result is ConsumerPushResult.Sent or ConsumerPushResult.Skipped) {
+						_lastKnownSequenceNumber = _nextSequenceNumber++;
+						_lastKnownMessage = message.EventPosition;
+					}
+
 					if (result == ConsumerPushResult.Sent) {
 						messagePointer.MarkSent();
-
-						if (newSequenceNumberAssigned) {
-							//the message was pushed and a new sequence number was assigned
-							//so we increment the next sequence number
-							_nextSequenceNumber++;
-						}
-
 						MarkBeginProcessing(message);
 					} else if (result == ConsumerPushResult.Skipped) {
-						// The consumer strategy skipped the message so leave it in the buffer and continue.
+						if (newSequenceNumberAssigned) {
+							Debug.Assert(!messagePointer.IsRetry);
+							messagePointer.MarkSent();
+							streamBuffer.AddRetryToEnd(message);
+						} else {
+							Debug.Assert(messagePointer.IsRetry);
+						}
 					} else if (result == ConsumerPushResult.NoMoreCapacity) {
 						return;
 					}
@@ -286,7 +309,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 						_nextEventToPullFrom = _settings.EventSource.GetStreamPositionFor(resolvedEvent);
 				}
 
-				TryPushingMessagesToClients();
+				SchedulePushToClients();
 			}
 		}
 
@@ -300,9 +323,11 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					(OutstandingMessage message, bool newSequenceNumberAssigned) =
 						OutstandingMessage.ForPushedEvent(messagePointer.Message, _nextSequenceNumber, _lastKnownMessage);
 					if (newSequenceNumberAssigned) {
-						_nextSequenceNumber++;
+						_lastKnownSequenceNumber = _nextSequenceNumber++;
+						_lastKnownMessage = message.EventPosition;
 					}
-					MarkBeginProcessing(message); //sequence number will be incremented in this call if a new one has been assigned
+
+					MarkBeginProcessing(message);
 					yield return (messagePointer.Message.ResolvedEvent, messagePointer.Message.RetryCount);
 				}
 			}
@@ -310,10 +335,6 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 		private void MarkBeginProcessing(OutstandingMessage message) {
 			_statistics.IncrementProcessed();
-			if (message.EventSequenceNumber > _lastKnownSequenceNumber) {
-				_lastKnownSequenceNumber = message.EventSequenceNumber.Value;
-				_lastKnownMessage = _settings.EventSource.GetStreamPositionFor(message.ResolvedEvent);
-			}
 
 			StartMessage(message,
 				_settings.MessageTimeout == TimeSpan.MaxValue
@@ -335,7 +356,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					return;
 				}
 
-				TryPushingMessagesToClients();
+				SchedulePushToClients();
 			}
 		}
 
@@ -365,7 +386,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					RetryMessage(m);
 				}
 
-				TryPushingMessagesToClients();
+				SchedulePushToClients();
 				return true;
 			}
 		}
@@ -378,7 +399,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					RetryMessage(m);
 				}
 
-				TryPushingMessagesToClients();
+				SchedulePushToClients();
 			}
 		}
 
@@ -447,7 +468,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				RemoveProcessingMessages(processedEventIds);
 				TryMarkCheckpoint(false);
 				TryReadingNewBatch();
-				TryPushingMessagesToClients();
+				SchedulePushToClients();
 			}
 		}
 
@@ -463,7 +484,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				RemoveProcessingMessages(processedEventIds);
 				TryMarkCheckpoint(false);
 				TryReadingNewBatch();
-				TryPushingMessagesToClients();
+				SchedulePushToClients();
 			}
 		}
 
@@ -517,7 +538,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				lock (_lock) {
 					_outstandingMessages.Remove(e.OriginalEvent.EventId);
 					_pushClients.RemoveProcessingMessages(e.OriginalEvent.EventId);
-					TryPushingMessagesToClients();
+					SchedulePushToClients();
 				}
 			});
 		}
@@ -585,7 +606,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					streamBuffer.AddRetry(OutstandingMessage.ForParkedEvent(ev));
 				}
 
-				TryPushingMessagesToClients();
+				SchedulePushToClients();
 
 				var newStreamPosition = newPosition as PersistentSubscriptionSingleStreamPosition;
 				Ensure.NotNull(newStreamPosition, "newStreamPosition");
@@ -654,10 +675,10 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					}
 				}
 
-				TryPushingMessagesToClients();
+				SchedulePushToClients();
 				TryMarkCheckpoint(true);
-				if ((_state & PersistentSubscriptionState.Behind |
-					 PersistentSubscriptionState.OutstandingPageRequest) ==
+				if ((_state & (PersistentSubscriptionState.Behind |
+					 PersistentSubscriptionState.OutstandingPageRequest)) ==
 					PersistentSubscriptionState.Behind)
 					TryReadingNewBatch();
 			}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -192,6 +192,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		}
 
 		public void HandleReadCompleted(IReadOnlyList<ResolvedEvent> events, IPersistentSubscriptionStreamPosition newPosition, bool isEndOfStream) {
+			bool shouldSchedule;
 			lock (_lock) {
 				if (!TryGetStreamBuffer(out var streamBuffer))
 					return;
@@ -223,20 +224,28 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 				_nextEventToPullFrom = newPosition;
 				TryReadingNewBatch();
-				SchedulePushToClients();
+				shouldSchedule = RequestPushToClients();
 			}
+			SchedulePushToClients(shouldSchedule);
 		}
 
-		private void SchedulePushToClients() {
+		private bool RequestPushToClients() {
 			if (_settings.PushScheduler == null) {
 				PushToClients();
-				return;
+				return false;
 			}
 
 			if (_pushScheduled)
-				return;
+				return false;
 
 			_pushScheduled = true;
+			return true;
+		}
+
+		private void SchedulePushToClients(bool shouldSchedule) {
+			if (!shouldSchedule)
+				return;
+
 			_settings.PushScheduler.SchedulePush();
 		}
 
@@ -282,6 +291,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		}
 
 		public void NotifyLiveSubscriptionMessage(ResolvedEvent resolvedEvent) {
+			bool shouldSchedule;
 			lock (_lock) {
 				if (!TryGetStreamBuffer(out var streamBuffer))
 					return;
@@ -309,8 +319,9 @@ namespace EventStore.Core.Services.PersistentSubscription {
 						_nextEventToPullFrom = _settings.EventSource.GetStreamPositionFor(resolvedEvent);
 				}
 
-				SchedulePushToClients();
+				shouldSchedule = RequestPushToClients();
 			}
+			SchedulePushToClients(shouldSchedule);
 		}
 
 		public IEnumerable<(ResolvedEvent ResolvedEvent, int RetryCount)> GetNextNOrLessMessages(int count) {
@@ -344,6 +355,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 		public void AddClient(Guid correlationId, Guid connectionId, string connectionName, IEnvelope envelope, int maxInFlight, string user,
 			string @from) {
+			bool shouldSchedule;
 			lock (_lock) {
 				var client = new PersistentSubscriptionClient(correlationId, connectionId, connectionName, envelope, maxInFlight, user,
 					@from, _totalTimeWatch, _settings.ExtraStatistics);
@@ -356,8 +368,9 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					return;
 				}
 
-				SchedulePushToClients();
+				shouldSchedule = RequestPushToClients();
 			}
+			SchedulePushToClients(shouldSchedule);
 		}
 
 		public void Shutdown() {
@@ -374,6 +387,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		}
 
 		public bool RemoveClientByConnectionId(Guid connectionId) {
+			bool shouldSchedule;
 			lock (_lock) {
 				if (!_pushClients.RemoveClientByConnectionId(connectionId,
 					    out var unconfirmedEvents))
@@ -386,12 +400,14 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					RetryMessage(m);
 				}
 
-				SchedulePushToClients();
-				return true;
+				shouldSchedule = RequestPushToClients();
 			}
+			SchedulePushToClients(shouldSchedule);
+			return true;
 		}
 
 		public void RemoveClientByCorrelationId(Guid correlationId, bool sendDropNotification) {
+			bool shouldSchedule;
 			lock (_lock) {
 				var lostMessages = _pushClients.RemoveClientByCorrelationId(correlationId, sendDropNotification)
 					.OrderBy(v => v.ResolvedEvent.OriginalEventNumber);
@@ -399,8 +415,9 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					RetryMessage(m);
 				}
 
-				SchedulePushToClients();
+				shouldSchedule = RequestPushToClients();
 			}
+			SchedulePushToClients(shouldSchedule);
 		}
 
 		public void TryMarkCheckpoint(bool isTimeCheck) {
@@ -464,16 +481,19 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		}
 
 		public void AcknowledgeMessagesProcessed(Guid correlationId, Guid[] processedEventIds) {
+			bool shouldSchedule;
 			lock (_lock) {
 				RemoveProcessingMessages(processedEventIds);
 				TryMarkCheckpoint(false);
 				TryReadingNewBatch();
-				SchedulePushToClients();
+				shouldSchedule = RequestPushToClients();
 			}
+			SchedulePushToClients(shouldSchedule);
 		}
 
 		public void NotAcknowledgeMessagesProcessed(Guid correlationId, Guid[] processedEventIds, NakAction action,
 			string reason) {
+			bool shouldSchedule;
 			lock (_lock) {
 				foreach (var id in processedEventIds) {
 					Log.Verbose("Message NAK'ed id {id} action to take {action} reason '{reason}'", id, action,
@@ -484,8 +504,9 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				RemoveProcessingMessages(processedEventIds);
 				TryMarkCheckpoint(false);
 				TryReadingNewBatch();
-				SchedulePushToClients();
+				shouldSchedule = RequestPushToClients();
 			}
+			SchedulePushToClients(shouldSchedule);
 		}
 
 		private void HandleNackedMessage(NakAction action, Guid id, string reason) {
@@ -535,11 +556,13 @@ namespace EventStore.Core.Services.PersistentSubscription {
 						e.OriginalEventNumber, result);
 				}
 
+				bool shouldSchedule;
 				lock (_lock) {
 					_outstandingMessages.Remove(e.OriginalEvent.EventId);
 					_pushClients.RemoveProcessingMessages(e.OriginalEvent.EventId);
-					SchedulePushToClients();
+					shouldSchedule = RequestPushToClients();
 				}
+				SchedulePushToClients(shouldSchedule);
 			});
 		}
 
@@ -585,6 +608,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		}
 
 		public void HandleParkedReadCompleted(IReadOnlyList<ResolvedEvent> events, IPersistentSubscriptionStreamPosition newPosition, bool isEndofStream, long stopAt) {
+			bool shouldSchedule;
 			lock (_lock) {
 				if (!TryGetStreamBuffer(out var streamBuffer))
 					return;
@@ -606,7 +630,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					streamBuffer.AddRetry(OutstandingMessage.ForParkedEvent(ev));
 				}
 
-				SchedulePushToClients();
+				shouldSchedule = RequestPushToClients();
 
 				var newStreamPosition = newPosition as PersistentSubscriptionSingleStreamPosition;
 				Ensure.NotNull(newStreamPosition, "newStreamPosition");
@@ -626,6 +650,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					TryReadingParkedMessagesFrom(newStreamPosition.StreamEventNumber, stopAt);
 				}
 			}
+			SchedulePushToClients(shouldSchedule);
 		}
 
 		private static (DateTime?, bool) GetOldestParkedMessageTimeStamp(IReadOnlyList<ResolvedEvent> events, long replayedEnd) {
@@ -665,6 +690,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		}
 
 		public void NotifyClockTick(DateTime time) {
+			bool shouldSchedule;
 			lock (_lock) {
 				if (_state == PersistentSubscriptionState.NotReady)
 					return;
@@ -675,13 +701,14 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					}
 				}
 
-				SchedulePushToClients();
+				shouldSchedule = RequestPushToClients();
 				TryMarkCheckpoint(true);
 				if ((_state & (PersistentSubscriptionState.Behind |
 					 PersistentSubscriptionState.OutstandingPageRequest)) ==
 					PersistentSubscriptionState.Behind)
 					TryReadingNewBatch();
 			}
+			SchedulePushToClients(shouldSchedule);
 		}
 
 		private bool ActionTakenForRetriedMessage(OutstandingMessage message) {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
@@ -24,6 +24,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		private readonly IPersistentSubscriptionStreamReader _streamReader;
 		private readonly IPersistentSubscriptionCheckpointReader _checkpointReader;
 		private readonly IPersistentSubscriptionCheckpointWriter _checkpointWriter;
+		private readonly IPersistentSubscriptionPushScheduler _pushScheduler;
 		private IPersistentSubscriptionMessageParker _messageParker;
 
 		public PersistentSubscriptionParams(bool resolveLinkTos, string subscriptionId,
@@ -38,7 +39,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			IPersistentSubscriptionStreamReader streamReader,
 			IPersistentSubscriptionCheckpointReader checkpointReader,
 			IPersistentSubscriptionCheckpointWriter checkpointWriter,
-			IPersistentSubscriptionMessageParker messageParker) {
+			IPersistentSubscriptionMessageParker messageParker,
+			IPersistentSubscriptionPushScheduler pushScheduler = null) {
 			_resolveLinkTos = resolveLinkTos;
 			_subscriptionId = subscriptionId;
 			_eventSource = eventSource;
@@ -59,6 +61,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			_checkpointReader = checkpointReader;
 			_checkpointWriter = checkpointWriter;
 			_messageParker = messageParker;
+			_pushScheduler = pushScheduler;
 		}
 
 		public bool ResolveLinkTos {
@@ -103,6 +106,10 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 		public IPersistentSubscriptionMessageParker MessageParker {
 			get { return _messageParker; }
+		}
+
+		public IPersistentSubscriptionPushScheduler PushScheduler {
+			get { return _pushScheduler; }
 		}
 
 		public int MaxRetryCount {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParamsBuilder.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParamsBuilder.cs
@@ -22,6 +22,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		private IPersistentSubscriptionCheckpointReader _checkpointReader;
 		private IPersistentSubscriptionCheckpointWriter _checkpointWriter;
 		private IPersistentSubscriptionMessageParker _messageParker;
+		private IPersistentSubscriptionPushScheduler _pushScheduler;
 		private TimeSpan _checkPointAfter;
 		private int _minCheckPointCount;
 		private int _maxCheckPointCount;
@@ -76,6 +77,11 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		/// <returns></returns>
 		public PersistentSubscriptionParamsBuilder WithMessageParker(IPersistentSubscriptionMessageParker parker) {
 			_messageParker = parker;
+			return this;
+		}
+
+		public PersistentSubscriptionParamsBuilder WithPushScheduler(IPersistentSubscriptionPushScheduler scheduler) {
+			_pushScheduler = scheduler;
 			return this;
 		}
 
@@ -310,7 +316,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				builder._streamReader,
 				builder._checkpointReader,
 				builder._checkpointWriter,
-				builder._messageParker);
+				builder._messageParker,
+				builder._pushScheduler);
 		}
 	}
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionPushScheduler.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionPushScheduler.cs
@@ -1,0 +1,19 @@
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+
+namespace EventStore.Core.Services.PersistentSubscription {
+	public class PersistentSubscriptionPushScheduler : IPersistentSubscriptionPushScheduler {
+		private readonly IPublisher _publisher;
+		private readonly Message _message;
+
+		public PersistentSubscriptionPushScheduler(string subscriptionId, IPublisher publisher) {
+			_publisher = publisher;
+			_message = new SubscriptionMessage.PersistentSubscriptionPushToClients(subscriptionId);
+		}
+
+		public void SchedulePush() {
+			_publisher.Publish(_message);
+		}
+	}
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -32,6 +32,7 @@ public class PersistentSubscriptionService<TStreamId> :
 	IHandle<SystemMessage.BecomeLeader>,
 	IHandle<SubscriptionMessage.PersistentSubscriptionsRestart>,
 	IHandle<SubscriptionMessage.PersistentSubscriptionTimerTick>,
+	IHandle<SubscriptionMessage.PersistentSubscriptionPushToClients>,
 	IHandle<ClientMessage.ReplayParkedMessages>,
 	IHandle<ClientMessage.ReplayParkedMessage>,
 	IHandle<SystemMessage.StateChangeMessage>,
@@ -566,7 +567,8 @@ public class PersistentSubscriptionService<TStreamId> :
 				_streamReader,
 				_checkpointReader,
 				new PersistentSubscriptionCheckpointWriter(key, _ioDispatcher),
-				new PersistentSubscriptionMessageParker(key, _ioDispatcher)));
+				new PersistentSubscriptionMessageParker(key, _ioDispatcher),
+				new PersistentSubscriptionPushScheduler(key, _bus)));
 
 		var updateEntry = new PersistentSubscriptionEntry
 		{
@@ -796,7 +798,8 @@ public class PersistentSubscriptionService<TStreamId> :
 				_streamReader,
 				_checkpointReader,
 				new PersistentSubscriptionCheckpointWriter(key, _ioDispatcher),
-				new PersistentSubscriptionMessageParker(key, _ioDispatcher)));
+				new PersistentSubscriptionMessageParker(key, _ioDispatcher),
+				new PersistentSubscriptionPushScheduler(key, _bus)));
 
 		UpdateSubscription(stream, groupName, subscription);
 		return true;
@@ -1560,6 +1563,14 @@ public class PersistentSubscriptionService<TStreamId> :
 				_bus,
 				new SubscriptionMessage.PersistentSubscriptionTimerTick(_timerTickCorrelationId)));
 		}
+	}
+
+	public void Handle(SubscriptionMessage.PersistentSubscriptionPushToClients message)
+	{
+		if (!_started) return;
+
+		if (_subscriptionsById.TryGetValue(message.SubscriptionId, out var subscription))
+			subscription.PushToClientsFromSchedule();
 	}
 
 	private void WakeSubscriptions()

--- a/src/EventStore.Core/Services/PersistentSubscription/StreamBuffer.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/StreamBuffer.cs
@@ -85,6 +85,10 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			_retry.AddLast(ev);
 		}
 
+		public void AddRetryToEnd(OutstandingMessage ev) {
+			_retry.AddLast(ev);
+		}
+
 		public void AddLiveMessage(OutstandingMessage ev) {
 			if (Live) {
 				if (_buffer.Count < _maxBufferSize)
@@ -122,6 +126,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 			foreach (var list in new[] {_retry, _buffer}) // save on code duplication
 			{
+				var isRetry = ReferenceEquals(list, _retry);
 				var current = list.First;
 				if (current != null) {
 					do {
@@ -129,7 +134,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 						// that current is removed from the list setting next to null.
 						var next = current.Next;
 
-						yield return new OutstandingMessagePointer(current);
+						yield return new OutstandingMessagePointer(current, isRetry);
 
 						current = next;
 					} while (current != null);
@@ -157,12 +162,14 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			return result;
 		}
 
-		public struct OutstandingMessagePointer {
+		public readonly struct OutstandingMessagePointer {
 			private readonly LinkedListNode<OutstandingMessage> _entry;
+			private readonly bool _isRetry;
 
-			internal OutstandingMessagePointer(LinkedListNode<OutstandingMessage> entry)
+			internal OutstandingMessagePointer(LinkedListNode<OutstandingMessage> entry, bool isRetry)
 				: this() {
 				_entry = entry;
+				_isRetry = isRetry;
 			}
 
 			public OutstandingMessage Message {
@@ -175,6 +182,10 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				}
 
 				_entry.List.Remove(_entry);
+			}
+
+			public bool IsRetry {
+				get { return _isRetry; }
 			}
 		}
 	}

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
@@ -292,14 +292,17 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 									checkpoint = eventPosition;
 								}
 
+								if (checkpoint < completed.CurrentPos && completed.CurrentPos < completed.NextPos)
+									checkpoint = completed.CurrentPos;
+
 								checkpointIntervalCounter += completed.ConsideredEventsCount;
 								Log.Verbose(
 									"Subscription {subscriptionId} to $all:{eventFilter} considered {consideredEventsCount} catch-up events (interval: {checkpointInterval}, counter: {checkpointIntervalCounter})",
 									_subscriptionId, _eventFilter, completed.ConsideredEventsCount, _checkpointInterval, checkpointIntervalCounter);
 
 								if (completed.IsEndOfStream) {
-									if (checkpoint < completed.CurrentPos)
-										checkpoint = completed.CurrentPos;
+									if (checkpoint < TFPos.FirstRecordOfTf && TFPos.FirstRecordOfTf < completed.NextPos)
+										checkpoint = TFPos.FirstRecordOfTf;
 
 									// issue a checkpoint when going live to make sure that at least
 									// one checkpoint is issued within the checkpoint interval
@@ -311,9 +314,6 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 
 								if (checkpointIntervalCounter >= _checkpointInterval) {
 									checkpointIntervalCounter %= _checkpointInterval;
-
-									if (checkpoint < completed.CurrentPos)
-										checkpoint = completed.CurrentPos;
 
 									Log.Verbose(
 										"Subscription {subscriptionId} to $all:{eventFilter} reached checkpoint at {position} during catch-up (interval: {checkpointInterval}, counter: {checkpointIntervalCounter})",

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.cs
@@ -5,7 +5,7 @@ using EventStore.Core.Messages;
 namespace EventStore.Core.Services.Transport.Enumerators {
 	public static partial class Enumerator {
 		private const int MaxLiveEventBufferCount = 32;
-		private const int ReadBatchSize = 32; // TODO  JPB make this configurable
+		public const int ReadBatchSize = 32; // TODO  JPB make this configurable
 
 		private static readonly BoundedChannelOptions BoundedChannelOptions =
 			new(MaxLiveEventBufferCount) {


### PR DESCRIPTION
- Keep persistent subscriptions from losing checkpoint safety when pinned dispatch skips messages before their assigned clients can accept them.
- Prevent bursty live workloads from repeatedly scanning buffers while acknowledgements are still catching up.
- Preserve filtered all-stream checkpoints when empty catch-up pages would otherwise hide the last safe position.