### PR TITLE
chore(cache): remove unused LRU callback hooks

### DIFF
--- a/src/EventStore.Core/DataStructures/LRUCache.cs
+++ b/src/EventStore.Core/DataStructures/LRUCache.cs
@@ -33,7 +33,6 @@ namespace EventStore.Core.DataStructures {
 		private readonly Dictionary<TKey, LinkedListNode<LRUItem>> _items = new();
 		private readonly Queue<LinkedListNode<LRUItem>> _nodesPool = new();
 		private readonly object _lock = new();
-		private readonly Func<object, bool> _onPut, _onRemove; //_onPut is not called if a key-value pair already exists in the cache
 		private readonly string _unit;
 		private readonly CalculateItemSize _calculateItemSize;
 		private readonly CalculateFreedSize _calculateFreedSize;
@@ -74,23 +73,6 @@ namespace EventStore.Core.DataStructures {
 			_unit = unit ?? "items";
 		}
 
-		public LRUCache(
-			string name,
-			long capacity,
-			Func<object, bool> onPut,
-			Func<object, bool> onRemove) {
-			Ensure.NotNull(name, nameof(name));
-			Ensure.Nonnegative(capacity, "capacity");
-			Name = name;
-			_capacity = capacity;
-			_size = 0L;
-			_onPut = onPut;
-			_onRemove = onRemove;
-			_calculateItemSize = _unitSize;
-			_calculateFreedSize = _zeroSize;
-			_unit = "items";
-		}
-
 		public static int ApproximateItemSize(int keyRefsSize, int valueRefsSize) =>
 			LRUItem.Size +
 			keyRefsSize +
@@ -111,8 +93,6 @@ namespace EventStore.Core.DataStructures {
 				_items.Add(key, node);
 				_orderList.AddLast(node);
 				_size += itemSize;
-
-				_onPut?.Invoke(node.Value.Value);
 			}
 		}
 
@@ -144,10 +124,7 @@ namespace EventStore.Core.DataStructures {
 					_size -= _calculateItemSize(key, node.Value.Value);
 					_freedSize += _calculateFreedSize(node.Value.Key, node.Value.Value, true, true, false);
 
-					var value = node.Value.Value;
 					ReturnNode(node);
-
-					_onRemove?.Invoke(value);
 				}
 			}
 		}
@@ -163,11 +140,8 @@ namespace EventStore.Core.DataStructures {
 				_size -= _calculateItemSize(node.Value.Key, node.Value.Value);
 				_freedSize += _calculateFreedSize(node.Value.Key, node.Value.Value, true, true, !reuseNode);
 
-				var value = node.Value.Value;
 				if (reuseNode)
 					ReturnNode(node);
-
-				_onRemove?.Invoke(value);
 			}
 		}
 


### PR DESCRIPTION
- Keeps the cache implementation focused on the active eviction path by removing an unused callback hook.
- Reduces stale API surface that can make future cache behavior harder to reason about.