### PR TITLE
feat(grpc): preserve replication stats parity

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -2744,6 +2744,65 @@
                 "type": "bool"
               }
             ]
+          },
+          {
+            "name": "ReplicationStatsReq"
+          },
+          {
+            "name": "ReplicationStatsResp",
+            "fields": [
+              {
+                "id": 1,
+                "name": "stats",
+                "type": "ReplicationStats",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ReplicationStats",
+            "fields": [
+              {
+                "id": 1,
+                "name": "subscription_id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "connection_id",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "subscription_endpoint",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "total_bytes_sent",
+                "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "total_bytes_received",
+                "type": "int64"
+              },
+              {
+                "id": 6,
+                "name": "pending_send_bytes",
+                "type": "int32"
+              },
+              {
+                "id": 7,
+                "name": "pending_received_bytes",
+                "type": "int32"
+              },
+              {
+                "id": 8,
+                "name": "send_queue_size",
+                "type": "int32"
+              }
+            ]
           }
         ],
         "services": [
@@ -2760,6 +2819,11 @@
                 "name": "TcpStats",
                 "in_type": "TcpStatsReq",
                 "out_type": "TcpStatsResp"
+              },
+              {
+                "name": "ReplicationStats",
+                "in_type": "ReplicationStatsReq",
+                "out_type": "ReplicationStatsResp"
               }
             ]
           }

--- a/src/EventStore.ClusterNode/Components/Services/ClusterStatusService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/ClusterStatusService.cs
@@ -74,6 +74,11 @@ public sealed class ClusterStatusService(
 			return ParseReplicaStats(response, clusterInfo.Members, leader, leaderEndpoint, DateTime.UtcNow);
 		} catch (RpcException ex) when (ex.StatusCode is StatusCode.Unauthenticated or StatusCode.PermissionDenied) {
 			return ClusterReplicaPage.Unavailable("Replica statistics access was denied.");
+		} catch (RpcException ex) when (ex.StatusCode == StatusCode.Cancelled) {
+			if (cancellationToken.IsCancellationRequested)
+				throw new OperationCanceledException(null, ex, cancellationToken);
+
+			return ClusterReplicaPage.Unavailable("Timed out reading replica statistics.");
 		} catch (OperationCanceledException) {
 			if (cancellationToken.IsCancellationRequested)
 				throw;

--- a/src/EventStore.ClusterNode/Components/Services/ClusterStatusService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/ClusterStatusService.cs
@@ -3,20 +3,21 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Security.Claims;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Client.Monitoring;
 using EventStore.Core;
 using EventStore.Core.Cluster;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.Transport.Http.NodeHttpClientFactory;
 using EventStore.Plugins.Authorization;
+using Grpc.Core;
+using Grpc.Net.Client;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Net.Http.Headers;
+using MonitoringClient = EventStore.Client.Monitoring.Monitoring.MonitoringClient;
 
 namespace EventStore.ClusterNode.Components.Services;
 
@@ -28,7 +29,7 @@ public sealed class ClusterStatusService(
 	private static readonly TimeSpan ReadTimeout = TimeSpan.FromSeconds(8);
 	private static readonly Operation ReadOperation = new(Operations.Node.Gossip.ClientRead);
 	private static readonly Operation ReplicationOperation = new(Operations.Node.Statistics.Replication);
-	private readonly ConcurrentDictionary<string, HttpClient> _clients = new(StringComparer.OrdinalIgnoreCase);
+	private readonly ConcurrentDictionary<string, LeaderMonitoringClient> _clients = new(StringComparer.OrdinalIgnoreCase);
 	private readonly object _replicaGate = new();
 	private Dictionary<Guid, ClusterReplicaRow> _previousReplicas = new();
 	private string _previousLeaderEndpoint = "";
@@ -67,27 +68,12 @@ public sealed class ClusterStatusService(
 		try {
 			using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 			timeout.CancelAfter(ReadTimeout);
-			using var request = new HttpRequestMessage(
-				HttpMethod.Get,
-				BuildLeaderUri(context.Request, leader, "/stats/replication", "format=json"));
-			NodeHttpRequestHelper.CopyHeader(context.Request, request, HeaderNames.Authorization);
-			NodeHttpRequestHelper.CopyHeader(context.Request, request, HeaderNames.Cookie);
-
-			using var response = await ClientFor(leader.HttpEndPointIp).SendAsync(
-				request,
-				HttpCompletionOption.ResponseHeadersRead,
-				timeout.Token);
-
-			if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
-				return ClusterReplicaPage.Unavailable("Replica statistics access was denied.");
-
-			if (!response.IsSuccessStatusCode)
-				return ClusterReplicaPage.Unavailable(
-					$"Replica stats endpoint returned {(int)response.StatusCode} {response.ReasonPhrase}.");
-
-			await using var content = await response.Content.ReadAsStreamAsync(timeout.Token);
-			using var document = await JsonDocument.ParseAsync(content, cancellationToken: timeout.Token);
-			return ParseReplicaStats(document, clusterInfo.Members, leader, leaderEndpoint, DateTime.UtcNow);
+			var response = await ClientFor(context.Request, leader).Client.ReplicationStatsAsync(
+				new ReplicationStatsReq(),
+				cancellationToken: timeout.Token);
+			return ParseReplicaStats(response, clusterInfo.Members, leader, leaderEndpoint, DateTime.UtcNow);
+		} catch (RpcException ex) when (ex.StatusCode is StatusCode.Unauthenticated or StatusCode.PermissionDenied) {
+			return ClusterReplicaPage.Unavailable("Replica statistics access was denied.");
 		} catch (OperationCanceledException) {
 			if (cancellationToken.IsCancellationRequested)
 				throw;
@@ -98,8 +84,17 @@ public sealed class ClusterStatusService(
 		}
 	}
 
-	private HttpClient ClientFor(string host) =>
-		_clients.GetOrAdd(host, static (value, factory) => factory.CreateHttpClient(new[] { value }), nodeHttpClientFactory);
+	private LeaderMonitoringClient ClientFor(
+		HttpRequest request,
+		ClientClusterInfo.ClientMemberInfo leader) {
+		var key = $"{request.Scheme}://{HttpEndpoint(leader)}";
+		return _clients.GetOrAdd(
+			key,
+			static (_, state) => LeaderMonitoringClient.Create(
+				BuildLeaderAddress(state.Request, state.Leader),
+				state.Factory.CreateHttpClient([state.Leader.HttpEndPointIp])),
+			(Request: request, Leader: leader, Factory: nodeHttpClientFactory));
+	}
 
 	public void Dispose() {
 		foreach (var client in _clients.Values)
@@ -107,23 +102,18 @@ public sealed class ClusterStatusService(
 	}
 
 	private ClusterReplicaPage ParseReplicaStats(
-		JsonDocument document,
+		ReplicationStatsResp response,
 		IReadOnlyList<ClientClusterInfo.ClientMemberInfo> members,
 		ClientClusterInfo.ClientMemberInfo leader,
 		string leaderEndpoint,
 		DateTime now) {
-		if (document.RootElement.ValueKind != JsonValueKind.Array)
-			return ClusterReplicaPage.Unavailable("Replica statistics are unavailable.");
-
 		lock (_replicaGate) {
 			if (!string.Equals(_previousLeaderEndpoint, leaderEndpoint, StringComparison.OrdinalIgnoreCase)) {
 				_previousLeaderEndpoint = leaderEndpoint;
 				_previousReplicas = new Dictionary<Guid, ClusterReplicaRow>();
 			}
 
-			var rows = document.RootElement
-				.EnumerateArray()
-				.Where(x => x.ValueKind == JsonValueKind.Object)
+			var rows = response.Stats
 				.Select(x => ParseReplicaRow(x, members, leader, now))
 				.ToArray();
 
@@ -133,14 +123,16 @@ public sealed class ClusterStatusService(
 	}
 
 	private ClusterReplicaRow ParseReplicaRow(
-		JsonElement row,
+		ReplicationStats row,
 		IReadOnlyList<ClientClusterInfo.ClientMemberInfo> members,
 		ClientClusterInfo.ClientMemberInfo leader,
 		DateTime now) {
-		var connectionId = ReadGuid(row, "connectionId", "ConnectionId");
-		var totalBytesSent = ReadLong(row, "totalBytesSent", "TotalBytesSent");
+		var connectionId = Guid.TryParse(row.ConnectionId, out var parsedConnectionId)
+			? parsedConnectionId
+			: Guid.Empty;
+		var totalBytesSent = row.TotalBytesSent;
 		var previousRow = _previousReplicas.GetValueOrDefault(connectionId);
-		var replicaNode = FindMemberByInternalEndpoint(members, ReadString(row, "subscriptionEndpoint", "SubscriptionEndpoint"));
+		var replicaNode = FindMemberByInternalEndpoint(members, row.SubscriptionEndpoint);
 		var isCatchingUp = replicaNode?.State == VNodeState.CatchingUp;
 		var catchupStartTime = now;
 		var catchupStartBytesSent = totalBytesSent;
@@ -158,12 +150,12 @@ public sealed class ClusterStatusService(
 
 		return new ClusterReplicaRow(
 			connectionId,
-			ReadString(row, "subscriptionEndpoint", "SubscriptionEndpoint", "<none>"),
+			string.IsNullOrWhiteSpace(row.SubscriptionEndpoint) ? "<none>" : row.SubscriptionEndpoint,
 			totalBytesSent,
-			ReadLong(row, "totalBytesReceived", "TotalBytesReceived"),
-			ReadInt(row, "pendingSendBytes", "PendingSendBytes"),
-			ReadInt(row, "pendingReceivedBytes", "PendingReceivedBytes"),
-			ReadInt(row, "sendQueueSize", "SendQueueSize"),
+			row.TotalBytesReceived,
+			row.PendingSendBytes,
+			row.PendingReceivedBytes,
+			row.SendQueueSize,
 			isCatchingUp,
 			bytesToCatchUp,
 			approximateSpeed,
@@ -181,19 +173,10 @@ public sealed class ClusterStatusService(
 		return members.FirstOrDefault(x => string.Equals(InternalTcpEndpoint(x), cleaned, StringComparison.OrdinalIgnoreCase));
 	}
 
-	private static Uri BuildLeaderUri(
+	private static Uri BuildLeaderAddress(
 		HttpRequest request,
-		ClientClusterInfo.ClientMemberInfo leader,
-		string path,
-		string query) {
-		var normalizedPath = path.StartsWith('/') ? path : $"/{path}";
-		var builder = new UriBuilder(request.Scheme, leader.HttpEndPointIp, leader.HttpEndPointPort) {
-			Path = $"{request.PathBase}{normalizedPath}",
-			Query = query
-		};
-
-		return builder.Uri;
-	}
+		ClientClusterInfo.ClientMemberInfo leader) =>
+		new UriBuilder(request.Scheme, leader.HttpEndPointIp, leader.HttpEndPointPort).Uri;
 
 	private static string InternalTcpEndpoint(ClientClusterInfo.ClientMemberInfo member) =>
 		Endpoint(
@@ -206,49 +189,29 @@ public sealed class ClusterStatusService(
 	private static string Endpoint(string host, int port) =>
 		$"{(string.IsNullOrWhiteSpace(host) ? "<none>" : host)}:{port}";
 
-	private static string ReadString(JsonElement row, string camelName, string pascalName, string fallback = "") {
-		if (!TryGetProperty(row, camelName, pascalName, out var value))
-			return fallback;
+	private sealed class LeaderMonitoringClient : IDisposable {
+		private readonly GrpcChannel _channel;
+		private readonly HttpClient _httpClient;
 
-		return value.ValueKind switch {
-			JsonValueKind.String => value.GetString() ?? fallback,
-			JsonValueKind.Null => fallback,
-			JsonValueKind.Undefined => fallback,
-			_ => value.ToString()
-		};
+		private LeaderMonitoringClient(Uri address, HttpClient httpClient) {
+			_httpClient = httpClient;
+			_channel = GrpcChannel.ForAddress(address, new GrpcChannelOptions {
+				HttpClient = _httpClient,
+				DisposeHttpClient = false
+			});
+			Client = new MonitoringClient(_channel);
+		}
+
+		public MonitoringClient Client { get; }
+
+		public static LeaderMonitoringClient Create(Uri address, HttpClient httpClient) =>
+			new(address, httpClient);
+
+		public void Dispose() {
+			_channel.Dispose();
+			_httpClient.Dispose();
+		}
 	}
-
-	private static int ReadInt(JsonElement row, string camelName, string pascalName) {
-		if (!TryGetProperty(row, camelName, pascalName, out var value))
-			return 0;
-
-		if (value.ValueKind == JsonValueKind.Number && value.TryGetInt32(out var number))
-			return number;
-
-		return int.TryParse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
-			? parsed
-			: 0;
-	}
-
-	private static long ReadLong(JsonElement row, string camelName, string pascalName) {
-		if (!TryGetProperty(row, camelName, pascalName, out var value))
-			return 0;
-
-		if (value.ValueKind == JsonValueKind.Number && value.TryGetInt64(out var number))
-			return number;
-
-		return long.TryParse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
-			? parsed
-			: 0;
-	}
-
-	private static Guid ReadGuid(JsonElement row, string camelName, string pascalName) {
-		var value = ReadString(row, camelName, pascalName);
-		return Guid.TryParse(value, out var parsed) ? parsed : Guid.Empty;
-	}
-
-	private static bool TryGetProperty(JsonElement row, string camelName, string pascalName, out JsonElement value) =>
-		row.TryGetProperty(camelName, out value) || row.TryGetProperty(pascalName, out value);
 }
 
 public sealed record ClusterReplicaPage(

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/MonitoringTests/ReplicationStatsTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/MonitoringTests/ReplicationStatsTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Client.Monitoring;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using Grpc.Core;
+using NUnit.Framework;
+using CoreReplicationStats = EventStore.Core.Messages.ReplicationMessage.ReplicationStats;
+
+namespace EventStore.Core.Tests.Services.Transport.Grpc.MonitoringTests;
+
+[TestFixture]
+public class ReplicationStatsTests {
+	private readonly Guid _subscriptionId = Guid.Parse("3c870871-1a1a-48f1-a9d6-89f471512f1e");
+	private readonly Guid _connectionId = Guid.Parse("d8b2ac45-2510-4a29-9e2a-713a5af7d6c5");
+	private ReplicationStatsResp _response;
+	private CapturingPublisher _publisher;
+
+	[SetUp]
+	public async Task SetUp() {
+		_publisher = new CapturingPublisher(new List<CoreReplicationStats> {
+			new(
+				_subscriptionId,
+				_connectionId,
+				"127.0.0.1:1112",
+				sendQueueSize: 9,
+				totalBytesSent: 123,
+				totalBytesReceived: 456,
+				pendingSendBytes: 7,
+				pendingReceivedBytes: 8),
+			new(
+				Guid.Empty,
+				Guid.Empty,
+				null,
+				sendQueueSize: 0,
+				totalBytesSent: 0,
+				totalBytesReceived: 0,
+				pendingSendBytes: 0,
+				pendingReceivedBytes: 0)
+		});
+		var serviceType = typeof(MonitoringMessage).Assembly.GetType(
+			"EventStore.Core.Services.Transport.Grpc.Monitoring",
+			throwOnError: true);
+		var service = Activator.CreateInstance(
+			serviceType!,
+			BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+			binder: null,
+			args: [_publisher],
+			culture: null);
+
+		var task = (Task<ReplicationStatsResp>)serviceType!.GetMethod(
+				nameof(EventStore.Client.Monitoring.Monitoring.MonitoringBase.ReplicationStats))!
+			.Invoke(service, [new ReplicationStatsReq(), TestServerCallContext.Instance])!;
+		_response = await task;
+	}
+
+	[Test]
+	public void should_request_replication_stats() {
+		Assert.IsTrue(_publisher.RequestedReplicationStats);
+	}
+
+	[Test]
+	public void should_return_the_replication_stats() {
+		Assert.AreEqual(2, _response.Stats.Count);
+	}
+
+	[Test]
+	public void should_map_all_replication_stats_fields() {
+		var stats = _response.Stats[0];
+
+		Assert.AreEqual(_subscriptionId.ToString("D"), stats.SubscriptionId);
+		Assert.AreEqual(_connectionId.ToString("D"), stats.ConnectionId);
+		Assert.AreEqual("127.0.0.1:1112", stats.SubscriptionEndpoint);
+		Assert.AreEqual(123, stats.TotalBytesSent);
+		Assert.AreEqual(456, stats.TotalBytesReceived);
+		Assert.AreEqual(7, stats.PendingSendBytes);
+		Assert.AreEqual(8, stats.PendingReceivedBytes);
+		Assert.AreEqual(9, stats.SendQueueSize);
+	}
+
+	[Test]
+	public void should_map_null_strings_to_empty_values() {
+		Assert.AreEqual(string.Empty, _response.Stats[1].SubscriptionEndpoint);
+	}
+
+	private sealed class CapturingPublisher(List<CoreReplicationStats> replicationStats) : IPublisher {
+		public bool RequestedReplicationStats { get; private set; }
+
+		public void Publish(Message message) {
+			if (message is not ReplicationMessage.GetReplicationStats request)
+				throw new InvalidOperationException($"Unexpected message {message.GetType().Name}");
+
+			RequestedReplicationStats = true;
+			request.Envelope.ReplyWith(new ReplicationMessage.GetReplicationStatsCompleted(replicationStats));
+		}
+	}
+
+	private sealed class TestServerCallContext : ServerCallContext {
+		public static readonly TestServerCallContext Instance = new();
+
+		private TestServerCallContext() {
+		}
+
+		protected override string MethodCore =>
+			nameof(EventStore.Client.Monitoring.Monitoring.MonitoringBase.ReplicationStats);
+		protected override string HostCore => "localhost";
+		protected override string PeerCore => "ipv4:127.0.0.1:0";
+		protected override DateTime DeadlineCore => DateTime.MaxValue;
+		protected override Metadata RequestHeadersCore { get; } = new();
+		protected override CancellationToken CancellationTokenCore => CancellationToken.None;
+		protected override Metadata ResponseTrailersCore { get; } = new();
+		protected override Status StatusCore { get; set; }
+		protected override WriteOptions WriteOptionsCore { get; set; }
+		protected override AuthContext AuthContextCore => new(null, new Dictionary<string, List<AuthProperty>>());
+		protected override IDictionary<object, object> UserStateCore { get; } = new Dictionary<object, object>();
+		protected override ContextPropagationToken CreatePropagationTokenCore(ContextPropagationOptions options) =>
+			throw new NotSupportedException();
+		protected override Task WriteResponseHeadersAsyncCore(Metadata responseHeaders) => Task.CompletedTask;
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
@@ -181,7 +181,6 @@ public class Authorization<TLogFormat, TStreamId> : specification_with_cluster<T
 		[Values(
 			"/ping;GET;None",
 			"/stats;GET;None",
-			"/stats/replication;GET;None",
 			"/stats/{*statPath};GET;None",
 			"/ui/assets/{*remaining_path};GET;None",
 			";GET;None"

--- a/src/EventStore.Core.Tests/Services/Transport/Http/http_service_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/http_service_should.cs
@@ -75,7 +75,7 @@ public class http_service_should : SpecificationWithDirectory
 		await using var node = new MiniNode<LogFormat.V2, string>(PathName);
 		await node.Start();
 
-		var request = new HttpRequestMessage(HttpMethod.Get, "/stats/replication");
+		var request = new HttpRequestMessage(HttpMethod.Get, "/stats");
 		request.Headers.Add("Origin", "https://example.com");
 
 		var result = await node.HttpClient.SendAsync(request);

--- a/src/EventStore.Core.Tests/Services/Transport/Http/open_api_document.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/open_api_document.cs
@@ -15,13 +15,7 @@ public class open_api_document<TLogFormat, TStreamId> : specification_with_a_sin
 	[Test]
 	public async Task should_document_the_actions_of_all_controllers()
 	{
-		var skipActionPaths = new[] {
-			// handled by: /stats/{statPath}
-			"/stats/replication",
-		};
-
 		var httpActions = _node.Node.HttpService.Actions
-			.Where(a => !skipActionPaths.Contains(a.UriTemplate))
 			.Where(a => !a.UriTemplate.StartsWith("/test"))
 			.ToArray();
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Monitoring.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Monitoring.cs
@@ -81,6 +81,37 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			return responseSource.Task.WaitAsync(context.CancellationToken);
 		}
 
+		public override Task<ReplicationStatsResp> ReplicationStats(ReplicationStatsReq request, ServerCallContext context) {
+			var responseSource =
+				new TaskCompletionSource<ReplicationStatsResp>(TaskCreationOptions.RunContinuationsAsynchronously);
+			var envelope = new CallbackEnvelope(message => {
+				if (message is not ReplicationMessage.GetReplicationStatsCompleted completed) {
+					responseSource.TrySetException(
+						UnknownMessage<ReplicationMessage.GetReplicationStatsCompleted>(message));
+					return;
+				}
+
+				var response = new ReplicationStatsResp();
+				foreach (var stats in completed.ReplicationStats) {
+					response.Stats.Add(new ReplicationStats {
+						SubscriptionId = stats.SubscriptionId.ToString("D"),
+						ConnectionId = stats.ConnectionId.ToString("D"),
+						SubscriptionEndpoint = stats.SubscriptionEndpoint ?? string.Empty,
+						TotalBytesSent = stats.TotalBytesSent,
+						TotalBytesReceived = stats.TotalBytesReceived,
+						PendingSendBytes = stats.PendingSendBytes,
+						PendingReceivedBytes = stats.PendingReceivedBytes,
+						SendQueueSize = stats.SendQueueSize
+					});
+				}
+
+				responseSource.TrySetResult(response);
+			});
+
+			_publisher.Publish(new ReplicationMessage.GetReplicationStats(envelope));
+			return responseSource.Task.WaitAsync(context.CancellationToken);
+		}
+
 		public Monitoring(IPublisher publisher) {
 			_publisher = publisher;
 		}

--- a/src/EventStore.Core/Services/Transport/Http/Configure.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Configure.cs
@@ -154,15 +154,5 @@ namespace EventStore.Core.Services.Transport.Http {
 				: NotFound();
 		}
 
-		public static ResponseConfiguration GetReplicationStatsCompleted(HttpResponseConfiguratorArgs entity,
-			Message message) {
-			var completed = message as ReplicationMessage.GetReplicationStatsCompleted;
-			if (completed == null)
-				return InternalServerError();
-
-			var cacheSeconds = (int)MonitoringService.MemoizePeriod.TotalSeconds;
-			return Ok(entity.ResponseCodec.ContentType, Helper.UTF8NoBom, null, cacheSeconds, isCachePublic: true);
-		}
-
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/StatController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/StatController.cs
@@ -25,9 +25,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			service.RegisterAction(new ControllerAction("/stats", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Statistics.Read)),
 				OnGetFreshStats);
 			service.RegisterAction(
-				new ControllerAction("/stats/replication", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Statistics.Replication)),
-				OnGetReplicationStats);
-			service.RegisterAction(
 				new ControllerAction("/stats/{*statPath}", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Statistics.Custom)),
 				OnGetFreshStats);
 		}
@@ -87,14 +84,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 
 				return dict;
 			};
-		}
-
-		private void OnGetReplicationStats(HttpEntityManager entity, UriTemplateMatch match) {
-			var envelope = new SendToHttpEnvelope(_networkSendQueue,
-				entity,
-				Format.GetReplicationStatsCompleted,
-				Configure.GetReplicationStatsCompleted);
-			Publish(new ReplicationMessage.GetReplicationStats(envelope));
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Http/Format.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Format.cs
@@ -17,14 +17,5 @@ namespace EventStore.Core.Services.Transport.Http {
 			return entity.ResponseCodec.To(completed.Stats);
 		}
 
-		public static string GetReplicationStatsCompleted(HttpResponseFormatterArgs entity, Message message) {
-			if (message.GetType() != typeof(ReplicationMessage.GetReplicationStatsCompleted))
-				throw new Exception(string.Format("Unexpected type of Response message: {0}, expected: {1}",
-					message.GetType().Name,
-					typeof(ReplicationMessage.GetReplicationStatsCompleted).Name));
-			var completed = message as ReplicationMessage.GetReplicationStatsCompleted;
-			return entity.ResponseCodec.To(completed.ReplicationStats);
-		}
-
 	}
 }

--- a/src/Protos/Grpc/monitoring.proto
+++ b/src/Protos/Grpc/monitoring.proto
@@ -5,6 +5,7 @@ option java_package = "com.eventstore.dbclient.proto.monitoring";
 service Monitoring {
 	rpc Stats(StatsReq) returns (stream StatsResp);
 	rpc TcpStats(TcpStatsReq) returns (TcpStatsResp);
+	rpc ReplicationStats(ReplicationStatsReq) returns (ReplicationStatsResp);
 }
 
 message StatsReq {
@@ -34,4 +35,22 @@ message TcpConnectionStats {
 	int32 pending_received_bytes = 8;
 	bool is_external_connection = 9;
 	bool is_ssl_connection = 10;
+}
+
+message ReplicationStatsReq {
+}
+
+message ReplicationStatsResp {
+	repeated ReplicationStats stats = 1;
+}
+
+message ReplicationStats {
+	string subscription_id = 1;
+	string connection_id = 2;
+	string subscription_endpoint = 3;
+	int64 total_bytes_sent = 4;
+	int64 total_bytes_received = 5;
+	int32 pending_send_bytes = 6;
+	int32 pending_received_bytes = 7;
+	int32 send_queue_size = 8;
 }


### PR DESCRIPTION
- Replica connection visibility should survive the removal of legacy stats HTTP routes.
- The Razor cluster page needs a gRPC-owned leader hop before the public replication stats endpoint can disappear.