### PR TITLE
fix(archive): rely on AWS profile environment

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageTestsBase.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageTestsBase.cs
@@ -29,7 +29,7 @@ public abstract class ArchiveStorageTestsBase<T> : DirectoryPerTest<T>
 			{
 				StorageType = storageType,
 				FileSystem = new() { Path = ArchivePath },
-				S3 = new() { AwsCliProfileName = "default", Bucket = "archiver-unit-tests", Region = "eu-west-1", }
+				S3 = new() { Bucket = "archiver-unit-tests", Region = "eu-west-1", }
 			},
 			chunkNamer);
 		return factory;

--- a/src/EventStore.Core/Services/Archive/ArchiveOptions.cs
+++ b/src/EventStore.Core/Services/Archive/ArchiveOptions.cs
@@ -73,7 +73,6 @@ public class FileSystemOptions
 
 public class S3Options
 {
-	public string AwsCliProfileName { get; init; } = "default";
 	public string Bucket { get; init; } = "";
 	public string Region { get; init; } = "";
 

--- a/src/EventStore.Core/Services/Archive/Storage/S3Reader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/S3Reader.cs
@@ -35,7 +35,6 @@ public class S3Reader : FluentReader, IArchiveStorageReader
 			throw new InvalidConfigurationException("Please specify an Archive S3 Region");
 
 		_awsBlobStorage = StorageFactory.Blobs.AwsS3(
-			awsCliProfileName: options.AwsCliProfileName,
 			bucketName: options.Bucket,
 			region: options.Region) as IAwsS3BlobStorage;
 	}

--- a/src/EventStore.Core/Services/Archive/Storage/S3Writer.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/S3Writer.cs
@@ -11,7 +11,6 @@ public class S3Writer : FluentWriter, IArchiveStorageWriter
 	{
 		AwsTraceLogging.Configure();
 		BlobStorage = StorageFactory.Blobs.AwsS3(
-			awsCliProfileName: options.AwsCliProfileName,
 			bucketName: options.Bucket,
 			region: options.Region);
 	}


### PR DESCRIPTION
- S3 archive credentials should use the standard AWS provider chain so operators can configure profile selection consistently through environment-managed deployment systems.
- Removing a dedicated archive-only profile setting keeps S3-compatible archive configuration smaller and avoids a second source of truth for AWS identity.