### PR TITLE
chore(ci): prevent C# quality drift

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -27,6 +27,46 @@ permissions:
   packages: read
 
 jobs:
+  csharp-quality:
+    runs-on: ubuntu-latest
+    name: C# Quality
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install net8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Set up .NET NuGet authentication
+        run: |
+          dotnet nuget add source "https://nuget.pkg.github.com/TrogonStack/index.json" \
+            --name "github" \
+            --username ${{ github.actor }} \
+            --password ${{ secrets.GITHUB_TOKEN }} \
+            --store-password-in-clear-text
+      - name: Resolve comparison refs
+        id: refs
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "base=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+            echo "head=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "base=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
+            echo "head=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Restore
+        run: |
+          dotnet restore src/EventStore.sln
+      - name: Lint unused variables
+        run: |
+          dotnet build --no-restore --configuration Release -p:Platform=x64 -warnaserror:CS0168,CS0219,CS8321 src/EventStore.sln
+      - name: Verify C# formatting
+        run: |
+          ./ci/csharp-format-changed.sh src/EventStore.sln "${{ steps.refs.outputs.base }}" "${{ steps.refs.outputs.head }}"
+
   vulnerability-scan:
     runs-on: ubuntu-latest
     name: Scan for Vulnerabilities

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           dotnet nuget add source "https://nuget.pkg.github.com/TrogonStack/index.json" \
             --name "github" \
-            --username ${{ github.actor }} \
+            --username "${{ github.actor }}" \
             --password ${{ secrets.GITHUB_TOKEN }} \
             --store-password-in-clear-text
       - name: Resolve comparison refs

--- a/ci/csharp-format-changed.sh
+++ b/ci/csharp-format-changed.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+solution="${1:?solution path is required}"
+base_ref="${2:?base ref is required}"
+head_ref="${3:-HEAD}"
+solution_dir="$(dirname "$solution")"
+solution_file="$(basename "$solution")"
+
+if [[ "$base_ref" =~ ^0+$ ]]; then
+	base_ref="$(git rev-list --max-parents=0 "$head_ref")"
+fi
+
+comparison_base="$base_ref"
+if merge_base="$(git merge-base "$base_ref" "$head_ref" 2>/dev/null)"; then
+	comparison_base="$merge_base"
+fi
+
+mapfile -t changed_files < <(git diff --name-only --diff-filter=ACMR "$comparison_base" "$head_ref" -- "*.cs")
+
+include_files=()
+for file in "${changed_files[@]}"; do
+	if [[ "$solution_dir" == "." ]]; then
+		include_files+=("$file")
+	elif [[ "$file" == "$solution_dir"/* ]]; then
+		include_files+=("${file#"$solution_dir"/}")
+	else
+		echo "Skipping C# file outside $solution_file: $file"
+	fi
+done
+
+if ((${#include_files[@]} == 0)); then
+	echo "No changed C# files to format under $solution_dir."
+	exit 0
+fi
+
+printf "Checking C# formatting for:\n"
+printf "  %s\n" "${include_files[@]}"
+
+(
+	cd "$solution_dir"
+	dotnet format whitespace "$solution_file" --verify-no-changes --no-restore --include "${include_files[@]}"
+	dotnet format style "$solution_file" --verify-no-changes --no-restore --diagnostics IDE0005 IDE0059 --severity info --include "${include_files[@]}"
+)


### PR DESCRIPTION
- Quality drift is cheaper to stop during review than after inconsistent C# style reaches master.
- Unused variables should fail close to the authoring moment because they hide stale intent and make reviews noisier.