### PR TITLE
chore(ui): decouple queue dashboards from stats http

### DIFF
--- a/src/EventStore.ClusterNode/Components/Pages/Cluster.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Cluster.razor
@@ -11,6 +11,7 @@
 <PageTitle>EventStore Cluster</PageTitle>
 
 <div data-queue-dashboard="home">
+<script type="application/json" data-queue-dashboard-payload>@((MarkupString)DashboardPayloadJson)</script>
 <section id="cluster-status" class="mb-5 overflow-hidden rounded-[2rem] border border-white/80 bg-white/85 shadow-[0_20px_70px_rgba(23,32,51,0.09)]">
 	<div class="flex flex-col gap-3 border-b border-es-ink/10 px-5 py-5 xl:flex-row xl:items-start xl:justify-between">
 		<div>
@@ -176,7 +177,7 @@
 			<div>
 				<p class="text-xs font-black uppercase tracking-[0.22em] text-es-green">Queue pressure</p>
 				<h2 class="mt-2 text-3xl font-black tracking-tight text-es-ink">Live node workload</h2>
-				<p class="mt-2 text-sm text-es-muted">Updates every second from the node stats endpoint while this tab is visible.</p>
+				<p class="mt-2 text-sm text-es-muted">Updates every second while this tab is visible.</p>
 			</div>
 			<div class="flex flex-wrap gap-2">
 				<span class="rounded-full border border-es-green/20 bg-es-green/10 px-4 py-2 text-sm font-bold text-es-forest" data-queue-status>Connecting live stats...</span>
@@ -339,6 +340,8 @@
 		: $"Snapshot {ClusterReadAt.Value:HH:mm:ss} UTC";
 
 	private string ReplicaStatusLabel => Replicas.StatusLabel;
+
+	private string DashboardPayloadJson => Page?.ClientPayloadJson ?? "{}";
 
 	private string ClusterEmptyMessage => string.IsNullOrWhiteSpace(ClusterMessage)
 		? "No nodes in the cluster."

--- a/src/EventStore.ClusterNode/Components/Pages/Observability.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Observability.razor
@@ -5,6 +5,7 @@
 <PageTitle>Observability - EventStore UI</PageTitle>
 
 <div data-queue-dashboard="observability" data-queue-expanded="@Expanded">
+<script type="application/json" data-queue-dashboard-payload>@((MarkupString)DashboardPayloadJson)</script>
 <section class="grid gap-8 xl:grid-cols-[0.95fr_1.05fr] xl:items-start">
 	<div>
 		<p class="text-sm font-black uppercase tracking-[0.28em] text-es-green">Observability</p>
@@ -32,7 +33,7 @@
 		<div>
 			<p class="text-xs font-black uppercase tracking-[0.22em] text-es-green">Queue dashboard</p>
 			<h2 class="mt-2 text-3xl font-black tracking-tight text-es-ink">Realtime queues</h2>
-			<p class="mt-2 text-sm text-es-muted">Updates every second from the node stats endpoint while this tab is visible.</p>
+			<p class="mt-2 text-sm text-es-muted">Updates every second while this tab is visible.</p>
 		</div>
 		<div class="flex flex-wrap gap-2">
 			<span class="rounded-full border border-es-green/20 bg-es-green/10 px-4 py-2 text-sm font-bold text-es-forest" data-queue-status>Connecting live stats...</span>
@@ -94,8 +95,8 @@
 			<p class="mt-2 text-sm text-es-muted">Shows active connections with per-second sent and received byte rates.</p>
 		</div>
 		<div class="flex flex-wrap gap-2">
-			<span class="rounded-full border border-es-green/20 bg-es-green/10 px-4 py-2 text-sm font-bold text-es-forest" data-tcp-status>Connecting TCP stats...</span>
-			<span class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-muted" data-tcp-page-status>No pages</span>
+			<span class="rounded-full border border-es-green/20 bg-es-green/10 px-4 py-2 text-sm font-bold text-es-forest" data-tcp-status>@TcpStatusLabel</span>
+			<span class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-muted" data-tcp-page-status>@TcpPageStatusLabel</span>
 			<button type="button" class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-green disabled:cursor-not-allowed disabled:opacity-40" data-tcp-page="previous" disabled>Previous</button>
 			<button type="button" class="rounded-full border border-es-ink/10 bg-white px-4 py-2 text-sm font-bold text-es-ink transition hover:border-es-green/30 hover:text-es-green disabled:cursor-not-allowed disabled:opacity-40" data-tcp-page="next" disabled>Next</button>
 		</div>
@@ -119,9 +120,19 @@
 					</tr>
 				</thead>
 				<tbody class="divide-y divide-es-ink/10" data-tcp-table-body>
-					<tr>
-						<td class="px-5 py-4 text-es-muted" colspan="10">Loading TCP connection statistics...</td>
-					</tr>
+					@if (TcpRows.Count == 0)
+					{
+						<tr>
+							<td class="px-5 py-4 text-es-muted" colspan="10">@TcpEmptyMessage</td>
+						</tr>
+					}
+					else
+					{
+						foreach (var connection in TcpRows.Take(5))
+						{
+							@RenderTcpRow(connection)
+						}
+					}
 				</tbody>
 			</table>
 		</div>
@@ -135,6 +146,31 @@
 
 	[SupplyParameterFromQuery(Name = "expanded")]
 	private string Expanded { get; set; } = "";
+
+	private string DashboardPayloadJson => Page?.ClientPayloadJson ?? "{}";
+	private IReadOnlyList<TcpConnectionRow> TcpRows => Page?.TcpConnections ?? Array.Empty<TcpConnectionRow>();
+	private string TcpErrorMessage => !string.IsNullOrWhiteSpace(Page?.TcpMessage)
+		? Page.TcpMessage
+		: Page?.Message ?? "";
+	private string TcpStatusLabel {
+		get {
+			if (Page is null)
+				return "Connecting TCP stats...";
+
+			if (!string.IsNullOrWhiteSpace(TcpErrorMessage))
+				return "TCP unavailable";
+
+			return TcpRows.Count == 0
+				? "TCP live"
+				: string.Create(CultureInfo.InvariantCulture, $"TCP live · {TcpRows.Count} connection{(TcpRows.Count == 1 ? "" : "s")}");
+		}
+	}
+	private string TcpPageStatusLabel => TcpRows.Count == 0
+		? "No pages"
+		: string.Create(CultureInfo.InvariantCulture, $"Page 1 of {Math.Max(1, (int)Math.Ceiling(TcpRows.Count / 5.0))}");
+	private string TcpEmptyMessage => string.IsNullOrWhiteSpace(TcpErrorMessage)
+		? "No TCP connections are currently reported."
+		: TcpErrorMessage;
 
 	protected override async Task OnParametersSetAsync() {
 		Page = null;
@@ -178,6 +214,19 @@
 		<td class="px-5 py-4 text-right font-mono text-es-ink">@row.AvgProcessingTimeLabel</td>
 		<td class="px-5 py-4 text-right font-mono text-es-ink">@row.TotalItemsProcessedLabel</td>
 		<td class="px-5 py-4 font-mono text-xs text-es-muted">@row.CurrentLastMessageLabel</td>
+	</tr>;
+
+	private RenderFragment RenderTcpRow(TcpConnectionRow connection) => @<tr class="bg-white/70 text-es-ink">
+		<td class="max-w-[14rem] truncate px-5 py-4 font-mono text-xs text-es-muted">@connection.IdLabel</td>
+		<td class="px-5 py-4 font-bold text-es-ink">@connection.ClientLabel</td>
+		<td class="px-5 py-4 text-es-muted">@connection.TypeLabel</td>
+		<td class="px-5 py-4 font-mono text-xs text-es-muted">@connection.RemoteEndPointLabel</td>
+		<td class="px-5 py-4 text-right font-mono text-es-ink">@connection.SentRateLabel</td>
+		<td class="px-5 py-4 text-right font-mono text-es-ink">@connection.TotalBytesSentLabel</td>
+		<td class="px-5 py-4 text-right font-mono text-es-ink">@connection.PendingSendBytesLabel</td>
+		<td class="px-5 py-4 text-right font-mono text-es-ink">@connection.ReceivedRateLabel</td>
+		<td class="px-5 py-4 text-right font-mono text-es-ink">@connection.TotalBytesReceivedLabel</td>
+		<td class="px-5 py-4 text-right font-mono text-es-ink">@connection.PendingReceivedBytesLabel</td>
 	</tr>;
 
 	private bool IsExpanded(string groupName) =>

--- a/src/EventStore.ClusterNode/Components/Services/ClusterStatusService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/ClusterStatusService.cs
@@ -56,11 +56,11 @@ public sealed class ClusterStatusService(
 		if (leader is null)
 			return ClusterReplicaPage.Unavailable("Replica stats are unavailable until a leader is known.");
 
+		var leaderEndpoint = HttpEndpoint(leader);
 		var context = httpContextAccessor.HttpContext;
 		if (context is null)
 			return ClusterReplicaPage.Unavailable("Replica stats are unavailable outside an HTTP request.");
 
-		var leaderEndpoint = HttpEndpoint(leader);
 		if (string.IsNullOrWhiteSpace(leader.HttpEndPointIp) || leader.HttpEndPointPort <= 0)
 			return ClusterReplicaPage.Unavailable("Leader HTTP endpoint is unavailable.");
 

--- a/src/EventStore.ClusterNode/Components/Services/QueueDashboardEndpoints.cs
+++ b/src/EventStore.ClusterNode/Components/Services/QueueDashboardEndpoints.cs
@@ -1,0 +1,20 @@
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace EventStore.ClusterNode.Components.Services;
+
+internal static class QueueDashboardEndpoints {
+	public static IEndpointRouteBuilder MapQueueDashboardEndpoints(this IEndpointRouteBuilder app) {
+		app.MapGet("/ui/queue-dashboard/payload", async (
+			HttpContext context,
+			QueueDashboardService dashboard) => {
+			var page = await dashboard.Read(context.RequestAborted);
+			context.Response.Headers.CacheControl = "no-store";
+			return Results.Text(page.ClientPayloadJson, "application/json", Encoding.UTF8);
+		}).RequireAuthorization();
+
+		return app;
+	}
+}

--- a/src/EventStore.ClusterNode/Components/Services/QueueDashboardService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/QueueDashboardService.cs
@@ -2,39 +2,37 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
 using System.Security.Claims;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core;
-using EventStore.Core.Services.Transport.Grpc;
-using EventStore.Core.Services.Transport.Http.NodeHttpClientFactory;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
 using EventStore.Plugins.Authorization;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Net.Http.Headers;
 
 namespace EventStore.ClusterNode.Components.Services;
 
-public sealed class QueueDashboardService : IDisposable {
+public sealed class QueueDashboardService {
 	private static readonly TimeSpan ReadTimeout = TimeSpan.FromSeconds(10);
 	private static readonly Operation StatisticsOperation = new(Operations.Node.Statistics.Read);
+	private static readonly Operation TcpStatisticsOperation = new(Operations.Node.Statistics.Tcp);
 
 	private readonly IAuthorizationProvider _authorizationProvider;
 	private readonly IHttpContextAccessor _httpContextAccessor;
-	private readonly HttpClient _client;
-	private readonly LocalHttpEndPoint _statsEndPoint;
+	private readonly IPublisher _monitoringQueue;
+	private readonly object _tcpGate = new();
+	private Dictionary<Guid, TcpConnectionRow> _previousTcpConnections = new();
+	private DateTime? _lastTcpRefresh;
 
 	public QueueDashboardService(
 		IAuthorizationProvider authorizationProvider,
 		IHttpContextAccessor httpContextAccessor,
-		INodeHttpClientFactory nodeHttpClientFactory,
 		StandardComponents standardComponents) {
 		_authorizationProvider = authorizationProvider;
 		_httpContextAccessor = httpContextAccessor;
-		_statsEndPoint = NodeHttpRequestHelper.GetLocalEndPoint(standardComponents);
-		_client = nodeHttpClientFactory.CreateHttpClient([_statsEndPoint.Host]);
+		_monitoringQueue = standardComponents.MonitoringQueue;
 	}
 
 	public async Task<QueueDashboardPage> Read(CancellationToken cancellationToken = default) {
@@ -42,29 +40,12 @@ public sealed class QueueDashboardService : IDisposable {
 			return QueueDashboardPage.Unavailable("Runtime statistics access was denied.");
 
 		try {
-			var context = _httpContextAccessor.HttpContext;
-			if (context is null)
-				return QueueDashboardPage.Unavailable("Runtime statistics are unavailable outside an HTTP request.");
-
 			using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 			timeout.CancelAfter(ReadTimeout);
-			using var request = new HttpRequestMessage(
-				HttpMethod.Get,
-				NodeHttpRequestHelper.BuildUri(context.Request, _statsEndPoint, "/stats", "format=json"));
-			NodeHttpRequestHelper.CopyHeader(context.Request, request, HeaderNames.Authorization);
-			NodeHttpRequestHelper.CopyHeader(context.Request, request, HeaderNames.Cookie);
 
-			using var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeout.Token);
-			if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
-				return QueueDashboardPage.Unavailable("Runtime statistics access was denied.");
-
-			if (!response.IsSuccessStatusCode)
-				return QueueDashboardPage.Unavailable(
-					$"Queue statistics endpoint returned {(int)response.StatusCode} {response.ReasonPhrase}.");
-
-			await using var content = await response.Content.ReadAsStreamAsync(timeout.Token);
-			using var document = await JsonDocument.ParseAsync(content, cancellationToken: timeout.Token);
-			return ParseQueueStats(document);
+			var queues = await ReadQueueStats(timeout.Token);
+			var tcp = await ReadTcpStatsSafe(timeout.Token, cancellationToken);
+			return QueueDashboardPage.Success(queues, tcp.Rows, tcp.Message);
 		} catch (TimeoutException) {
 			return QueueDashboardPage.Unavailable("Timed out reading queue statistics.");
 		} catch (OperationCanceledException) {
@@ -77,36 +58,110 @@ public sealed class QueueDashboardService : IDisposable {
 		}
 	}
 
-	public void Dispose() =>
-		_client.Dispose();
-
 	private ClaimsPrincipal CurrentUser =>
 		_httpContextAccessor.HttpContext?.User ?? new ClaimsPrincipal(new ClaimsIdentity());
 
 	private Task<bool> HasAccess(Operation operation, CancellationToken cancellationToken) =>
 		_authorizationProvider.CheckAccessAsync(CurrentUser, operation, cancellationToken).AsTask();
 
-	private static QueueDashboardPage ParseQueueStats(JsonDocument document) {
-		if (!document.RootElement.TryGetProperty("es", out var es) ||
-		    !es.TryGetProperty("queue", out var queueStats) ||
-		    queueStats.ValueKind != JsonValueKind.Object) {
-			return QueueDashboardPage.Unavailable("Queue statistics are unavailable.");
-		}
+	private async Task<IReadOnlyList<QueueDashboardRow>> ReadQueueStats(CancellationToken cancellationToken) {
+		var envelope = new TaskCompletionEnvelope<MonitoringMessage.GetFreshStatsCompleted>();
+		_monitoringQueue.Publish(new MonitoringMessage.GetFreshStats(envelope, x => x, useMetadata: false, useGrouping: true));
+		var completed = await envelope.Task.WaitAsync(ReadTimeout, cancellationToken);
+		if (!completed.Success ||
+		    !QueueDashboardStats.TryReadDictionary(completed.Stats, "es", out var es) ||
+		    !QueueDashboardStats.TryReadDictionary(es, "queue", out var queueStats))
+			return Array.Empty<QueueDashboardRow>();
 
 		var queues = new List<QueueDashboardRow>();
-		foreach (var entry in queueStats.EnumerateObject()) {
+		foreach (var entry in queueStats) {
 			if (QueueDashboardRow.TryFrom(entry, out var queue))
 				queues.Add(queue);
 		}
 
-		return QueueDashboardPage.Success(queues);
+		return queues;
+	}
+
+	private async Task<TcpConnectionResult> ReadTcpStats(CancellationToken cancellationToken) {
+		if (!await HasAccess(TcpStatisticsOperation, cancellationToken))
+			return new TcpConnectionResult(Array.Empty<TcpConnectionRow>(), "TCP statistics access was denied.");
+
+		var envelope = new TaskCompletionEnvelope<MonitoringMessage.GetFreshTcpConnectionStatsCompleted>();
+		_monitoringQueue.Publish(new MonitoringMessage.GetFreshTcpConnectionStats(envelope));
+		var completed = await envelope.Task.WaitAsync(ReadTimeout, cancellationToken);
+		return BuildTcpRows(completed.ConnectionStats ?? []);
+	}
+
+	private async Task<TcpConnectionResult> ReadTcpStatsSafe(
+		CancellationToken timeoutToken,
+		CancellationToken cancellationToken) {
+		try {
+			return await ReadTcpStats(timeoutToken);
+		} catch (TimeoutException) {
+			return new TcpConnectionResult(Array.Empty<TcpConnectionRow>(), "Timed out reading TCP statistics.");
+		} catch (OperationCanceledException) {
+			if (cancellationToken.IsCancellationRequested)
+				throw;
+
+			return new TcpConnectionResult(Array.Empty<TcpConnectionRow>(), "Timed out reading TCP statistics.");
+		} catch (Exception ex) {
+			return new TcpConnectionResult(
+				Array.Empty<TcpConnectionRow>(),
+				$"Unable to read TCP statistics: {UiMessages.Friendly(ex)}");
+		}
+	}
+
+	private TcpConnectionResult BuildTcpRows(IReadOnlyList<MonitoringMessage.TcpConnectionStats> connections) {
+		lock (_tcpGate) {
+			var now = DateTime.UtcNow;
+			var elapsedSeconds = _lastTcpRefresh.HasValue
+				? Math.Max(1, (now - _lastTcpRefresh.Value).TotalSeconds)
+				: 1;
+
+			var rows = connections
+				.Select(x => TcpConnectionRow.From(x, _previousTcpConnections.GetValueOrDefault(x.ConnectionId), elapsedSeconds))
+				.OrderBy(x => x.ClientConnectionName, StringComparer.OrdinalIgnoreCase)
+				.ThenBy(x => x.ConnectionId)
+				.ToArray();
+
+			_previousTcpConnections = rows.ToDictionary(x => x.ConnectionId);
+			_lastTcpRefresh = now;
+			return new TcpConnectionResult(rows, "");
+		}
+	}
+
+}
+
+file static class QueueDashboardStats {
+	public static bool TryReadDictionary(
+		IReadOnlyDictionary<string, object> stats,
+		string key,
+		out IReadOnlyDictionary<string, object> value) {
+		value = null;
+		return stats is not null &&
+		       stats.TryGetValue(key, out var item) &&
+		       TryReadDictionary(item, out value);
+	}
+
+	public static bool TryReadDictionary(object value, out IReadOnlyDictionary<string, object> dictionary) {
+		dictionary = value switch {
+			IDictionary<string, object> mutable => new Dictionary<string, object>(mutable, StringComparer.OrdinalIgnoreCase),
+			IReadOnlyDictionary<string, object> readOnly => new Dictionary<string, object>(readOnly, StringComparer.OrdinalIgnoreCase),
+			_ => null
+		};
+
+		return dictionary is not null;
 	}
 }
 
 public sealed record QueueDashboardPage(
 	IReadOnlyList<QueueDashboardBlock> Blocks,
 	IReadOnlyList<QueueDashboardRow> Queues,
+	IReadOnlyList<TcpConnectionRow> TcpConnections,
+	string TcpMessage,
 	string Message) {
+	private static readonly JsonSerializerOptions PayloadJsonOptions = new(JsonSerializerDefaults.Web);
+
 	public bool IsAvailable => string.IsNullOrWhiteSpace(Message);
 	public bool HasRows => Blocks.Count > 0;
 	public int BusyQueueCount => Queues.Count(x => x.IsBusy);
@@ -116,12 +171,27 @@ public sealed record QueueDashboardPage(
 	public string BusyQueueCountLabel => IsAvailable ? BusyQueueCount.ToString(CultureInfo.InvariantCulture) : "-";
 	public string TotalBacklogLabel => IsAvailable ? TotalBacklog.ToString(CultureInfo.InvariantCulture) : "-";
 	public string TotalRateLabel => IsAvailable ? TotalRate.ToString(CultureInfo.InvariantCulture) : "-";
+	public string ClientPayloadJson => JsonSerializer.Serialize(
+		new QueueDashboardPayload(
+			Queues.Select(QueuePayload.From).ToArray(),
+			TcpConnections.Select(TcpConnectionPayload.From).ToArray(),
+			Message,
+			TcpMessage),
+		PayloadJsonOptions);
 
-	public static QueueDashboardPage Success(IReadOnlyList<QueueDashboardRow> queues) =>
-		new(BuildBlocks(queues), queues, "");
+	public static QueueDashboardPage Success(
+		IReadOnlyList<QueueDashboardRow> queues,
+		IReadOnlyList<TcpConnectionRow> tcpConnections,
+		string tcpMessage) =>
+		new(BuildBlocks(queues), queues, tcpConnections, tcpMessage, "");
 
 	public static QueueDashboardPage Unavailable(string message) =>
-		new(Array.Empty<QueueDashboardBlock>(), Array.Empty<QueueDashboardRow>(), message);
+		new(
+			Array.Empty<QueueDashboardBlock>(),
+			Array.Empty<QueueDashboardRow>(),
+			Array.Empty<TcpConnectionRow>(),
+			message,
+			message);
 
 	private static IReadOnlyList<QueueDashboardBlock> BuildBlocks(IReadOnlyList<QueueDashboardRow> queues) {
 		var blocks = new List<QueueDashboardBlock>();
@@ -149,6 +219,129 @@ public sealed record QueueDashboardBlock(
 	QueueDashboardRow Summary,
 	IReadOnlyList<QueueDashboardRow> Children) {
 	public bool HasChildren => Children.Count > 0;
+}
+
+public sealed record TcpConnectionResult(
+	IReadOnlyList<TcpConnectionRow> Rows,
+	string Message);
+
+public sealed record QueueDashboardPayload(
+	IReadOnlyList<QueuePayload> Queues,
+	IReadOnlyList<TcpConnectionPayload> TcpConnections,
+	string Message,
+	string TcpMessage);
+
+public sealed record QueuePayload(
+	string Kind,
+	string Name,
+	string GroupName,
+	int Length,
+	long LengthCurrentTryPeak,
+	long LengthLifetimePeak,
+	int AvgItemsPerSecond,
+	double AvgProcessingTime,
+	long TotalItemsProcessed,
+	string InProgressMessage,
+	string LastProcessedMessage) {
+	public static QueuePayload From(QueueDashboardRow row) =>
+		new(
+			"queue",
+			row.Name,
+			row.GroupName,
+			row.Length,
+			row.LengthCurrentTryPeak,
+			row.LengthLifetimePeak,
+			row.AvgItemsPerSecond,
+			row.AvgProcessingTime,
+			row.TotalItemsProcessed,
+			row.InProgressMessage,
+			row.LastProcessedMessage);
+}
+
+public sealed record TcpConnectionPayload(
+	Guid ConnectionId,
+	string ClientConnectionName,
+	string RemoteEndPoint,
+	string LocalEndPoint,
+	long TotalBytesSent,
+	long TotalBytesReceived,
+	int PendingSendBytes,
+	int PendingReceivedBytes,
+	double SentRate,
+	double ReceivedRate,
+	bool IsExternalConnection,
+	bool IsSslConnection) {
+	public static TcpConnectionPayload From(TcpConnectionRow row) =>
+		new(
+			row.ConnectionId,
+			row.ClientConnectionName,
+			row.RemoteEndPoint,
+			row.LocalEndPoint,
+			row.TotalBytesSent,
+			row.TotalBytesReceived,
+			row.PendingSendBytes,
+			row.PendingReceivedBytes,
+			row.SentRate,
+			row.ReceivedRate,
+			row.IsExternalConnection,
+			row.IsSslConnection);
+}
+
+public sealed record TcpConnectionRow(
+	Guid ConnectionId,
+	string ClientConnectionName,
+	string RemoteEndPoint,
+	string LocalEndPoint,
+	long TotalBytesSent,
+	long TotalBytesReceived,
+	int PendingSendBytes,
+	int PendingReceivedBytes,
+	double SentRate,
+	double ReceivedRate,
+	bool IsExternalConnection,
+	bool IsSslConnection) {
+	public string IdLabel => ConnectionId == Guid.Empty ? "<none>" : ConnectionId.ToString("D");
+	public string ClientLabel => DisplayMessage(ClientConnectionName);
+	public string TypeLabel => $"{(IsExternalConnection ? "External" : "Internal")} {(IsSslConnection ? "TLS" : "TCP")}";
+	public string RemoteEndPointLabel => DisplayMessage(RemoteEndPoint);
+	public string SentRateLabel => FormatByteRate(SentRate);
+	public string ReceivedRateLabel => FormatByteRate(ReceivedRate);
+	public string TotalBytesSentLabel => TotalBytesSent.ToString("N0", CultureInfo.InvariantCulture);
+	public string TotalBytesReceivedLabel => TotalBytesReceived.ToString("N0", CultureInfo.InvariantCulture);
+	public string PendingSendBytesLabel => PendingSendBytes.ToString("N0", CultureInfo.InvariantCulture);
+	public string PendingReceivedBytesLabel => PendingReceivedBytes.ToString("N0", CultureInfo.InvariantCulture);
+
+	public static TcpConnectionRow From(
+		MonitoringMessage.TcpConnectionStats stats,
+		TcpConnectionRow previous,
+		double elapsedSeconds) {
+		var sentRate = previous is null
+			? 0
+			: Math.Max(0, (stats.TotalBytesSent - previous.TotalBytesSent) / elapsedSeconds);
+		var receivedRate = previous is null
+			? 0
+			: Math.Max(0, (stats.TotalBytesReceived - previous.TotalBytesReceived) / elapsedSeconds);
+
+		return new TcpConnectionRow(
+			stats.ConnectionId,
+			stats.ClientConnectionName ?? "",
+			stats.RemoteEndPoint ?? "",
+			stats.LocalEndPoint ?? "",
+			stats.TotalBytesSent,
+			stats.TotalBytesReceived,
+			stats.PendingSendBytes,
+			stats.PendingReceivedBytes,
+			sentRate,
+			receivedRate,
+			stats.IsExternalConnection,
+			stats.IsSslConnection);
+	}
+
+	private static string DisplayMessage(string value) =>
+		string.IsNullOrWhiteSpace(value) ? "<none>" : value;
+
+	private static string FormatByteRate(double value) =>
+		$"{Math.Round(value).ToString("N0", CultureInfo.InvariantCulture)} B/s";
 }
 
 public enum QueueDashboardRowKind {
@@ -196,24 +389,24 @@ public sealed record QueueDashboardRow(
 
 	public QueueDashboardRow AsGroupMember() => this with { Kind = QueueDashboardRowKind.GroupMember };
 
-	public static bool TryFrom(JsonProperty entry, out QueueDashboardRow row) {
-		if (entry.Value.ValueKind != JsonValueKind.Object) {
+	public static bool TryFrom(KeyValuePair<string, object> entry, out QueueDashboardRow row) {
+		if (!QueueDashboardStats.TryReadDictionary(entry.Value, out var stats)) {
 			row = null;
 			return false;
 		}
 
 		row = new QueueDashboardRow(
 			QueueDashboardRowKind.Queue,
-			ReadString(entry.Value, "queueName", entry.Name),
-			ReadString(entry.Value, "groupName", ""),
-			ReadInt(entry.Value, "length"),
-			ReadLong(entry.Value, "lengthCurrentTryPeak"),
-			ReadLong(entry.Value, "lengthLifetimePeak"),
-			ReadInt(entry.Value, "avgItemsPerSecond"),
-			ReadDouble(entry.Value, "avgProcessingTime"),
-			ReadLong(entry.Value, "totalItemsProcessed"),
-			ReadString(entry.Value, "inProgressMessage", "<none>"),
-			ReadString(entry.Value, "lastProcessedMessage", "<none>"));
+			ReadString(stats, "queueName", entry.Key),
+			ReadString(stats, "groupName", ""),
+			ReadInt(stats, "length"),
+			ReadLong(stats, "lengthCurrentTryPeak"),
+			ReadLong(stats, "lengthLifetimePeak"),
+			ReadInt(stats, "avgItemsPerSecond"),
+			ReadDouble(stats, "avgProcessingTime"),
+			ReadLong(stats, "totalItemsProcessed"),
+			ReadString(stats, "inProgressMessage", "<none>"),
+			ReadString(stats, "lastProcessedMessage", "<none>"));
 		return true;
 	}
 
@@ -243,48 +436,48 @@ public sealed record QueueDashboardRow(
 		return rows.Count == 0 ? 0 : rows.Average(x => x.AvgProcessingTime);
 	}
 
-	private static string ReadString(JsonElement stats, string key, string fallback) {
-		if (!stats.TryGetProperty(key, out var value) || value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
-			return fallback;
+	private static string ReadString(IReadOnlyDictionary<string, object> stats, string key, string fallback) =>
+		stats.TryGetValue(key, out var value) && value is not null
+			? Convert.ToString(value, CultureInfo.InvariantCulture) ?? fallback
+			: fallback;
 
-		if (value.ValueKind == JsonValueKind.String)
-			return value.GetString() ?? fallback;
-
-		return value.ToString();
-	}
-
-	private static int ReadInt(JsonElement stats, string key) =>
+	private static int ReadInt(IReadOnlyDictionary<string, object> stats, string key) =>
 		(int)Math.Min(int.MaxValue, Math.Max(int.MinValue, ReadLong(stats, key)));
 
-	private static long ReadLong(JsonElement stats, string key) {
-		if (!stats.TryGetProperty(key, out var value) || value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+	private static long ReadLong(IReadOnlyDictionary<string, object> stats, string key) {
+		if (!stats.TryGetValue(key, out var value) || value is null)
 			return 0;
 
-		if (value.ValueKind == JsonValueKind.Number) {
-			if (value.TryGetInt64(out var integer))
-				return integer;
-
-			if (value.TryGetDouble(out var numeric))
-				return Convert.ToInt64(numeric);
-		}
-
-		return value.ValueKind == JsonValueKind.String &&
-		       long.TryParse(value.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
-			? parsed
-			: 0;
+		return value switch {
+			long longValue => longValue,
+			int intValue => intValue,
+			uint uintValue => uintValue,
+			ulong ulongValue => ulongValue > long.MaxValue ? long.MaxValue : (long)ulongValue,
+			double doubleValue => Convert.ToInt64(doubleValue),
+			float floatValue => Convert.ToInt64(floatValue),
+			decimal decimalValue => Convert.ToInt64(decimalValue),
+			_ => long.TryParse(Convert.ToString(value, CultureInfo.InvariantCulture), NumberStyles.Integer,
+				CultureInfo.InvariantCulture, out var parsed)
+				? parsed
+				: 0
+		};
 	}
 
-	private static double ReadDouble(JsonElement stats, string key) {
-		if (!stats.TryGetProperty(key, out var value) || value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+	private static double ReadDouble(IReadOnlyDictionary<string, object> stats, string key) {
+		if (!stats.TryGetValue(key, out var value) || value is null)
 			return 0;
 
-		if (value.ValueKind == JsonValueKind.Number && value.TryGetDouble(out var numeric))
-			return numeric;
-
-		return value.ValueKind == JsonValueKind.String &&
-		       double.TryParse(value.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
-			? parsed
-			: 0;
+		return value switch {
+			double doubleValue => doubleValue,
+			float floatValue => floatValue,
+			decimal decimalValue => Convert.ToDouble(decimalValue, CultureInfo.InvariantCulture),
+			long longValue => longValue,
+			int intValue => intValue,
+			_ => double.TryParse(Convert.ToString(value, CultureInfo.InvariantCulture), NumberStyles.Float,
+				CultureInfo.InvariantCulture, out var parsed)
+				? parsed
+				: 0
+		};
 	}
 
 	private static string DisplayMessage(string message) =>

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -296,6 +296,7 @@ internal static class Program
 					hostedService.Node.Startup.Configure(app);
 					if (adminUiEnabled) {
 						app.MapAdminOperationsEndpoints();
+						app.MapQueueDashboardEndpoints();
 						app.MapRazorComponents<App>();
 					}
 

--- a/src/EventStore.ClusterNode/ui-assets/js/queue-dashboard.js
+++ b/src/EventStore.ClusterNode/ui-assets/js/queue-dashboard.js
@@ -21,15 +21,17 @@
 			blocks: [],
 			queues: [],
 			tcpConnections: [],
-			tcpLastSeen: null,
 			tcpPage: 0,
 			timer: null,
-			inFlight: false,
-			tcpInFlight: false
+			inFlight: false
 		};
 
 		dashboards.set(root, state);
 		openDashboardSnapshot();
+		var initialPayload = readPayload(document, state);
+		if (initialPayload)
+			applyPayload(state, initialPayload);
+
 		root.addEventListener("click", function (event) {
 			var tcpPager = event.target.closest("[data-tcp-page]");
 			if (tcpPager && root.contains(tcpPager)) {
@@ -54,13 +56,11 @@
 		});
 
 		refresh(state);
-		refreshTcp(state);
 		state.timer = window.setInterval(function () {
 			if (document.hidden)
 				return;
 
 			refresh(state);
-			refreshTcp(state);
 		}, pollIntervalMs);
 	}
 
@@ -99,76 +99,96 @@
 			snapshot.open = true;
 	}
 
+	function readPayload(doc, state) {
+		var roots = doc.querySelectorAll("[data-queue-dashboard]");
+		var dashboardName = state.root.getAttribute("data-queue-dashboard");
+		for (var i = 0; i < roots.length; i++) {
+			if (roots[i].getAttribute("data-queue-dashboard") !== dashboardName)
+				continue;
+
+			var payload = roots[i].querySelector("[data-queue-dashboard-payload]");
+			if (!payload)
+				return null;
+
+			try {
+				return JSON.parse(payload.textContent || "{}");
+			} catch (_) {
+				return null;
+			}
+		}
+
+		return null;
+	}
+
+	function applyPayload(state, payload) {
+		var parsed = parseQueues(payload);
+		state.queues = parsed.queues;
+		state.blocks = parsed.blocks;
+		state.tcpConnections = parseTcpConnections(payload);
+		setStatus(
+			state.root,
+			payload.message ? "Live stats unavailable" : "Live stats",
+			payload.message || "Updated " + formatTime(new Date()));
+		render(state);
+
+		if (state.root.querySelector("[data-tcp-table-body]")) {
+			var tcpMessage = payload.tcpMessage || payload.message || "";
+			setTcpStatus(
+				state.root,
+				tcpMessage ? "TCP unavailable" : "TCP live",
+				tcpMessage || state.tcpConnections.length + " connection" + (state.tcpConnections.length === 1 ? "" : "s"));
+			renderTcpTable(state.root, state.tcpConnections, state);
+		}
+	}
+
 	async function refresh(state) {
 		if (state.inFlight)
 			return;
 
 		state.inFlight = true;
 		try {
-			var response = await fetch("/stats?format=json", {
+			var response = await fetch(payloadUrl(), {
 				credentials: "same-origin",
 				headers: { "Accept": "application/json" }
 			});
 
 			if (!response.ok)
-				throw new Error("Stats endpoint returned " + response.status + " " + response.statusText);
+				throw new Error("Dashboard refresh returned " + response.status + " " + response.statusText);
 
-			var payload = await response.json();
-			var parsed = parseQueues(payload);
-			state.queues = parsed.queues;
-			state.blocks = parsed.blocks;
-			setStatus(state.root, "Live stats", "Updated " + formatTime(new Date()));
-			render(state);
+			applyPayload(state, await response.json());
 		} catch (error) {
+			state.queues = [];
+			state.blocks = [];
+			state.tcpConnections = [];
 			setStatus(state.root, "Live stats unavailable", friendlyMessage(error));
+			setTcpStatus(state.root, "TCP unavailable", friendlyMessage(error));
+			render(state);
+			renderTcpTable(state.root, state.tcpConnections, state);
 		} finally {
 			state.inFlight = false;
 		}
 	}
 
-	async function refreshTcp(state) {
-		if (state.tcpInFlight || !state.root.querySelector("[data-tcp-table-body]"))
-			return;
+	function payloadUrl() {
+		var pathname = window.location.pathname;
+		var marker = "/ui/";
+		var markerIndex = pathname.toLowerCase().indexOf(marker);
+		var pathBase = markerIndex === -1 ? "" : pathname.substring(0, markerIndex);
 
-		state.tcpInFlight = true;
-		try {
-			var response = await fetch("/stats/tcp?format=json", {
-				credentials: "same-origin",
-				headers: { "Accept": "application/json" }
-			});
-
-			if (!response.ok)
-				throw new Error("TCP stats endpoint returned " + response.status + " " + response.statusText);
-
-			var payload = await response.json();
-			var now = Date.now();
-			var elapsedSeconds = state.tcpLastSeen
-				? Math.max(1, (now - state.tcpLastSeen) / 1000)
-				: 1;
-
-			state.tcpConnections = parseTcpConnections(payload, state.tcpConnections, elapsedSeconds);
-			state.tcpLastSeen = now;
-			setTcpStatus(state.root, "TCP live", state.tcpConnections.length + " connection" + (state.tcpConnections.length === 1 ? "" : "s"));
-			renderTcpTable(state.root, state.tcpConnections, state);
-		} catch (error) {
-			setTcpStatus(state.root, "TCP unavailable", friendlyMessage(error));
-		} finally {
-			state.tcpInFlight = false;
-		}
+		return pathBase + "/ui/queue-dashboard/payload";
 	}
 
 	function parseQueues(payload) {
-		var stats = payload && payload.es && payload.es.queue;
+		var stats = payload && payload.queues;
 		var queues = [];
-		if (stats && typeof stats === "object") {
-			Object.keys(stats).forEach(function (key) {
-				var value = stats[key];
+		if (Array.isArray(stats)) {
+			stats.forEach(function (value) {
 				if (!value || typeof value !== "object")
 					return;
 
 				queues.push({
 					kind: "queue",
-					name: readString(value.queueName, key),
+					name: readString(value.name, ""),
 					groupName: readString(value.groupName, ""),
 					length: readNumber(value.length),
 					lengthCurrentTryPeak: readNumber(value.lengthCurrentTryPeak),
@@ -188,24 +208,13 @@
 		};
 	}
 
-	function parseTcpConnections(payload, previousConnections, elapsedSeconds) {
-		var rows = Array.isArray(payload) ? payload : [];
-		var previous = new Map();
-		previousConnections.forEach(function (connection) {
-			previous.set(connection.id, connection);
-		});
+	function parseTcpConnections(payload) {
+		var rows = payload && Array.isArray(payload.tcpConnections) ? payload.tcpConnections : [];
 
 		return rows.map(function (row) {
 			var id = readFieldString(row, ["connectionId", "ConnectionId"], "");
 			var totalBytesSent = readFieldNumber(row, ["totalBytesSent", "TotalBytesSent"]);
 			var totalBytesReceived = readFieldNumber(row, ["totalBytesReceived", "TotalBytesReceived"]);
-			var previousRow = previous.get(id);
-			var sentRate = previousRow
-				? Math.max(0, (totalBytesSent - previousRow.totalBytesSent) / elapsedSeconds)
-				: 0;
-			var receivedRate = previousRow
-				? Math.max(0, (totalBytesReceived - previousRow.totalBytesReceived) / elapsedSeconds)
-				: 0;
 
 			return {
 				id: id,
@@ -216,8 +225,8 @@
 				totalBytesReceived: totalBytesReceived,
 				pendingSendBytes: readFieldNumber(row, ["pendingSendBytes", "PendingSendBytes"]),
 				pendingReceivedBytes: readFieldNumber(row, ["pendingReceivedBytes", "PendingReceivedBytes"]),
-				sentRate: sentRate,
-				receivedRate: receivedRate,
+				sentRate: readFieldNumber(row, ["sentRate", "SentRate"]),
+				receivedRate: readFieldNumber(row, ["receivedRate", "ReceivedRate"]),
 				isExternalConnection: readFieldBoolean(row, ["isExternalConnection", "IsExternalConnection"]),
 				isSslConnection: readFieldBoolean(row, ["isSslConnection", "IsSslConnection"])
 			};

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1607,7 +1607,7 @@ public class ClusterVNode<TStreamId> :
 		_subsystems = options.Subsystems;
 
 		var standardComponents = new StandardComponents(Db.Config, _mainQueue, _mainBus, _timerService, _timeProvider,
-			httpSendService, new IHttpService[] { _httpService }, _workersHandler, _queueStatsManager,
+			httpSendService, new IHttpService[] { _httpService }, _workersHandler, monitoringQueue, _queueStatsManager,
 			trackers.QueueTrackers, metricsConfiguration.ProjectionStats);
 
 		IServiceCollection ConfigureNodeServices(IServiceCollection services)

--- a/src/EventStore.Core/StandardComponents.cs
+++ b/src/EventStore.Core/StandardComponents.cs
@@ -15,6 +15,7 @@ namespace EventStore.Core {
 		private readonly IHttpForwarder _httpForwarder;
 		private readonly IHttpService[] _httpServices;
 		private readonly IPublisher _networkSendService;
+		private readonly IPublisher _monitoringQueue;
 		private readonly QueueStatsManager _queueStatsManager;
 
 		public StandardComponents(
@@ -26,6 +27,7 @@ namespace EventStore.Core {
 			IHttpForwarder httpForwarder,
 			IHttpService[] httpServices,
 			IPublisher networkSendService,
+			IPublisher monitoringQueue,
 			QueueStatsManager queueStatsManager,
 			QueueTrackers trackers,
 			bool projectionStats) {
@@ -37,6 +39,7 @@ namespace EventStore.Core {
 			_httpForwarder = httpForwarder;
 			_httpServices = httpServices;
 			_networkSendService = networkSendService;
+			_monitoringQueue = monitoringQueue;
 			_queueStatsManager = queueStatsManager;
 			QueueTrackers = trackers;
 			ProjectionStats = projectionStats;
@@ -72,6 +75,10 @@ namespace EventStore.Core {
 
 		public IPublisher NetworkSendService {
 			get { return _networkSendService; }
+		}
+
+		public IPublisher MonitoringQueue {
+			get { return _monitoringQueue; }
 		}
 
 		public QueueStatsManager QueueStatsManager {

--- a/src/EventStore.Projections.Core.Javascript.Tests/Integration/ProjectionRuntimeScenario.cs
+++ b/src/EventStore.Projections.Core.Javascript.Tests/Integration/ProjectionRuntimeScenario.cs
@@ -45,7 +45,7 @@ public abstract class ProjectionRuntimeScenario : SubsystemScenario
 		var timeProvider = new RealTimeProvider();
 		var ts = new TimerService(new TimerBasedScheduler(new RealTimer(), timeProvider));
 		var sc = new StandardComponents(db.Config, mainQueue, mainBus, ts, timeProvider, null, new IHttpService[] { },
-			mainBus, qs, new(), true);
+			mainBus, mainQueue, qs, new(), true);
 
 		var subsystem = new ProjectionsSubsystem(options);
 

--- a/src/EventStore.Projections.Core.Tests/Subsystem/TestFixtureWithProjectionSubsystem.cs
+++ b/src/EventStore.Projections.Core.Tests/Subsystem/TestFixtureWithProjectionSubsystem.cs
@@ -52,7 +52,7 @@ public class TestFixtureWithProjectionSubsystem
 
 		return new StandardComponents(dbConfig, mainQueue, mainBus,
 			timerService, timeProvider: null, httpForwarder: null, httpServices: new IHttpService[] { },
-			networkSendService: null, queueStatsManager: new QueueStatsManager(),
+			networkSendService: null, monitoringQueue: mainQueue, queueStatsManager: new QueueStatsManager(),
 			trackers: new(), true);
 	}
 


### PR DESCRIPTION
- Runtime queue dashboards should stop depending on legacy stats routes before the stats controller can be retired.\n- The replica view still needs the leader stats path until there is real cross-node parity outside HTTP.\n- Keeping this slice narrow makes the remaining StatController surface easier to reason about without hiding functionality loss.