### PR TITLE
chore(http): remove subscription info endpoint

### DIFF
--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/creating.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/creating.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using EventStore.Core.Tests.Http.Users.users;
-using EventStore.Transport.Http;
-using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using HttpResponseMessage = System.Net.Http.HttpResponseMessage;
 using HttpStatusCode = System.Net.HttpStatusCode;
@@ -200,7 +198,6 @@ class when_creating_persistent_subscription_with_message_timeout_0<TLogFormat, T
 	protected string SubscriptionPath;
 	protected string GroupName;
 	protected HttpResponseMessage Response;
-	protected JObject SubsciptionInfo;
 
 	protected override Task Given() => Task.CompletedTask;
 
@@ -215,8 +212,6 @@ class when_creating_persistent_subscription_with_message_timeout_0<TLogFormat, T
 				MessageTimeoutMilliseconds = 0
 			},
 			_admin);
-
-		SubsciptionInfo = await GetJson<JObject>(SubscriptionPath + "/info", ContentType.Json);
 	}
 
 	[OneTimeTearDown]
@@ -229,14 +224,6 @@ class when_creating_persistent_subscription_with_message_timeout_0<TLogFormat, T
 	public void returns_created()
 	{
 		Assert.AreEqual(HttpStatusCode.Created, Response.StatusCode);
-
-	}
-
-	[Test]
-	public void timeout_set_to_0()
-	{
-		Assert.AreEqual(0, SubsciptionInfo.Value<JObject>("config").Value<long?>("messageTimeoutMilliseconds"));
-
 	}
 }
 
@@ -247,7 +234,6 @@ class when_creating_persistent_subscription_without_message_timeout<TLogFormat, 
 	protected string SubscriptionPath;
 	protected string GroupName;
 	protected HttpResponseMessage Response;
-	protected JObject SubsciptionInfo;
 
 	protected override Task Given() => Task.CompletedTask;
 	protected override async Task When()
@@ -260,8 +246,6 @@ class when_creating_persistent_subscription_without_message_timeout<TLogFormat, 
 				ResolveLinkTos = true,
 			},
 			_admin);
-
-		SubsciptionInfo = await GetJson<JObject>(SubscriptionPath + "/info", ContentType.Json);
 	}
 
 	[OneTimeTearDown]
@@ -274,13 +258,5 @@ class when_creating_persistent_subscription_without_message_timeout<TLogFormat, 
 	public void returns_created()
 	{
 		Assert.AreEqual(HttpStatusCode.Created, Response.StatusCode);
-
-	}
-
-	[Test]
-	public void timeout_set_to_default_10000()
-	{
-		Assert.AreEqual(10000, SubsciptionInfo.Value<JObject>("config").Value<long?>("messageTimeoutMilliseconds"));
-
 	}
 }

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using EventStore.ClientAPI;
@@ -96,129 +95,6 @@ class when_getting_all_statistics_in_xml<TLogFormat, TStreamId> : with_subscript
 
 [Category("LongRunning")]
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
-class when_getting_non_existent_single_statistics<TLogFormat, TStreamId> : with_admin_user<TLogFormat, TStreamId>
-{
-	private HttpResponseMessage _response;
-
-	protected override Task Given() => Task.CompletedTask;
-
-	protected override async Task When()
-	{
-		var request = CreateRequest("/subscriptions/fu/fubar/info", null, "GET", "text/xml");
-		_response = await GetRequestResponse(request);
-	}
-
-	[Test]
-	[Retry(5)]
-	public void returns_not_found()
-	{
-		Assert.AreEqual(HttpStatusCode.NotFound, _response.StatusCode);
-	}
-}
-
-[Category("LongRunning")]
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-class when_getting_subscription_statistics_for_individual<TLogFormat, TStreamId> : SpecificationWithPersistentSubscriptionAndConnections<TLogFormat, TStreamId>
-{
-	private JObject _json;
-
-
-	protected override async Task When()
-	{
-		_json = await GetJson<JObject>("/subscriptions/" + _streamName + "/" + _groupName + "/info", ContentType.Json);
-	}
-
-	[Test]
-	[Retry(5)]
-	public void returns_ok()
-	{
-		Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
-	}
-
-	[Test]
-	[Retry(5)]
-	public void detail_rel_href_is_correct()
-	{
-		Assert.AreEqual(
-			string.Format("http://{0}/subscriptions/{1}/{2}/info", _node.HttpEndPoint, _streamName, _groupName),
-			_json["links"][0]["href"].Value<string>());
-	}
-
-	[Test]
-	[Retry(5)]
-	public void has_detail_rel_link()
-	{
-		Assert.AreEqual(1,
-			_json["links"].Count());
-	}
-
-	[Test]
-	[Retry(5)]
-	public void the_view_detail_rel_is_correct()
-	{
-		Assert.AreEqual("detail",
-			_json["links"][0]["rel"].Value<string>());
-	}
-
-	[Test]
-	[Retry(5)]
-	public void the_event_stream_is_correct()
-	{
-		Assert.AreEqual(_streamName, _json["eventStreamId"].Value<string>());
-	}
-
-	[Test]
-	[Retry(5)]
-	public void the_groupname_is_correct()
-	{
-		Assert.AreEqual(_groupName, _json["groupName"].Value<string>());
-	}
-
-	[Test]
-	[Retry(5)]
-	public void the_status_is_live()
-	{
-		Assert.AreEqual("Live", _json["status"].Value<string>());
-	}
-
-	[Test]
-	[Retry(5)]
-	public void there_are_two_connections()
-	{
-		Assert.AreEqual(2, _json["connections"].Count());
-	}
-
-	[Test]
-	[Retry(5)]
-	public void the_first_connection_has_endpoint()
-	{
-		Assert.IsNotNull(_json["connections"][0]["from"]);
-	}
-
-	[Test]
-	[Retry(5)]
-	public void the_second_connection_has_endpoint()
-	{
-		Assert.IsNotNull(_json["connections"][1]["from"]);
-	}
-
-	[Test]
-	[Retry(5)]
-	public void the_first_connection_has_user()
-	{
-		Assert.AreEqual("admin", _json["connections"][0]["username"].Value<string>());
-	}
-
-	[Test]
-	[Retry(5)]
-	public void the_second_connection_has_user()
-	{
-		Assert.AreEqual("admin", _json["connections"][1]["username"].Value<string>());
-	}
-}
-
-[Category("LongRunning")]
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
 class when_getting_subscription_stats_summary<TLogFormat, TStreamId> : SpecificationWithPersistentSubscriptionAndConnections<TLogFormat, TStreamId>
 {
 	private readonly PersistentSubscriptionSettings _settings = PersistentSubscriptionSettings.Create()
@@ -286,53 +162,18 @@ class when_getting_subscription_stats_summary<TLogFormat, TStreamId> : Specifica
 
 	[Test]
 	[Retry(5)]
-	public void the_first_event_stream_detail_uri_is_correct()
+	public void the_first_event_stream_has_no_http_detail_links()
 	{
-		Assert.AreEqual(
-			string.Format("http://{0}/subscriptions/{1}/{2}/info", _node.HttpEndPoint, _streamName, _groupName),
-			_json[0]["links"][0]["href"].Value<string>());
-	}
-
-	[Test]
-	[Retry(5)]
-	public void the_first_event_stream_detail_has_one_link()
-	{
-		Assert.AreEqual(1,
+		Assert.AreEqual(0,
 			_json[0]["links"].Count());
 	}
 
 	[Test]
 	[Retry(5)]
-	public void the_first_event_stream_detail_rel_is_correct()
+	public void the_second_event_stream_has_no_http_detail_links()
 	{
-		Assert.AreEqual("detail",
-			_json[0]["links"][0]["rel"].Value<string>());
-	}
-
-	[Test]
-	[Retry(5)]
-	public void the_second_event_stream_detail_uri_is_correct()
-	{
-		Assert.AreEqual(
-			string.Format("http://{0}/subscriptions/{1}/{2}/info", _node.HttpEndPoint, _streamName,
-				"secondgroup"),
-			_json[1]["links"][0]["href"].Value<string>());
-	}
-
-	[Test]
-	[Retry(5)]
-	public void the_second_event_stream_detail_has_one_link()
-	{
-		Assert.AreEqual(1,
+		Assert.AreEqual(0,
 			_json[1]["links"].Count());
-	}
-
-	[Test]
-	[Retry(5)]
-	public void the_second_event_stream_detail_rel_is_correct()
-	{
-		Assert.AreEqual("detail",
-			_json[1]["links"][0]["rel"].Value<string>());
 	}
 
 	[Test]

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/GetInfoTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/GetInfoTests.cs
@@ -179,6 +179,50 @@ public class GetInfoTests
 
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	public class
+		when_getting_info_for_missing_persistent_subscription_on_stream<TLogFormat, TStreamId>
+			: GrpcSpecification<TLogFormat, TStreamId>
+	{
+		private RpcException _exception;
+		private PersistentSubscriptions.PersistentSubscriptionsClient _persistentSubscriptionsClient;
+
+		protected override Task Given()
+		{
+			_persistentSubscriptionsClient = new PersistentSubscriptions.PersistentSubscriptionsClient(Channel);
+			return Task.CompletedTask;
+		}
+
+		protected override async Task When()
+		{
+			try
+			{
+				await _persistentSubscriptionsClient.GetInfoAsync(new GetInfoReq
+				{
+					Options = new GetInfoReq.Types.Options
+					{
+						GroupName = "missing-group",
+						StreamIdentifier = new StreamIdentifier
+						{
+							StreamName = ByteString.CopyFromUtf8("missing-stream")
+						}
+					}
+				}, GetCallOptions(AdminCredentials));
+			}
+			catch (RpcException ex)
+			{
+				_exception = ex;
+			}
+		}
+
+		[Test]
+		public void returns_not_found()
+		{
+			Assert.IsNotNull(_exception);
+			Assert.AreEqual(StatusCode.NotFound, _exception.Status.StatusCode);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class
 		when_listing_persistent_subscriptions_on_missing_stream<TLogFormat, TStreamId>
 			: GrpcSpecification<TLogFormat, TStreamId>
 	{

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
@@ -182,7 +182,6 @@ public class Authorization<TLogFormat, TStreamId> : specification_with_cluster<T
 			"/subscriptions;GET;User",
 			"/subscriptions/{stream}/{subscription};PUT;Ops",
 			"/subscriptions/{stream}/{subscription};POST;Ops",
-			"/subscriptions/{stream}/{subscription}/info;GET;User",
 			"/users;GET;Admin",
 			"/users/;GET;Admin",
 			"/users/{login};GET;Admin",

--- a/src/EventStore.Core.Tests/swagger.yaml
+++ b/src/EventStore.Core.Tests/swagger.yaml
@@ -113,11 +113,6 @@ paths:
       responses:
         "200":
           description: OK
-  "/subscriptions/{stream}/{subscription}/info":
-    get:
-      responses:
-        "200":
-          description: OK
   /users:
     get:
       responses:

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -36,8 +36,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				DefaultCodecs, new Operation(Operations.Subscriptions.Create));
 			Register(service, "/subscriptions/{stream}/{subscription}", HttpMethod.Post, PostSubscription,
 				DefaultCodecs, DefaultCodecs, new Operation(Operations.Subscriptions.Update));
-			Register(service, "/subscriptions/{stream}/{subscription}/info", HttpMethod.Get, GetSubscriptionInfo,
-				Codec.NoCodecs, DefaultCodecs, new Operation(Operations.Subscriptions.Statistics));
 		}
 
 		private void PutSubscription(HttpEntityManager http, UriTemplateMatch match) {
@@ -308,22 +306,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			Publish(cmd);
 		}
 
-		private void GetSubscriptionInfo(HttpEntityManager http, UriTemplateMatch match) {
-			if (_httpForwarder.ForwardRequest(http))
-				return;
-			var stream = match.BoundVariables["stream"];
-			var groupName = match.BoundVariables["subscription"];
-			var envelope = new SendToHttpEnvelope(
-				_networkSendQueue, http,
-				(args, message) =>
-					http.ResponseCodec.To(
-						ToDto(http, message as MonitoringMessage.GetPersistentSubscriptionStatsCompleted)
-							.FirstOrDefault()),
-				(args, message) => StatsConfiguration(args, message));
-			var cmd = new MonitoringMessage.GetPersistentSubscriptionStats(envelope, stream, groupName);
-			Publish(cmd);
-		}
-		
 		private static ResponseConfiguration StatsConfiguration(HttpResponseConfiguratorArgs http, Message message) {
 			int code;
 			if (message is ClientMessage.NotHandled notHandled)
@@ -350,97 +332,14 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				http.ResponseCodec.Encoding);
 		}
 
-		private IEnumerable<SubscriptionInfo> ToDto(HttpEntityManager manager,
-			MonitoringMessage.GetPersistentSubscriptionStatsCompleted message) {
-			if (message == null) yield break;
-			if (message.SubscriptionStats == null) yield break;
-
-			foreach (var stat in message.SubscriptionStats) {
-				string escapedStreamId = Uri.EscapeDataString(stat.EventSource);
-				string escapedGroupName = Uri.EscapeDataString(stat.GroupName);
-				var info = new SubscriptionInfo {
-					Links = new List<RelLink>() {
-						new RelLink(
-							MakeUrl(manager,
-								string.Format("/subscriptions/{0}/{1}/info", escapedStreamId, escapedGroupName)),
-							"detail")
-					},
-					EventStreamId = stat.EventSource,
-					GroupName = stat.GroupName,
-					Status = stat.Status,
-					AverageItemsPerSecond = stat.AveragePerSecond,
-					TotalItemsProcessed = stat.TotalItems,
-					CountSinceLastMeasurement = stat.CountSinceLastMeasurement,
-					#pragma warning disable 612
-					LastKnownEventNumber = long.TryParse(stat.LastKnownEventPosition, out var lastKnownMsg) ? lastKnownMsg : 0,
-					#pragma warning restore 612
-					LastKnownEventPosition = stat.LastKnownEventPosition,
-					#pragma warning disable 612
-					LastProcessedEventNumber = long.TryParse(stat.LastCheckpointedEventPosition, out var lastProcessedPos) ? lastProcessedPos : 0,
-					#pragma warning restore 612
-					LastCheckpointedEventPosition = stat.LastCheckpointedEventPosition,
-					ReadBufferCount = stat.ReadBufferCount,
-					LiveBufferCount = stat.LiveBufferCount,
-					RetryBufferCount = stat.RetryBufferCount,
-					TotalInFlightMessages = stat.TotalInFlightMessages,
-					OutstandingMessagesCount = stat.OutstandingMessagesCount,
-					Config = new SubscriptionConfigData {
-						CheckPointAfterMilliseconds = stat.CheckPointAfterMilliseconds,
-						BufferSize = stat.BufferSize,
-						LiveBufferSize = stat.LiveBufferSize,
-						MaxCheckPointCount = stat.MaxCheckPointCount,
-						MaxRetryCount = stat.MaxRetryCount,
-						MessageTimeoutMilliseconds = stat.MessageTimeoutMilliseconds,
-						MinCheckPointCount = stat.MinCheckPointCount,
-						NamedConsumerStrategy = stat.NamedConsumerStrategy,
-						PreferRoundRobin = stat.NamedConsumerStrategy == SystemConsumerStrategies.RoundRobin,
-						ReadBatchSize = stat.ReadBatchSize,
-						ResolveLinktos = stat.ResolveLinktos,
-						#pragma warning disable 612
-						StartFrom = long.TryParse(stat.StartFrom, out var startFrom) ? startFrom : 0,
-						#pragma warning restore 612
-						StartPosition = stat.StartFrom,
-						ExtraStatistics = stat.ExtraStatistics,
-						MaxSubscriberCount = stat.MaxSubscriberCount,
-					},
-					Connections = new List<ConnectionInfo>(),
-					ParkedMessageCount = stat.ParkedMessageCount
-				};
-				if (stat.Connections != null) {
-					foreach (var connection in stat.Connections) {
-						info.Connections.Add(new ConnectionInfo {
-							Username = connection.Username,
-							From = connection.From,
-							AverageItemsPerSecond = connection.AverageItemsPerSecond,
-							CountSinceLastMeasurement = connection.CountSinceLastMeasurement,
-							TotalItemsProcessed = connection.TotalItems,
-							AvailableSlots = connection.AvailableSlots,
-							InFlightMessages = connection.InFlightMessages,
-							ExtraStatistics = connection.ObservedMeasurements ?? new List<Measurement>(),
-							ConnectionName = connection.ConnectionName,
-						});
-					}
-				}
-
-				yield return info;
-			}
-		}
-
 		private IEnumerable<SubscriptionSummary> ToSummaryDto(HttpEntityManager manager,
 			MonitoringMessage.GetPersistentSubscriptionStatsCompleted message) {
 			if (message == null) yield break;
 			if (message.SubscriptionStats == null) yield break;
 
 			foreach (var stat in message.SubscriptionStats) {
-				string escapedStreamId = Uri.EscapeDataString(stat.EventSource);
-				string escapedGroupName = Uri.EscapeDataString(stat.GroupName);
 				var info = new SubscriptionSummary {
-					Links = new List<RelLink>() {
-						new RelLink(
-							MakeUrl(manager,
-								string.Format("/subscriptions/{0}/{1}/info", escapedStreamId, escapedGroupName)),
-							"detail"),
-					},
+					Links = new List<RelLink>(),
 					EventStreamId = stat.EventSource,
 					GroupName = stat.GroupName,
 					Status = stat.Status,
@@ -560,38 +459,5 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			public int TotalInFlightMessages { get; set; }
 		}
 
-		public class SubscriptionInfo {
-			public List<RelLink> Links { get; set; }
-			public SubscriptionConfigData Config { get; set; }
-			public string EventStreamId { get; set; }
-			public string GroupName { get; set; }
-			public string Status { get; set; }
-			public decimal AverageItemsPerSecond { get; set; }
-			public long TotalItemsProcessed { get; set; }
-			public long CountSinceLastMeasurement { get; set; }
-			[Obsolete] public long LastProcessedEventNumber { get; set; }
-			public string LastCheckpointedEventPosition { get; set; }
-			[Obsolete] public long LastKnownEventNumber { get; set; }
-			public string LastKnownEventPosition { get; set; }
-			public int ReadBufferCount { get; set; }
-			public long LiveBufferCount { get; set; }
-			public int RetryBufferCount { get; set; }
-			public int TotalInFlightMessages { get; set; }
-			public int OutstandingMessagesCount { get; set; }
-			public List<ConnectionInfo> Connections { get; set; }
-			public long ParkedMessageCount { get; set; }
-		}
-
-		public class ConnectionInfo {
-			public string From { get; set; }
-			public string Username { get; set; }
-			public decimal AverageItemsPerSecond { get; set; }
-			public long TotalItemsProcessed { get; set; }
-			public long CountSinceLastMeasurement { get; set; }
-			public List<Measurement> ExtraStatistics { get; set; }
-			public int AvailableSlots { get; set; }
-			public int InFlightMessages { get; set; }
-			public string ConnectionName { get; set; }
-		}
 	}
 }


### PR DESCRIPTION
- Persistent subscription detail reads already have a gRPC management path, so retaining the HTTP detail route keeps duplicate read surfaces alive without preserving unique capability.