### PR TITLE
chore(http): remove user password command

### DIFF
--- a/src/EventStore.Core.Tests/ClientAPI/UserManagement/reset_change_password.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/UserManagement/reset_change_password.cs
@@ -42,114 +42,12 @@ public class reset_password<TLogFormat, TStreamId> : TestWithUser<TLogFormat, TS
 	public async Task can_reset_password()
 	{
 		await _manager.ResetPasswordAsync(_username, "foo", new UserCredentials("admin", "changeit"));
-		var ex = await AssertEx.ThrowsAsync<UserCommandFailedException>(
-			() => _manager.ChangePasswordAsync(_username, "password", "foobar",
-				new UserCredentials(_username, "password"))
-		);
+		var ex = await AssertEx.ThrowsAsync<AggregateException>(
+			() => _manager.GetCurrentUserAsync(new UserCredentials(_username, "password")));
 		Assert.AreEqual(HttpStatusCode.Unauthorized,
-			ex.HttpStatusCode);
-	}
-}
+			((UserCommandFailedException)ex.InnerException).HttpStatusCode);
 
-[TestFixture(typeof(LogFormat.V2), typeof(string))]
-public class change_password<TLogFormat, TStreamId> : TestWithUser<TLogFormat, TStreamId>
-{
-	[Test]
-	public async Task null_username_throws()
-	{
-		await AssertEx.ThrowsAsync<ArgumentNullException>(() =>
-			_manager.ChangePasswordAsync(null, "oldpassword", "newpassword",
-				new UserCredentials("admin", "changeit")));
-	}
-
-	[Test]
-	public async Task empty_username_throws()
-	{
-		await AssertEx.ThrowsAsync<ArgumentNullException>(() =>
-			_manager.ChangePasswordAsync("", "oldpassword", "newpassword", new UserCredentials("admin", "changeit"))
-				);
-	}
-
-	[Test]
-	public async Task null_current_password_throws()
-	{
-		await AssertEx.ThrowsAsync<ArgumentNullException>(() =>
-			_manager.ChangePasswordAsync(_username, null, "newpassword", new UserCredentials("admin", "changeit"))
-				);
-	}
-
-	[Test]
-	public async Task empty_current_password_throws()
-	{
-		await AssertEx.ThrowsAsync<ArgumentNullException>(() =>
-			_manager.ChangePasswordAsync(_username, "", "newpassword", new UserCredentials("admin", "changeit"))
-				);
-	}
-
-	[Test]
-	public async Task null_new_password_throws()
-	{
-		await AssertEx.ThrowsAsync<ArgumentNullException>(() =>
-			_manager.ChangePasswordAsync(_username, "oldpasword", null, new UserCredentials("admin", "changeit"))
-				);
-	}
-
-	[Test]
-	public async Task empty_new_password_throws()
-	{
-		await AssertEx.ThrowsAsync<ArgumentNullException>(() =>
-			_manager.ChangePasswordAsync(_username, "oldpassword", "", new UserCredentials("admin", "changeit"))
-				);
-	}
-
-	[Test]
-	public async Task can_change_password()
-	{
-		await _manager.ChangePasswordAsync(_username, "password", "fubar", new UserCredentials(_username, "password"));
-		var ex = await AssertEx.ThrowsAsync<UserCommandFailedException>(
-			() => _manager.ChangePasswordAsync(_username, "password", "foobar",
-				new UserCredentials(_username, "password"))
-		);
-		Assert.AreEqual(HttpStatusCode.Unauthorized,
-			ex.HttpStatusCode);
-	}
-}
-
-[TestFixture(typeof(LogFormat.V2), typeof(string), "newpassword")]
-[TestFixture(typeof(LogFormat.V2), typeof(string), "n£wpasswordUnicode码")]
-[TestFixture(typeof(LogFormat.V2), typeof(string), "password")] // same as old password
-public class change_password_and_use_the_new_one<TLogFormat, TStreamId> : TestWithUser<TLogFormat, TStreamId>
-{
-	private readonly string _newPassword;
-	private const string OldPassword = "password";
-	private readonly TimeSpan _passwordChangeDelay = TimeSpan.FromSeconds(20);
-
-	public change_password_and_use_the_new_one(string newPassword)
-	{
-		_newPassword = newPassword;
-	}
-
-	[Test, Category("LongRunning"), Explicit]
-	public async Task can_change_password_and_use_the_new_one()
-	{
-		var oldCredentials = new UserCredentials(_username, OldPassword);
-		var newCredentials = new UserCredentials(_username, _newPassword);
-
-		// change the password to the new one
-		await _manager.ChangePasswordAsync(
-			login: _username,
-			oldPassword: OldPassword,
-			newPassword: _newPassword,
-			userCredentials: oldCredentials);
-
-		// wait for some time to allow the password change notification reader to detect the change
-		await Task.Delay(_passwordChangeDelay);
-
-		// change the password again but with the new credentials to see if they work
-		await _manager.ChangePasswordAsync(
-			login: _username,
-			oldPassword: _newPassword,
-			newPassword: "foobar",
-			userCredentials: newCredentials);
+		var current = await _manager.GetCurrentUserAsync(new UserCredentials(_username, "foo"));
+		Assert.AreEqual(_username, current.LoginName);
 	}
 }

--- a/src/EventStore.Core.Tests/Http/Users/users.cs
+++ b/src/EventStore.Core.Tests/Http/Users/users.cs
@@ -102,15 +102,10 @@ namespace EventStore.Core.Tests.Http.Users
 								Disabled = false,
 								Password___ = false,
 								Links = new[] {
-									new {
-										Href = "http://" + _node.HttpEndPoint +
-											   "/users/test1/command/reset-password",
-										Rel = "reset-password"
-									},
-									new {
-										Href = "http://" + _node.HttpEndPoint +
-											   "/users/test1/command/change-password",
-										Rel = "change-password"
+										new {
+											Href = "http://" + _node.HttpEndPoint +
+												   "/users/test1/command/reset-password",
+											Rel = "reset-password"
 									},
 									new {
 										Href = "http://" + _node.HttpEndPoint + "/users/test1",
@@ -174,15 +169,10 @@ namespace EventStore.Core.Tests.Http.Users
 							new
 							{
 								Links = new[] {
-									new {
-										Href = "http://" + _node.HttpEndPoint +
-											   "/users/test2/command/reset-password",
-										Rel = "reset-password"
-									},
-									new {
-										Href = "http://" + _node.HttpEndPoint +
-											   "/users/test2/command/change-password",
-										Rel = "change-password"
+										new {
+											Href = "http://" + _node.HttpEndPoint +
+												   "/users/test2/command/reset-password",
+											Rel = "reset-password"
 									},
 									new {
 										Href = "http://" + _node.HttpEndPoint + "/users/test2",
@@ -378,13 +368,10 @@ namespace EventStore.Core.Tests.Http.Users
 			}
 
 			[Test]
-			public async Task can_change_password_using_the_new_password()
+			public async Task can_authenticate_using_the_new_password()
 			{
-				var response = await MakeJsonPost(
-					"/users/test1/command/change-password",
-					new { CurrentPassword = "NewPassword!", NewPassword = "TheVeryNewPassword!" },
-					new NetworkCredential("test1", "NewPassword!"));
-				Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+				await GetJson<JObject>("/test1", credentials: new NetworkCredential("test1", "NewPassword!"));
+				Assert.AreNotEqual(HttpStatusCode.Unauthorized, _lastResponse.StatusCode);
 			}
 		}
 

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/UsersTests/ChangePasswordTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/UsersTests/ChangePasswordTests.cs
@@ -1,0 +1,69 @@
+using System.Threading.Tasks;
+using EventStore.Client.Users;
+using EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests;
+using Grpc.Core;
+using NUnit.Framework;
+using UsersClient = EventStore.Client.Users.Users.UsersClient;
+
+namespace EventStore.Core.Tests.Services.Transport.Grpc.UsersTests;
+
+public class ChangePasswordTests {
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_changing_password_with_correct_current_password<TLogFormat, TStreamId>
+		: GrpcSpecification<TLogFormat, TStreamId> {
+		private UsersClient _client;
+		private bool _completed;
+
+		protected override async Task Given() {
+			_client = new UsersClient(Channel);
+			await Task.CompletedTask;
+		}
+
+		protected override async Task When() {
+			await _client.ChangePasswordAsync(ChangePasswordRequest("admin", "changeit", "NewPa55w0rd!"),
+				GetCallOptions(AdminCredentials));
+			_completed = true;
+		}
+
+		[Test]
+		public void succeeds() {
+			Assert.IsTrue(_completed);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_changing_password_with_incorrect_current_password<TLogFormat, TStreamId>
+		: GrpcSpecification<TLogFormat, TStreamId> {
+		private UsersClient _client;
+		private RpcException _exception;
+
+		protected override async Task Given() {
+			_client = new UsersClient(Channel);
+			await Task.CompletedTask;
+		}
+
+		protected override async Task When() {
+			try {
+				await _client.ChangePasswordAsync(ChangePasswordRequest("admin", "WrongPa55w0rd!", "NewPa55w0rd!"),
+					GetCallOptions(AdminCredentials));
+			} catch (RpcException ex) {
+				_exception = ex;
+			}
+		}
+
+		[Test]
+		public void returns_permission_denied() {
+			Assert.IsNotNull(_exception);
+			Assert.AreEqual(StatusCode.PermissionDenied, _exception.Status.StatusCode);
+		}
+	}
+
+	private static ChangePasswordReq ChangePasswordRequest(string loginName, string currentPassword, string newPassword) =>
+		new() {
+			Options = new ChangePasswordReq.Types.Options {
+				LoginName = loginName,
+				CurrentPassword = currentPassword,
+				NewPassword = newPassword
+			}
+		};
+}

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
@@ -193,7 +193,6 @@ public class Authorization<TLogFormat, TStreamId> : specification_with_cluster<T
 			"/users/{login}/command/enable;POST;Admin",
 			"/users/{login}/command/disable;POST;Admin",
 			"/users/{login}/command/reset-password;POST;Admin",
-			//"/users/{login}/command/change-password;POST;User", Users can only change their own password, so this url won't be correct in these tests
 			"/ui/assets/{*remaining_path};GET;None",
 			";GET;None"
 		)] string httpEndpointDetails
@@ -248,7 +247,7 @@ public class Authorization<TLogFormat, TStreamId> : specification_with_cluster<T
 	{
 		if (httpMethod == HttpMethod.Post || httpMethod == HttpMethod.Put || httpMethod == HttpMethod.Delete)
 		{
-			if (url.Equals("/users/{login}/command/change-password") || url.Equals("/users/{login}/command/reset-password"))
+				if (url.Equals("/users/{login}/command/reset-password"))
 			{
 				return "{newPassword: \"changeit\"}";
 			}

--- a/src/EventStore.Core.Tests/Services/Transport/Http/speed_test.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/speed_test.cs
@@ -89,11 +89,10 @@ public class FakeController : IHttpController
 		Register("/users/", HttpMethod.Post);
 		Register("/users/{login}", HttpMethod.Put);
 		Register("/users/{login}", HttpMethod.Delete);
-		Register("/users/{login}/command/enable", HttpMethod.Post);
-		Register("/users/{login}/command/disable", HttpMethod.Post);
-		Register("/users/{login}/command/reset-password", HttpMethod.Post);
-		Register("/users/{login}/command/change-password", HttpMethod.Post);
-	}
+			Register("/users/{login}/command/enable", HttpMethod.Post);
+			Register("/users/{login}/command/disable", HttpMethod.Post);
+			Register("/users/{login}/command/reset-password", HttpMethod.Post);
+		}
 
 	private void Register(string route, string verb)
 	{

--- a/src/EventStore.Core.Tests/swagger.yaml
+++ b/src/EventStore.Core.Tests/swagger.yaml
@@ -150,11 +150,6 @@ paths:
       responses:
         "200":
           description: OK
-  "/users/{login}/command/change-password":
-    post:
-      responses:
-        "200":
-          description: OK
   /projections/any:
     get:
       responses:

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -77,7 +77,7 @@
 		<Protobuf Include="..\Protos\Grpc\streams.proto" GrpcServices="Both" LinkBase="Services/Transport/Grpc" ProtoRoot="../Protos/Grpc">
 			<Link>Services\Transport\Grpc\Protos\streams.proto</Link>
 		</Protobuf>
-		<Protobuf Include="..\Protos\Grpc\users.proto" GrpcServices="Server" LinkBase="Services/Transport/Grpc" ProtoRoot="../Protos/Grpc">
+		<Protobuf Include="..\Protos\Grpc\users.proto" GrpcServices="Both" LinkBase="Services/Transport/Grpc" ProtoRoot="../Protos/Grpc">
 			<Link>Services\Transport\Grpc\Protos\users.proto</Link>
 		</Protobuf>
 		<Protobuf Include="..\Protos\Grpc\monitoring.proto" GrpcServices="Both" LinkBase="Services/Transport/Grpc" ProtoRoot="../Protos/Grpc">

--- a/src/EventStore.Core/Messages/UserManagementMessage.cs
+++ b/src/EventStore.Core/Messages/UserManagementMessage.cs
@@ -186,7 +186,6 @@ namespace EventStore.Core.Messages {
 				Links = new List<RelLink>();
 				var userLocalUrl = "/users/" + userData.LoginName;
 				Links.Add(new RelLink(makeAbsoluteUrl(userLocalUrl + "/command/reset-password"), "reset-password"));
-				Links.Add(new RelLink(makeAbsoluteUrl(userLocalUrl + "/command/change-password"), "change-password"));
 				Links.Add(new RelLink(makeAbsoluteUrl(userLocalUrl), "edit"));
 				Links.Add(new RelLink(makeAbsoluteUrl(userLocalUrl), "delete"));
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/UsersController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/UsersController.cs
@@ -33,12 +33,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			RegisterUrlBased(service, "/users/{login}/command/disable", HttpMethod.Post, new Operation(Operations.Users.Disable), PostCommandDisable);
 			Register(service, "/users/{login}/command/reset-password", HttpMethod.Post, PostCommandResetPassword,
 				DefaultCodecs, DefaultCodecs, new Operation(Operations.Users.ResetPassword));
-			Register(service, "/users/{login}/command/change-password", HttpMethod.Post, PostCommandChangePassword,
-				DefaultCodecs, DefaultCodecs, ForUser(Operations.Users.ChangePassword));
-		}
-
-		private static Func<UriTemplateMatch, Operation> ForUser(OperationDefinition definition) {
-			return match => new Operation(definition).WithParameter(Operations.Users.Parameters.User(match.BoundVariables["login"]));
 		}
 
 		private void GetUsers(HttpEntityManager http, UriTemplateMatch match) {
@@ -154,21 +148,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				}, x => Log.Debug(x, "Reply Text Content Failed."));
 		}
 
-		private void PostCommandChangePassword(HttpEntityManager http, UriTemplateMatch match) {
-			if (_httpForwarder.ForwardRequest(http))
-				return;
-			var envelope = CreateReplyEnvelope<UserManagementMessage.UpdateResult>(http);
-			http.ReadTextRequestAsync(
-				(o, s) => {
-					var login = match.BoundVariables["login"];
-					var data = http.RequestCodec.From<ChangePasswordData>(s);
-					var message = new UserManagementMessage.ChangePassword(
-						envelope, http.User, login, data.CurrentPassword, data.NewPassword);
-					Publish(message);
-				},
-				x => Log.Debug(x, "Reply Text Content Failed."));
-		}
-
 		private SendToHttpEnvelope<T> CreateReplyEnvelope<T>(
 			HttpEntityManager http, Func<ICodec, T, string> formatter = null,
 			Func<ICodec, T, ResponseConfiguration> configurator = null)
@@ -238,9 +217,5 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			public string NewPassword { get; set; }
 		}
 
-		private class ChangePasswordData {
-			public string CurrentPassword { get; set; }
-			public string NewPassword { get; set; }
-		}
 	}
 }


### PR DESCRIPTION
- User password changes already have a gRPC management path, so retaining the HTTP command route keeps duplicate credential-management surfaces alive without preserving unique capability.