### PR TITLE
chore(tests): prune obsolete openapi reader package

### DIFF
--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -13,7 +13,6 @@
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" />
 		<PackageReference Include="Microsoft.CSharp" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
-		<PackageReference Include="Microsoft.OpenApi.Readers" />
 		<PackageReference Include="NUnit" />
 		<PackageReference Include="NUnit3TestAdapter" />
 		<PackageReference Include="Google.Protobuf" />


### PR DESCRIPTION
- once the controller-action OpenAPI artifact is retired, keeping the reader package around only preserves dependency weight for a test path we no longer ship
- splitting the package drop from the artifact retirement makes it easy to verify that this branch only removes residue, not behavior
- the smaller follow-up also keeps future dependency audits honest about what the test project still truly needs