### PR TITLE
chore(http): align endpoint exposure guidance

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -328,37 +328,27 @@ For the gRPC heartbeats, EventStoreDB and its gRPC clients use the protocol feat
 
 ## Exposing endpoints
 
-If you need to disable some HTTP endpoints on the external HTTP interface, you can change some settings below. It is possible to disable the Admin UI, stats and gossip port to be exposed externally.
+If you need to reduce the HTTP surface, you can disable the browser-facing Admin UI and the Prometheus metrics endpoint. Health probes and gRPC remain part of the supported HTTP listener.
 
-You can disable the Admin UI on external HTTP by setting `AdminOnExt` setting to `false`.
-
-| Format               | Syntax                    |
-|:---------------------|:--------------------------|
-| Command line         | `--admin-on-ext`          |
-| YAML                 | `AdminOnExt`              |
-| Environment variable | `EVENTSTORE_ADMIN_ON_EXT` | 
-
-**Default**: `true`, Admin UI is enabled on the external HTTP.
-
-Exposing the `stats` endpoint externally is required for the Admin UI and can also be useful if you collect stats for an external monitoring tool.
+You can disable the Admin UI by setting `DisableAdminUi` to `true`.
 
 | Format               | Syntax                    |
 |:---------------------|:--------------------------|
-| Command line         | `--stats-on-ext`          |
-| YAML                 | `StatsOnExt`              |
-| Environment variable | `EVENTSTORE_STATS_ON_EXT` | 
+| Command line         | `--disable-admin-ui`      |
+| YAML                 | `DisableAdminUi`          |
+| Environment variable | `EVENTSTORE_DISABLE_ADMIN_UI` |
 
-**Default**: `true`, stats endpoint is enabled on the external HTTP.
+**Default**: `false`, Admin UI is enabled.
 
-You can also disable the gossip protocol in the external HTTP interface. If you do that, ensure that the internal interface is properly configured. Also, if you use [gossip with DNS](cluster.md#cluster-with-dns), ensure that the [gossip port](cluster.md#gossip-port) is set to the internal HTTP port.
+You can disable the Prometheus metrics endpoint by setting `DisableStatsOnHttp` to `true`.
 
-| Format               | Syntax                     |
-|:---------------------|:---------------------------|
-| Command line         | `--gossip-on-ext`          |
-| YAML                 | `GossipOnExt`              |
-| Environment variable | `EVENTSTORE_GOSSIP_ON_EXT` | 
+| Format               | Syntax                              |
+|:---------------------|:------------------------------------|
+| Command line         | `--disable-stats-on-http`           |
+| YAML                 | `DisableStatsOnHttp`                |
+| Environment variable | `EVENTSTORE_DISABLE_STATS_ON_HTTP`  |
 
-**Default**: `true`, gossip is enabled on the external HTTP.
+**Default**: `false`, the Prometheus metrics endpoint is enabled on `/-/metrics`.
 
 ## External TCP 
 
@@ -453,5 +443,4 @@ When the plugin starts, you should see a log similar to the following:
 ```
 [11212, 1,18:44:34.070,INF] "TcpApi" "24.6.0.0" plugin enabled.
 ```
-
 

--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterNodeOptionsTests/when_building/with_default_settings.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterNodeOptionsTests/when_building/with_default_settings.cs
@@ -54,8 +54,8 @@ public class with_default_node_as_single_node<TLogFormat, TStreamId> : SingleNod
 			"ScavengeHistoryMaxAge");
 		Assert.AreEqual(false, _options.Database.DisableScavengeMerging,
 			"DisableScavengeMerging");
-		Assert.AreEqual(false, _options.Interface.DisableAdminUi, "AdminOnPublic");
-		Assert.AreEqual(false, _options.Interface.DisableStatsOnHttp, "StatsOnPublic");
+		Assert.AreEqual(false, _options.Interface.DisableAdminUi, "DisableAdminUi");
+		Assert.AreEqual(false, _options.Interface.DisableStatsOnHttp, "DisableStatsOnHttp");
 		Assert.AreEqual(1_000_000, _options.Database.MaxMemTableSize, "MaxMemtableEntryCount");
 		Assert.AreEqual(false, _options.Projection.RunProjections > ProjectionType.System,
 			"StartStandardProjections");
@@ -94,7 +94,6 @@ public class with_default_node_as_node_in_a_cluster<TLogFormat, TStreamId> : Clu
 	public void should_have_default_secure_endpoints()
 	{
 		var internalTcp = new IPEndPoint(IPAddress.Loopback, 1112);
-		var externalTcp = new IPEndPoint(IPAddress.Loopback, 1113);
 		var httpEndPoint = new IPEndPoint(IPAddress.Loopback, 2113);
 
 		Assert.AreEqual(internalTcp, _node.NodeInfo.InternalSecureTcp);
@@ -126,7 +125,6 @@ public class with_default_node_as_node_in_an_insecure_cluster<TLogFormat, TStrea
 	public void should_have_default_endpoints()
 	{
 		var internalTcp = new IPEndPoint(IPAddress.Loopback, 1112);
-		var externalTcp = new IPEndPoint(IPAddress.Loopback, 1113);
 		var httpEndPoint = new IPEndPoint(IPAddress.Loopback, 2113);
 
 		Assert.AreEqual(internalTcp, _node.NodeInfo.InternalTcp);


### PR DESCRIPTION
- Keep operator-facing networking guidance aligned with the supported HTTP surface after the legacy management endpoints were retired.
- Reduce confusion around removed endpoint exposure settings by documenting the current Admin UI and Prometheus metrics switches.