### PR TITLE
feat(grpc): preserve stats parity

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -2657,6 +2657,16 @@
                 "type": "bool"
               },
               {
+                "id": 2,
+                "name": "stats_path",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "use_grouping",
+                "type": "bool"
+              },
+              {
                 "id": 4,
                 "name": "refresh_time_period_in_ms",
                 "type": "uint64"
@@ -2665,6 +2675,13 @@
           },
           {
             "name": "StatsResp",
+            "fields": [
+              {
+                "id": 2,
+                "name": "structured_stats",
+                "type": "google.protobuf.Value"
+              }
+            ],
             "maps": [
               {
                 "key_type": "string",
@@ -2826,6 +2843,11 @@
                 "out_type": "ReplicationStatsResp"
               }
             ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "google/protobuf/struct.proto"
           }
         ],
         "package": {

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/MonitoringTests/StatsRpcTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/MonitoringTests/StatsRpcTests.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Client.Monitoring;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.Monitoring.Stats;
+using Grpc.Core;
+using NUnit.Framework;
+namespace EventStore.Core.Tests.Services.Transport.Grpc.MonitoringTests;
+
+[TestFixture]
+public class StatsRpcTests {
+	[Test]
+	public async Task should_preserve_flat_stats_by_default() {
+		var publisher = new CapturingPublisher(
+			stats: new Dictionary<string, object> {
+				["es-queue-mainQueue"] = 12
+			});
+		var response = await ReadSingleResponse(
+			publisher,
+			new StatsReq {
+				RefreshTimePeriodInMs = 1
+			});
+
+		Assert.IsTrue(publisher.RequestedStats);
+		Assert.IsFalse(publisher.UseMetadata);
+		Assert.IsFalse(publisher.UseGrouping);
+		Assert.That(response.Stats["es-queue-mainQueue"], Is.EqualTo("12"));
+		Assert.That(response.StructuredStats.StructValue.Fields["es-queue-mainQueue"].NumberValue, Is.EqualTo(12));
+	}
+
+	[Test]
+	public async Task should_honor_stats_path_when_grouping_enabled() {
+		var publisher = new CapturingPublisher(
+			stats: new Dictionary<string, object> {
+				["es"] = new Dictionary<string, object> {
+					["queue"] = new Dictionary<string, object> {
+						["mainQueue"] = 12
+					}
+				}
+			},
+			applySelector: true);
+		var response = await ReadSingleResponse(
+			publisher,
+			new StatsReq {
+				RefreshTimePeriodInMs = 1,
+				StatsPath = "es/queue",
+				UseGrouping = true
+			});
+
+		Assert.That(response.StructuredStats.StructValue.Fields.ContainsKey("mainQueue"));
+		Assert.That(response.StructuredStats.StructValue.Fields["mainQueue"].NumberValue, Is.EqualTo(12));
+	}
+
+	[Test]
+	public void should_reject_stats_path_when_grouping_is_disabled() {
+		var publisher = new CapturingPublisher(new Dictionary<string, object>());
+
+		var ex = Assert.ThrowsAsync<RpcException>(async () =>
+			await ReadSingleResponse(
+				publisher,
+				new StatsReq {
+					RefreshTimePeriodInMs = 1,
+					StatsPath = "es/queue",
+					UseGrouping = false
+				}));
+
+		Assert.That(ex!.StatusCode, Is.EqualTo(StatusCode.InvalidArgument));
+	}
+
+	[Test]
+	public async Task should_map_metadata_when_requested() {
+		var publisher = new CapturingPublisher(
+			stats: new Dictionary<string, object> {
+				["proc"] = new Dictionary<string, object> {
+					["mem"] = new StatMetadata(123L, "Process", "Process Virtual Memory")
+				}
+			});
+		var response = await ReadSingleResponse(
+			publisher,
+			new StatsReq {
+				RefreshTimePeriodInMs = 1,
+				UseMetadata = true
+			});
+
+		Assert.IsTrue(publisher.UseMetadata);
+		var metadata = response.StructuredStats.StructValue.Fields["proc"].StructValue.Fields["mem"].StructValue.Fields;
+		Assert.That(metadata["value"].NumberValue, Is.EqualTo(123));
+		Assert.That(metadata["category"].StringValue, Is.EqualTo("Process"));
+		Assert.That(metadata["title"].StringValue, Is.EqualTo("Process Virtual Memory"));
+		Assert.That(metadata["drawChart"].BoolValue, Is.True);
+	}
+
+	[Test]
+	public void should_return_not_found_for_missing_stats_path() {
+		var publisher = new CapturingPublisher(
+			stats: new Dictionary<string, object> {
+				["es"] = new Dictionary<string, object> {
+					["queue"] = new Dictionary<string, object> {
+						["mainQueue"] = 12
+					}
+				}
+			},
+			applySelector: true);
+
+		var ex = Assert.ThrowsAsync<RpcException>(async () =>
+			await ReadSingleResponse(
+				publisher,
+				new StatsReq {
+					RefreshTimePeriodInMs = 1,
+					StatsPath = "es/missing",
+					UseGrouping = true
+				}));
+
+		Assert.That(ex!.StatusCode, Is.EqualTo(StatusCode.NotFound));
+	}
+
+	private static async Task<StatsResp> ReadSingleResponse(CapturingPublisher publisher, StatsReq request) {
+		var serviceType = typeof(MonitoringMessage).Assembly.GetType(
+			"EventStore.Core.Services.Transport.Grpc.Monitoring",
+			throwOnError: true);
+		var service = Activator.CreateInstance(
+			serviceType!,
+			BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+			binder: null,
+			args: [publisher],
+			culture: null);
+
+		using var cts = new CancellationTokenSource();
+		var stream = new CapturingResponseStream(cts);
+		Task task;
+		try {
+			task = (Task)serviceType!.GetMethod(nameof(EventStore.Client.Monitoring.Monitoring.MonitoringBase.Stats))!
+				.Invoke(service, [request, stream, new TestServerCallContext(cts.Token)])!;
+		} catch (TargetInvocationException ex) when (ex.InnerException is not null) {
+			throw ex.InnerException;
+		}
+
+		try {
+			await task;
+		} catch (OperationCanceledException) when (cts.IsCancellationRequested) {
+		}
+
+		return stream.SingleResponse!;
+	}
+
+	private sealed class CapturingPublisher(
+		Dictionary<string, object> stats,
+		bool applySelector = false) : IPublisher {
+		public bool RequestedStats { get; private set; }
+		public bool UseMetadata { get; private set; }
+		public bool UseGrouping { get; private set; }
+
+		public void Publish(Message message) {
+			if (message is not MonitoringMessage.GetFreshStats request)
+				throw new InvalidOperationException($"Unexpected message {message.GetType().Name}");
+
+			RequestedStats = true;
+			UseMetadata = request.UseMetadata;
+			UseGrouping = request.UseGrouping;
+
+			var responseStats = applySelector ? request.StatsSelector(stats) : stats;
+			request.Envelope.ReplyWith(
+				new MonitoringMessage.GetFreshStatsCompleted(
+					success: responseStats is not null,
+					stats: responseStats));
+		}
+	}
+
+	private sealed class CapturingResponseStream(CancellationTokenSource cts) : IServerStreamWriter<StatsResp> {
+		public StatsResp SingleResponse { get; private set; }
+		public WriteOptions WriteOptions { get; set; }
+
+		public Task WriteAsync(StatsResp message) {
+			SingleResponse = message;
+			cts.Cancel();
+			return Task.CompletedTask;
+		}
+	}
+
+	private sealed class TestServerCallContext(CancellationToken cancellationToken) : ServerCallContext {
+		protected override string MethodCore => nameof(EventStore.Client.Monitoring.Monitoring.MonitoringBase.Stats);
+		protected override string HostCore => "localhost";
+		protected override string PeerCore => "ipv4:127.0.0.1:0";
+		protected override DateTime DeadlineCore => DateTime.MaxValue;
+		protected override Metadata RequestHeadersCore { get; } = new();
+		protected override CancellationToken CancellationTokenCore => cancellationToken;
+		protected override Metadata ResponseTrailersCore { get; } = new();
+		protected override Status StatusCore { get; set; }
+		protected override WriteOptions WriteOptionsCore { get; set; }
+		protected override AuthContext AuthContextCore => new(null, new Dictionary<string, List<AuthProperty>>());
+		protected override IDictionary<object, object> UserStateCore { get; } = new Dictionary<object, object>();
+		protected override ContextPropagationToken CreatePropagationTokenCore(ContextPropagationOptions options) =>
+			throw new NotSupportedException();
+		protected override Task WriteResponseHeadersAsyncCore(Metadata responseHeaders) => Task.CompletedTask;
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Grpc/Monitoring.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Monitoring.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Linq;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 using EventStore.Client.Monitoring;
 using EventStore.Core.Bus;
@@ -13,39 +11,60 @@ namespace EventStore.Core.Services.Transport.Grpc {
 		private readonly IPublisher _publisher;
 		
 		public override Task Stats(StatsReq request, IServerStreamWriter<StatsResp> responseStream, ServerCallContext context) {
-			var channel = Channel.CreateBounded<StatsResp>(new BoundedChannelOptions(1) {
-				SingleReader = true,
-				SingleWriter = true
-			});
+			var useGrouping = request.HasUseGrouping ? request.UseGrouping : false;
+			if (!useGrouping && !string.IsNullOrEmpty(request.StatsPath))
+				throw new RpcException(
+					new Status(StatusCode.InvalidArgument,
+						"Dynamic stats selection works only with grouping enabled"));
 
-			_ = Receive();
+			return StreamStats();
 
-			return channel.Reader.ReadAllAsync(context.CancellationToken)
-				.ForEachAwaitAsync(responseStream.WriteAsync, context.CancellationToken);
-			
-			async Task Receive() {
+			async Task StreamStats() {
 				var delay = TimeSpan.FromMilliseconds(request.RefreshTimePeriodInMs);
+				while (!context.CancellationToken.IsCancellationRequested) {
+					var completed = await GetFreshStats(context.CancellationToken);
+					if (!completed.Success) {
+						throw new RpcException(
+							new Status(StatusCode.NotFound, "Statistics path was not found."));
+					}
+
+					var response = new StatsResp {
+						StructuredStats = MonitoringStats.ToValue(completed.Stats)
+					};
+					if (!useGrouping) {
+						foreach (var (key, value) in completed.Stats) {
+							if (value is not null)
+								response.Stats.Add(key, value.ToString());
+						}
+					}
+
+					await responseStream.WriteAsync(response);
+					await Task.Delay(delay, context.CancellationToken);
+				}
+			}
+
+			Task<MonitoringMessage.GetFreshStatsCompleted> GetFreshStats(System.Threading.CancellationToken cancellationToken) {
+				var responseSource =
+					new TaskCompletionSource<MonitoringMessage.GetFreshStatsCompleted>(
+						TaskCreationOptions.RunContinuationsAsynchronously);
 				var envelope = new CallbackEnvelope(message => {
 					if (message is not MonitoringMessage.GetFreshStatsCompleted completed) {
-						channel.Writer.TryComplete(UnknownMessage<MonitoringMessage.GetFreshStatsCompleted>(message));
+						responseSource.TrySetException(
+							UnknownMessage<MonitoringMessage.GetFreshStatsCompleted>(message));
 						return;
 					}
 
-					var response = new StatsResp();
-
-					foreach (var (key, value) in completed.Stats.Where(stat => stat.Value is not null)) {
-						response.Stats.Add(key, value.ToString());
-					}
-
-					channel.Writer.TryWrite(response);
-
+					responseSource.TrySetResult(completed);
 				});
-				while (!context.CancellationToken.IsCancellationRequested) {
-					_publisher.Publish(
-						new MonitoringMessage.GetFreshStats(envelope, x => x, request.UseMetadata, false));
 
-					await Task.Delay(delay, context.CancellationToken);
-				}
+				_publisher.Publish(
+					new MonitoringMessage.GetFreshStats(
+						envelope,
+						MonitoringStats.GetStatSelector(request.StatsPath),
+						request.UseMetadata,
+						useGrouping));
+
+				return responseSource.Task.WaitAsync(cancellationToken);
 			}
 		}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/MonitoringStats.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/MonitoringStats.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using EventStore.Common.Utils;
+using EventStore.Core.Services.Monitoring.Stats;
+using Google.Protobuf.WellKnownTypes;
+
+namespace EventStore.Core.Services.Transport.Grpc;
+
+internal static class MonitoringStats {
+	public static Func<Dictionary<string, object>, Dictionary<string, object>> GetStatSelector(string statPath) {
+		if (string.IsNullOrEmpty(statPath))
+			return dict => dict;
+
+		if (statPath.StartsWith("stats/")) {
+			statPath = statPath.Substring(6);
+			if (string.IsNullOrEmpty(statPath))
+				return dict => dict;
+		}
+
+		var groups = statPath.Split('/');
+
+		return dict => {
+			Ensure.NotNull(dict, "dictionary");
+
+			foreach (var groupName in groups) {
+				if (!dict.TryGetValue(groupName, out var item))
+					return null;
+
+				dict = item as Dictionary<string, object>;
+				if (dict is null)
+					return null;
+			}
+
+			return dict;
+		};
+	}
+
+	public static Value ToValue(object value) =>
+		value switch {
+			null => new Value { NullValue = NullValue.NullValue },
+			Value grpcValue => grpcValue,
+			string stringValue => new Value { StringValue = stringValue },
+			bool boolValue => new Value { BoolValue = boolValue },
+			byte numberValue => ToNumberValue(numberValue),
+			sbyte numberValue => ToNumberValue(numberValue),
+			short numberValue => ToNumberValue(numberValue),
+			ushort numberValue => ToNumberValue(numberValue),
+			int numberValue => ToNumberValue(numberValue),
+			uint numberValue => ToNumberValue(numberValue),
+			long numberValue => ToNumberValue(numberValue),
+			ulong numberValue => ToNumberValue(numberValue),
+			float numberValue => ToNumberValue(numberValue),
+			double numberValue => ToNumberValue(numberValue),
+			decimal numberValue => ToNumberValue(numberValue),
+			Dictionary<string, object> dictionary => ToStructValue(dictionary),
+			IReadOnlyDictionary<string, object> dictionary => ToStructValue(dictionary),
+			StatMetadata metadata => ToStructValue(new Dictionary<string, object> {
+				["value"] = metadata.Value,
+				["category"] = metadata.Category,
+				["title"] = metadata.Title,
+				["drawChart"] = metadata.DrawChart
+			}),
+			_ => new Value { StringValue = Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty }
+		};
+
+	private static Value ToNumberValue<T>(T value) where T : struct, IConvertible =>
+		new() { NumberValue = value.ToDouble(CultureInfo.InvariantCulture) };
+
+	private static Value ToStructValue(IEnumerable<KeyValuePair<string, object>> values) {
+		var structValue = new Struct();
+		foreach (var (key, value) in values)
+			structValue.Fields.Add(key, ToValue(value));
+
+		return new Value { StructValue = structValue };
+	}
+}

--- a/src/Protos/Grpc/monitoring.proto
+++ b/src/Protos/Grpc/monitoring.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 package event_store.client.monitoring;
 option java_package = "com.eventstore.dbclient.proto.monitoring";
 
+import "google/protobuf/struct.proto";
+
 service Monitoring {
 	rpc Stats(StatsReq) returns (stream StatsResp);
 	rpc TcpStats(TcpStatsReq) returns (TcpStatsResp);
@@ -10,11 +12,14 @@ service Monitoring {
 
 message StatsReq {
 	bool use_metadata = 1;
+	string stats_path = 2;
+	optional bool use_grouping = 3;
 	uint64 refresh_time_period_in_ms = 4;
 }
 
 message StatsResp {
 	map<string, string> stats = 1;
+	google.protobuf.Value structured_stats = 2;
 }
 
 message TcpStatsReq {


### PR DESCRIPTION
- keeps the gRPC monitoring surface aligned with the remaining `/stats` behavior so we can continue retiring management HTTP safely
- avoids breaking existing flat stats consumers while adding the structured payload needed for grouped and path-selected stats
- gives us direct parity coverage for the missing stats-selection and metadata cases before removing more HTTP surface