### PR TITLE
feat(projections): preserve parity before retiring legacy routes

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -4506,6 +4506,41 @@
                     "id": 4,
                     "name": "query",
                     "type": "string"
+                  },
+                  {
+                    "id": 5,
+                    "name": "handler_type",
+                    "type": "string"
+                  },
+                  {
+                    "id": 6,
+                    "name": "enabled",
+                    "type": "bool"
+                  },
+                  {
+                    "id": 7,
+                    "name": "no_enabled_option",
+                    "type": "event_store.client.Empty"
+                  },
+                  {
+                    "id": 8,
+                    "name": "name",
+                    "type": "string"
+                  },
+                  {
+                    "id": 9,
+                    "name": "checkpoints_enabled",
+                    "type": "bool"
+                  },
+                  {
+                    "id": 10,
+                    "name": "emit_enabled",
+                    "type": "bool"
+                  },
+                  {
+                    "id": 11,
+                    "name": "track_emitted_streams",
+                    "type": "bool"
                   }
                 ],
                 "messages": [
@@ -4587,6 +4622,85 @@
             "name": "UpdateResp"
           },
           {
+            "name": "GetQueryReq",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "Options"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Options",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "GetQueryResp",
+            "fields": [
+              {
+                "id": 1,
+                "name": "details",
+                "type": "Details"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Details",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "name",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "query",
+                    "type": "string"
+                  },
+                  {
+                    "id": 3,
+                    "name": "emit_enabled",
+                    "type": "bool"
+                  },
+                  {
+                    "id": 4,
+                    "name": "projection_type",
+                    "type": "string"
+                  },
+                  {
+                    "id": 5,
+                    "name": "track_emitted_streams",
+                    "type": "bool"
+                  },
+                  {
+                    "id": 6,
+                    "name": "checkpoints_enabled",
+                    "type": "bool"
+                  },
+                  {
+                    "id": 7,
+                    "name": "definition_json",
+                    "type": "string"
+                  },
+                  {
+                    "id": 8,
+                    "name": "output_config_json",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          },
+          {
             "name": "DeleteReq",
             "fields": [
               {
@@ -4662,6 +4776,11 @@
                   {
                     "id": 5,
                     "name": "one_time",
+                    "type": "event_store.client.Empty"
+                  },
+                  {
+                    "id": 6,
+                    "name": "all_non_transient",
                     "type": "event_store.client.Empty"
                   }
                 ]
@@ -4855,6 +4974,160 @@
             ]
           },
           {
+            "name": "GetConfigReq",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "Options"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Options",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "GetConfigResp",
+            "fields": [
+              {
+                "id": 1,
+                "name": "details",
+                "type": "Details"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Details",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "emit_enabled",
+                    "type": "bool"
+                  },
+                  {
+                    "id": 2,
+                    "name": "track_emitted_streams",
+                    "type": "bool"
+                  },
+                  {
+                    "id": 3,
+                    "name": "checkpoint_after_ms",
+                    "type": "int32"
+                  },
+                  {
+                    "id": 4,
+                    "name": "checkpoint_handled_threshold",
+                    "type": "int32"
+                  },
+                  {
+                    "id": 5,
+                    "name": "checkpoint_unhandled_bytes_threshold",
+                    "type": "int32"
+                  },
+                  {
+                    "id": 6,
+                    "name": "pending_events_threshold",
+                    "type": "int32"
+                  },
+                  {
+                    "id": 7,
+                    "name": "max_write_batch_length",
+                    "type": "int32"
+                  },
+                  {
+                    "id": 8,
+                    "name": "max_allowed_writes_in_flight",
+                    "type": "int32"
+                  },
+                  {
+                    "id": 9,
+                    "name": "projection_execution_timeout",
+                    "type": "int32"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "UpdateConfigReq",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "Options"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Options",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "name",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "emit_enabled",
+                    "type": "bool"
+                  },
+                  {
+                    "id": 3,
+                    "name": "track_emitted_streams",
+                    "type": "bool"
+                  },
+                  {
+                    "id": 4,
+                    "name": "checkpoint_after_ms",
+                    "type": "int32"
+                  },
+                  {
+                    "id": 5,
+                    "name": "checkpoint_handled_threshold",
+                    "type": "int32"
+                  },
+                  {
+                    "id": 6,
+                    "name": "checkpoint_unhandled_bytes_threshold",
+                    "type": "int32"
+                  },
+                  {
+                    "id": 7,
+                    "name": "pending_events_threshold",
+                    "type": "int32"
+                  },
+                  {
+                    "id": 8,
+                    "name": "max_write_batch_length",
+                    "type": "int32"
+                  },
+                  {
+                    "id": 9,
+                    "name": "max_allowed_writes_in_flight",
+                    "type": "int32"
+                  },
+                  {
+                    "id": 10,
+                    "name": "projection_execution_timeout",
+                    "type": "int32"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "UpdateConfigResp"
+          },
+          {
             "name": "ResetReq",
             "fields": [
               {
@@ -4883,6 +5156,31 @@
           },
           {
             "name": "ResetResp"
+          },
+          {
+            "name": "AbortReq",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "Options"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Options",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "AbortResp"
           },
           {
             "name": "EnableReq",
@@ -4938,6 +5236,118 @@
           },
           {
             "name": "DisableResp"
+          },
+          {
+            "name": "ReadEventsReq",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "Options"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Options",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "query_sources_json",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "position_json",
+                    "type": "string"
+                  },
+                  {
+                    "id": 3,
+                    "name": "max_events",
+                    "type": "int32"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "ReadEventsResp",
+            "fields": [
+              {
+                "id": 1,
+                "name": "details",
+                "type": "Details"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Details",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "correlation_id",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "reader_position_json",
+                    "type": "string"
+                  },
+                  {
+                    "id": 3,
+                    "name": "events",
+                    "type": "Event",
+                    "is_repeated": true
+                  }
+                ],
+                "messages": [
+                  {
+                    "name": "Event",
+                    "fields": [
+                      {
+                        "id": 1,
+                        "name": "event_stream_id",
+                        "type": "string"
+                      },
+                      {
+                        "id": 2,
+                        "name": "event_number",
+                        "type": "int64"
+                      },
+                      {
+                        "id": 3,
+                        "name": "event_type",
+                        "type": "string"
+                      },
+                      {
+                        "id": 4,
+                        "name": "data",
+                        "type": "google.protobuf.Value"
+                      },
+                      {
+                        "id": 5,
+                        "name": "metadata",
+                        "type": "google.protobuf.Value"
+                      },
+                      {
+                        "id": 6,
+                        "name": "link_metadata",
+                        "type": "google.protobuf.Value"
+                      },
+                      {
+                        "id": 7,
+                        "name": "is_json",
+                        "type": "bool"
+                      },
+                      {
+                        "id": 8,
+                        "name": "reader_position_json",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         ],
         "services": [
@@ -4953,6 +5363,11 @@
                 "name": "Update",
                 "in_type": "UpdateReq",
                 "out_type": "UpdateResp"
+              },
+              {
+                "name": "GetQuery",
+                "in_type": "GetQueryReq",
+                "out_type": "GetQueryResp"
               },
               {
                 "name": "Delete",
@@ -4981,6 +5396,11 @@
                 "out_type": "ResetResp"
               },
               {
+                "name": "Abort",
+                "in_type": "AbortReq",
+                "out_type": "AbortResp"
+              },
+              {
                 "name": "State",
                 "in_type": "StateReq",
                 "out_type": "StateResp"
@@ -4989,6 +5409,21 @@
                 "name": "Result",
                 "in_type": "ResultReq",
                 "out_type": "ResultResp"
+              },
+              {
+                "name": "GetConfig",
+                "in_type": "GetConfigReq",
+                "out_type": "GetConfigResp"
+              },
+              {
+                "name": "UpdateConfig",
+                "in_type": "UpdateConfigReq",
+                "out_type": "UpdateConfigResp"
+              },
+              {
+                "name": "ReadEvents",
+                "in_type": "ReadEventsReq",
+                "out_type": "ReadEventsResp"
               },
               {
                 "name": "RestartSubsystem",

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -24,6 +24,7 @@
 		<PackageReference Include="NUnit3TestAdapter" />
 		<PackageReference Include="Serilog.Sinks.TextWriter" />
 		<PackageReference Include="Google.Protobuf" />
+		<PackageReference Include="Grpc.AspNetCore.HealthChecks" />
 		<PackageReference Include="Grpc.Tools">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/EventStore.Projections.Core.Tests/Services/grpc_service/ProjectionManagementParityTests.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/grpc_service/ProjectionManagementParityTests.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using EventStore.Client;
+using EventStore.Client.Projections;
+using EventStore.Common.Utils;
+using EventStore.Core.Tests;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Services.Processing.Checkpointing;
+using EventStore.Projections.Core.Tests.ClientAPI.projectionsManager;
+using Grpc.Core;
+using Grpc.Net.Client;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.grpc_service;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class ProjectionManagementParityTests<TLogFormat, TStreamId> : SpecificationWithNodeAndProjectionsManager<TLogFormat, TStreamId>
+{
+	private const string ProjectionName = "grpc-parity-projection";
+	private const string DisabledOneTimeProjectionName = "grpc-parity-one-time";
+	private const string TransientProjectionName = "grpc-parity-transient";
+	private const string DebugStream = "grpc-parity-stream";
+
+	private GrpcChannel _channel;
+	private Client.Projections.Projections.ProjectionsClient _client;
+	private GetQueryResp _query;
+	private GetConfigResp _initialConfig;
+	private GetConfigResp _updatedConfig;
+	private ReadEventsResp _feedPage;
+	private StatisticsResp.Types.Details[] _allNonTransientStatistics;
+
+	public override async Task Given()
+	{
+		_channel = GrpcChannel.ForAddress(
+			new Uri($"https://{_node.HttpEndPoint}"),
+			new GrpcChannelOptions {
+				HttpHandler = _node.HttpMessageHandler
+			});
+		_client = new Client.Projections.Projections.ProjectionsClient(_channel);
+
+		await _client.CreateAsync(new CreateReq {
+			Options = new CreateReq.Types.Options {
+				Continuous = new CreateReq.Types.Options.Types.Continuous {
+					Name = ProjectionName,
+					EmitEnabled = true,
+					TrackEmittedStreams = true
+				},
+				Query = "something invalid"
+			}
+		}, GetCallOptions());
+
+		await _client.CreateAsync(new CreateReq {
+			Options = new CreateReq.Types.Options {
+				OneTime = new EventStore.Client.Empty(),
+				Enabled = false,
+				Name = DisabledOneTimeProjectionName,
+				CheckpointsEnabled = true,
+				EmitEnabled = false,
+				TrackEmittedStreams = false,
+				Query = "fromAll().when({$any:function(s,e){return s;}});"
+			}
+		}, GetCallOptions());
+
+		await _client.CreateAsync(new CreateReq {
+			Options = new CreateReq.Types.Options {
+				Transient = new CreateReq.Types.Options.Types.Transient {
+					Name = TransientProjectionName
+				},
+				Query = $"fromStream(\"{DebugStream}\").when({{$any:function(s,e){{return s;}}}});"
+			}
+		}, GetCallOptions());
+
+		await PostEvent(DebugStream, "type1", "{\"value\":1}");
+		await PostEvent(DebugStream, "type2", "{\"value\":2}");
+	}
+
+	public override async Task When()
+	{
+		_query = await _client.GetQueryAsync(new GetQueryReq {
+			Options = new GetQueryReq.Types.Options {
+				Name = ProjectionName
+			}
+		}, GetCallOptions());
+
+		_initialConfig = await _client.GetConfigAsync(new GetConfigReq {
+			Options = new GetConfigReq.Types.Options {
+				Name = ProjectionName
+			}
+		}, GetCallOptions());
+
+		await WaitForStatus(ProjectionName, "Faulted");
+
+		await _client.UpdateConfigAsync(new UpdateConfigReq {
+			Options = new UpdateConfigReq.Types.Options {
+				Name = ProjectionName,
+				EmitEnabled = _initialConfig.Details.EmitEnabled,
+				TrackEmittedStreams = _initialConfig.Details.TrackEmittedStreams,
+				CheckpointAfterMs = 1750,
+				CheckpointHandledThreshold = 18,
+				CheckpointUnhandledBytesThreshold = 4096,
+				PendingEventsThreshold = 42,
+				MaxWriteBatchLength = 17,
+				MaxAllowedWritesInFlight = 6,
+				ProjectionExecutionTimeout = 11
+			}
+		}, GetCallOptions());
+
+		_updatedConfig = await _client.GetConfigAsync(new GetConfigReq {
+			Options = new GetConfigReq.Types.Options {
+				Name = ProjectionName
+			}
+		}, GetCallOptions());
+
+		_feedPage = await _client.ReadEventsAsync(new ReadEventsReq {
+			Options = new ReadEventsReq.Types.Options {
+				QuerySourcesJson = new QuerySourcesDefinition {
+					Streams = new[] { DebugStream },
+					AllEvents = true
+				}.ToJson(),
+				PositionJson = CheckpointTag.FromStreamPosition(0, DebugStream, -1).ToJsonRaw().ToString(),
+				MaxEvents = 10
+			}
+		}, GetCallOptions());
+
+		await _client.AbortAsync(new AbortReq {
+			Options = new AbortReq.Types.Options {
+				Name = TransientProjectionName
+			}
+		}, GetCallOptions());
+
+		_allNonTransientStatistics = await ReadStatisticsAsync(new StatisticsReq {
+			Options = new StatisticsReq.Types.Options {
+				AllNonTransient = new EventStore.Client.Empty()
+			}
+		});
+	}
+
+	[Test]
+	public void get_query_returns_projection_metadata()
+	{
+		Assert.That(_query.Details.Name, Is.EqualTo(ProjectionName));
+		Assert.That(_query.Details.Query, Is.EqualTo("something invalid"));
+		Assert.That(_query.Details.EmitEnabled, Is.True);
+		Assert.That(_query.Details.TrackEmittedStreams, Is.True);
+		Assert.That(_query.Details.CheckpointsEnabled, Is.True);
+		Assert.That(_query.Details.DefinitionJson, Is.Not.Empty);
+		Assert.That(_query.Details.OutputConfigJson, Is.Not.Empty);
+	}
+
+	[Test]
+	public void update_config_round_trips_through_grpc()
+	{
+		Assert.That(_updatedConfig.Details.CheckpointAfterMs, Is.EqualTo(1750));
+		Assert.That(_updatedConfig.Details.CheckpointHandledThreshold, Is.EqualTo(18));
+		Assert.That(_updatedConfig.Details.CheckpointUnhandledBytesThreshold, Is.EqualTo(4096));
+		Assert.That(_updatedConfig.Details.PendingEventsThreshold, Is.EqualTo(42));
+		Assert.That(_updatedConfig.Details.MaxWriteBatchLength, Is.EqualTo(17));
+		Assert.That(_updatedConfig.Details.MaxAllowedWritesInFlight, Is.EqualTo(6));
+		Assert.That(_updatedConfig.Details.ProjectionExecutionTimeout, Is.EqualTo(11));
+	}
+
+	[Test]
+	public void read_events_returns_feed_page_details()
+	{
+		Assert.That(_feedPage.Details.CorrelationId, Is.Not.Empty);
+		Assert.That(_feedPage.Details.ReaderPositionJson, Is.Not.Empty);
+		Assert.That(_feedPage.Details.Events.Count, Is.GreaterThanOrEqualTo(2));
+		Assert.That(_feedPage.Details.Events.Any(x => x.EventStreamId == DebugStream && x.EventType == "type1"), Is.True);
+		Assert.That(_feedPage.Details.Events.Any(x => x.EventStreamId == DebugStream && x.EventType == "type2"), Is.True);
+	}
+
+	[Test]
+	public void all_non_transient_statistics_excludes_transient_projections()
+	{
+		Assert.That(_allNonTransientStatistics.Any(x => x.Name == ProjectionName), Is.True);
+		Assert.That(_allNonTransientStatistics.Any(x => x.Name == DisabledOneTimeProjectionName), Is.True);
+		Assert.That(_allNonTransientStatistics.Any(x => x.Name == TransientProjectionName), Is.False);
+	}
+
+	[OneTimeTearDown]
+	public override Task TestFixtureTearDown()
+	{
+		_channel?.Dispose();
+		return base.TestFixtureTearDown();
+	}
+
+	private static CallOptions GetCallOptions(TimeSpan? deadline = null)
+	{
+		var credentials = CallCredentials.FromInterceptor((_, metadata) => {
+			metadata.Add("authorization",
+				$"Basic {Convert.ToBase64String(Encoding.ASCII.GetBytes("admin:changeit"))}");
+			return Task.CompletedTask;
+		});
+
+		return new CallOptions(
+			credentials: credentials,
+			deadline: Debugger.IsAttached
+				? DateTime.UtcNow.AddDays(1)
+				: deadline is { } value
+					? DateTime.UtcNow.Add(value)
+					: null);
+	}
+
+	private async Task WaitForStatus(string projectionName, string expectedStatus)
+	{
+		for (var attempt = 0; attempt < 40; attempt++)
+		{
+			using var statistics = _client.Statistics(new StatisticsReq {
+				Options = new StatisticsReq.Types.Options {
+					Name = projectionName
+				}
+			}, GetCallOptions(TimeSpan.FromSeconds(10)));
+
+			while (await statistics.ResponseStream.MoveNext(default))
+			{
+				if (statistics.ResponseStream.Current.Details.Status == expectedStatus)
+				{
+					return;
+				}
+			}
+
+			await Task.Delay(250);
+		}
+
+		Assert.Fail($"Projection '{projectionName}' never reached status '{expectedStatus}'.");
+	}
+
+	private async Task<StatisticsResp.Types.Details[]> ReadStatisticsAsync(StatisticsReq request)
+	{
+		using var statistics = _client.Statistics(request, GetCallOptions(TimeSpan.FromSeconds(10)));
+		var results = new System.Collections.Generic.List<StatisticsResp.Types.Details>();
+		while (await statistics.ResponseStream.MoveNext(default))
+		{
+			results.Add(statistics.ResponseStream.Current.Details);
+		}
+
+		return results.ToArray();
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Services/grpc_service/ProjectionManagementParityTests.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/grpc_service/ProjectionManagementParityTests.cs
@@ -28,6 +28,7 @@ public class ProjectionManagementParityTests<TLogFormat, TStreamId> : Specificat
 	private GrpcChannel _channel;
 	private Client.Projections.Projections.ProjectionsClient _client;
 	private GetQueryResp _query;
+	private GetQueryResp _disabledOneTimeQuery;
 	private GetConfigResp _initialConfig;
 	private GetConfigResp _updatedConfig;
 	private ReadEventsResp _feedPage;
@@ -83,6 +84,12 @@ public class ProjectionManagementParityTests<TLogFormat, TStreamId> : Specificat
 		_query = await _client.GetQueryAsync(new GetQueryReq {
 			Options = new GetQueryReq.Types.Options {
 				Name = ProjectionName
+			}
+		}, GetCallOptions());
+
+		_disabledOneTimeQuery = await _client.GetQueryAsync(new GetQueryReq {
+			Options = new GetQueryReq.Types.Options {
+				Name = DisabledOneTimeProjectionName
 			}
 		}, GetCallOptions());
 
@@ -149,6 +156,13 @@ public class ProjectionManagementParityTests<TLogFormat, TStreamId> : Specificat
 		Assert.That(_query.Details.CheckpointsEnabled, Is.True);
 		Assert.That(_query.Details.DefinitionJson, Is.Not.Empty);
 		Assert.That(_query.Details.OutputConfigJson, Is.Not.Empty);
+	}
+
+	[Test]
+	public void create_ignores_track_emitted_streams_when_emit_is_disabled()
+	{
+		Assert.That(_disabledOneTimeQuery.Details.EmitEnabled, Is.False);
+		Assert.That(_disabledOneTimeQuery.Details.TrackEmittedStreams, Is.False);
 	}
 
 	[Test]

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Abort.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Abort.cs
@@ -15,6 +15,8 @@ internal partial class ProjectionManagement
 	public override async Task<AbortResp> Abort(AbortReq request, ServerCallContext context)
 	{
 		var abortSource = new TaskCompletionSource<bool>();
+		using var cancellationRegistration =
+			context.CancellationToken.Register(() => abortSource.TrySetCanceled(context.CancellationToken));
 		var name = request.Options.Name;
 		var user = context.GetHttpContext().User;
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Abort.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Abort.cs
@@ -1,0 +1,51 @@
+using System.Threading.Tasks;
+using EventStore.Client.Projections;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.Transport.Grpc;
+using EventStore.Plugins.Authorization;
+using EventStore.Projections.Core.Messages;
+using Grpc.Core;
+
+namespace EventStore.Projections.Core.Services.Grpc;
+
+internal partial class ProjectionManagement
+{
+	private static readonly Operation AbortOperation = new Operation(Operations.Projections.Abort);
+
+	public override async Task<AbortResp> Abort(AbortReq request, ServerCallContext context)
+	{
+		var abortSource = new TaskCompletionSource<bool>();
+		var name = request.Options.Name;
+		var user = context.GetHttpContext().User;
+
+		if (!await _authorizationProvider.CheckAccessAsync(user, AbortOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+
+		var envelope = new CallbackEnvelope(OnMessage);
+		_publisher.Publish(new ProjectionManagementMessage.Command.Abort(
+			envelope,
+			name,
+			new ProjectionManagementMessage.RunAs(user)));
+
+		await abortSource.Task;
+		return new AbortResp();
+
+		void OnMessage(Message message)
+		{
+			switch (message)
+			{
+				case ProjectionManagementMessage.Updated:
+					abortSource.TrySetResult(true);
+					break;
+				case ProjectionManagementMessage.NotFound:
+					abortSource.TrySetException(ProjectionNotFound(name));
+					break;
+				default:
+					abortSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
+					break;
+			}
+		}
+	}
+}

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Config.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Config.cs
@@ -1,0 +1,116 @@
+using System.Threading.Tasks;
+using EventStore.Client.Projections;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.Transport.Grpc;
+using EventStore.Plugins.Authorization;
+using EventStore.Projections.Core.Messages;
+using Grpc.Core;
+
+namespace EventStore.Projections.Core.Services.Grpc;
+
+internal partial class ProjectionManagement
+{
+	private static readonly Operation ReadConfigurationOperation = new Operation(Operations.Projections.ReadConfiguration);
+	private static readonly Operation UpdateConfigurationOperation = new Operation(Operations.Projections.UpdateConfiguration);
+
+	public override async Task<GetConfigResp> GetConfig(GetConfigReq request, ServerCallContext context)
+	{
+		var configSource = new TaskCompletionSource<ProjectionManagementMessage.ProjectionConfig>();
+		var name = request.Options.Name;
+		var user = context.GetHttpContext().User;
+
+		if (!await _authorizationProvider.CheckAccessAsync(user, ReadConfigurationOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+
+		var envelope = new CallbackEnvelope(OnMessage);
+		_publisher.Publish(new ProjectionManagementMessage.Command.GetConfig(
+			envelope,
+			name,
+			new ProjectionManagementMessage.RunAs(user)));
+
+		var config = await configSource.Task;
+		var details = new GetConfigResp.Types.Details {
+			EmitEnabled = config.EmitEnabled,
+			TrackEmittedStreams = config.TrackEmittedStreams,
+			CheckpointAfterMs = config.CheckpointAfterMs,
+			CheckpointHandledThreshold = config.CheckpointHandledThreshold,
+			CheckpointUnhandledBytesThreshold = config.CheckpointUnhandledBytesThreshold,
+			PendingEventsThreshold = config.PendingEventsThreshold,
+			MaxWriteBatchLength = config.MaxWriteBatchLength,
+			MaxAllowedWritesInFlight = config.MaxAllowedWritesInFlight
+		};
+		if (config.ProjectionExecutionTimeout is { } projectionExecutionTimeout)
+		{
+			details.ProjectionExecutionTimeout = projectionExecutionTimeout;
+		}
+
+		return new GetConfigResp {
+			Details = details
+		};
+
+		void OnMessage(Message message)
+		{
+			switch (message)
+			{
+				case ProjectionManagementMessage.ProjectionConfig projectionConfig:
+					configSource.TrySetResult(projectionConfig);
+					break;
+				case ProjectionManagementMessage.NotFound:
+					configSource.TrySetException(ProjectionNotFound(name));
+					break;
+				default:
+					configSource.TrySetException(UnknownMessage<ProjectionManagementMessage.ProjectionConfig>(message));
+					break;
+			}
+		}
+	}
+
+	public override async Task<UpdateConfigResp> UpdateConfig(UpdateConfigReq request, ServerCallContext context)
+	{
+		var updateSource = new TaskCompletionSource<bool>();
+		var options = request.Options;
+		var name = options.Name;
+		var user = context.GetHttpContext().User;
+
+		if (!await _authorizationProvider.CheckAccessAsync(user, UpdateConfigurationOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+
+		var envelope = new CallbackEnvelope(OnMessage);
+		_publisher.Publish(new ProjectionManagementMessage.Command.UpdateConfig(
+			envelope,
+			name,
+			options.EmitEnabled,
+			options.TrackEmittedStreams,
+			options.CheckpointAfterMs,
+			options.CheckpointHandledThreshold,
+			options.CheckpointUnhandledBytesThreshold,
+			options.PendingEventsThreshold,
+			options.MaxWriteBatchLength,
+			options.MaxAllowedWritesInFlight,
+			new ProjectionManagementMessage.RunAs(user),
+			options.HasProjectionExecutionTimeout ? options.ProjectionExecutionTimeout : null));
+
+		await updateSource.Task;
+		return new UpdateConfigResp();
+
+		void OnMessage(Message message)
+		{
+			switch (message)
+			{
+				case ProjectionManagementMessage.Updated:
+					updateSource.TrySetResult(true);
+					break;
+				case ProjectionManagementMessage.NotFound:
+					updateSource.TrySetException(ProjectionNotFound(name));
+					break;
+				default:
+					updateSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
+					break;
+			}
+		}
+	}
+}

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Config.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Config.cs
@@ -16,6 +16,8 @@ internal partial class ProjectionManagement
 	public override async Task<GetConfigResp> GetConfig(GetConfigReq request, ServerCallContext context)
 	{
 		var configSource = new TaskCompletionSource<ProjectionManagementMessage.ProjectionConfig>();
+		using var getConfigCancellationRegistration =
+			context.CancellationToken.Register(() => configSource.TrySetCanceled(context.CancellationToken));
 		var name = request.Options.Name;
 		var user = context.GetHttpContext().User;
 
@@ -70,6 +72,8 @@ internal partial class ProjectionManagement
 	public override async Task<UpdateConfigResp> UpdateConfig(UpdateConfigReq request, ServerCallContext context)
 	{
 		var updateSource = new TaskCompletionSource<bool>();
+		using var updateConfigCancellationRegistration =
+			context.CancellationToken.Register(() => updateSource.TrySetCanceled(context.CancellationToken));
 		var options = request.Options;
 		var name = options.Name;
 		var user = context.GetHttpContext().User;

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Create.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Create.cs
@@ -51,10 +51,6 @@ internal partial class ProjectionManagement
 		{
 			(ModeOneofCase.OneTime, true) when options.TrackEmittedStreams => true,
 			(ModeOneofCase.Continuous, true) when options.Continuous.TrackEmittedStreams => true,
-			(ModeOneofCase.OneTime, false) when options.TrackEmittedStreams =>
-				throw new InvalidOperationException("EmitEnabled must be set to true to track emitted streams."),
-			(ModeOneofCase.Continuous, false) when options.Continuous.TrackEmittedStreams =>
-				throw new InvalidOperationException("EmitEnabled must be set to true to track emitted streams."),
 			_ => false
 		};
 		var checkpointsEnabled = options.ModeCase switch

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Create.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Create.cs
@@ -24,12 +24,14 @@ internal partial class ProjectionManagement
 		{
 			throw RpcExceptions.AccessDenied();
 		}
-		const string handlerType = "JS";
+		var handlerType = string.IsNullOrWhiteSpace(options.HandlerType) ? "JS" : options.HandlerType;
 		var name = options.ModeCase switch
 		{
 			ModeOneofCase.Continuous => options.Continuous.Name,
 			ModeOneofCase.Transient => options.Transient.Name,
-			ModeOneofCase.OneTime => Guid.NewGuid().ToString("D"),
+			ModeOneofCase.OneTime => string.IsNullOrWhiteSpace(options.Name)
+				? Guid.NewGuid().ToString("D")
+				: options.Name,
 			_ => throw new InvalidOperationException()
 		};
 		var projectionMode = options.ModeCase switch
@@ -41,21 +43,33 @@ internal partial class ProjectionManagement
 		};
 		var emitEnabled = options.ModeCase switch
 		{
+			ModeOneofCase.OneTime => options.EmitEnabled,
 			ModeOneofCase.Continuous => options.Continuous.EmitEnabled,
 			_ => false
 		};
-		var trackEmittedStreams = (options.ModeCase, emitEnabled, options.Continuous?.TrackEmittedStreams) switch
+		var trackEmittedStreams = (options.ModeCase, emitEnabled) switch
 		{
-			(ModeOneofCase.Continuous, true, true) => true,
-			(ModeOneofCase.Continuous, false, true) =>
+			(ModeOneofCase.OneTime, true) when options.TrackEmittedStreams => true,
+			(ModeOneofCase.Continuous, true) when options.Continuous.TrackEmittedStreams => true,
+			(ModeOneofCase.OneTime, false) when options.TrackEmittedStreams =>
+				throw new InvalidOperationException("EmitEnabled must be set to true to track emitted streams."),
+			(ModeOneofCase.Continuous, false) when options.Continuous.TrackEmittedStreams =>
 				throw new InvalidOperationException("EmitEnabled must be set to true to track emitted streams."),
 			_ => false
 		};
 		var checkpointsEnabled = options.ModeCase switch
 		{
 			ModeOneofCase.Continuous => true,
-			ModeOneofCase.OneTime => false,
+			ModeOneofCase.OneTime => options.CheckpointsEnabled,
 			ModeOneofCase.Transient => false,
+			_ => throw new InvalidOperationException()
+		};
+		var enabled = (options.EnabledOptionCase, options.Enabled) switch
+		{
+			(EnabledOptionOneofCase.Enabled, true) => true,
+			(EnabledOptionOneofCase.Enabled, false) => false,
+			(EnabledOptionOneofCase.NoEnabledOption, _) => true,
+			(EnabledOptionOneofCase.None, _) => true,
 			_ => throw new InvalidOperationException()
 		};
 
@@ -64,7 +78,7 @@ internal partial class ProjectionManagement
 		var envelope = new CallbackEnvelope(OnMessage);
 
 		_publisher.Publish(new ProjectionManagementMessage.Command.Post(envelope, projectionMode, name, runAs,
-			handlerType, options.Query, true, checkpointsEnabled, emitEnabled, trackEmittedStreams, true));
+			handlerType, options.Query, enabled, checkpointsEnabled, emitEnabled, trackEmittedStreams, true));
 
 		await createdSource.Task;
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Query.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Query.cs
@@ -1,0 +1,71 @@
+using System.Threading.Tasks;
+using EventStore.Client.Projections;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.Transport.Grpc;
+using EventStore.Plugins.Authorization;
+using EventStore.Projections.Core.Messages;
+using Grpc.Core;
+
+namespace EventStore.Projections.Core.Services.Grpc;
+
+internal partial class ProjectionManagement
+{
+	private static readonly Operation ReadOperation = new Operation(Operations.Projections.Read);
+
+	public override async Task<GetQueryResp> GetQuery(GetQueryReq request, ServerCallContext context)
+	{
+		var querySource = new TaskCompletionSource<ProjectionManagementMessage.ProjectionQuery>();
+		var name = request.Options.Name;
+		var user = context.GetHttpContext().User;
+
+		if (!await _authorizationProvider.CheckAccessAsync(user, ReadOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+
+		var envelope = new CallbackEnvelope(OnMessage);
+		_publisher.Publish(new ProjectionManagementMessage.Command.GetQuery(
+			envelope,
+			name,
+			new ProjectionManagementMessage.RunAs(user)));
+
+		var query = await querySource.Task;
+		var details = new GetQueryResp.Types.Details {
+			Name = query.Name ?? string.Empty,
+			Query = query.Query ?? string.Empty,
+			EmitEnabled = query.EmitEnabled,
+			ProjectionType = query.Type ?? string.Empty,
+			DefinitionJson = ToJson(query.Definition),
+			OutputConfigJson = ToJson(query.OutputConfig)
+		};
+		if (query.TrackEmittedStreams is { } trackEmittedStreams)
+		{
+			details.TrackEmittedStreams = trackEmittedStreams;
+		}
+
+		if (query.CheckpointsEnabled is { } checkpointsEnabled)
+		{
+			details.CheckpointsEnabled = checkpointsEnabled;
+		}
+
+		return new GetQueryResp {
+			Details = details
+		};
+
+		void OnMessage(Message message)
+		{
+			switch (message)
+			{
+				case ProjectionManagementMessage.ProjectionQuery projectionQuery:
+					querySource.TrySetResult(projectionQuery);
+					break;
+				case ProjectionManagementMessage.NotFound:
+					querySource.TrySetException(ProjectionNotFound(name));
+					break;
+				default:
+					querySource.TrySetException(UnknownMessage<ProjectionManagementMessage.ProjectionQuery>(message));
+					break;
+			}
+		}
+	}
+}

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Query.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Query.cs
@@ -15,6 +15,8 @@ internal partial class ProjectionManagement
 	public override async Task<GetQueryResp> GetQuery(GetQueryReq request, ServerCallContext context)
 	{
 		var querySource = new TaskCompletionSource<ProjectionManagementMessage.ProjectionQuery>();
+		using var cancellationRegistration =
+			context.CancellationToken.Register(() => querySource.TrySetCanceled(context.CancellationToken));
 		var name = request.Options.Name;
 		var user = context.GetHttpContext().User;
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.ReadEvents.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.ReadEvents.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Threading.Tasks;
+using EventStore.Client.Projections;
+using EventStore.Common.Utils;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.Transport.Grpc;
+using EventStore.Plugins.Authorization;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Messages.EventReaders.Feeds;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Services.Processing.Checkpointing;
+using Grpc.Core;
+using Newtonsoft.Json.Linq;
+
+namespace EventStore.Projections.Core.Services.Grpc;
+
+internal partial class ProjectionManagement
+{
+	private static readonly Operation DebugProjectionOperation = new Operation(Operations.Projections.DebugProjection);
+
+	public override async Task<ReadEventsResp> ReadEvents(ReadEventsReq request, ServerCallContext context)
+	{
+		var readSource = new TaskCompletionSource<FeedReaderMessage.FeedPage>();
+		var options = request.Options;
+		var user = context.GetHttpContext().User;
+
+		if (!await _authorizationProvider.CheckAccessAsync(user, DebugProjectionOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+
+		var querySource = ParseQuerySources(options.QuerySourcesJson);
+		var fromPosition = ParseCheckpointTag(options.PositionJson);
+		var maxEvents = options.MaxEvents > 0 ? options.MaxEvents : 10;
+
+		var envelope = new CallbackEnvelope(OnMessage);
+		_publisher.Publish(new FeedReaderMessage.ReadPage(
+			Guid.NewGuid(),
+			envelope,
+			user,
+			querySource,
+			fromPosition,
+			maxEvents));
+
+		var page = await readSource.Task;
+		if (page.Error == FeedReaderMessage.FeedPage.ErrorStatus.NotAuthorized)
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+
+		var details = new ReadEventsResp.Types.Details {
+			CorrelationId = page.CorrelationId.ToString("D"),
+			ReaderPositionJson = page.LastReaderPosition.ToJsonRaw().ToString()
+		};
+
+		foreach (var taggedEvent in page.Events)
+		{
+			var resolvedEvent = taggedEvent.ResolvedEvent;
+			details.Events.Add(new ReadEventsResp.Types.Details.Types.Event {
+				EventStreamId = resolvedEvent.EventStreamId ?? string.Empty,
+				EventNumber = resolvedEvent.EventSequenceNumber,
+				EventType = resolvedEvent.EventType ?? string.Empty,
+				Data = GetProtoValue(resolvedEvent.Data, resolvedEvent.IsJson),
+				Metadata = GetProtoValue(resolvedEvent.Metadata, resolvedEvent.IsJson),
+				LinkMetadata = GetProtoValue(resolvedEvent.PositionMetadata, resolvedEvent.IsJson),
+				IsJson = resolvedEvent.IsJson,
+				ReaderPositionJson = taggedEvent.ReaderPosition.ToJsonRaw().ToString()
+			});
+		}
+
+		return new ReadEventsResp {
+			Details = details
+		};
+
+		void OnMessage(Message message)
+		{
+			if (message is not FeedReaderMessage.FeedPage page)
+			{
+				readSource.TrySetException(UnknownMessage<FeedReaderMessage.FeedPage>(message));
+				return;
+			}
+
+			readSource.TrySetResult(page);
+		}
+	}
+
+	private static QuerySourcesDefinition ParseQuerySources(string querySourcesJson)
+	{
+		if (string.IsNullOrWhiteSpace(querySourcesJson))
+		{
+			throw RpcExceptions.InvalidArgument("A projection query source definition is required.");
+		}
+
+		try
+		{
+			var parsed = querySourcesJson.ParseJson<QuerySourcesDefinition>();
+			return parsed ?? throw RpcExceptions.InvalidArgument("A projection query source definition is required.");
+		}
+		catch (Exception ex) when (ex is not RpcException)
+		{
+			throw RpcExceptions.InvalidArgument($"Failed to parse query source definition: {ex.Message}");
+		}
+	}
+
+	private static CheckpointTag ParseCheckpointTag(string positionJson)
+	{
+		if (string.IsNullOrWhiteSpace(positionJson))
+		{
+			throw RpcExceptions.InvalidArgument("A projection checkpoint position is required.");
+		}
+
+		try
+		{
+			using var tokenReader = new JTokenReader(JToken.Parse(positionJson));
+			return CheckpointTag.FromJson(tokenReader, new ProjectionVersion(0, 0, 0)).Tag;
+		}
+		catch (Exception ex) when (ex is not RpcException)
+		{
+			throw RpcExceptions.InvalidArgument($"Failed to parse checkpoint position: {ex.Message}");
+		}
+	}
+}

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.ReadEvents.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.ReadEvents.cs
@@ -21,6 +21,8 @@ internal partial class ProjectionManagement
 	public override async Task<ReadEventsResp> ReadEvents(ReadEventsReq request, ServerCallContext context)
 	{
 		var readSource = new TaskCompletionSource<FeedReaderMessage.FeedPage>();
+		using var cancellationRegistration =
+			context.CancellationToken.Register(() => readSource.TrySetCanceled(context.CancellationToken));
 		var options = request.Options;
 		var user = context.GetHttpContext().User;
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Reset.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Reset.cs
@@ -10,7 +10,7 @@ namespace EventStore.Projections.Core.Services.Grpc;
 
 internal partial class ProjectionManagement
 {
-	private static readonly Operation ResetOperation = new Operation(Operations.Projections.Create);
+	private static readonly Operation ResetOperation = new Operation(Operations.Projections.Reset);
 	public override async Task<ResetResp> Reset(ResetReq request, ServerCallContext context)
 	{
 		var resetSource = new TaskCompletionSource<bool>();

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Statistics.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Statistics.cs
@@ -28,6 +28,7 @@ internal partial class ProjectionManagement
 		var name = string.IsNullOrEmpty(options.Name) ? null : options.Name;
 		var mode = options.ModeCase switch
 		{
+			ModeOneofCase.AllNonTransient => ProjectionMode.AllNonTransient,
 			ModeOneofCase.Continuous => ProjectionMode.Continuous,
 			ModeOneofCase.Transient => ProjectionMode.Transient,
 			ModeOneofCase.OneTime => ProjectionMode.OneTime,

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Text.Json;
+using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.Transport.Grpc;
@@ -78,6 +79,38 @@ namespace EventStore.Projections.Core.Services.Grpc
 			}
 
 			return structValue;
+		}
+
+		private static string ToJson<T>(T value) where T : class =>
+			value is null ? "{}" : value.ToJson();
+
+		private static Value GetProtoValue(string value, bool isJson)
+		{
+			if (string.IsNullOrEmpty(value))
+			{
+				return new Value {
+					StructValue = new Struct()
+				};
+			}
+
+			if (!isJson)
+			{
+				return new Value {
+					StringValue = value
+				};
+			}
+
+			try
+			{
+				using var document = JsonDocument.Parse(value);
+				return GetProtoValue(document.RootElement);
+			}
+			catch (JsonException)
+			{
+				return new Value {
+					StringValue = value
+				};
+			}
 		}
 	}
 }

--- a/src/Protos/Grpc/projections.proto
+++ b/src/Protos/Grpc/projections.proto
@@ -8,13 +8,18 @@ import "shared.proto";
 service Projections {
 	rpc Create (CreateReq) returns (CreateResp);
 	rpc Update (UpdateReq) returns (UpdateResp);
+	rpc GetQuery (GetQueryReq) returns (GetQueryResp);
 	rpc Delete (DeleteReq) returns (DeleteResp);
 	rpc Statistics (StatisticsReq) returns (stream StatisticsResp);
 	rpc Disable (DisableReq) returns (DisableResp);
 	rpc Enable (EnableReq) returns (EnableResp);
 	rpc Reset (ResetReq) returns (ResetResp);
+	rpc Abort (AbortReq) returns (AbortResp);
 	rpc State (StateReq) returns (StateResp);
 	rpc Result (ResultReq) returns (ResultResp);
+	rpc GetConfig (GetConfigReq) returns (GetConfigResp);
+	rpc UpdateConfig (UpdateConfigReq) returns (UpdateConfigResp);
+	rpc ReadEvents (ReadEventsReq) returns (ReadEventsResp);
 	rpc RestartSubsystem (event_store.client.Empty) returns (event_store.client.Empty);
 }
 
@@ -28,6 +33,15 @@ message CreateReq {
 			Continuous continuous = 3;
 		}
 		string query = 4;
+		string handler_type = 5;
+		oneof enabled_option {
+			bool enabled = 6;
+			event_store.client.Empty no_enabled_option = 7;
+		}
+		optional string name = 8;
+		bool checkpoints_enabled = 9;
+		bool emit_enabled = 10;
+		bool track_emitted_streams = 11;
 
 		message Transient {
 			string name = 1;
@@ -59,6 +73,29 @@ message UpdateReq {
 message UpdateResp {
 }
 
+message GetQueryReq {
+	Options options = 1;
+
+	message Options {
+		string name = 1;
+	}
+}
+
+message GetQueryResp {
+	Details details = 1;
+
+	message Details {
+		string name = 1;
+		string query = 2;
+		bool emit_enabled = 3;
+		string projection_type = 4;
+		optional bool track_emitted_streams = 5;
+		optional bool checkpoints_enabled = 6;
+		string definition_json = 7;
+		string output_config_json = 8;
+	}
+}
+
 message DeleteReq {
 	Options options = 1;
 
@@ -82,6 +119,7 @@ message StatisticsReq {
 			event_store.client.Empty transient = 3;
 			event_store.client.Empty continuous = 4;
 			event_store.client.Empty one_time = 5;
+			event_store.client.Empty all_non_transient = 6;
 		}
 	}
 }
@@ -138,6 +176,50 @@ message ResultResp {
 	google.protobuf.Value result = 1;
 }
 
+message GetConfigReq {
+	Options options = 1;
+
+	message Options {
+		string name = 1;
+	}
+}
+
+message GetConfigResp {
+	Details details = 1;
+
+	message Details {
+		bool emit_enabled = 1;
+		bool track_emitted_streams = 2;
+		int32 checkpoint_after_ms = 3;
+		int32 checkpoint_handled_threshold = 4;
+		int32 checkpoint_unhandled_bytes_threshold = 5;
+		int32 pending_events_threshold = 6;
+		int32 max_write_batch_length = 7;
+		int32 max_allowed_writes_in_flight = 8;
+		optional int32 projection_execution_timeout = 9;
+	}
+}
+
+message UpdateConfigReq {
+	Options options = 1;
+
+	message Options {
+		string name = 1;
+		bool emit_enabled = 2;
+		bool track_emitted_streams = 3;
+		int32 checkpoint_after_ms = 4;
+		int32 checkpoint_handled_threshold = 5;
+		int32 checkpoint_unhandled_bytes_threshold = 6;
+		int32 pending_events_threshold = 7;
+		int32 max_write_batch_length = 8;
+		int32 max_allowed_writes_in_flight = 9;
+		optional int32 projection_execution_timeout = 10;
+	}
+}
+
+message UpdateConfigResp {
+}
+
 message ResetReq {
 	Options options = 1;
 
@@ -150,6 +232,16 @@ message ResetReq {
 message ResetResp {
 }
 
+message AbortReq {
+	Options options = 1;
+
+	message Options {
+		string name = 1;
+	}
+}
+
+message AbortResp {
+}
 
 message EnableReq {
 	Options options = 1;
@@ -172,4 +264,35 @@ message DisableReq {
 }
 
 message DisableResp {
+}
+
+message ReadEventsReq {
+	Options options = 1;
+
+	message Options {
+		string query_sources_json = 1;
+		string position_json = 2;
+		int32 max_events = 3;
+	}
+}
+
+message ReadEventsResp {
+	Details details = 1;
+
+	message Details {
+		string correlation_id = 1;
+		string reader_position_json = 2;
+		repeated Event events = 3;
+
+		message Event {
+			string event_stream_id = 1;
+			int64 event_number = 2;
+			string event_type = 3;
+			google.protobuf.Value data = 4;
+			google.protobuf.Value metadata = 5;
+			google.protobuf.Value link_metadata = 6;
+			bool is_json = 7;
+			string reader_position_json = 8;
+		}
+	}
 }


### PR DESCRIPTION
- Legacy projection routes are the last substantial feature surface still trapped behind the old HTTP bridge, so gRPC needs to speak the same management language before that controller can safely disappear.
- Keeping the missing query, config, abort, feed-read, and non-transient listing behaviors on the gRPC side lets the next cleanup remove legacy routing without cutting off existing projection workflows.
- Preserving create semantics such as disabled startup and handler selection avoids forcing projection clients into a narrower contract while the transport surface is being simplified.