### PR TITLE
chore(docs): prune legacy http api guidance

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -5,7 +5,7 @@ title: Networking
 ## Network configuration
 
 EventStoreDB provides two interfaces: 
-- HTTP(S) for gRPC communication and REST APIs
+- HTTP(S) for gRPC communication, the Admin UI, and operational endpoints such as health checks and metrics
 - TCP for cluster replication (internal)
 
 Nodes in the cluster replicate with each other using the TCP protocol, but use gRPC for [discovering other cluster nodes](cluster.md#discovering-cluster-members).
@@ -16,7 +16,7 @@ For gRPC and HTTP, there's no internal vs external separation of traffic.
 
 ## HTTP configuration
 
-HTTP is the primary protocol for EventStoreDB. It is used in gRPC communication and HTTP APIs (management, gossip and diagnostics).
+HTTP is the primary protocol for EventStoreDB. It carries gRPC communication, the Admin UI, health checks, metrics, and supported diagnostics endpoints.
 The HTTP endpoint always binds to the IP address configured in the `NodeIp` setting (previously referred to as `ExtIp`).
 
 | Format               | Syntax               |
@@ -453,6 +453,5 @@ When the plugin starts, you should see a log similar to the following:
 ```
 [11212, 1,18:44:34.070,INF] "TcpApi" "24.6.0.0" plugin enabled.
 ```
-
 
 

--- a/docs/persistent-subscriptions.md
+++ b/docs/persistent-subscriptions.md
@@ -38,11 +38,7 @@ Messages that have been retried too often will be parked in the persistent subsc
 
 If you want to retry the parked messages, you can `Replay` the parked messages for that subscription. This will push the parked messages to subscribers before any new events on the subscription.
 
-You can also specify the number of parked messages to replay over the HTTP endpoint. This can be done by providing the `stopAt` parameter when requesting to replay messages through the HTTP url. For example:
-
-```bash:no-line-numbers
-curl -i -X POST -d {} https://localhost:2113/subscriptions/{stream}/{groupnanme}/replayParked?stopAt={numberofevents} -u "admin:changeit"
-```
+The Admin UI and gRPC `PersistentSubscriptions.ReplayParked` RPC can limit how many parked messages are replayed.
 
 If you don't want to replay any of the parked messages for a subscription and want to clear them out, you can do this by deleting the parked stream like a normal stream.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -713,8 +713,7 @@ This default ACL gives `ouro` and `$admins` create and write permissions on all 
 can read from them. Be careful allowing default access to system streams to non-admins as they would also have
 access to `$settings` unless you specifically override it.
 
-Refer to the documentation of the HTTP API or SDK of your choice for more information about changing ACLs
-programmatically.
+Refer to the documentation of the SDK of your choice for more information about changing ACLs programmatically.
 
 ## Trusted intermediary
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -92,8 +92,7 @@ We have disabled anonymous access to streams by default in this version. This me
 If you see authentication errors when connecting to EventStoreDB after upgrading, please ensure that you are either using default credentials on the connection, or are providing user credentials with the request itself.
 
 If you want to revert back to the old behavior, you can enable the `AllowAnonymousStreamAccess` and `AllowAnonymousEndpointAccess` options in EventStoreDB.
-Requests to the HTTP API must be authenticated by default.
-Like with anonymous access to streams, anonymous access to the HTTP and gRPC endpoints has been disabled by default. The HTTP exceptions are `/-/liveness`, `/-/readiness`, static UI content, and redirects.
+Like with anonymous access to streams, anonymous access to gRPC and protected HTTP endpoints has been disabled by default. The HTTP exceptions are `/-/liveness`, `/-/readiness`, static UI content, and redirects.
 
 Any tools or monitoring scripts still using legacy HTTP diagnostics endpoints must move to the supported metrics and gRPC monitoring surfaces in this release.
 


### PR DESCRIPTION
- Stale HTTP management examples push operators toward endpoints that have gRPC or Admin UI replacements.
- The networking and security docs should describe the supported surface area without implying the retired HTTP API remains a primary integration path.