### PR TITLE
chore(http): remove user read endpoint

### DIFF
--- a/src/EventStore.Core.Tests/Http/Users/users.cs
+++ b/src/EventStore.Core.Tests/Http/Users/users.cs
@@ -5,11 +5,8 @@ using System.Threading.Tasks;
 using EventStore.Client.Users;
 using EventStore.Core.Services;
 using EventStore.Core.Services.Transport.Http.Controllers;
-using EventStore.Core.Tests.Helpers;
 using Grpc.Core;
 using Grpc.Net.Client;
-using Newtonsoft.Json.Linq;
-using NUnit.Framework;
 using UsersClient = EventStore.Client.Users.Users.UsersClient;
 
 namespace EventStore.Core.Tests.Http.Users
@@ -84,89 +81,5 @@ namespace EventStore.Core.Tests.Http.Users
 				"Basic " + Convert.ToBase64String(
 					Encoding.ASCII.GetBytes($"{credentials.UserName}:{credentials.Password}"));
 		}
-
-		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		class when_retrieving_a_user_details<TLogFormat, TStreamId> : with_admin_user<TLogFormat, TStreamId>
-		{
-			private JObject _response;
-
-			protected override async Task Given()
-			{
-				await CreateUser("test1", "User Full Name", new[] {"admin", "other"}, "Pa55w0rd!", _admin);
-			}
-
-			protected override async Task When()
-			{
-				_response = await GetJson<JObject>("/users/test1");
-			}
-
-			[Test]
-			public void returns_ok_status_code()
-			{
-				Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
-			}
-
-			[Test]
-			public void returns_valid_json_data()
-			{
-				HelperExtensions.AssertJson(
-					new
-					{
-						Success = true,
-						Error = "Success",
-						Data =
-							new
-							{
-								LoginName = "test1",
-								FullName = "User Full Name",
-								Groups = new[] { "admin", "other" },
-								Disabled = false,
-								Password___ = false
-							}
-					}, _response);
-			}
-		}
-
-		[Category("LongRunning")]
-		[TestFixture(typeof(LogFormat.V2), typeof(string))]
-		class when_retrieving_a_disabled_user_details<TLogFormat, TStreamId> : with_admin_user<TLogFormat, TStreamId>
-		{
-			private JObject _response;
-
-			protected override async Task Given()
-			{
-				await CreateUser("test2", "User Full Name", new[] {"admin", "other"}, "Pa55w0rd!", _admin);
-				await DisableUser("test2", _admin);
-			}
-
-			protected override async Task When()
-			{
-				_response = await GetJson<JObject>("/users/test2");
-			}
-
-			[Test]
-			public void returns_ok_status_code()
-			{
-				Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
-			}
-
-			[Test]
-			public void returns_valid_json_data()
-			{
-				HelperExtensions.AssertJson(
-					new
-					{
-						Success = true,
-						Error = "Success",
-						Data =
-							new
-							{
-								Disabled = true
-							}
-					}, _response);
-			}
-		}
-
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/UsersTests/DetailsTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/UsersTests/DetailsTests.cs
@@ -1,0 +1,81 @@
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Client.Users;
+using EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests;
+using Grpc.Core;
+using NUnit.Framework;
+using UsersClient = EventStore.Client.Users.Users.UsersClient;
+
+namespace EventStore.Core.Tests.Services.Transport.Grpc.UsersTests;
+
+public class DetailsTests {
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_reading_created_user<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
+		private UsersClient _client;
+		private DetailsResp _details;
+
+		protected override async Task Given() {
+			_client = new UsersClient(Channel);
+			await _client.CreateAsync(CreateRequest("details-test-user"), GetCallOptions(AdminCredentials));
+		}
+
+		protected override async Task When() {
+			_details = await ReadSingleDetail(_client, "details-test-user", GetCallOptions(AdminCredentials));
+		}
+
+		[Test]
+		public void returns_the_user_details() {
+			Assert.AreEqual("details-test-user", _details.UserDetails.LoginName);
+			Assert.AreEqual("Details Test User", _details.UserDetails.FullName);
+			Assert.AreEqual(new[] {"admin", "other"}, _details.UserDetails.Groups.ToArray());
+			Assert.IsFalse(_details.UserDetails.Disabled);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_reading_missing_user<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
+		private UsersClient _client;
+		private RpcException _exception;
+
+		protected override async Task Given() {
+			_client = new UsersClient(Channel);
+			await Task.CompletedTask;
+		}
+
+		protected override async Task When() {
+			try {
+				await ReadSingleDetail(_client, "missing-details-test-user", GetCallOptions(AdminCredentials));
+			} catch (RpcException ex) {
+				_exception = ex;
+			}
+		}
+
+		[Test]
+		public void returns_not_found() {
+			Assert.IsNotNull(_exception);
+			Assert.AreEqual(StatusCode.NotFound, _exception.Status.StatusCode);
+		}
+	}
+
+	private static CreateReq CreateRequest(string loginName) =>
+		new() {
+			Options = new CreateReq.Types.Options {
+				LoginName = loginName,
+				Password = "Pa55w0rd!",
+				FullName = "Details Test User",
+				Groups = {"admin", "other"}
+			}
+		};
+
+	private static DetailsReq DetailsRequest(string loginName) =>
+		new() {
+			Options = new DetailsReq.Types.Options {
+				LoginName = loginName
+			}
+		};
+
+	private static async Task<DetailsResp> ReadSingleDetail(UsersClient client, string loginName, CallOptions options) {
+		using var call = client.Details(DetailsRequest(loginName), options);
+		return (await call.ResponseStream.ReadAllAsync().ToArrayAsync()).Single();
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/UsersTests/DetailsTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/UsersTests/DetailsTests.cs
@@ -57,13 +57,125 @@ public class DetailsTests {
 		}
 	}
 
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_reading_disabled_user<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
+		private UsersClient _client;
+		private DetailsResp _details;
+
+		protected override async Task Given() {
+			_client = new UsersClient(Channel);
+			await _client.CreateAsync(CreateRequest("disabled-details-test-user"), GetCallOptions(AdminCredentials));
+			await _client.DisableAsync(DisableRequest("disabled-details-test-user"), GetCallOptions(AdminCredentials));
+		}
+
+		protected override async Task When() {
+			_details = await ReadSingleDetail(_client, "disabled-details-test-user", GetCallOptions(AdminCredentials));
+		}
+
+		[Test]
+		public void returns_the_disabled_state() {
+			Assert.IsTrue(_details.UserDetails.Disabled);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_reading_own_user_without_admin_credentials<TLogFormat, TStreamId>
+		: GrpcSpecification<TLogFormat, TStreamId> {
+		private const string LoginName = "details-self-test-user";
+		private const string Password = "Pa55w0rd!";
+		private UsersClient _client;
+		private DetailsResp _details;
+
+		protected override async Task Given() {
+			_client = new UsersClient(Channel);
+			await _client.CreateAsync(CreateRequest(LoginName, Password), GetCallOptions(AdminCredentials));
+		}
+
+		protected override async Task When() {
+			_details = await ReadSingleDetail(_client, LoginName, GetCallOptions((LoginName, Password)));
+		}
+
+		[Test]
+		public void returns_the_user_details() {
+			Assert.AreEqual(LoginName, _details.UserDetails.LoginName);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_reading_another_user_without_admin_credentials<TLogFormat, TStreamId>
+		: GrpcSpecification<TLogFormat, TStreamId> {
+		private const string ActorLogin = "details-denied-actor";
+		private const string TargetLogin = "details-denied-target";
+		private const string Password = "Pa55w0rd!";
+		private UsersClient _client;
+		private RpcException _exception;
+
+		protected override async Task Given() {
+			_client = new UsersClient(Channel);
+			await _client.CreateAsync(CreateRequest(ActorLogin, Password), GetCallOptions(AdminCredentials));
+			await _client.CreateAsync(CreateRequest(TargetLogin, Password), GetCallOptions(AdminCredentials));
+		}
+
+		protected override async Task When() {
+			try {
+				await ReadSingleDetail(_client, TargetLogin, GetCallOptions((ActorLogin, Password)));
+			} catch (RpcException ex) {
+				_exception = ex;
+			}
+		}
+
+		[Test]
+		public void returns_permission_denied() {
+			Assert.IsNotNull(_exception);
+			Assert.AreEqual(StatusCode.PermissionDenied, _exception.Status.StatusCode);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_listing_users_without_admin_credentials<TLogFormat, TStreamId>
+		: GrpcSpecification<TLogFormat, TStreamId> {
+		private const string LoginName = "details-list-denied-user";
+		private const string Password = "Pa55w0rd!";
+		private UsersClient _client;
+		private RpcException _exception;
+
+		protected override async Task Given() {
+			_client = new UsersClient(Channel);
+			await _client.CreateAsync(CreateRequest(LoginName, Password), GetCallOptions(AdminCredentials));
+		}
+
+		protected override async Task When() {
+			try {
+				await ReadDetails(_client, GetCallOptions((LoginName, Password)));
+			} catch (RpcException ex) {
+				_exception = ex;
+			}
+		}
+
+		[Test]
+		public void returns_permission_denied() {
+			Assert.IsNotNull(_exception);
+			Assert.AreEqual(StatusCode.PermissionDenied, _exception.Status.StatusCode);
+		}
+	}
+
 	private static CreateReq CreateRequest(string loginName) =>
+		CreateRequest(loginName, "Pa55w0rd!");
+
+	private static CreateReq CreateRequest(string loginName, string password) =>
 		new() {
 			Options = new CreateReq.Types.Options {
 				LoginName = loginName,
-				Password = "Pa55w0rd!",
+				Password = password,
 				FullName = "Details Test User",
 				Groups = {"admin", "other"}
+			}
+		};
+
+	private static DisableReq DisableRequest(string loginName) =>
+		new() {
+			Options = new DisableReq.Types.Options {
+				LoginName = loginName
 			}
 		};
 
@@ -74,8 +186,18 @@ public class DetailsTests {
 			}
 		};
 
+	private static DetailsReq DetailsRequest() =>
+		new() {
+			Options = new DetailsReq.Types.Options()
+		};
+
 	private static async Task<DetailsResp> ReadSingleDetail(UsersClient client, string loginName, CallOptions options) {
 		using var call = client.Details(DetailsRequest(loginName), options);
 		return (await call.ResponseStream.ReadAllAsync().ToArrayAsync()).Single();
+	}
+
+	private static async Task<DetailsResp[]> ReadDetails(UsersClient client, CallOptions options) {
+		using var call = client.Details(DetailsRequest(), options);
+		return await call.ResponseStream.ReadAllAsync().ToArrayAsync();
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
@@ -197,7 +197,6 @@ public class Authorization<TLogFormat, TStreamId> : specification_with_cluster<T
 			"/subscriptions/{stream}/{subscription};POST;Ops",
 			"/users;GET;Admin",
 			"/users/;GET;Admin",
-			"/users/{login};GET;Admin",
 			"/users/$current;GET;User",
 			"/ui/assets/{*remaining_path};GET;None",
 			";GET;None"

--- a/src/EventStore.Core.Tests/Services/Transport/Http/speed_test.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/speed_test.cs
@@ -85,7 +85,6 @@ public class FakeController : IHttpController
 		Register("/stats", HttpMethod.Get);
 		Register("/stats/{*statPath}", HttpMethod.Get);
 		Register("/users/", HttpMethod.Get);
-		Register("/users/{login}", HttpMethod.Get);
 	}
 
 	private void Register(string route, string verb)

--- a/src/EventStore.Core.Tests/swagger.yaml
+++ b/src/EventStore.Core.Tests/swagger.yaml
@@ -118,11 +118,6 @@ paths:
       responses:
         "200":
           description: OK
-  "/users/{login}":
-    get:
-      responses:
-        "200":
-          description: OK
   /projections/any:
     get:
       responses:

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.Details.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.Details.cs
@@ -9,27 +9,26 @@ using Grpc.Core;
 namespace EventStore.Core.Services.Transport.Grpc {
 	internal partial class Users {
 		private static readonly Operation ReadOperation = new Operation(Plugins.Authorization.Operations.Users.Read);
+		private static readonly Operation ListOperation = new Operation(Plugins.Authorization.Operations.Users.List);
 		public override async Task Details(DetailsReq request, IServerStreamWriter<DetailsResp> responseStream,
 			ServerCallContext context) {
 			var options = request.Options;
+			var loginName = options?.LoginName;
 
 			var user = context.GetHttpContext().User;
-			var readOperation = ReadOperation;
-			if (user?.Identity?.Name != null) {
-				readOperation =
-					readOperation.WithParameter(
-						Plugins.Authorization.Operations.Users.Parameters.User(user.Identity.Name));
-			}
-			if (!await _authorizationProvider.CheckAccessAsync(user, readOperation, context.CancellationToken)) {
+			var operation = string.IsNullOrWhiteSpace(loginName)
+				? ListOperation
+				: ReadOperation.WithParameter(Plugins.Authorization.Operations.Users.Parameters.User(loginName));
+			if (!await _authorizationProvider.CheckAccessAsync(user, operation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			var detailsSource = new TaskCompletionSource<UserManagementMessage.UserData[]>();
 
 			var envelope = new CallbackEnvelope(OnMessage);
 
-			_publisher.Publish(string.IsNullOrWhiteSpace(options?.LoginName)
+			_publisher.Publish(string.IsNullOrWhiteSpace(loginName)
 				? (Message)new UserManagementMessage.GetAll(envelope, user)
-				: new UserManagementMessage.Get(envelope, user, options.LoginName));
+				: new UserManagementMessage.Get(envelope, user, loginName));
 
 			var details = await detailsSource.Task;
 
@@ -49,7 +48,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			}
 
 			void OnMessage(Message message) {
-				if (HandleErrors(options?.LoginName, message, detailsSource)) return;
+				if (HandleErrors(loginName, message, detailsSource)) return;
 
 				switch (message) {
 					case UserManagementMessage.UserDetailsResult userDetails:

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/UsersController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/UsersController.cs
@@ -20,7 +20,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		protected override void SubscribeCore(IHttpService service) {
 			RegisterUrlBased(service, "/users", HttpMethod.Get, new Operation(Operations.Users.List), GetUsers);
 			RegisterUrlBased(service, "/users/", HttpMethod.Get, new Operation(Operations.Users.List), GetUsers);
-			RegisterUrlBased(service, "/users/{login}", HttpMethod.Get, new Operation(Operations.Users.Read), GetUser);
 			RegisterUrlBased(service, "/users/$current", HttpMethod.Get, new Operation(Operations.Users.CurrentUser), GetCurrentUser);
 		}
 
@@ -33,19 +32,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 					new UserManagementMessage.AllUserDetailsResultHttpFormatted(msg));
 
 			var message = new UserManagementMessage.GetAll(envelope, http.User);
-			Publish(message);
-		}
-
-		private void GetUser(HttpEntityManager http, UriTemplateMatch match) {
-			if (_httpForwarder.ForwardRequest(http))
-				return;
-
-			var envelope = CreateSendToHttpWithConversionEnvelope(http,
-				(UserManagementMessage.UserDetailsResult msg) =>
-					new UserManagementMessage.UserDetailsResultHttpFormatted(msg));
-
-			var login = match.BoundVariables["login"];
-			var message = new UserManagementMessage.Get(envelope, http.User, login);
 			Publish(message);
 		}
 


### PR DESCRIPTION
- User detail reads already have a maintained gRPC replacement, so keeping the legacy HTTP management route preserves a duplicate surface area without adding operator value.
- Removing the route keeps the API cleanup moving while preserving infra and current-user HTTP behavior that does not have the same gRPC shape.