### PR TITLE
chore(http): remove admin shutdown endpoint

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/OperationsTests/AdminTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/OperationsTests/AdminTests.cs
@@ -36,6 +36,12 @@ public class AdminTests {
 		"ResignNode",
 		EmptyMarshaller,
 		EmptyMarshaller);
+	private static readonly Method<Empty, Empty> ShutdownMethod = new(
+		MethodType.Unary,
+		OperationsService,
+		"Shutdown",
+		EmptyMarshaller,
+		EmptyMarshaller);
 
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	public class when_merging_indexes_as_admin<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
@@ -241,6 +247,31 @@ public class AdminTests {
 			try {
 				await Channel.CreateCallInvoker().AsyncUnaryCall(
 					ResignNodeMethod,
+					null,
+					GetCallOptions(),
+					new Empty());
+			} catch (Exception ex) {
+				_exception = ex;
+			}
+		}
+
+		[Test]
+		public void returns_permission_denied() {
+			Assert.IsInstanceOf<RpcException>(_exception);
+			Assert.AreEqual(StatusCode.PermissionDenied, ((RpcException)_exception).Status.StatusCode);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_shutting_down_without_permissions<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
+		private Exception _exception;
+
+		protected override Task Given() => Task.CompletedTask;
+
+		protected override async Task When() {
+			try {
+				await Channel.CreateCallInvoker().AsyncUnaryCall(
+					ShutdownMethod,
 					null,
 					GetCallOptions(),
 					new Empty());

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
@@ -179,7 +179,6 @@ public class Authorization<TLogFormat, TStreamId> : specification_with_cluster<T
 			"Admin"
 		)] string userAuthorizationLevel,
 		[Values(
-			"/admin/shutdown;POST;Ops", /* this test is not executed for Ops and Admin to prevent the node from shutting down */
 			"/admin/scavenge?startFromChunk={startFromChunk}&threads={threads};POST;Ops",
 			"/admin/scavenge/{scavengeId};DELETE;Ops",
 			"/admin/scavenge/current;GET;Ops",
@@ -204,12 +203,6 @@ public class Authorization<TLogFormat, TStreamId> : specification_with_cluster<T
 		var endpointUrl = httpEndpointTokens[0];
 		var httpMethod = GetHttpMethod(httpEndpointTokens[1]);
 		var requiredMinAuthorizationLevel = httpEndpointTokens[2];
-
-		/* this test was done manually for Admin and Ops */
-		if (endpointUrl == "/admin/shutdown" && (userAuthorizationLevel == "Admin" || userAuthorizationLevel == "Ops"))
-		{
-			return;
-		}
 
 		var url = $"https://{nodeEndpoint}{endpointUrl}";
 		var body = GetData(httpMethod, endpointUrl);

--- a/src/EventStore.Core.Tests/swagger.yaml
+++ b/src/EventStore.Core.Tests/swagger.yaml
@@ -20,11 +20,6 @@ paths:
       responses:
         "200":
           description: OK
-  /admin/shutdown:
-    post:
-      responses:
-        "200":
-          description: OK
   /admin/scavenge:
     post:
       responses:

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
@@ -27,9 +27,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 
 		protected override void SubscribeCore(IHttpService service) {
 			service.RegisterAction(
-				new ControllerAction("/admin/shutdown", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Shutdown)),
-				OnPostShutdown);
-			service.RegisterAction(
 				new ControllerAction("/admin/reloadconfig", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.ReloadConfiguration)),
 				OnPostReloadConfig);
 			service.RegisterAction(
@@ -47,17 +44,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			service.RegisterAction(
 				new ControllerAction("/admin/login", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Login)),
 				OnGetLogin);
-		}
-
-		private void OnPostShutdown(HttpEntityManager entity, UriTemplateMatch match) {
-			if (entity.User != null &&
-			    (entity.User.LegacyRoleCheck(SystemRoles.Admins) || entity.User.LegacyRoleCheck(SystemRoles.Operations))) {
-				Log.Information("Request shut down of node because shutdown command has been received.");
-				Publish(new ClientMessage.RequestShutdown(exitProcess: true, shutdownHttp: true));
-				entity.ReplyStatus(HttpStatusCode.OK, "OK", LogReplyError);
-			} else {
-				entity.ReplyStatus(HttpStatusCode.Unauthorized, "Unauthorized", LogReplyError);
-			}
 		}
 
 		private void OnPostReloadConfig(HttpEntityManager entity, UriTemplateMatch match) {


### PR DESCRIPTION
- Node shutdown requests should use the supported gRPC operations surface instead of preserving a duplicate HTTP command route.
- Operators should have one management transport for this command now that gRPC carries the same authorization and node message behavior.