### PR TITLE
fix(grpc): preserve user password authorization

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/UsersTests/ChangePasswordTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/UsersTests/ChangePasswordTests.cs
@@ -58,6 +58,42 @@ public class ChangePasswordTests {
 		}
 	}
 
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class when_changing_another_users_password<TLogFormat, TStreamId>
+		: GrpcSpecification<TLogFormat, TStreamId> {
+		private const string LoginName = "change-password-target";
+		private const string CurrentPassword = "CurrentPa55w0rd!";
+		private UsersClient _client;
+		private RpcException _exception;
+
+		protected override async Task Given() {
+			_client = new UsersClient(Channel);
+			await _client.CreateAsync(new CreateReq {
+				Options = new CreateReq.Types.Options {
+					LoginName = LoginName,
+					FullName = "Change Password Target",
+					Password = CurrentPassword,
+					Groups = { "$ops" }
+				}
+			}, GetCallOptions(AdminCredentials));
+		}
+
+		protected override async Task When() {
+			try {
+				await _client.ChangePasswordAsync(ChangePasswordRequest(LoginName, CurrentPassword, "NewPa55w0rd!"),
+					GetCallOptions(AdminCredentials));
+			} catch (RpcException ex) {
+				_exception = ex;
+			}
+		}
+
+		[Test]
+		public void returns_permission_denied() {
+			Assert.IsNotNull(_exception);
+			Assert.AreEqual(StatusCode.PermissionDenied, _exception.Status.StatusCode);
+		}
+	}
+
 	private static ChangePasswordReq ChangePasswordRequest(string loginName, string currentPassword, string newPassword) =>
 		new() {
 			Options = new ChangePasswordReq.Types.Options {

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.ChangePassword.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.ChangePassword.cs
@@ -14,10 +14,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 			var user = context.GetHttpContext().User;
 			var changePasswordOperation = ChangePasswordOperation;
-			if (user?.Identity?.Name != null) {
+			if (options?.LoginName != null) {
 				changePasswordOperation =
 					changePasswordOperation.WithParameter(
-						Plugins.Authorization.Operations.Users.Parameters.User(user.Identity.Name));
+						Plugins.Authorization.Operations.Users.Parameters.User(options.LoginName));
 			}
 			if (!await _authorizationProvider.CheckAccessAsync(user, changePasswordOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();


### PR DESCRIPTION
- Keep the gRPC user password command aligned with the authorization boundary that existed before the HTTP command was removed.