### PR TITLE
chore(http): remove admin priority endpoint

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/OperationsTests/AdminTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/OperationsTests/AdminTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using EventStore.Client;
+using EventStore.Client.Operations;
 using EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests;
 using Google.Protobuf;
 using Grpc.Core;
@@ -19,6 +20,15 @@ public class AdminTests {
 		OperationsService,
 		"MergeIndexes",
 		EmptyMarshaller,
+		EmptyMarshaller);
+	private static readonly Marshaller<SetNodePriorityReq> SetNodePriorityReqMarshaller = Marshallers.Create(
+		static message => message.ToByteArray(),
+		static bytes => SetNodePriorityReq.Parser.ParseFrom(bytes));
+	private static readonly Method<SetNodePriorityReq, Empty> SetNodePriorityMethod = new(
+		MethodType.Unary,
+		OperationsService,
+		"SetNodePriority",
+		SetNodePriorityReqMarshaller,
 		EmptyMarshaller);
 
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
@@ -82,6 +92,79 @@ public class AdminTests {
 					null,
 					GetCallOptions(),
 					new Empty());
+			} catch (Exception ex) {
+				_exception = ex;
+			}
+		}
+
+		[Test]
+		public void returns_permission_denied() {
+			Assert.IsInstanceOf<RpcException>(_exception);
+			Assert.AreEqual(StatusCode.PermissionDenied, ((RpcException)_exception).Status.StatusCode);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_setting_node_priority_as_admin<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
+		private Exception _exception;
+
+		protected override Task Given() => Task.CompletedTask;
+
+		protected override async Task When() {
+			try {
+				await Channel.CreateCallInvoker().AsyncUnaryCall(
+					SetNodePriorityMethod,
+					null,
+					GetCallOptions(AdminCredentials),
+					new SetNodePriorityReq { Priority = 17 });
+			} catch (Exception ex) {
+				_exception = ex;
+			}
+		}
+
+		[Test]
+		public void completes() {
+			Assert.IsNull(_exception);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_setting_node_priority_as_ops<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
+		private Exception _exception;
+
+		protected override Task Given() => Task.CompletedTask;
+
+		protected override async Task When() {
+			try {
+				await Channel.CreateCallInvoker().AsyncUnaryCall(
+					SetNodePriorityMethod,
+					null,
+					GetCallOptions(OpsCredentials),
+					new SetNodePriorityReq { Priority = 17 });
+			} catch (Exception ex) {
+				_exception = ex;
+			}
+		}
+
+		[Test]
+		public void completes() {
+			Assert.IsNull(_exception);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_setting_node_priority_without_permissions<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
+		private Exception _exception;
+
+		protected override Task Given() => Task.CompletedTask;
+
+		protected override async Task When() {
+			try {
+				await Channel.CreateCallInvoker().AsyncUnaryCall(
+					SetNodePriorityMethod,
+					null,
+					GetCallOptions(),
+					new SetNodePriorityReq { Priority = 17 });
 			} catch (Exception ex) {
 				_exception = ex;
 			}

--- a/src/EventStore.Core.Tests/swagger.yaml
+++ b/src/EventStore.Core.Tests/swagger.yaml
@@ -15,21 +15,6 @@ securityDefinitions:
 schemes:
   - https
 paths:
-  "/admin/node/priority/{nodePriority}":
-    post:
-      description: Issues a command to change the priority of a node.
-      summary: Change node priority
-      tags:
-        - Admin
-      operationId: Change node priority
-      parameters:
-        - name: nodePriority
-          in: path
-          required: true
-          type: integer
-      responses:
-        "200":
-          description: OK
   /admin/node/resign:
     post:
       responses:

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
@@ -45,9 +45,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				new ControllerAction("/admin/scavenge/last", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Scavenge.Read)),
 				OnGetLastScavenge);
 			service.RegisterAction(
-				new ControllerAction("/admin/node/priority/{nodePriority}", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.SetPriority)),
-				OnSetNodePriority);
-			service.RegisterAction(
 				new ControllerAction("/admin/node/resign", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Resign)),
 				OnResignNode);
 			service.RegisterAction(
@@ -244,30 +241,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			);
 
 			Publish(new ClientMessage.GetLastDatabaseScavenge(envelope, Guid.Empty, entity.User));
-		}
-
-		private void OnSetNodePriority(HttpEntityManager entity, UriTemplateMatch match) {
-			if (entity.User != null &&
-			    (entity.User.LegacyRoleCheck(SystemRoles.Admins) || entity.User.LegacyRoleCheck(SystemRoles.Operations))) {
-				Log.Information("Request to set node priority.");
-
-				int nodePriority;
-				var nodePriorityVariable = match.BoundVariables["nodePriority"];
-				if (nodePriorityVariable == null) {
-					SendBadRequest(entity, "Could not find expected `nodePriority` in the request body.");
-					return;
-				}
-
-				if (!int.TryParse(nodePriorityVariable, out nodePriority)) {
-					SendBadRequest(entity, "nodePriority must be an integer.");
-					return;
-				}
-
-				Publish(new ClientMessage.SetNodePriority(nodePriority));
-				entity.ReplyStatus(HttpStatusCode.OK, "OK", LogReplyError);
-			} else {
-				entity.ReplyStatus(HttpStatusCode.Unauthorized, "Unauthorized", LogReplyError);
-			}
 		}
 
 		private void OnResignNode(HttpEntityManager entity, UriTemplateMatch match) {


### PR DESCRIPTION
- Node priority changes should use the supported gRPC operations surface instead of preserving a duplicate HTTP command route.\n- Operators should have one management transport for this command now that gRPC carries the same authorization and node message behavior.