### PR TITLE
chore(http): remove subscriptions replay endpoint

### DIFF
--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
@@ -168,9 +168,9 @@ class when_getting_subscription_statistics_for_individual<TLogFormat, TStreamId>
 
 	[Test]
 	[Retry(5)]
-	public void has_two_rel_links()
+	public void has_detail_rel_link()
 	{
-		Assert.AreEqual(2,
+		Assert.AreEqual(1,
 			_json["links"].Count());
 	}
 

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
@@ -185,7 +185,6 @@ public class Authorization<TLogFormat, TStreamId> : specification_with_cluster<T
 			"/subscriptions/{stream}/{subscription};POST;Ops",
 			"/subscriptions/{stream}/{subscription};DELETE;Ops",
 			"/subscriptions/{stream}/{subscription}/info;GET;User",
-			"/subscriptions/{stream}/{subscription}/replayParked?stopAt=1;POST;Ops",
 			"/users;GET;Admin",
 			"/users/;GET;Admin",
 			"/users/{login};GET;Admin",

--- a/src/EventStore.Core.Tests/swagger.yaml
+++ b/src/EventStore.Core.Tests/swagger.yaml
@@ -127,11 +127,6 @@ paths:
       responses:
         "200":
           description: OK
-  "/subscriptions/{stream}/{subscription}/replayParked":
-    post:
-      responses:
-        "200":
-          description: OK
   /users:
     get:
       responses:

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -41,78 +41,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}", HttpMethod.Delete, new Operation(Operations.Subscriptions.Delete), DeleteSubscription);
 			Register(service, "/subscriptions/{stream}/{subscription}/info", HttpMethod.Get, GetSubscriptionInfo,
 				Codec.NoCodecs, DefaultCodecs, new Operation(Operations.Subscriptions.Statistics));
-			RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/replayParked?stopAt={stopAt}", HttpMethod.Post,
-				WithParameters(Operations.Subscriptions.ReplayParked), ReplayParkedMessages);
-		}
-
-		static Func<UriTemplateMatch, Operation> WithParameters(OperationDefinition definition) {
-			return match => {
-				var operation = new Operation(definition);
-				var stream = match.BoundVariables["stream"];
-				if(!string.IsNullOrEmpty(stream))
-					operation = operation.WithParameter(Operations.Subscriptions.Parameters.StreamId(stream));
-				var subscription = match.BoundVariables["subscription"];
-				if (!string.IsNullOrEmpty(subscription))
-					operation = operation.WithParameter(
-						Operations.Subscriptions.Parameters.SubscriptionId(subscription));
-				return operation;
-			};
-		}
-
-		private void ReplayParkedMessages(HttpEntityManager http, UriTemplateMatch match) {
-			if (_httpForwarder.ForwardRequest(http))
-				return;
-			var envelope = new SendToHttpEnvelope(
-				_networkSendQueue, http,
-				(args, message) => http.ResponseCodec.To(message),
-				(args, message) => {
-					int code;
-					if (message is ClientMessage.NotHandled notHandled)
-						return Configure.HandleNotHandled(args.RequestedUrl, notHandled);
-
-					var m = message as ClientMessage.ReplayMessagesReceived;
-					if (m == null) throw new Exception("unexpected message " + message);
-					switch (m.Result) {
-						case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Success:
-							code = HttpStatusCode.OK;
-							break;
-						case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.DoesNotExist:
-							code = HttpStatusCode.NotFound;
-							break;
-						case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.AccessDenied:
-							code = HttpStatusCode.Unauthorized;
-							break;
-						default:
-							code = HttpStatusCode.InternalServerError;
-							break;
-					}
-
-					return new ResponseConfiguration(code, http.ResponseCodec.ContentType,
-						http.ResponseCodec.Encoding);
-				});
-			var groupname = match.BoundVariables["subscription"];
-			var stream = match.BoundVariables["stream"];
-			var stopAtStr = match.BoundVariables["stopAt"];
-			
-			long? stopAt;
-			// if stopAt is declared...
-			if (stopAtStr != null) {
-				// check it is valid
-				if (!long.TryParse(stopAtStr, out var stopAtLong) || stopAtLong < 0) {
-					http.ReplyStatus(HttpStatusCode.BadRequest, "stopAt should be a properly formed positive long",
-						exception => { });
-					return;
-				}
-
-				stopAt = stopAtLong;
-			} else {
-				// else it's null
-				stopAt = null;
-			}
-
-			var cmd = new ClientMessage.ReplayParkedMessages(Guid.NewGuid(), Guid.NewGuid(), envelope, stream,
-				groupname, stopAt, http.User);
-			Publish(cmd);
 		}
 
 		private void PutSubscription(HttpEntityManager http, UriTemplateMatch match) {
@@ -458,25 +386,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			Publish(cmd);
 		}
 		
-		private IEnvelope CreateErrorEnvelope(HttpEntityManager http) {
-			return new SendToHttpEnvelope<SubscriptionMessage.InvalidPersistentSubscriptionsRestart>(
-				_networkSendQueue,
-				http,
-				ErrorFormatter,
-				ErrorConfigurator,
-				null);
-		}
-
-		private ResponseConfiguration ErrorConfigurator(ICodec codec, SubscriptionMessage.InvalidPersistentSubscriptionsRestart message) {
-			return new ResponseConfiguration(HttpStatusCode.BadRequest, "Bad Request", "text/plain",
-				Helper.UTF8NoBom);
-		}
-
-		private string ErrorFormatter(ICodec codec, SubscriptionMessage.InvalidPersistentSubscriptionsRestart message) {
-			return message.Reason;
-		}
-
-
 		private static ResponseConfiguration StatsConfiguration(HttpResponseConfiguratorArgs http, Message message) {
 			int code;
 			if (message is ClientMessage.NotHandled notHandled)
@@ -516,11 +425,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 						new RelLink(
 							MakeUrl(manager,
 								string.Format("/subscriptions/{0}/{1}/info", escapedStreamId, escapedGroupName)),
-							"detail"),
-						new RelLink(
-							MakeUrl(manager,
-								string.Format("/subscriptions/{0}/{1}/replayParked", escapedStreamId,
-									escapedGroupName)), "replayParked")
+							"detail")
 					},
 					EventStreamId = stat.EventSource,
 					GroupName = stat.GroupName,


### PR DESCRIPTION
- Persistent subscription parked-message replay already has a gRPC management path, so keeping the HTTP command route preserves duplicate control surfaces without adding capability.