### PR TITLE
chore(auth): remove legacy http authorization bypass

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -605,13 +605,6 @@ You can also use the trusted intermediary header for externalized authentication
 almost any authentication system with EventStoreDB. Read more
 about [the trusted intermediary header](#trusted-intermediary).
 
-### Disable HTTP authentication
-
-It is possible to disable authentication on all protected HTTP endpoints by setting
-the `DisableFirstLevelHttpAuthorization` setting to `true`. The setting is set to `false` by default. When
-enabled, the setting will force EventStoreDB to use the supplied credentials only to check the stream access
-using [ACLs](#access-control-lists).
-
 ## Access control lists
 
 By default, authenticated users have access to the whole EventStoreDB database. In addition to that, it allows

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -233,9 +233,6 @@ public partial record ClusterVNodeOptions
 		[Description("Path to the configuration file for Authentication configuration (if applicable).")]
 		public string? AuthenticationConfig { get; init; }
 
-		[Description("Disables first level authorization checks on all HTTP endpoints. " +
-		             "This option can be enabled for backwards compatibility with EventStore 5.0.1 or earlier.")]
-		public bool DisableFirstLevelHttpAuthorization { get; init; } = false;
 	}
 
 	[Description("Certificate Options (from file)")]


### PR DESCRIPTION
- The option advertises a legacy HTTP bypass that no longer maps to a live authorization path.
- Removing the stale setting prevents operators from depending on a security knob that cannot provide its documented behavior.