### PR TITLE
fix(http): route liveness checks through endpoints

### DIFF
--- a/src/EventStore.Core.Tests/Http/HealthChecks/when_performing_a_live_check.cs
+++ b/src/EventStore.Core.Tests/Http/HealthChecks/when_performing_a_live_check.cs
@@ -92,12 +92,12 @@ public class when_performing_a_live_check<TLogFormat, TStreamId> : Specification
 	}
 
 	[TestCaseSource(nameof(MethodNotAllowedTestCases))]
-	public async Task using_methods_other_than_get_or_head_returns_method_not_allowed(HttpMethod method)
+	public async Task using_methods_other_than_get_or_head_returns_not_found(HttpMethod method)
 	{
 		await StartNodeAndWaitForReadiness();
 		using var response = await _node.HttpClient.SendAsync(new HttpRequestMessage(method, "/health/live"));
 
-		Assert.AreEqual(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+		Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
 	}
 
 	private async Task StartNodeAndWaitForReadiness()

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -24,11 +24,6 @@ using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
-using MidFunc = System.Func<
-	Microsoft.AspNetCore.Http.HttpContext,
-	System.Func<System.Threading.Tasks.Task>,
-	System.Threading.Tasks.Task
->;
 using Operations = EventStore.Core.Services.Transport.Grpc.Operations;
 using ClusterGossip = EventStore.Core.Services.Transport.Grpc.Cluster.Gossip;
 using ClientGossip = EventStore.Core.Services.Transport.Grpc.Gossip;
@@ -127,7 +122,7 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 		var internalDispatcher = new InternalDispatcherEndpoint(_mainQueue, _httpMessageHandler);
 		_mainBus.Subscribe(internalDispatcher);
 
-		app = app.Map("/health", _statusCheck.Configure)
+		app = app
 			.UseCors("default")
 			// AuthenticationMiddleware uses _httpAuthenticationProviders and assigns
 			// the resulting ClaimsPrinciple to HttpContext.User
@@ -148,6 +143,8 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 
 		app.UseEndpoints(ep =>
 		{
+			_statusCheck.MapLiveness(ep);
+
 			_authenticationProvider.ConfigureEndpoints(ep);
 
 			ep.MapGrpcService<PersistentSubscriptions>();
@@ -342,12 +339,10 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 			_startup = startup;
 		}
 
-		public void Configure(IApplicationBuilder builder) =>
-			builder.Use(GetAndHeadOnly)
-				.UseRouter(router => router
-					.MapMiddlewareGet("live", inner => inner.Use(Live)));
+		public void MapLiveness(IEndpointRouteBuilder endpoints) =>
+			endpoints.MapMethods("/health/live", [HttpMethod.Get, HttpMethod.Head], Live);
 
-		private MidFunc Live => (context, next) =>
+		private Task Live(HttpContext context)
 		{
 			if (_startup._ready)
 			{
@@ -367,21 +362,6 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 			}
 
 			return Task.CompletedTask;
-		};
-
-		private static MidFunc GetAndHeadOnly => (context, next) =>
-		{
-			switch (context.Request.Method)
-			{
-				case "HEAD":
-					context.Request.Method = "GET";
-					return next();
-				case "GET":
-					return next();
-				default:
-					context.Response.StatusCode = 405;
-					return Task.CompletedTask;
-			}
-		};
+		}
 	}
 }


### PR DESCRIPTION
- Keeps health-check method semantics aligned with the endpoint routing model operators and clients see elsewhere.
- Reduces the risk of liveness checks drifting from the node's normal HTTP behavior as routing evolves.