### PR TITLE
chore(http): prune unused kestrel constructor args

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Http/http_service_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/http_service_should.cs
@@ -110,11 +110,9 @@ public class kestrel_http_service_should
 			ServiceAccessibility.Public,
 			inputBus,
 			new TrieUriRouter(),
-			multiQueuedHandler: null,
 			logHttpRequests: false,
 			advertiseAsHost: "127.0.0.1",
 			advertiseAsPort: 2113,
-			disableAuthorization: false,
 			new IPEndPoint(IPAddress.Loopback, 2113));
 
 		sut.Handle(new SystemMessage.SystemInit());
@@ -142,11 +140,9 @@ public class kestrel_http_service_should
 			ServiceAccessibility.Public,
 			inputBus,
 			new TrieUriRouter(),
-			multiQueuedHandler: null,
 			logHttpRequests: false,
 			advertiseAsHost: "127.0.0.1",
 			advertiseAsPort: 2113,
-			disableAuthorization: false,
 			new IPEndPoint(IPAddress.Loopback, 2113));
 
 		sut.Handle(new SystemMessage.SystemInit());

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -932,14 +932,13 @@ public class ClusterVNode<TStreamId> :
 		}
 
 		_httpService = new KestrelHttpService(ServiceAccessibility.Public, _mainQueue, new TrieUriRouter(),
-			_workersHandler, options.Application.LogHttpRequests,
+			options.Application.LogHttpRequests,
 			string.IsNullOrEmpty(GossipAdvertiseInfo.AdvertiseHostToClientAs)
 				? GossipAdvertiseInfo.AdvertiseExternalHostAs
 				: GossipAdvertiseInfo.AdvertiseHostToClientAs,
 			GossipAdvertiseInfo.AdvertiseHttpPortToClientAs == 0
 				? GossipAdvertiseInfo.AdvertiseHttpPortAs
 				: GossipAdvertiseInfo.AdvertiseHttpPortToClientAs,
-			options.Auth.DisableFirstLevelHttpAuthorization,
 			NodeInfo.HttpEndPoint);
 
 		var components = new AuthenticationProviderFactoryComponents

--- a/src/EventStore.Core/Services/Transport/Http/KestrelHttpService.cs
+++ b/src/EventStore.Core/Services/Transport/Http/KestrelHttpService.cs
@@ -41,8 +41,7 @@ namespace EventStore.Core.Services.Transport.Http {
 		private bool _isListening;
 
 		public KestrelHttpService(ServiceAccessibility accessibility, IPublisher inputBus, IUriRouter uriRouter,
-			MultiQueuedHandler multiQueuedHandler, bool logHttpRequests, string advertiseAsHost,
-			int advertiseAsPort, bool disableAuthorization, params EndPoint[] endPoints) {
+			bool logHttpRequests, string advertiseAsHost, int advertiseAsPort, params EndPoint[] endPoints) {
 			Ensure.NotNull(inputBus, nameof(inputBus));
 			Ensure.NotNull(uriRouter, nameof(uriRouter));
 			Ensure.NotNull(endPoints, nameof(endPoints));


### PR DESCRIPTION
- the Kestrel HTTP service constructor was still demanding bridge-era arguments that no longer influenced runtime behavior
- removing them narrows the live API surface to the values that still shape infrastructure behavior and makes future cleanup easier to reason about
- keeping this separate from broader HTTP cleanup makes it obvious that no request semantics changed, only dead wiring disappeared