### PR TITLE
chore(http): remove subscriptions restart endpoint

### DIFF
--- a/src/EventStore.Core.Tests/swagger.yaml
+++ b/src/EventStore.Core.Tests/swagger.yaml
@@ -132,11 +132,6 @@ paths:
       responses:
         "200":
           description: OK
-  /subscriptions/restart:
-    post:
-      responses:
-        "200":
-          description: OK
   /users:
     get:
       responses:

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -32,7 +32,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		protected override void SubscribeCore(IHttpService service) {
 			Register(service, "/subscriptions?offset={offset}&count={count}", HttpMethod.Get, GetAllSubscriptionInfo, Codec.NoCodecs, DefaultCodecs, new Operation(Operations.Subscriptions.Statistics));
 			Register(service, "/subscriptions", HttpMethod.Get, GetAllSubscriptionInfo, Codec.NoCodecs, DefaultCodecs, new Operation(Operations.Subscriptions.Statistics));
-			Register(service, "/subscriptions/restart", HttpMethod.Post, RestartPersistentSubscriptions, Codec.NoCodecs, DefaultCodecs, new Operation(Operations.Subscriptions.Restart));
 			Register(service, "/subscriptions/{stream}", HttpMethod.Get, GetSubscriptionInfoForStream, Codec.NoCodecs,
 				DefaultCodecs, new Operation(Operations.Subscriptions.Statistics));
 			Register(service, "/subscriptions/{stream}/{subscription}", HttpMethod.Put, PutSubscription, DefaultCodecs,
@@ -373,25 +372,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			Publish(cmd);
 		}
 		
-		private void RestartPersistentSubscriptions(HttpEntityManager http, UriTemplateMatch match) {
-			if (_httpForwarder.ForwardRequest(http))
-				return;
-
-			var envelope = new SendToHttpEnvelope<SubscriptionMessage.PersistentSubscriptionsRestarting>(_networkSendQueue, http,
-				(e, message) => e.To("Restarting"),
-				(e, message) => {
-					switch (message) {
-						case SubscriptionMessage.PersistentSubscriptionsRestarting _:
-							return Configure.Ok(e.ContentType);
-						default:
-							return Configure.InternalServerError();
-					}
-				}, CreateErrorEnvelope(http)
-			);
-
-			Publish(new SubscriptionMessage.PersistentSubscriptionsRestart(envelope));
-		}
-
 		private void GetAllSubscriptionInfo(HttpEntityManager http, UriTemplateMatch match) {
 			if (_httpForwarder.ForwardRequest(http))
 				return;


### PR DESCRIPTION
- Persistent subscription restart already has gRPC management coverage, so keeping the duplicate HTTP route preserves an avoidable programmatic surface.
- Programmatic management should converge on gRPC where parity exists, leaving HTTP for UI, probes, metrics, and documented gaps.