### PR TITLE
feat(grpc): preserve reload config parity

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -527,17 +527,9 @@ In the above example we have the links in a folder at path `/home/ubuntu/links`.
 
 ### Step 3: Reload the configuration
 
-You can reload the certificate configuration without restarting the node by issuing the following curl command.
-
-```bash:no-line-numbers
-curl -k -X POST --basic https://{nodeAddress}:{HttpPort}/admin/reloadconfig -u {username}:{Password}
-```
-
-For Example:
-
-```bash:no-line-numbers
-curl -k -X POST --basic https://127.0.0.1:2113/admin/reloadconfig -u admin:changeit
-```
+You can reload the certificate configuration without restarting the node by calling the gRPC
+`Operations.ReloadConfig` method with the credentials of an `admin` or `ops` user. You can also
+reload the configuration from the _Operations_ page of the Admin UI.
 
 #### Linux OS
 
@@ -558,7 +550,6 @@ pidof eventstored
 Once the configuration has been reloaded successfully, the server logs will look something like:
 
 ```
-[108277,30,14:46:07.453,INF] Reloading the node's configuration since a request has been received on /admin/reloadconfig.
 [108277,29,14:46:07.457,INF] Loading the node's certificate(s) from file: "/home/ubuntu/links/node.crt"
 [108277,29,14:46:07.488,INF] Loading the node's certificate. Subject: "CN=eventstoredb-node", Previous thumbprint: "05526714107700C519E24794E8964A3B30EF9BD0", New thumbprint: "BE6D5CD681D7B9281D60A5969B5A7E31AF775E9F"
 [108277,29,14:46:07.488,INF] Loading intermediate certificate. Subject: "CN=EventStoreDB Intermediate CA 78ae8d5a159b247568039cf64f4b04ad, O=Event Store Ltd, C=UK", Thumbprint: "ED4AA0C5ED4AD120DDEE2FA8B3B0CCC5A30B81E3"
@@ -577,7 +568,6 @@ If there are any errors during loading certificates, the new configuration chang
 The server logs the following error when the node certificate is not available at the path specified in the EventStore configuration file.
 
 ```
-[108277,30,14:49:47.481,INF] Reloading the node's configuration since a request has been received on /admin/reloadconfig.
 [108277,29,14:49:47.488,INF] Loading the node's certificate(s) from file: "/home/ubuntu/links/node.crt"
 [108277,29,14:49:47.489,ERR] An error has occurred while reloading the configuration
 System.IO.FileNotFoundException: Could not find file '/home/ubuntu/links/node.key'.

--- a/proto.lock
+++ b/proto.lock
@@ -2877,6 +2877,11 @@
                 "out_type": "ScavengeStatusResp"
               },
               {
+                "name": "ReloadConfig",
+                "in_type": "event_store.client.Empty",
+                "out_type": "event_store.client.Empty"
+              },
+              {
                 "name": "Shutdown",
                 "in_type": "event_store.client.Empty",
                 "out_type": "event_store.client.Empty"

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/OperationsTests/AdminTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/OperationsTests/AdminTests.cs
@@ -57,6 +57,12 @@ public class AdminTests {
 		"MergeIndexes",
 		EmptyMarshaller,
 		EmptyMarshaller);
+	private static readonly Method<Empty, Empty> ReloadConfigMethod = new(
+		MethodType.Unary,
+		OperationsService,
+		"ReloadConfig",
+		EmptyMarshaller,
+		EmptyMarshaller);
 	private static readonly Marshaller<SetNodePriorityReq> SetNodePriorityReqMarshaller = Marshallers.Create(
 		static message => message.ToByteArray(),
 		static bytes => SetNodePriorityReq.Parser.ParseFrom(bytes));
@@ -137,6 +143,55 @@ public class AdminTests {
 			try {
 				await Channel.CreateCallInvoker().AsyncUnaryCall(
 					MergeIndexesMethod,
+					null,
+					GetCallOptions(),
+					new Empty());
+			} catch (Exception ex) {
+				_exception = ex;
+			}
+		}
+
+		[Test]
+		public void returns_permission_denied() {
+			Assert.IsInstanceOf<RpcException>(_exception);
+			Assert.AreEqual(StatusCode.PermissionDenied, ((RpcException)_exception).Status.StatusCode);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_reloading_config_as_admin<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
+		private Exception _exception;
+
+		protected override Task Given() => Task.CompletedTask;
+
+		protected override async Task When() {
+			try {
+				await Channel.CreateCallInvoker().AsyncUnaryCall(
+					ReloadConfigMethod,
+					null,
+					GetCallOptions(AdminCredentials),
+					new Empty());
+			} catch (Exception ex) {
+				_exception = ex;
+			}
+		}
+
+		[Test]
+		public void completes() {
+			Assert.IsNull(_exception);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_reloading_config_without_permissions<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
+		private Exception _exception;
+
+		protected override Task Given() => Task.CompletedTask;
+
+		protected override async Task When() {
+			try {
+				await Channel.CreateCallInvoker().AsyncUnaryCall(
+					ReloadConfigMethod,
 					null,
 					GetCallOptions(),
 					new Empty());

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/OperationsTests/AdminTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/OperationsTests/AdminTests.cs
@@ -183,6 +183,30 @@ public class AdminTests {
 	}
 
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_reloading_config_as_ops<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
+		private Exception _exception;
+
+		protected override Task Given() => Task.CompletedTask;
+
+		protected override async Task When() {
+			try {
+				await Channel.CreateCallInvoker().AsyncUnaryCall(
+					ReloadConfigMethod,
+					null,
+					GetCallOptions(OpsCredentials),
+					new Empty());
+			} catch (Exception ex) {
+				_exception = ex;
+			}
+		}
+
+		[Test]
+		public void completes() {
+			Assert.IsNull(_exception);
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	public class when_reloading_config_without_permissions<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
 		private Exception _exception;
 

--- a/src/EventStore.Core.Tests/swagger.yaml
+++ b/src/EventStore.Core.Tests/swagger.yaml
@@ -15,11 +15,6 @@ securityDefinitions:
 schemes:
   - https
 paths:
-  /admin/reloadconfig:
-    post:
-      responses:
-        "200":
-          description: OK
   /info:
     get:
       responses:

--- a/src/EventStore.Core/Services/Transport/Grpc/Operations.Admin.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Operations.Admin.cs
@@ -20,6 +20,9 @@ namespace EventStore.Core.Services.Transport.Grpc {
 		private static readonly Operation SetNodePriorityOperation =
 			new Operation(Plugins.Authorization.Operations.Node.SetPriority);
 
+		private static readonly Operation ReloadConfigOperation =
+			new Operation(Plugins.Authorization.Operations.Node.ReloadConfiguration);
+
 		private static readonly Operation RestartPersistentSubscriptionsOperation =
 			new Operation(Plugins.Authorization.Operations.Subscriptions.Restart);
 
@@ -78,6 +81,16 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			}
 
 			_publisher.Publish(new ClientMessage.SetNodePriority(request.Priority));
+			return EmptyResult;
+		}
+
+		public override async Task<Empty> ReloadConfig(Empty request, ServerCallContext context) {
+			var user = context.GetHttpContext().User;
+			if (!await _authorizationProvider.CheckAccessAsync(user, ReloadConfigOperation, context.CancellationToken)) {
+				throw RpcExceptions.AccessDenied();
+			}
+
+			_publisher.Publish(new ClientMessage.ReloadConfig());
 			return EmptyResult;
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
@@ -23,22 +23,8 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 
 		protected override void SubscribeCore(IHttpService service) {
 			service.RegisterAction(
-				new ControllerAction("/admin/reloadconfig", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.ReloadConfiguration)),
-				OnPostReloadConfig);
-			service.RegisterAction(
 				new ControllerAction("/admin/login", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Login)),
 				OnGetLogin);
-		}
-
-		private void OnPostReloadConfig(HttpEntityManager entity, UriTemplateMatch match) {
-			if (entity.User != null &&
-			    (entity.User.LegacyRoleCheck(SystemRoles.Admins) || entity.User.LegacyRoleCheck(SystemRoles.Operations))) {
-				Log.Information("Reloading the node's configuration since a request has been received on /admin/reloadconfig.");
-				Publish(new ClientMessage.ReloadConfig());
-				entity.ReplyStatus(HttpStatusCode.OK, "OK", LogReplyError);
-			} else {
-				entity.ReplyStatus(HttpStatusCode.Unauthorized, "Unauthorized", LogReplyError);
-			}
 		}
 
 		private void OnGetLogin(HttpEntityManager entity, UriTemplateMatch match) {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
@@ -44,9 +44,5 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				new List<KeyValuePair<string, string>>(),
 					e => Log.Error(e, "Error while writing HTTP response"));
 		}
-
-		private void LogReplyError(Exception exc) {
-			Log.Debug("Error while closing HTTP connection (admin controller): {e}.", exc.Message);
-		}
 	}
 }

--- a/src/Protos/Grpc/operations.proto
+++ b/src/Protos/Grpc/operations.proto
@@ -9,6 +9,7 @@ service Operations {
 	rpc StopScavenge (StopScavengeReq) returns (ScavengeResp);
 	rpc GetCurrentScavenge (event_store.client.Empty) returns (ScavengeStatusResp);
 	rpc GetLastScavenge (event_store.client.Empty) returns (ScavengeStatusResp);
+	rpc ReloadConfig (event_store.client.Empty) returns (event_store.client.Empty);
 	rpc Shutdown (event_store.client.Empty) returns (event_store.client.Empty);
 	rpc MergeIndexes (event_store.client.Empty) returns (event_store.client.Empty);
 	rpc ResignNode (event_store.client.Empty) returns (event_store.client.Empty);


### PR DESCRIPTION
- Consolidates reload configuration onto the gRPC operations API so management capabilities keep moving behind one client protocol.
- Keeps certificate and configuration reload available to operators without preserving the legacy HTTP management route.