### PR TITLE
chore(http): prune service route inspection

### DIFF
--- a/src/EventStore.Core/Services/Transport/Http/IHttpService.cs
+++ b/src/EventStore.Core/Services/Transport/Http/IHttpService.cs
@@ -21,8 +21,6 @@ namespace EventStore.Core.Services.Transport.Http {
 		bool IsListening { get; }
 		IEnumerable<EndPoint> EndPoints { get; }
 
-		List<UriToActionMatch> GetAllUriMatches(Uri uri);
-
 		void RegisterCustomAction(ControllerAction action,
 			Func<HttpEntityManager, UriTemplateMatch, RequestParams> handler);
 

--- a/src/EventStore.Core/Services/Transport/Http/KestrelHttpService.cs
+++ b/src/EventStore.Core/Services/Transport/Http/KestrelHttpService.cs
@@ -92,7 +92,6 @@ namespace EventStore.Core.Services.Transport.Http {
 				return new RequestParams(ESConsts.HttpTimeout);
 			});
 		}
-		public List<UriToActionMatch> GetAllUriMatches(Uri uri) => UriRouter.GetAllUriMatches(uri);
 		public static void CreateAndSubscribePipeline(ISubscriber bus) {
 			var requestProcessor = new AuthenticatedHttpRequestProcessor();
 			bus.Subscribe<AuthenticatedHttpRequestMessage>(requestProcessor);


### PR DESCRIPTION
- once the controller-action artifact is gone, exposing route inspection on the live HTTP service no longer protects a supported contract
- keeping the router-level matching API for dedicated tests is enough, while removing the service-level shim avoids implying that runtime consumers should introspect routes there
- stacking this after the OpenAPI cleanup keeps the intent narrow and avoids mixing behavior changes with artifact retirement