### PR TITLE
fix(http): compress empty encoded responses

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Http/compress_response_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/compress_response_should.cs
@@ -4,8 +4,10 @@ using System.IO;
 using System.IO.Compression;
 using System.Net;
 using System.Text;
+using System.Threading;
 using EventStore.Transport.Http;
 using EventStore.Transport.Http.EntityManagement;
+using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Services.Transport.Http;
@@ -59,6 +61,57 @@ class compress_response_should
 	}
 
 	[Test]
+	public void with_gzip_compression_algo_empty_data_is_valid_gzip()
+	{
+		var response =
+			HttpEntityManager.CompressResponse(Array.Empty<byte>(), CompressionAlgorithms.Gzip);
+
+		Assert.Greater(response.Length, 0);
+
+		String uncompressed;
+
+		using (var inputStream = new MemoryStream(response))
+		using (var uncompressedStream = new GZipStream(inputStream, CompressionMode.Decompress))
+		using (var outputStream = new MemoryStream())
+		{
+			uncompressedStream.CopyTo(outputStream);
+			uncompressed = Encoding.UTF8.GetString(outputStream.ToArray());
+		}
+
+		Assert.AreEqual(uncompressed, string.Empty);
+	}
+
+	[Test]
+	public void empty_gzip_reply_has_a_valid_gzip_body()
+	{
+		using var completed = new ManualResetEventSlim();
+		using var responseBody = new MemoryStream();
+		var context = new DefaultHttpContext();
+		context.Request.Scheme = "http";
+		context.Request.Host = new HostString("localhost");
+		context.Request.Path = "/";
+		context.Request.Headers["Accept-Encoding"] = CompressionAlgorithms.Gzip;
+		context.Response.Body = responseBody;
+		var entity = new HttpEntity(context, logHttpRequests: false, advertiseAsHost: null, advertiseAsPort: 0,
+			completed.Set);
+		var manager = entity.CreateManager();
+		Exception error = null;
+
+		manager.Reply(Array.Empty<byte>(), 200, "OK", "text/plain", Encoding.UTF8, null, ex => error = ex);
+
+		Assert.IsTrue(completed.Wait(TimeSpan.FromSeconds(5)));
+		Assert.IsNull(error);
+		Assert.AreEqual(CompressionAlgorithms.Gzip, context.Response.Headers["Content-Encoding"].ToString());
+		Assert.Greater(responseBody.Length, 0);
+
+		responseBody.Position = 0;
+		using var uncompressedStream = new GZipStream(responseBody, CompressionMode.Decompress);
+		using var outputStream = new MemoryStream();
+		uncompressedStream.CopyTo(outputStream);
+		Assert.AreEqual(0, outputStream.Length);
+	}
+
+	[Test]
 	public void with_deflate_compression_algo_data_is_deflated()
 	{
 		var response =
@@ -99,6 +152,27 @@ class compress_response_should
 		}
 
 		Assert.AreEqual(uncompressed, testString);
+	}
+
+	[Test]
+	public void with_deflate_compression_algo_empty_data_is_valid_deflate()
+	{
+		var response =
+			HttpEntityManager.CompressResponse(Array.Empty<byte>(), CompressionAlgorithms.Deflate);
+
+		Assert.Greater(response.Length, 0);
+
+		String uncompressed;
+
+		using (var inputStream = new MemoryStream(response))
+		using (var uncompressedStream = new DeflateStream(inputStream, CompressionMode.Decompress))
+		using (var outputStream = new MemoryStream())
+		{
+			uncompressedStream.CopyTo(outputStream);
+			uncompressed = Encoding.UTF8.GetString(outputStream.ToArray());
+		}
+
+		Assert.AreEqual(uncompressed, string.Empty);
 	}
 
 	[Test]

--- a/src/EventStore.Core.Tests/Services/Transport/Http/compress_response_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/compress_response_should.cs
@@ -84,13 +84,26 @@ class compress_response_should
 	[Test]
 	public void empty_gzip_reply_has_a_valid_gzip_body()
 	{
+		AssertEmptyReplyHasValidBody(CompressionAlgorithms.Gzip, stream =>
+			new GZipStream(stream, CompressionMode.Decompress));
+	}
+
+	[Test]
+	public void empty_deflate_reply_has_a_valid_deflate_body()
+	{
+		AssertEmptyReplyHasValidBody(CompressionAlgorithms.Deflate, stream =>
+			new DeflateStream(stream, CompressionMode.Decompress));
+	}
+
+	private static void AssertEmptyReplyHasValidBody(string compressionAlgorithm, Func<Stream, Stream> decompress)
+	{
 		using var completed = new ManualResetEventSlim();
 		using var responseBody = new MemoryStream();
 		var context = new DefaultHttpContext();
 		context.Request.Scheme = "http";
 		context.Request.Host = new HostString("localhost");
 		context.Request.Path = "/";
-		context.Request.Headers["Accept-Encoding"] = CompressionAlgorithms.Gzip;
+		context.Request.Headers["Accept-Encoding"] = compressionAlgorithm;
 		context.Response.Body = responseBody;
 		var entity = new HttpEntity(context, logHttpRequests: false, advertiseAsHost: null, advertiseAsPort: 0,
 			completed.Set);
@@ -101,11 +114,11 @@ class compress_response_should
 
 		Assert.IsTrue(completed.Wait(TimeSpan.FromSeconds(5)));
 		Assert.IsNull(error);
-		Assert.AreEqual(CompressionAlgorithms.Gzip, context.Response.Headers["Content-Encoding"].ToString());
+		Assert.AreEqual(compressionAlgorithm, context.Response.Headers["Content-Encoding"].ToString());
 		Assert.Greater(responseBody.Length, 0);
 
 		responseBody.Position = 0;
-		using var uncompressedStream = new GZipStream(responseBody, CompressionMode.Decompress);
+		using var uncompressedStream = decompress(responseBody);
 		using var outputStream = new MemoryStream();
 		uncompressedStream.CopyTo(outputStream);
 		Assert.AreEqual(0, outputStream.Length);

--- a/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
+++ b/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
@@ -39,6 +39,30 @@ public sealed class HttpEntityManager
 	private static readonly string[] SupportedCompressionAlgorithms =
 		{CompressionAlgorithms.Gzip, CompressionAlgorithms.Deflate};
 
+	// .NET compression streams emit no payload until data is written, but clients still need a decodable member
+	// whenever a Content-Encoding header is advertised.
+	private static readonly byte[] EmptyGzipResponse =
+	{
+		0x1f, 0x8b,
+		0x08,
+		0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00,
+		0xff,
+		0x01,
+		0x00, 0x00,
+		0xff, 0xff,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00
+	};
+
+	private static readonly byte[] EmptyDeflateResponse =
+	{
+		0x01,
+		0x00, 0x00,
+		0xff, 0xff
+	};
+
 	private static readonly BufferManager
 		_compressionBufferManager = new BufferManager(20, 50 * 1024); //create 20 50KB buffers (1MB total)
 
@@ -299,18 +323,19 @@ public sealed class HttpEntityManager
 		if (!BeginReply(code, description, contentType, encoding, headers))
 			return;
 
+		LogResponse(response ?? Array.Empty<byte>());
+
+		if (!string.IsNullOrEmpty(_responseContentEncoding))
+			response = CompressResponse(response ?? Array.Empty<byte>(), _responseContentEncoding);
+
 		if (response == null || response.Length == 0)
 		{
-			LogResponse(Array.Empty<byte>());
 			SetResponseLength(0);
 			_onComplete();
 			CloseConnection(onError);
 		}
 		else
 		{
-			LogResponse(response);
-			if (!string.IsNullOrEmpty(_responseContentEncoding))
-				response = CompressResponse(response, _responseContentEncoding);
 			SetResponseLength(response.Length);
 			ContinueReply(response, onError, _onComplete);
 		}
@@ -501,6 +526,11 @@ public sealed class HttpEntityManager
 		if (string.IsNullOrEmpty(compressionAlgorithm) ||
 			!SupportedCompressionAlgorithms.Contains(compressionAlgorithm))
 			return response;
+
+		if (response.Length == 0)
+			return compressionAlgorithm.Equals(CompressionAlgorithms.Gzip)
+				? EmptyGzipResponse.ToArray()
+				: EmptyDeflateResponse.ToArray();
 
 		MemoryStream outputStream;
 		var useBufferManager =


### PR DESCRIPTION
- Prevents clients from receiving a declared gzip or deflate response that has no compressed payload to decode.
- Keeps HTTP compression behavior consistent for empty and non-empty responses.