### PR TITLE
chore(http): remove admin resign endpoint

### DIFF
--- a/src/EventStore.Core.Tests/Integration/when_node_becomes_leader_with_unindexed_data.cs
+++ b/src/EventStore.Core.Tests/Integration/when_node_becomes_leader_with_unindexed_data.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using EventStore.Client.Streams;
@@ -32,6 +31,15 @@ public class when_node_becomes_leader_with_unindexed_data<TLogFormat, TStreamId>
 
 	private const string AuthenticationScheme = "Basic";
 	private readonly string AuthenticationValue = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{Username}:{Password}"));
+	private static readonly Marshaller<Empty> EmptyMarshaller = Marshallers.Create(
+		static message => message.ToByteArray(),
+		static bytes => Empty.Parser.ParseFrom(bytes));
+	private static readonly Method<Empty, Empty> ResignNodeMethod = new(
+		MethodType.Unary,
+		"event_store.client.operations.Operations",
+		"ResignNode",
+		EmptyMarshaller,
+		EmptyMarshaller);
 	private class CommitTimeoutException : Exception { }
 	private class WrongExpectedVersionException : Exception { }
 
@@ -231,19 +239,13 @@ public class when_node_becomes_leader_with_unindexed_data<TLogFormat, TStreamId>
 	private async Task ResignLeader(int leaderIdx)
 	{
 		var httpEndPoint = _nodes[leaderIdx].HttpEndPoint;
-		var request = new HttpRequestMessage(HttpMethod.Post, $"https://{httpEndPoint}/admin/node/resign")
-		{
-			Content = new StringContent(""),
-			Headers = {
-				Authorization = new AuthenticationHeaderValue(AuthenticationScheme, AuthenticationValue)
-			}
-		};
-
-		var response = await _httpClient.SendAsync(request);
-		if (response.StatusCode != HttpStatusCode.OK)
-		{
-			throw new Exception($"Unexpected status code: {response.StatusCode}");
-		}
+		using var channel = GrpcChannel.ForAddress(new Uri($"https://{httpEndPoint}"),
+			new GrpcChannelOptions { HttpClient = _httpClient });
+		await channel.CreateCallInvoker().AsyncUnaryCall(
+			ResignNodeMethod,
+			null,
+			GetCallOptions(),
+			new Empty());
 
 		var start = DateTime.UtcNow;
 		while (_nodes[leaderIdx].NodeState != VNodeState.Unknown && DateTime.UtcNow - start < TimeSpan.FromSeconds(2))

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/OperationsTests/AdminTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/OperationsTests/AdminTests.cs
@@ -30,6 +30,12 @@ public class AdminTests {
 		"SetNodePriority",
 		SetNodePriorityReqMarshaller,
 		EmptyMarshaller);
+	private static readonly Method<Empty, Empty> ResignNodeMethod = new(
+		MethodType.Unary,
+		OperationsService,
+		"ResignNode",
+		EmptyMarshaller,
+		EmptyMarshaller);
 
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	public class when_merging_indexes_as_admin<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
@@ -165,6 +171,79 @@ public class AdminTests {
 					null,
 					GetCallOptions(),
 					new SetNodePriorityReq { Priority = 17 });
+			} catch (Exception ex) {
+				_exception = ex;
+			}
+		}
+
+		[Test]
+		public void returns_permission_denied() {
+			Assert.IsInstanceOf<RpcException>(_exception);
+			Assert.AreEqual(StatusCode.PermissionDenied, ((RpcException)_exception).Status.StatusCode);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_resigning_node_as_admin<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
+		private Exception _exception;
+
+		protected override Task Given() => Task.CompletedTask;
+
+		protected override async Task When() {
+			try {
+				await Channel.CreateCallInvoker().AsyncUnaryCall(
+					ResignNodeMethod,
+					null,
+					GetCallOptions(AdminCredentials),
+					new Empty());
+			} catch (Exception ex) {
+				_exception = ex;
+			}
+		}
+
+		[Test]
+		public void completes() {
+			Assert.IsNull(_exception);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_resigning_node_as_ops<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
+		private Exception _exception;
+
+		protected override Task Given() => Task.CompletedTask;
+
+		protected override async Task When() {
+			try {
+				await Channel.CreateCallInvoker().AsyncUnaryCall(
+					ResignNodeMethod,
+					null,
+					GetCallOptions(OpsCredentials),
+					new Empty());
+			} catch (Exception ex) {
+				_exception = ex;
+			}
+		}
+
+		[Test]
+		public void completes() {
+			Assert.IsNull(_exception);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_resigning_node_without_permissions<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
+		private Exception _exception;
+
+		protected override Task Given() => Task.CompletedTask;
+
+		protected override async Task When() {
+			try {
+				await Channel.CreateCallInvoker().AsyncUnaryCall(
+					ResignNodeMethod,
+					null,
+					GetCallOptions(),
+					new Empty());
 			} catch (Exception ex) {
 				_exception = ex;
 			}

--- a/src/EventStore.Core.Tests/swagger.yaml
+++ b/src/EventStore.Core.Tests/swagger.yaml
@@ -15,11 +15,6 @@ securityDefinitions:
 schemes:
   - https
 paths:
-  /admin/node/resign:
-    post:
-      responses:
-        "200":
-          description: OK
   /admin/reloadconfig:
     post:
       responses:

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
@@ -45,9 +45,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				new ControllerAction("/admin/scavenge/last", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Scavenge.Read)),
 				OnGetLastScavenge);
 			service.RegisterAction(
-				new ControllerAction("/admin/node/resign", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Resign)),
-				OnResignNode);
-			service.RegisterAction(
 				new ControllerAction("/admin/login", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Login)),
 				OnGetLogin);
 		}
@@ -241,17 +238,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			);
 
 			Publish(new ClientMessage.GetLastDatabaseScavenge(envelope, Guid.Empty, entity.User));
-		}
-
-		private void OnResignNode(HttpEntityManager entity, UriTemplateMatch match) {
-			if (entity.User != null &&
-			    (entity.User.LegacyRoleCheck(SystemRoles.Admins) || entity.User.LegacyRoleCheck(SystemRoles.Operations))) {
-				Log.Information("Request to resign node.");
-				Publish(new ClientMessage.ResignNode());
-				entity.ReplyStatus(HttpStatusCode.OK, "OK", LogReplyError);
-			} else {
-				entity.ReplyStatus(HttpStatusCode.Unauthorized, "Unauthorized", LogReplyError);
-			}
 		}
 
 		private void OnGetLogin(HttpEntityManager entity, UriTemplateMatch match) {


### PR DESCRIPTION
- Node resign requests should use the supported gRPC operations surface instead of preserving a duplicate HTTP command route.\n- Cluster leadership tests should exercise the same management transport operators are expected to use.