### PR TITLE
feat(otel): support signal-specific OTLP export

### DIFF
--- a/docs/diagnostics/integrations.md
+++ b/docs/diagnostics/integrations.md
@@ -21,45 +21,53 @@ Older versions can be monitored by Prometheus using the community-supported expo
 
 ## OpenTelemetry Exporter
 
-<wbr><Badge type="warning" vertical="middle" text="Commercial"/>
+EventStoreDB passively exposes metrics for scraping on the `/metrics` endpoint. It can also actively export metrics and logs using the [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otel/protocol/) (OTLP).
 
-EventStoreDB passively exposes metrics for scraping on the `/metrics` endpoint. If you would like EventStoreDB to actively export the metrics, the _OpenTelemetry Exporter Plugin_ can be used.
-
-The OpenTelemetry Exporter plugin allows you to export EventStoreDB metrics to a specified endpoint using the [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otel/protocol/) (OTLP). The following instructions will help you set up the exporter and customize its configuration, so you can receive, process, export and monitor metrics as needed.
-
-A number of APM providers natively support ingesting metrics using the OTLP protocol, so you might be able to directly use the OpenTelemetry Exporter to send metrics to your APM provider. Alternatively, you can export metrics to the OpenTelemetry Collector, which can then be configured to send metrics to a variety of backends. You can find out more about the [OpenTelemetry collector](https://opentelemetry.io/docs/collector/).
+A number of APM providers natively support OTLP, so you might be able to send EventStoreDB telemetry directly to your APM provider. Alternatively, you can export to the OpenTelemetry Collector, which can then fan out to a variety of backends. You can find out more about the [OpenTelemetry collector](https://opentelemetry.io/docs/collector/).
 
 ### Configuration
 
-Refer to the general [plugins configuration](../configuration.md#plugins-configuration) guide to see how to configure plugins with JSON files and environment variables.
-
 Sample JSON configuration:
+
 ```json
 {
-  "OpenTelemetry": {
-    "Otlp": {
-      "Endpoint": "http://localhost:4317",
-      "Headers": ""
+  "EventStore": {
+    "OpenTelemetry": {
+      "Otlp": {
+        "Endpoint": "http://localhost:4317",
+        "Headers": ""
+      },
+      "Logs": {
+        "Enabled": true
+      },
+      "Metrics": {
+        "Otlp": {
+          "Endpoint": "http://metrics-collector:4317"
+        }
+      }
     }
   }
 }
 ```
 
+The shared `EventStore:OpenTelemetry:Otlp` section provides defaults for every enabled OTLP signal. The `EventStore:OpenTelemetry:Logs:Otlp` and `EventStore:OpenTelemetry:Metrics:Otlp` sections can override only the settings that need to differ for each signal.
+
+All OpenTelemetry environment variables are optional. Configure them only in deployment environments that should export telemetry to an OTLP collector.
+
 The configuration can specify:
 
-| Name                          | Description                                            |
-|-------------------------------|--------------------------------------------------------|
-| OpenTelemetry__Otlp__Endpoint | Destination where the OTLP exporter will send the data |
-| OpenTelemetry__Otlp__Headers  | Optional headers for the connection                    |
+| Name                                               | Description                                                   |
+|----------------------------------------------------|---------------------------------------------------------------|
+| EventStore__OpenTelemetry__Otlp__Endpoint          | Shared destination where the OTLP exporter will send telemetry |
+| EventStore__OpenTelemetry__Otlp__Headers           | Optional shared headers for the connection                     |
+| EventStore__OpenTelemetry__Logs__Enabled           | Enables OTLP log export                                        |
+| EventStore__OpenTelemetry__Logs__Otlp__Endpoint    | Optional log-specific OTLP destination                         |
+| EventStore__OpenTelemetry__Metrics__Enabled        | Enables OTLP metric export from runtime configuration          |
+| EventStore__OpenTelemetry__Metrics__Otlp__Endpoint | Optional metric-specific OTLP destination                      |
 
 Headers are key-value pairs separated by commas. For example:
 ```:no-line-numbers
 "Headers": "api-key=value,other-config-value=value"
-```
-
-EventStoreDB will log a message on startup confirming the metrics export to your specified endpoint:
-```:no-line-numbers
-OtlpExporter: Exporting metrics to http://localhost:4317/ every 15.0 seconds
 ```
 
 The interval is taken from the `ExpectedScrapeIntervalSeconds` value in `metricsconfig.json` in the server installation directory:
@@ -70,14 +78,15 @@ The interval is taken from the `ExpectedScrapeIntervalSeconds` value in `metrics
 
 ### Troubleshooting
 
-| Symptom                                                                      | Solution                                                                                                                                                                                                                                                                                    |
-|------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| The OpenTelemetry Exporter plugin is not loaded                              | The OpenTelemetry Exporter plugin is only available in commercial editions. Check that it is present in `<installation-directory>/plugins`. <br/><br/> If it is present, on startup the server will log a message similar to: `Loaded SubsystemsPlugin plugin: "otlp-exporter" "24.6.0.0".` |
-| EventStoreDB logs a message on startup that it cannot find the configuration | The server logs a message: `OtlpExporter: No OpenTelemetry:Otlp configuration found. Not exporting metrics.`.<br/><br/> Check the configuration steps above.                                                                                                                                |
+| Symptom                                  | Solution                                                                                                                                       |
+|------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| Logs are not exported                    | Check that `EventStore__OpenTelemetry__Logs__Enabled` is set to `true`.                                                                        |
+| Metrics are not exported                 | Check that `EventStore__OpenTelemetry__Metrics__Enabled` is `true`, any `EventStore__OpenTelemetry__Metrics__Otlp__*` key is set, or `Otlp.Enabled` is `true` in `metricsconfig.json`. |
+| Telemetry arrives at the wrong collector | Check whether a per-signal `Logs:Otlp` or `Metrics:Otlp` section is overriding the shared `EventStore:OpenTelemetry:Otlp` destination.         |
 
 ## Datadog
 
-The best way to integrate EventStoreDB metrics with Datadog today is by using the [OpenTelemetry exporter]() built-in to the commercial version of the database. We currently don't support exporting logs via the exporter.
+The best way to integrate EventStoreDB telemetry with Datadog today is by using the built-in OpenTelemetry export support.
 
 You can use the community-supported integration to collect EventStoreDB logs and metrics in Datadog.
 

--- a/docs/diagnostics/metrics.md
+++ b/docs/diagnostics/metrics.md
@@ -2,7 +2,7 @@
 
 EventStoreDB collects metrics in [Prometheus format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format), available on the `/metrics` endpoint. Prometheus can be configured to scrape this endpoint directly. The metrics are configured in `metricsconfig.json`. 
 
-In addition, EventStoreDB can actively export metrics to a specified endpoint using the [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otel/protocol/) (OTLP). <Badge type="warning" text="Commercial" vertical="middle"></Badge>
+In addition, EventStoreDB can actively export metrics to a specified endpoint using the [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otel/protocol/) (OTLP).
 
 ## Metrics reference
 
@@ -583,4 +583,3 @@ Following metric is reported when `ExpectedScrapeIntervalSeconds` is set to `15`
 eventstore_writer_flush_size_max{range="16-20 seconds"} 1854 1688070655500
 ```
 In above example, maximum reported is `1854`. It is not a maximum measurement in last `15s` but rather maximum measurement in last `16` to last `20` seconds i.e. the maximum measurement could have been recorded in last `16s`, last `17s`, …, upto last `20s`.
-

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -75,6 +75,7 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.InMemory" Version="0.16.0" />
+    <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.1.1" />
     <PackageVersion Include="Serilog.Sinks.TextWriter" Version="3.0.0" />
     <PackageVersion Include="SharpDotYaml.Extensions.Configuration" Version="0.3.1" />
     <PackageVersion Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.21216.1" />

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -57,7 +57,8 @@ internal static class Program
 				options.Logging.LogFileInterval,
 				options.Logging.LogFileRetentionCount,
 				options.Logging.DisableLogFile,
-				options.Logging.LogConfig);
+				options.Logging.LogConfig,
+				configuration);
 
 			if (options.Application.Help)
 			{

--- a/src/EventStore.Core.XUnit.Tests/Metrics/OtlpMetricsConfigurationTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/OtlpMetricsConfigurationTests.cs
@@ -1,7 +1,10 @@
+using System;
 using System.Collections.Generic;
 using EventStore.Common.Configuration;
+using EventStore.Core.Configuration;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
+using OpenTelemetry.Exporter;
 using Xunit;
 
 namespace EventStore.Core.XUnit.Tests.Metrics;
@@ -31,5 +34,75 @@ public class OtlpMetricsConfigurationTests
 		var metrics = MetricsConfiguration.Get(configuration);
 
 		metrics.Otlp.Enabled.Should().BeTrue();
+		configuration.OtlpMetricsEnabled(metrics).Should().BeTrue();
+	}
+
+	[Fact]
+	public void DoesNotEnableMetricsWhenOnlySharedOpenTelemetryOtlpSectionExists()
+	{
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string>
+			{
+				["EventStore:OpenTelemetry:Otlp:Endpoint"] = "http://shared:4317",
+			})
+			.Build();
+
+		var metrics = MetricsConfiguration.Get(configuration);
+
+		configuration.OtlpMetricsEnabled(metrics).Should().BeFalse();
+	}
+
+	[Fact]
+	public void EnablesMetricsWhenRuntimeSwitchUsesSharedOpenTelemetryOtlpSettings()
+	{
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string>
+			{
+				["EventStore:OpenTelemetry:Metrics:Enabled"] = "true",
+				["EventStore:OpenTelemetry:Otlp:Endpoint"] = "http://shared:4317",
+			})
+			.Build();
+
+		var metrics = MetricsConfiguration.Get(configuration);
+		var options = configuration.GetOtlpExporterOptions(OpenTelemetryConfiguration.OtlpMetricsOtlpPrefix);
+
+		configuration.OtlpMetricsEnabled(metrics).Should().BeTrue();
+		options.Endpoint.Should().Be(new Uri("http://shared:4317"));
+	}
+
+	[Fact]
+	public void EnablesMetricsWhenPerSignalOpenTelemetryOtlpSectionExists()
+	{
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string>
+			{
+				["EventStore:OpenTelemetry:Metrics:Otlp:Endpoint"] = "http://metrics:4317",
+			})
+			.Build();
+
+		var metrics = MetricsConfiguration.Get(configuration);
+
+		configuration.OtlpMetricsEnabled(metrics).Should().BeTrue();
+	}
+
+	[Fact]
+	public void PerSignalMetricsOtlpOverridesSharedSettings()
+	{
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string>
+			{
+				["EventStore:OpenTelemetry:Otlp:Endpoint"] = "http://shared:4317",
+				["EventStore:OpenTelemetry:Otlp:Headers"] = "key=shared",
+				["EventStore:OpenTelemetry:Metrics:Otlp:Endpoint"] = "http://metrics:4317",
+				["EventStore:OpenTelemetry:Metrics:Otlp:Headers"] = "key=metrics",
+				["EventStore:OpenTelemetry:Metrics:Otlp:Protocol"] = "HttpProtobuf",
+			})
+			.Build();
+
+		var options = configuration.GetOtlpExporterOptions(OpenTelemetryConfiguration.OtlpMetricsOtlpPrefix);
+
+		options.Endpoint.Should().Be(new Uri("http://metrics:4317"));
+		options.Headers.Should().Be("key=metrics");
+		options.Protocol.Should().Be(OtlpExportProtocol.HttpProtobuf);
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/OpenTelemetry/OpenTelemetryLoggerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/OpenTelemetry/OpenTelemetryLoggerTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using EventStore.Common.Log;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using OpenTelemetry.Exporter;
+using Serilog;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.OpenTelemetry;
+
+public class OpenTelemetryLoggerTests
+{
+	[Fact]
+	public void DoesNotConfigureExporterWhenLogsDisabled()
+	{
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string>
+			{
+				["EventStore:OpenTelemetry:Otlp:Endpoint"] = "http://shared:4317",
+			})
+			.Build();
+		OtlpExporterOptions captured = null;
+
+		new LoggerConfiguration().AddOpenTelemetryLogger(configuration, "test-node", options => captured = options);
+
+		captured.Should().BeNull();
+	}
+
+	[Fact]
+	public void UsesSharedOtlpConfigWhenNoPerSignalSectionExists()
+	{
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string>
+			{
+				["EventStore:OpenTelemetry:Otlp:Endpoint"] = "http://shared:4317",
+				["EventStore:OpenTelemetry:Otlp:Headers"] = "key=shared",
+				["EventStore:OpenTelemetry:Logs:Enabled"] = "true",
+			})
+			.Build();
+		OtlpExporterOptions captured = null;
+
+		new LoggerConfiguration().AddOpenTelemetryLogger(configuration, "test-node", options => captured = options);
+
+		captured.Should().NotBeNull();
+		captured.Endpoint.Should().Be(new Uri("http://shared:4317"));
+		captured.Headers.Should().Be("key=shared");
+		captured.Protocol.Should().Be(OtlpExportProtocol.Grpc);
+	}
+
+	[Fact]
+	public void PerSignalLogsOtlpOverridesSharedSettings()
+	{
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string>
+			{
+				["EventStore:OpenTelemetry:Otlp:Endpoint"] = "http://shared:4317",
+				["EventStore:OpenTelemetry:Otlp:Headers"] = "key=shared",
+				["EventStore:OpenTelemetry:Logs:Enabled"] = "true",
+				["EventStore:OpenTelemetry:Logs:Otlp:Endpoint"] = "http://logs:4317",
+				["EventStore:OpenTelemetry:Logs:Otlp:Headers"] = "key=logs",
+				["EventStore:OpenTelemetry:Logs:Otlp:Protocol"] = "HttpProtobuf",
+			})
+			.Build();
+		OtlpExporterOptions captured = null;
+
+		new LoggerConfiguration().AddOpenTelemetryLogger(configuration, "test-node", options => captured = options);
+
+		captured.Should().NotBeNull();
+		captured.Endpoint.Should().Be(new Uri("http://logs:4317"));
+		captured.Headers.Should().Be("key=logs");
+		captured.Protocol.Should().Be(OtlpExportProtocol.HttpProtobuf);
+	}
+
+	[Theory]
+	[InlineData("http://logs:4318", "http://logs:4318/v1/logs")]
+	[InlineData("http://logs:4318/", "http://logs:4318/v1/logs")]
+	[InlineData("http://logs:4318/custom/logs", "http://logs:4318/custom/logs")]
+	public void HttpProtobufLogsEndpointUsesSignalPathForBaseEndpoints(string endpoint, string expected)
+	{
+		var method = typeof(OpenTelemetryLogger).GetMethod(
+			"GetHttpProtobufLogsEndpoint",
+			BindingFlags.NonPublic | BindingFlags.Static);
+
+		method.Should().NotBeNull();
+		method!.Invoke(null, [new Uri(endpoint)]).Should().Be(expected);
+	}
+}

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using EventStore.Common.Configuration;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
+using EventStore.Core.Configuration;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Services.Transport.Grpc;
@@ -229,7 +230,7 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 			.AddSingleton<ServerFeatures>()
 
 			.AddOpenTelemetry()
-			.WithMetrics(meterOptions => ConfigureMetrics(meterOptions, metricsConfiguration))
+			.WithMetrics(meterOptions => ConfigureMetrics(meterOptions, metricsConfiguration, _configuration))
 			.Services
 
 			// gRPC
@@ -253,7 +254,10 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 			component.ConfigureServices(services, _configuration);
 	}
 
-	private static void ConfigureMetrics(MeterProviderBuilder meterOptions, MetricsConfiguration metricsConfiguration)
+	private static void ConfigureMetrics(
+		MeterProviderBuilder meterOptions,
+		MetricsConfiguration metricsConfiguration,
+		IConfiguration configuration)
 	{
 		meterOptions
 			.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("eventstore"))
@@ -306,18 +310,32 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 			})
 			.AddPrometheusExporter(options => options.ScrapeResponseCacheDurationMilliseconds = 1000);
 
-		ConfigureOtlpMetrics(meterOptions, metricsConfiguration);
+		ConfigureOtlpMetrics(meterOptions, metricsConfiguration, configuration);
 	}
 
 	private static void ConfigureOtlpMetrics(
 		MeterProviderBuilder meterOptions,
-		MetricsConfiguration metricsConfiguration)
+		MetricsConfiguration metricsConfiguration,
+		IConfiguration configuration)
 	{
-		var options = metricsConfiguration.Otlp;
-		if (!options.Enabled)
+		if (!configuration.OtlpMetricsEnabled(metricsConfiguration))
 			return;
 
-		meterOptions.AddOtlpExporter();
+		meterOptions.AddOtlpExporter((exporterOptions, metricReaderOptions) =>
+		{
+			configuration.BindOtlpExporterOptions(
+				OpenTelemetryConfiguration.OtlpMetricsOtlpPrefix,
+				exporterOptions);
+			configuration.GetSection(OpenTelemetryConfiguration.OtlpMetricsPrefix).Bind(metricReaderOptions);
+
+			var periodicOptions = metricReaderOptions.PeriodicExportingMetricReaderOptions;
+			if (periodicOptions.ExportIntervalMilliseconds is null &&
+				metricsConfiguration.ExpectedScrapeIntervalSeconds > 0)
+			{
+				periodicOptions.ExportIntervalMilliseconds =
+					metricsConfiguration.ExpectedScrapeIntervalSeconds * 1000;
+			}
+		});
 	}
 
 	public void Handle(SystemMessage.SystemReady _) => _ready = true;

--- a/src/EventStore.Core/Configuration/OpenTelemetryConfiguration.cs
+++ b/src/EventStore.Core/Configuration/OpenTelemetryConfiguration.cs
@@ -1,0 +1,45 @@
+using System;
+using EventStore.Common.Configuration;
+using Microsoft.Extensions.Configuration;
+using OpenTelemetry.Exporter;
+
+namespace EventStore.Core.Configuration;
+
+public static class OpenTelemetryConfiguration
+{
+	public const string RootPrefix = "EventStore";
+	public const string OpenTelemetryPrefix = $"{RootPrefix}:OpenTelemetry";
+	public const string OtlpConfigPrefix = $"{OpenTelemetryPrefix}:Otlp";
+	public const string OtlpLogsPrefix = $"{OpenTelemetryPrefix}:Logs";
+	public const string OtlpLogsOtlpPrefix = $"{OpenTelemetryPrefix}:Logs:Otlp";
+	public const string OtlpMetricsPrefix = $"{OpenTelemetryPrefix}:Metrics";
+	public const string OtlpMetricsOtlpPrefix = $"{OpenTelemetryPrefix}:Metrics:Otlp";
+
+	public static bool OtlpLogsEnabled(this IConfiguration configuration) =>
+		configuration.GetValue<bool>($"{OtlpLogsPrefix}:Enabled");
+
+	public static bool OtlpMetricsEnabled(this IConfiguration configuration, MetricsConfiguration metricsConfiguration) =>
+		metricsConfiguration.Otlp.Enabled ||
+		configuration.GetSection(OtlpMetricsOtlpPrefix).Exists() ||
+		configuration.GetValue<bool>($"{OtlpMetricsPrefix}:Enabled");
+
+	public static OtlpExporterOptions GetOtlpExporterOptions(
+		this IConfiguration configuration,
+		string perSignalOtlpPrefix,
+		Action<OtlpExporterOptions> configure = null)
+	{
+		var options = configuration.GetSection(OtlpConfigPrefix).Get<OtlpExporterOptions>() ?? new();
+		configuration.GetSection(perSignalOtlpPrefix).Bind(options);
+		configure?.Invoke(options);
+		return options;
+	}
+
+	public static void BindOtlpExporterOptions(
+		this IConfiguration configuration,
+		string perSignalOtlpPrefix,
+		OtlpExporterOptions options)
+	{
+		configuration.GetSection(OtlpConfigPrefix).Bind(options);
+		configuration.GetSection(perSignalOtlpPrefix).Bind(options);
+	}
+}

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -23,6 +23,7 @@
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" />
 		<PackageReference Include="Quickenshtein" />
 		<PackageReference Include="Scrutor" />
+		<PackageReference Include="Serilog.Sinks.OpenTelemetry" />
 		<PackageReference Include="System.Diagnostics.DiagnosticSource" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" />
 		<PackageReference Include="System.IO.Pipelines" />

--- a/src/EventStore.Core/Log/EventStoreLoggerConfiguration.cs
+++ b/src/EventStore.Core/Log/EventStoreLoggerConfiguration.cs
@@ -53,7 +53,7 @@ namespace EventStore.Common.Log {
 
 		public static void Initialize(string logsDirectory, string componentName, LogConsoleFormat logConsoleFormat,
 			int logFileSize, RollingInterval logFileInterval, int logFileRetentionCount, bool disableLogFile,
-			string logConfig = "logconfig.json") {
+			string logConfig = "logconfig.json", IConfiguration telemetryConfiguration = null) {
 			if (Interlocked.Exchange(ref Initialized, 1) == 1) {
 				throw new InvalidOperationException($"{nameof(Initialize)} may not be called more than once.");
 			}
@@ -75,6 +75,7 @@ namespace EventStore.Common.Log {
 						.ReadFrom.Configuration(configurationRoot)
 					: Default(logsDirectory, componentName, configurationRoot, logConsoleFormat, logFileInterval,
 						logFileSize, logFileRetentionCount, disableLogFile))
+				.AddOpenTelemetryLogger(telemetryConfiguration, componentName)
 				.CreateLogger();
 
 			Serilog.Debugging.SelfLog.Disable();

--- a/src/EventStore.Core/Log/OpenTelemetryLogger.cs
+++ b/src/EventStore.Core/Log/OpenTelemetryLogger.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using EventStore.Common.Utils;
+using EventStore.Core.Configuration;
+using Microsoft.Extensions.Configuration;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Logs;
+using Serilog;
+using Serilog.Filters;
+using Serilog.Sinks.OpenTelemetry;
+
+namespace EventStore.Common.Log;
+
+public static class OpenTelemetryLogger
+{
+	public static LoggerConfiguration AddOpenTelemetryLogger(
+		this LoggerConfiguration loggerConfiguration,
+		IConfiguration configuration,
+		string componentName,
+		Action<OtlpExporterOptions> configureOtlp = null)
+	{
+		if (configuration is null || !configuration.OtlpLogsEnabled())
+			return loggerConfiguration;
+
+		var logExporterConfig = configuration
+			.GetSection(OpenTelemetryConfiguration.OtlpLogsPrefix)
+			.Get<LogRecordExportProcessorOptions>() ?? new();
+		var otlpExporterConfig = configuration.GetOtlpExporterOptions(
+			OpenTelemetryConfiguration.OtlpLogsOtlpPrefix,
+			configureOtlp);
+
+		return loggerConfiguration.WriteTo.Logger(sinkConfiguration => sinkConfiguration
+			.Filter.ByExcluding(Matching.FromSource("REGULAR-STATS-LOGGER"))
+			.WriteTo.OpenTelemetry(options =>
+			{
+				options.ResourceAttributes = new Dictionary<string, object>
+				{
+					["service.name"] = "eventstore",
+					["service.instance.id"] = componentName,
+					["service.version"] = VersionInfo.Version
+				};
+				options.Protocol = otlpExporterConfig.Protocol switch
+				{
+					OtlpExportProtocol.Grpc => OtlpProtocol.Grpc,
+					OtlpExportProtocol.HttpProtobuf => OtlpProtocol.HttpProtobuf,
+					_ => throw new ArgumentOutOfRangeException(
+						nameof(otlpExporterConfig.Protocol),
+						$">{otlpExporterConfig.Protocol}<",
+						"Invalid protocol for OTLP exporter.")
+				};
+				if (otlpExporterConfig.Protocol == OtlpExportProtocol.HttpProtobuf)
+				{
+					options.Endpoint = null;
+					options.LogsEndpoint = GetHttpProtobufLogsEndpoint(otlpExporterConfig.Endpoint);
+				}
+				else
+				{
+					options.Endpoint = otlpExporterConfig.Endpoint.AbsoluteUri;
+				}
+				options.BatchingOptions.BatchSizeLimit =
+					logExporterConfig.BatchExportProcessorOptions.MaxExportBatchSize;
+				options.BatchingOptions.BufferingTimeLimit = TimeSpan.FromMilliseconds(
+					logExporterConfig.BatchExportProcessorOptions.ScheduledDelayMilliseconds);
+				options.BatchingOptions.QueueLimit =
+					logExporterConfig.BatchExportProcessorOptions.MaxQueueSize;
+			}, getConfigurationVariable: name => name switch
+			{
+				"OTEL_EXPORTER_OTLP_HEADERS" => otlpExporterConfig.Headers ?? Environment.GetEnvironmentVariable(name),
+				_ => Environment.GetEnvironmentVariable(name),
+			}));
+	}
+
+	private static string GetHttpProtobufLogsEndpoint(Uri endpoint)
+	{
+		var builder = new UriBuilder(endpoint);
+		var path = builder.Path.Trim('/');
+
+		if (string.IsNullOrWhiteSpace(path))
+			builder.Path = "v1/logs";
+
+		return builder.Uri.AbsoluteUri;
+	}
+}


### PR DESCRIPTION
- Operators need one observability path for logs and metrics instead of a metrics-only exporter story.
- OTLP deployments often route each signal to a different collector, so shared defaults need safe per-signal overrides.
- The public diagnostics docs need to match the built-in telemetry surface operators can actually configure.