### PR TITLE
chore(http): prune subsystem endpoint

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -121,7 +121,7 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable
 			? new[] { NodeSubsystems.Projections }
 			: Array.Empty<NodeSubsystems>();
 
-		RegisterWebControllers(EnabledNodeSubsystems.ToArray());
+		RegisterWebControllers();
 		return;
 
 		(ClusterVNodeOptions, AuthorizationProviderFactory) GetAuthorizationProviderFactory()
@@ -349,12 +349,11 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable
 		}
 	}
 
-	private void RegisterWebControllers(NodeSubsystems[] enabledNodeSubsystems)
+	private void RegisterWebControllers()
 	{
 		if (!_options.Interface.DisableAdminUi)
 		{
-			Node.HttpService.SetupController(new NodeUiController(Node.MainQueue,
-				enabledNodeSubsystems));
+			Node.HttpService.SetupController(new NodeUiController(Node.MainQueue));
 		}
 	}
 

--- a/src/EventStore.Core.Tests/swagger.yaml
+++ b/src/EventStore.Core.Tests/swagger.yaml
@@ -25,11 +25,6 @@ paths:
       responses:
         "200":
           description: OK
-  /sys/subsystems:
-    get:
-      responses:
-        "200":
-          description: OK
   /projections/any:
     get:
       responses:

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/NodeUiController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/NodeUiController.cs
@@ -5,36 +5,15 @@ using EventStore.Plugins.Authorization;
 using EventStore.Transport.Http;
 using EventStore.Transport.Http.Codecs;
 using EventStore.Transport.Http.EntityManagement;
-using ILogger = Serilog.ILogger;
 
 namespace EventStore.Core.Services.Transport.Http.Controllers {
 	public class NodeUiController : CommunicationController {
-		private static readonly ILogger Log = Serilog.Log.ForContext<NodeUiController>();
-
-		private readonly NodeSubsystems[] _enabledNodeSubsystems;
-
-		public NodeUiController(IPublisher publisher, NodeSubsystems[] enabledNodeSubsystems)
+		public NodeUiController(IPublisher publisher)
 			: base(publisher) {
-			_enabledNodeSubsystems = enabledNodeSubsystems;
 		}
 
 		protected override void SubscribeCore(IHttpService service) {
 			RegisterRedirectAction(service, "", "/ui");
-
-			service.RegisterAction(
-				new ControllerAction("/sys/subsystems", HttpMethod.Get, Codec.NoCodecs, new ICodec[] {Codec.Json}, new Operation(Operations.Node.Information.Subsystems)),
-				OnListNodeSubsystems);
-		}
-
-		private void OnListNodeSubsystems(HttpEntityManager http, UriTemplateMatch match) {
-			http.ReplyTextContent(
-				Codec.Json.To(_enabledNodeSubsystems),
-				200,
-				"OK",
-				"application/json",
-				null,
-				ex => Log.Information(ex, "Failed to prepare main menu")
-			);
 		}
 
 		private static void RegisterRedirectAction(IHttpService service, string fromUrl, string toUrl) {

--- a/src/EventStore.Projections.Core.Tests/Services/http_service/authorization_tests.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/http_service/authorization_tests.cs
@@ -182,7 +182,6 @@ public class Authorization<TLogFormat, TStreamId> : specification_with_standard_
 			"/projection/{name}/command/abort?enableRunAs={enableRunAs};POST;User",
 			"/projection/{name}/config;GET;Ops",
 			"/projection/{name}/config;PUT;Ops"
-			/*"/sys/subsystems;GET;Ops"*/ /* this endpoint has been commented since this controller is not registered when using a MiniNode */
 		)] string httpEndpointDetails
 	)
 	{


### PR DESCRIPTION
- Subsystem state is already available to Razor server-side, so keeping a duplicate HTTP data endpoint only preserves legacy surface area.
- The browser still needs the root redirect into the Razor UI, so this keeps navigation plumbing while shrinking management HTTP.