### PR TITLE
chore(dotnet): upgrade runtime to .NET 10

### DIFF
--- a/.github/workflows/build-container-reusable.yml
+++ b/.github/workflows/build-container-reusable.yml
@@ -34,10 +34,10 @@ jobs:
         with:
           fetch-depth: 0
         if: ${{ inputs.mode != 'test-only' }}
-      - name: Install net8.0
+      - name: Install net10.0
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
         if: ${{ inputs.mode != 'test-only' }}
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -31,10 +31,10 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 3.1.x
-      - name: Install net8.0
+      - name: Install net10.0
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       - name: Authenticate NuGet GitHub Packages
         shell: bash
         run: |

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -35,10 +35,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install net8.0
+      - name: Install net10.0
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       - name: Set up .NET NuGet authentication
         run: |
           dotnet nuget add source "https://nuget.pkg.github.com/TrogonStack/index.json" \
@@ -73,10 +73,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install net8.0
+      - name: Install net10.0
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       - name: Set up .NET NuGet authentication
         run: |
           dotnet nuget add source "https://nuget.pkg.github.com/TrogonStack/index.json" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # "build" image
 ARG CONTAINER_RUNTIME=noble
-FROM mcr.microsoft.com/dotnet/sdk:8.0-noble AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS build
 ARG RUNTIME=linux-x64
 
 WORKDIR /build
@@ -37,7 +37,7 @@ RUN find /build/src -maxdepth 1 -type d -name "*.Tests" -print0 | xargs -r -I{} 
     'dotnet publish --runtime=${RUNTIME} --no-self-contained --configuration Release --output /build/published-tests/`basename $1` $1' - '{}'
 
 # "test" image
-FROM mcr.microsoft.com/dotnet/sdk:8.0-${CONTAINER_RUNTIME} AS test
+FROM mcr.microsoft.com/dotnet/sdk:10.0-${CONTAINER_RUNTIME} AS test
 WORKDIR /build
 COPY --from=build ./build/published-tests ./published-tests
 COPY --from=build ./build/ci ./ci
@@ -53,10 +53,10 @@ FROM build AS publish
 ARG RUNTIME=linux-x64
 
 RUN dotnet publish --configuration=Release --runtime=${RUNTIME} --self-contained \
-     --framework=net8.0 --output /publish EventStore.ClusterNode
+     --framework=net10.0 --output /publish EventStore.ClusterNode
 
 # "runtime" image
-FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-${CONTAINER_RUNTIME} AS runtime
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-${CONTAINER_RUNTIME} AS runtime
 ARG RUNTIME=linux-x64
 ARG UID=10000
 ARG GID=10000

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The build scripts: `build.sh` and `build.ps1` are also available for Linux and W
 To start a single node, you can then run:
 
 ```
-dotnet ./src/EventStore.ClusterNode/bin/x64/Release/net8.0/EventStore.ClusterNode.dll --dev --db ./tmp/data --index ./tmp/index --log ./tmp/log
+dotnet ./src/EventStore.ClusterNode/bin/x64/Release/net10.0/EventStore.ClusterNode.dll --dev --db ./tmp/data --index ./tmp/index --log ./tmp/log
 ```
 
 ### Running the tests

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ TrogonDB is written in a mixture of C# and JavaScript. It can run on Windows, Li
 
 **Prerequisites**
 
-- [.NET Core SDK 8.0](https://dotnet.microsoft.com/download/dotnet/8.0)
+- [.NET SDK 10.0](https://dotnet.microsoft.com/download/dotnet/10.0)
 
 Once you've installed the prerequisites for your system, you can launch a `Release` build of EventStore as follows:
 

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ COPYRIGHT="Copyright 2021 Event Store Ltd. All rights reserved."
 # ------------ End of configuration -------------
 
 CONFIGURATION="Release"
-NET_FRAMEWORK="net8.0"
+NET_FRAMEWORK="net10.0"
 
 function usage() {    
 cat <<EOF

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,8 +10,8 @@
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Copyright>Copyright 2012-2024 Event Store Ltd</Copyright>
 		<PackageReleaseNotes>https://eventstore.com/blog/</PackageReleaseNotes>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>12.0</LangVersion>
+		<TargetFramework>net10.0</TargetFramework>
+		<LangVersion>14.0</LangVersion>
 		<Platforms>AnyCPU;x64;ARM64</Platforms>
 		<IsPackable>false</IsPackable>
 		<VersionPrefix>24.10.0</VersionPrefix>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -33,7 +33,7 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageVersion Include="Jint" Version="4.4.0" />
     <PackageVersion Include="librdkafka.redist" Version="2.5.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
     <!--
@@ -42,16 +42,12 @@
     -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.16" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.621003" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Composite" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.18" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.7" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
-    <PackageVersion Include="Microsoft.Net.Http.Headers" Version="8.0.18" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.24" />
     <PackageVersion Include="Mono.Posix.NETStandard" Version="1.0.0" />
@@ -71,8 +67,8 @@
     <PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageVersion Include="Serilog.Expressions" Version="5.0.0" />
-    <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
-    <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.4" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
@@ -81,20 +77,11 @@
     <PackageVersion Include="Serilog.Sinks.TextWriter" Version="3.0.0" />
     <PackageVersion Include="SharpDotYaml.Extensions.Configuration" Version="0.3.1" />
     <PackageVersion Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.21216.1" />
-    <PackageVersion Include="System.ComponentModel.Composition" Version="8.0.0" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
-    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="8.0.1" />
-    <PackageVersion Include="System.Formats.Asn1" Version="8.0.2" />
-    <PackageVersion Include="System.IO.Pipelines" Version="8.0.0" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.3" />
-    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+    <PackageVersion Include="System.ComponentModel.Composition" Version="10.0.7" />
+    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="10.0.7" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.7" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageVersion Include="System.ServiceModel.Http" Version="6.2.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.6" />
-    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageVersion Include="System.Threading.Channels" Version="9.0.8" />
     <PackageVersion Include="TrogonEventStore.Plugins" Version="24.10.9" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.2">

--- a/src/EventStore.BufferManagement.Tests/BufferPoolStreamTests.cs
+++ b/src/EventStore.BufferManagement.Tests/BufferPoolStreamTests.cs
@@ -43,7 +43,7 @@ public class when_reading_from_the_stream : has_buffer_pool_fixture
 		stream.Write(new byte[500], 0, 500);
 		stream.Seek(0, SeekOrigin.Begin);
 		Assert.AreEqual(0, stream.Position);
-		stream.Read(new byte[50], 0, 50);
+		Assert.AreEqual(50, stream.Read(new byte[50], 0, 50));
 		Assert.AreEqual(50, stream.Position);
 	}
 

--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionConfig.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionConfig.razor
@@ -102,16 +102,16 @@
 @code {
 	[Parameter] public string Name { get; set; } = "";
 
-	private ProjectionConfigInput _input = new();
-
 	[SupplyParameterFromForm(FormName = "projection-config")]
-	private ProjectionConfigInput Input { get => _input; set => _input = value ?? new(); }
+	private ProjectionConfigInput Input { get; set; }
 
 	private ProjectionConfigPage Page { get; set; }
 	private ProjectionCommandResult Result { get; set; }
 	private string DetailHref => $"/ui/projections/{Uri.EscapeDataString(Name)}";
 
 	protected override async Task OnParametersSetAsync() {
+		Input ??= new();
+
 		var hasSubmittedForm = string.Equals(Input.Name, Name, StringComparison.OrdinalIgnoreCase);
 		if (hasSubmittedForm)
 			return;

--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionConfig.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionConfig.razor
@@ -102,8 +102,10 @@
 @code {
 	[Parameter] public string Name { get; set; } = "";
 
+	private ProjectionConfigInput _input = new();
+
 	[SupplyParameterFromForm(FormName = "projection-config")]
-	private ProjectionConfigInput Input { get; set; } = new();
+	private ProjectionConfigInput Input { get => _input; set => _input = value ?? new(); }
 
 	private ProjectionConfigPage Page { get; set; }
 	private ProjectionCommandResult Result { get; set; }

--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionCreate.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionCreate.razor
@@ -87,12 +87,14 @@
 @code {
 	private const string DefaultQuery = "fromAll().when({\n  $init: function () { return {}; },\n  $any: function (state, event) {\n    return state;\n  }\n});";
 
-	private ProjectionCreateInput _input = new();
-
 	[SupplyParameterFromForm(FormName = "projection-create")]
-	private ProjectionCreateInput Input { get => _input; set => _input = value ?? new(); }
+	private ProjectionCreateInput Input { get; set; }
 
 	private ProjectionCommandResult Result { get; set; }
+
+	protected override void OnParametersSet() {
+		Input ??= new();
+	}
 
 	private async Task CreateProjection() {
 		var redirectTo = "";

--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionCreate.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionCreate.razor
@@ -87,8 +87,10 @@
 @code {
 	private const string DefaultQuery = "fromAll().when({\n  $init: function () { return {}; },\n  $any: function (state, event) {\n    return state;\n  }\n});";
 
+	private ProjectionCreateInput _input = new();
+
 	[SupplyParameterFromForm(FormName = "projection-create")]
-	private ProjectionCreateInput Input { get; set; } = new();
+	private ProjectionCreateInput Input { get => _input; set => _input = value ?? new(); }
 
 	private ProjectionCommandResult Result { get; set; }
 

--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionDebug.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionDebug.razor
@@ -94,15 +94,11 @@
 	[Parameter] public string Name { get; set; } = "";
 	[SupplyParameterFromQuery] public string FromQueryState { get; set; } = "";
 
-	private ProjectionDebugInput _disableInput = new();
-
 	[SupplyParameterFromForm(FormName = "projection-debug-disable")]
-	private ProjectionDebugInput DisableInput { get => _disableInput; set => _disableInput = value ?? new(); }
-
-	private ProjectionDebugInput _resetInput = new();
+	private ProjectionDebugInput DisableInput { get; set; }
 
 	[SupplyParameterFromForm(FormName = "projection-debug-reset")]
-	private ProjectionDebugInput ResetInput { get => _resetInput; set => _resetInput = value ?? new(); }
+	private ProjectionDebugInput ResetInput { get; set; }
 
 	private ProjectionDetailPage Page { get; set; }
 	private ProjectionCommandResult CommandResult { get; set; }
@@ -112,6 +108,9 @@
 	private string QueryHref => $"/ui/query?location={Uri.EscapeDataString(LinkName)}";
 
 	protected override async Task OnParametersSetAsync() {
+		DisableInput ??= new();
+		ResetInput ??= new();
+
 		try {
 			Page = await Projections.ReadProjection(Name);
 		} catch (OperationCanceledException) {

--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionDebug.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionDebug.razor
@@ -94,11 +94,15 @@
 	[Parameter] public string Name { get; set; } = "";
 	[SupplyParameterFromQuery] public string FromQueryState { get; set; } = "";
 
+	private ProjectionDebugInput _disableInput = new();
+
 	[SupplyParameterFromForm(FormName = "projection-debug-disable")]
-	private ProjectionDebugInput DisableInput { get; set; } = new();
+	private ProjectionDebugInput DisableInput { get => _disableInput; set => _disableInput = value ?? new(); }
+
+	private ProjectionDebugInput _resetInput = new();
 
 	[SupplyParameterFromForm(FormName = "projection-debug-reset")]
-	private ProjectionDebugInput ResetInput { get; set; } = new();
+	private ProjectionDebugInput ResetInput { get => _resetInput; set => _resetInput = value ?? new(); }
 
 	private ProjectionDetailPage Page { get; set; }
 	private ProjectionCommandResult CommandResult { get; set; }

--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionDelete.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionDelete.razor
@@ -83,8 +83,10 @@
 @code {
 	[Parameter] public string Name { get; set; } = "";
 
+	private ProjectionDeleteInput _input = new();
+
 	[SupplyParameterFromForm(FormName = "projection-delete")]
-	private ProjectionDeleteInput Input { get; set; } = new();
+	private ProjectionDeleteInput Input { get => _input; set => _input = value ?? new(); }
 
 	private ProjectionDetailPage Page { get; set; }
 	private ProjectionCommandResult Result { get; set; }

--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionDelete.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionDelete.razor
@@ -83,16 +83,16 @@
 @code {
 	[Parameter] public string Name { get; set; } = "";
 
-	private ProjectionDeleteInput _input = new();
-
 	[SupplyParameterFromForm(FormName = "projection-delete")]
-	private ProjectionDeleteInput Input { get => _input; set => _input = value ?? new(); }
+	private ProjectionDeleteInput Input { get; set; }
 
 	private ProjectionDetailPage Page { get; set; }
 	private ProjectionCommandResult Result { get; set; }
 	private string DetailHref => $"/ui/projections/{Uri.EscapeDataString(Name)}";
 
 	protected override async Task OnParametersSetAsync() {
+		Input ??= new();
+
 		if (!string.Equals(Input.Name, Name, StringComparison.OrdinalIgnoreCase))
 			Input.Name = Name;
 

--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionDetail.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionDetail.razor
@@ -182,26 +182,24 @@
 	[Parameter] public string Name { get; set; } = "";
 	[SupplyParameterFromQuery] public string Partition { get; set; } = "";
 
-	private ProjectionActionInput _enableInput = new();
-
 	[SupplyParameterFromForm(FormName = "projection-detail-enable")]
-	private ProjectionActionInput EnableInput { get => _enableInput; set => _enableInput = value ?? new(); }
-
-	private ProjectionActionInput _disableInput = new();
+	private ProjectionActionInput EnableInput { get; set; }
 
 	[SupplyParameterFromForm(FormName = "projection-detail-disable")]
-	private ProjectionActionInput DisableInput { get => _disableInput; set => _disableInput = value ?? new(); }
-
-	private ProjectionActionInput _resetInput = new();
+	private ProjectionActionInput DisableInput { get; set; }
 
 	[SupplyParameterFromForm(FormName = "projection-detail-reset")]
-	private ProjectionActionInput ResetInput { get => _resetInput; set => _resetInput = value ?? new(); }
+	private ProjectionActionInput ResetInput { get; set; }
 
 	private ProjectionDetailPage Page { get; set; }
 	private ProjectionCommandResult CommandResult { get; set; }
 	private long _loadSequence;
 
 	protected override async Task OnParametersSetAsync() {
+		EnableInput ??= new();
+		DisableInput ??= new();
+		ResetInput ??= new();
+
 		var requestedName = Name;
 		var requestedPartition = Partition;
 		var sequence = ++_loadSequence;

--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionDetail.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionDetail.razor
@@ -182,14 +182,20 @@
 	[Parameter] public string Name { get; set; } = "";
 	[SupplyParameterFromQuery] public string Partition { get; set; } = "";
 
+	private ProjectionActionInput _enableInput = new();
+
 	[SupplyParameterFromForm(FormName = "projection-detail-enable")]
-	private ProjectionActionInput EnableInput { get; set; } = new();
+	private ProjectionActionInput EnableInput { get => _enableInput; set => _enableInput = value ?? new(); }
+
+	private ProjectionActionInput _disableInput = new();
 
 	[SupplyParameterFromForm(FormName = "projection-detail-disable")]
-	private ProjectionActionInput DisableInput { get; set; } = new();
+	private ProjectionActionInput DisableInput { get => _disableInput; set => _disableInput = value ?? new(); }
+
+	private ProjectionActionInput _resetInput = new();
 
 	[SupplyParameterFromForm(FormName = "projection-detail-reset")]
-	private ProjectionActionInput ResetInput { get; set; } = new();
+	private ProjectionActionInput ResetInput { get => _resetInput; set => _resetInput = value ?? new(); }
 
 	private ProjectionDetailPage Page { get; set; }
 	private ProjectionCommandResult CommandResult { get; set; }

--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionEdit.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionEdit.razor
@@ -77,11 +77,15 @@
 @code {
 	[Parameter] public string Name { get; set; } = "";
 
+	private ProjectionEditInput _input = new();
+
 	[SupplyParameterFromForm(FormName = "projection-edit")]
-	private ProjectionEditInput Input { get; set; } = new();
+	private ProjectionEditInput Input { get => _input; set => _input = value ?? new(); }
+
+	private ProjectionResetInput _resetInput = new();
 
 	[SupplyParameterFromForm(FormName = "projection-edit-reset")]
-	private ProjectionResetInput ResetInput { get; set; } = new();
+	private ProjectionResetInput ResetInput { get => _resetInput; set => _resetInput = value ?? new(); }
 
 	private ProjectionQueryPage Page { get; set; }
 	private ProjectionCommandResult SaveResult { get; set; }

--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionEdit.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionEdit.razor
@@ -77,15 +77,11 @@
 @code {
 	[Parameter] public string Name { get; set; } = "";
 
-	private ProjectionEditInput _input = new();
-
 	[SupplyParameterFromForm(FormName = "projection-edit")]
-	private ProjectionEditInput Input { get => _input; set => _input = value ?? new(); }
-
-	private ProjectionResetInput _resetInput = new();
+	private ProjectionEditInput Input { get; set; }
 
 	[SupplyParameterFromForm(FormName = "projection-edit-reset")]
-	private ProjectionResetInput ResetInput { get => _resetInput; set => _resetInput = value ?? new(); }
+	private ProjectionResetInput ResetInput { get; set; }
 
 	private ProjectionQueryPage Page { get; set; }
 	private ProjectionCommandResult SaveResult { get; set; }
@@ -93,6 +89,9 @@
 	private string DetailHref => $"/ui/projections/{Uri.EscapeDataString(Name)}";
 
 	protected override async Task OnParametersSetAsync() {
+		Input ??= new();
+		ResetInput ??= new();
+
 		var hasSubmittedForm = string.Equals(Input.Name, Name, StringComparison.OrdinalIgnoreCase);
 		if (hasSubmittedForm)
 			return;

--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionStandardCreate.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionStandardCreate.razor
@@ -60,8 +60,10 @@
 </section>
 
 @code {
+	private StandardProjectionCreateInput _input = new();
+
 	[SupplyParameterFromForm(FormName = "projection-standard-create")]
-	private StandardProjectionCreateInput Input { get; set; } = new();
+	private StandardProjectionCreateInput Input { get => _input; set => _input = value ?? new(); }
 
 	private ProjectionCommandResult Result { get; set; }
 

--- a/src/EventStore.ClusterNode/Components/Pages/ProjectionStandardCreate.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/ProjectionStandardCreate.razor
@@ -60,12 +60,14 @@
 </section>
 
 @code {
-	private StandardProjectionCreateInput _input = new();
-
 	[SupplyParameterFromForm(FormName = "projection-standard-create")]
-	private StandardProjectionCreateInput Input { get => _input; set => _input = value ?? new(); }
+	private StandardProjectionCreateInput Input { get; set; }
 
 	private ProjectionCommandResult Result { get; set; }
+
+	protected override void OnParametersSet() {
+		Input ??= new();
+	}
 
 	private async Task CreateProjection() {
 		var redirectTo = "";

--- a/src/EventStore.ClusterNode/Components/Pages/Projections.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Projections.razor
@@ -130,15 +130,11 @@
 @code {
 	[SupplyParameterFromQuery] public bool IncludeQueries { get; set; }
 
-	private ProjectionBulkInput _enableAllInput = new();
-
 	[SupplyParameterFromForm(FormName = "projection-enable-all")]
-	private ProjectionBulkInput EnableAllInput { get => _enableAllInput; set => _enableAllInput = value ?? new(); }
-
-	private ProjectionBulkInput _disableAllInput = new();
+	private ProjectionBulkInput EnableAllInput { get; set; }
 
 	[SupplyParameterFromForm(FormName = "projection-disable-all")]
-	private ProjectionBulkInput DisableAllInput { get => _disableAllInput; set => _disableAllInput = value ?? new(); }
+	private ProjectionBulkInput DisableAllInput { get; set; }
 
 	private ProjectionListPage Page { get; set; }
 	private ProjectionBulkCommandResult CommandResult { get; set; }
@@ -146,6 +142,9 @@
 		Page?.IncludeQueries == true ? "No projections are available." : "No non-transient projections are available.";
 
 	protected override async Task OnParametersSetAsync() {
+		EnableAllInput ??= new();
+		DisableAllInput ??= new();
+
 		Page = null;
 
 		try

--- a/src/EventStore.ClusterNode/Components/Pages/Projections.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Projections.razor
@@ -130,11 +130,15 @@
 @code {
 	[SupplyParameterFromQuery] public bool IncludeQueries { get; set; }
 
+	private ProjectionBulkInput _enableAllInput = new();
+
 	[SupplyParameterFromForm(FormName = "projection-enable-all")]
-	private ProjectionBulkInput EnableAllInput { get; set; } = new();
+	private ProjectionBulkInput EnableAllInput { get => _enableAllInput; set => _enableAllInput = value ?? new(); }
+
+	private ProjectionBulkInput _disableAllInput = new();
 
 	[SupplyParameterFromForm(FormName = "projection-disable-all")]
-	private ProjectionBulkInput DisableAllInput { get; set; } = new();
+	private ProjectionBulkInput DisableAllInput { get => _disableAllInput; set => _disableAllInput = value ?? new(); }
 
 	private ProjectionListPage Page { get; set; }
 	private ProjectionBulkCommandResult CommandResult { get; set; }

--- a/src/EventStore.ClusterNode/Components/Pages/Query.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Query.razor
@@ -87,13 +87,17 @@
 	[SupplyParameterFromQuery] public string InitStreamId { get; set; } = "";
 	[SupplyParameterFromQuery] public string Location { get; set; } = "";
 
-	[SupplyParameterFromForm(FormName = "transient-query")]
-	private QueryInput Input { get; set; } = new() {
+	private QueryInput _input = new() {
 		Query = DefaultQuery
 	};
 
+	[SupplyParameterFromForm(FormName = "transient-query")]
+	private QueryInput Input { get => _input; set => _input = value ?? new() { Query = DefaultQuery }; }
+
+	private QueryStopInput _stopInput = new();
+
 	[SupplyParameterFromForm(FormName = "query-stop")]
-	private QueryStopInput StopInput { get; set; } = new();
+	private QueryStopInput StopInput { get => _stopInput; set => _stopInput = value ?? new(); }
 
 	private QueryRunPage Result { get; set; }
 	private ProjectionCommandResult CommandResult { get; set; }

--- a/src/EventStore.ClusterNode/Components/Pages/Query.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/Query.razor
@@ -87,17 +87,11 @@
 	[SupplyParameterFromQuery] public string InitStreamId { get; set; } = "";
 	[SupplyParameterFromQuery] public string Location { get; set; } = "";
 
-	private QueryInput _input = new() {
-		Query = DefaultQuery
-	};
-
 	[SupplyParameterFromForm(FormName = "transient-query")]
-	private QueryInput Input { get => _input; set => _input = value ?? new() { Query = DefaultQuery }; }
-
-	private QueryStopInput _stopInput = new();
+	private QueryInput Input { get; set; }
 
 	[SupplyParameterFromForm(FormName = "query-stop")]
-	private QueryStopInput StopInput { get => _stopInput; set => _stopInput = value ?? new(); }
+	private QueryStopInput StopInput { get; set; }
 
 	private QueryRunPage Result { get; set; }
 	private ProjectionCommandResult CommandResult { get; set; }
@@ -107,6 +101,9 @@
 		DataProtectionProvider.CreateProtector("EventStore.ClusterNode.Components.Pages.Query.StopProjection");
 
 	protected override async Task OnParametersSetAsync() {
+		Input ??= new() { Query = DefaultQuery };
+		StopInput ??= new();
+
 		if (!string.IsNullOrWhiteSpace(Location)) {
 			if (string.Equals(_lastLoadedLocation, Location, StringComparison.OrdinalIgnoreCase) ||
 				(string.IsNullOrWhiteSpace(_lastLoadedLocation) && !CanSeedQuery()))

--- a/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
@@ -82,8 +82,10 @@
 	[SupplyParameterFromQuery(Name = "returnUrl")]
 	private string ReturnUrl { get; set; } = "";
 
+	private SignInInput _input = new();
+
 	[SupplyParameterFromForm(FormName = "ui-signin")]
-	private SignInInput Input { get; set; } = new();
+	private SignInInput Input { get => _input; set => _input = value ?? new(); }
 
 	private SecurityAuthenticationInfo Authentication { get; set; } = SecurityAuthenticationInfo.Unavailable();
 	private bool AuthenticationAvailable { get; set; } = true;

--- a/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
@@ -82,10 +82,8 @@
 	[SupplyParameterFromQuery(Name = "returnUrl")]
 	private string ReturnUrl { get; set; } = "";
 
-	private SignInInput _input = new();
-
 	[SupplyParameterFromForm(FormName = "ui-signin")]
-	private SignInInput Input { get => _input; set => _input = value ?? new(); }
+	private SignInInput Input { get; set; }
 
 	private SecurityAuthenticationInfo Authentication { get; set; } = SecurityAuthenticationInfo.Unavailable();
 	private bool AuthenticationAvailable { get; set; } = true;
@@ -93,6 +91,8 @@
 	private string Destination => SecurityBrowserService.NormalizeReturnUrl(ReturnUrl);
 
 	protected override void OnParametersSet() {
+		Input ??= new();
+
 		try {
 			Authentication = Security.AuthenticationInfo();
 			AuthenticationAvailable = true;

--- a/src/EventStore.ClusterNode/Components/Pages/StreamAcl.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/StreamAcl.razor
@@ -79,8 +79,10 @@ else
 @code {
 	[Parameter] public string StreamId { get; set; } = "";
 
+	private StreamAclForm _input = new();
+
 	[SupplyParameterFromForm(FormName = "stream-acl")]
-	private StreamAclForm Input { get; set; } = new();
+	private StreamAclForm Input { get => _input; set => _input = value ?? new(); }
 
 	private StreamAclPage Page { get; set; }
 	private StreamCommandResult Result { get; set; }

--- a/src/EventStore.ClusterNode/Components/Pages/StreamAcl.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/StreamAcl.razor
@@ -79,15 +79,15 @@ else
 @code {
 	[Parameter] public string StreamId { get; set; } = "";
 
-	private StreamAclForm _input = new();
-
 	[SupplyParameterFromForm(FormName = "stream-acl")]
-	private StreamAclForm Input { get => _input; set => _input = value ?? new(); }
+	private StreamAclForm Input { get; set; }
 
 	private StreamAclPage Page { get; set; }
 	private StreamCommandResult Result { get; set; }
 
 	protected override async Task OnParametersSetAsync() {
+		Input ??= new();
+
 		var requested = StreamId;
 		var hasSubmittedForm = string.Equals(Input.StreamId, requested, StringComparison.OrdinalIgnoreCase);
 		Page = null;

--- a/src/EventStore.ClusterNode/Components/Pages/StreamAppend.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/StreamAppend.razor
@@ -74,8 +74,10 @@
 	[Parameter] public string StreamId { get; set; } = "";
 	[SupplyParameterFromQuery] public long? FromEvent { get; set; }
 
+	private StreamAppendInput _input = NewInput("");
+
 	[SupplyParameterFromForm(FormName = "stream-append")]
-	private StreamAppendInput Input { get; set; } = NewInput("");
+	private StreamAppendInput Input { get => _input; set => _input = value ?? NewInput(""); }
 
 	private StreamCommandResult Result { get; set; }
 	private string _lastRequestedStreamId = "";

--- a/src/EventStore.ClusterNode/Components/Pages/StreamAppend.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/StreamAppend.razor
@@ -74,10 +74,8 @@
 	[Parameter] public string StreamId { get; set; } = "";
 	[SupplyParameterFromQuery] public long? FromEvent { get; set; }
 
-	private StreamAppendInput _input = NewInput("");
-
 	[SupplyParameterFromForm(FormName = "stream-append")]
-	private StreamAppendInput Input { get => _input; set => _input = value ?? NewInput(""); }
+	private StreamAppendInput Input { get; set; }
 
 	private StreamCommandResult Result { get; set; }
 	private string _lastRequestedStreamId = "";
@@ -87,6 +85,8 @@
 		: $"/ui/streams/{Uri.EscapeDataString(Input.StreamId)}";
 
 	protected override async Task OnParametersSetAsync() {
+		Input ??= NewInput("");
+
 		var requestedStream = StreamId ?? "";
 		var requestedFromEvent = FromEvent;
 		var sameRequest = string.Equals(_lastRequestedStreamId, requestedStream, StringComparison.OrdinalIgnoreCase) &&

--- a/src/EventStore.ClusterNode/Components/Pages/StreamDelete.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/StreamDelete.razor
@@ -48,12 +48,14 @@
 @code {
 	[Parameter] public string StreamId { get; set; } = "";
 
-	private StreamDeleteInput _input = new();
-
 	[SupplyParameterFromForm(FormName = "stream-delete")]
-	private StreamDeleteInput Input { get => _input; set => _input = value ?? new(); }
+	private StreamDeleteInput Input { get; set; }
 
 	private StreamCommandResult Result { get; set; }
+
+	protected override void OnParametersSet() {
+		Input ??= new();
+	}
 
 	private async Task Delete() {
 		try {

--- a/src/EventStore.ClusterNode/Components/Pages/StreamDelete.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/StreamDelete.razor
@@ -48,8 +48,10 @@
 @code {
 	[Parameter] public string StreamId { get; set; } = "";
 
+	private StreamDeleteInput _input = new();
+
 	[SupplyParameterFromForm(FormName = "stream-delete")]
-	private StreamDeleteInput Input { get; set; } = new();
+	private StreamDeleteInput Input { get => _input; set => _input = value ?? new(); }
 
 	private StreamCommandResult Result { get; set; }
 

--- a/src/EventStore.ClusterNode/Components/Pages/SubscriptionCreate.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SubscriptionCreate.razor
@@ -39,12 +39,14 @@
 </section>
 
 @code {
-	private SubscriptionSettingsInput _input = new();
-
 	[SupplyParameterFromForm(FormName = "subscription-create")]
-	private SubscriptionSettingsInput Input { get => _input; set => _input = value ?? new(); }
+	private SubscriptionSettingsInput Input { get; set; }
 
 	private SubscriptionCommandResult Result { get; set; }
+
+	protected override void OnParametersSet() {
+		Input ??= new();
+	}
 
 	private async Task CreateSubscription() {
 		var redirectTo = "";

--- a/src/EventStore.ClusterNode/Components/Pages/SubscriptionCreate.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SubscriptionCreate.razor
@@ -39,8 +39,10 @@
 </section>
 
 @code {
+	private SubscriptionSettingsInput _input = new();
+
 	[SupplyParameterFromForm(FormName = "subscription-create")]
-	private SubscriptionSettingsInput Input { get; set; } = new();
+	private SubscriptionSettingsInput Input { get => _input; set => _input = value ?? new(); }
 
 	private SubscriptionCommandResult Result { get; set; }
 

--- a/src/EventStore.ClusterNode/Components/Pages/SubscriptionDelete.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SubscriptionDelete.razor
@@ -70,15 +70,15 @@ else
 	[Parameter] public string StreamId { get; set; } = "";
 	[Parameter] public string GroupName { get; set; } = "";
 
-	private SubscriptionDeleteInput _input = new();
-
 	[SupplyParameterFromForm(FormName = "subscription-delete")]
-	private SubscriptionDeleteInput Input { get => _input; set => _input = value ?? new(); }
+	private SubscriptionDeleteInput Input { get; set; }
 
 	private SubscriptionDetailPage Page { get; set; }
 	private SubscriptionCommandResult Result { get; set; }
 
 	protected override async Task OnParametersSetAsync() {
+		Input ??= new();
+
 		var requestedStream = StreamId;
 		var requestedGroup = GroupName;
 		Page = null;

--- a/src/EventStore.ClusterNode/Components/Pages/SubscriptionDelete.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SubscriptionDelete.razor
@@ -70,8 +70,10 @@ else
 	[Parameter] public string StreamId { get; set; } = "";
 	[Parameter] public string GroupName { get; set; } = "";
 
+	private SubscriptionDeleteInput _input = new();
+
 	[SupplyParameterFromForm(FormName = "subscription-delete")]
-	private SubscriptionDeleteInput Input { get; set; } = new();
+	private SubscriptionDeleteInput Input { get => _input; set => _input = value ?? new(); }
 
 	private SubscriptionDetailPage Page { get; set; }
 	private SubscriptionCommandResult Result { get; set; }

--- a/src/EventStore.ClusterNode/Components/Pages/SubscriptionDetail.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SubscriptionDetail.razor
@@ -117,15 +117,15 @@ else
 	[Parameter] public string StreamId { get; set; } = "";
 	[Parameter] public string GroupName { get; set; } = "";
 
-	private ReplayParkedInput _replayInput = new();
-
 	[SupplyParameterFromForm(FormName = "subscription-detail-replay")]
-	private ReplayParkedInput ReplayInput { get => _replayInput; set => _replayInput = value ?? new(); }
+	private ReplayParkedInput ReplayInput { get; set; }
 
 	private SubscriptionDetailPage Page { get; set; }
 	private SubscriptionCommandResult Result { get; set; }
 
 	protected override async Task OnParametersSetAsync() {
+		ReplayInput ??= new();
+
 		var requestedStream = StreamId;
 		var requestedGroup = GroupName;
 		Page = null;

--- a/src/EventStore.ClusterNode/Components/Pages/SubscriptionDetail.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SubscriptionDetail.razor
@@ -117,8 +117,10 @@ else
 	[Parameter] public string StreamId { get; set; } = "";
 	[Parameter] public string GroupName { get; set; } = "";
 
+	private ReplayParkedInput _replayInput = new();
+
 	[SupplyParameterFromForm(FormName = "subscription-detail-replay")]
-	private ReplayParkedInput ReplayInput { get; set; } = new();
+	private ReplayParkedInput ReplayInput { get => _replayInput; set => _replayInput = value ?? new(); }
 
 	private SubscriptionDetailPage Page { get; set; }
 	private SubscriptionCommandResult Result { get; set; }

--- a/src/EventStore.ClusterNode/Components/Pages/SubscriptionEdit.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SubscriptionEdit.razor
@@ -61,8 +61,10 @@ else
 	[Parameter] public string StreamId { get; set; } = "";
 	[Parameter] public string GroupName { get; set; } = "";
 
+	private SubscriptionSettingsInput _input = new();
+
 	[SupplyParameterFromForm(FormName = "subscription-edit")]
-	private SubscriptionSettingsInput Input { get; set; } = new();
+	private SubscriptionSettingsInput Input { get => _input; set => _input = value ?? new(); }
 
 	private SubscriptionDetailPage Page { get; set; }
 	private SubscriptionCommandResult Result { get; set; }

--- a/src/EventStore.ClusterNode/Components/Pages/SubscriptionEdit.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SubscriptionEdit.razor
@@ -61,15 +61,15 @@ else
 	[Parameter] public string StreamId { get; set; } = "";
 	[Parameter] public string GroupName { get; set; } = "";
 
-	private SubscriptionSettingsInput _input = new();
-
 	[SupplyParameterFromForm(FormName = "subscription-edit")]
-	private SubscriptionSettingsInput Input { get => _input; set => _input = value ?? new(); }
+	private SubscriptionSettingsInput Input { get; set; }
 
 	private SubscriptionDetailPage Page { get; set; }
 	private SubscriptionCommandResult Result { get; set; }
 
 	protected override async Task OnParametersSetAsync() {
+		Input ??= new();
+
 		var requestedStream = StreamId;
 		var requestedGroup = GroupName;
 		var hasSubmittedForm =

--- a/src/EventStore.ClusterNode/Components/Pages/SubscriptionParked.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SubscriptionParked.razor
@@ -108,8 +108,10 @@ else
 	[SupplyParameterFromQuery] public long? From { get; set; }
 	[SupplyParameterFromQuery] public string Direction { get; set; } = "";
 
+	private ReplayParkedInput _replayInput = new();
+
 	[SupplyParameterFromForm(FormName = "subscription-parked-replay")]
-	private ReplayParkedInput ReplayInput { get; set; } = new();
+	private ReplayParkedInput ReplayInput { get => _replayInput; set => _replayInput = value ?? new(); }
 
 	private SubscriptionDetailPage Page { get; set; }
 	private StreamReadPage EventsPage { get; set; }

--- a/src/EventStore.ClusterNode/Components/Pages/SubscriptionParked.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SubscriptionParked.razor
@@ -108,10 +108,8 @@ else
 	[SupplyParameterFromQuery] public long? From { get; set; }
 	[SupplyParameterFromQuery] public string Direction { get; set; } = "";
 
-	private ReplayParkedInput _replayInput = new();
-
 	[SupplyParameterFromForm(FormName = "subscription-parked-replay")]
-	private ReplayParkedInput ReplayInput { get => _replayInput; set => _replayInput = value ?? new(); }
+	private ReplayParkedInput ReplayInput { get; set; }
 
 	private SubscriptionDetailPage Page { get; set; }
 	private StreamReadPage EventsPage { get; set; }
@@ -138,6 +136,8 @@ else
 	}
 
 	protected override async Task OnParametersSetAsync() {
+		ReplayInput ??= new();
+
 		var requestedStream = StreamId;
 		var requestedGroup = GroupName;
 		var requestedFrom = From;

--- a/src/EventStore.ClusterNode/Components/Pages/UserCommandConfirm.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/UserCommandConfirm.razor
@@ -74,16 +74,16 @@ else
 @code {
 	[Parameter] public string LoginName { get; set; } = "";
 
-	private UserCommandInput _input = new();
-
 	[SupplyParameterFromForm(FormName = "user-command-confirm")]
-	private UserCommandInput Input { get => _input; set => _input = value ?? new(); }
+	private UserCommandInput Input { get; set; }
 
 	private UserDetailPage Page { get; set; }
 	private UserCommandResult Result { get; set; }
 	private UserAction Action => ResolveAction();
 
 	protected override async Task OnParametersSetAsync() {
+		Input ??= new();
+
 		var requested = LoginName;
 		Page = null;
 		Result = null;

--- a/src/EventStore.ClusterNode/Components/Pages/UserCommandConfirm.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/UserCommandConfirm.razor
@@ -74,8 +74,10 @@ else
 @code {
 	[Parameter] public string LoginName { get; set; } = "";
 
+	private UserCommandInput _input = new();
+
 	[SupplyParameterFromForm(FormName = "user-command-confirm")]
-	private UserCommandInput Input { get; set; } = new();
+	private UserCommandInput Input { get => _input; set => _input = value ?? new(); }
 
 	private UserDetailPage Page { get; set; }
 	private UserCommandResult Result { get; set; }

--- a/src/EventStore.ClusterNode/Components/Pages/UserCreate.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/UserCreate.razor
@@ -75,12 +75,14 @@
 </section>
 
 @code {
-	private UserCreateInput _input = new();
-
 	[SupplyParameterFromForm(FormName = "user-create")]
-	private UserCreateInput Input { get => _input; set => _input = value ?? new(); }
+	private UserCreateInput Input { get; set; }
 
 	private UserCommandResult Result { get; set; }
+
+	protected override void OnParametersSet() {
+		Input ??= new();
+	}
 
 	private async Task CreateUser() {
 		var redirectTo = "";

--- a/src/EventStore.ClusterNode/Components/Pages/UserCreate.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/UserCreate.razor
@@ -75,8 +75,10 @@
 </section>
 
 @code {
+	private UserCreateInput _input = new();
+
 	[SupplyParameterFromForm(FormName = "user-create")]
-	private UserCreateInput Input { get; set; } = new();
+	private UserCreateInput Input { get => _input; set => _input = value ?? new(); }
 
 	private UserCommandResult Result { get; set; }
 

--- a/src/EventStore.ClusterNode/Components/Pages/UserEdit.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/UserEdit.razor
@@ -83,15 +83,15 @@ else
 @code {
 	[Parameter] public string LoginName { get; set; } = "";
 
-	private UserEditInput _input = new();
-
 	[SupplyParameterFromForm(FormName = "user-edit")]
-	private UserEditInput Input { get => _input; set => _input = value ?? new(); }
+	private UserEditInput Input { get; set; }
 
 	private UserDetailPage Page { get; set; }
 	private UserCommandResult Result { get; set; }
 
 	protected override async Task OnParametersSetAsync() {
+		Input ??= new();
+
 		var requested = LoginName;
 		var hasSubmittedForm = string.Equals(Input.LoginName, requested, StringComparison.OrdinalIgnoreCase);
 		Page = null;

--- a/src/EventStore.ClusterNode/Components/Pages/UserEdit.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/UserEdit.razor
@@ -83,8 +83,10 @@ else
 @code {
 	[Parameter] public string LoginName { get; set; } = "";
 
+	private UserEditInput _input = new();
+
 	[SupplyParameterFromForm(FormName = "user-edit")]
-	private UserEditInput Input { get; set; } = new();
+	private UserEditInput Input { get => _input; set => _input = value ?? new(); }
 
 	private UserDetailPage Page { get; set; }
 	private UserCommandResult Result { get; set; }

--- a/src/EventStore.ClusterNode/Components/Pages/UserResetPassword.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/UserResetPassword.razor
@@ -70,15 +70,15 @@ else
 @code {
 	[Parameter] public string LoginName { get; set; } = "";
 
-	private UserPasswordInput _input = new();
-
 	[SupplyParameterFromForm(FormName = "user-reset-password")]
-	private UserPasswordInput Input { get => _input; set => _input = value ?? new(); }
+	private UserPasswordInput Input { get; set; }
 
 	private UserDetailPage Page { get; set; }
 	private UserCommandResult Result { get; set; }
 
 	protected override async Task OnParametersSetAsync() {
+		Input ??= new();
+
 		var requested = LoginName;
 		var hasSubmittedForm = string.Equals(Input.LoginName, requested, StringComparison.OrdinalIgnoreCase);
 		Page = null;

--- a/src/EventStore.ClusterNode/Components/Pages/UserResetPassword.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/UserResetPassword.razor
@@ -70,8 +70,10 @@ else
 @code {
 	[Parameter] public string LoginName { get; set; } = "";
 
+	private UserPasswordInput _input = new();
+
 	[SupplyParameterFromForm(FormName = "user-reset-password")]
-	private UserPasswordInput Input { get; set; } = new();
+	private UserPasswordInput Input { get => _input; set => _input = value ?? new(); }
 
 	private UserDetailPage Page { get; set; }
 	private UserCommandResult Result { get; set; }

--- a/src/EventStore.Common.Tests/EventStore.Common.Tests.csproj
+++ b/src/EventStore.Common.Tests/EventStore.Common.Tests.csproj
@@ -7,8 +7,6 @@
 	<ItemGroup>
 		<PackageReference Include="GitHubActionsTestLogger" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
-		<PackageReference Include="System.Net.Http" />
-		<PackageReference Include="System.Text.RegularExpressions" />
 		<PackageReference Include="xunit" />
 		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/EventStore.Common/DevCertificates/CertificateManager.cs
+++ b/src/EventStore.Common/DevCertificates/CertificateManager.cs
@@ -376,7 +376,7 @@ public abstract class CertificateManager
 		try
 		{
 			Log.LoadCertificateStart(certificatePath);
-			certificate = new X509Certificate2(certificatePath, password,
+			certificate = X509CertificateLoader.LoadPkcs12FromFile(certificatePath, password,
 				X509KeyStorageFlags.Exportable | X509KeyStorageFlags.EphemeralKeySet);
 			if (Log.IsEnabled())
 			{

--- a/src/EventStore.Common/DevCertificates/UnixCertificateManager.cs
+++ b/src/EventStore.Common/DevCertificates/UnixCertificateManager.cs
@@ -24,7 +24,7 @@ internal sealed class UnixCertificateManager : CertificateManager
 	{
 		var export = certificate.ExportToPkcs12(string.Empty);
 		certificate.Dispose();
-		certificate = new X509Certificate2(export, "",
+		certificate = X509CertificateLoader.LoadPkcs12(export, "",
 			X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
 		Array.Clear(export, 0, export.Length);
 

--- a/src/EventStore.Common/DevCertificates/WindowsCertificateManager.cs
+++ b/src/EventStore.Common/DevCertificates/WindowsCertificateManager.cs
@@ -57,7 +57,7 @@ internal sealed class WindowsCertificateManager : CertificateManager
 		// key that we generated gets persisted.
 		var export = certificate.ExportToPkcs12(string.Empty);
 		certificate.Dispose();
-		certificate = new X509Certificate2(export, "",
+		certificate = X509CertificateLoader.LoadPkcs12(export, "",
 			X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
 		Array.Clear(export, 0, export.Length);
 		certificate.FriendlyName = EventStoreHttpsOidFriendlyName;
@@ -76,7 +76,7 @@ internal sealed class WindowsCertificateManager : CertificateManager
 
 	protected override void TrustCertificateCore(X509Certificate2 certificate)
 	{
-		using var publicCertificate = new X509Certificate2(certificate.Export(X509ContentType.Cert));
+		using var publicCertificate = X509CertificateLoader.LoadCertificate(certificate.Export(X509ContentType.Cert));
 
 		publicCertificate.FriendlyName = certificate.FriendlyName;
 

--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -11,8 +11,6 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" />
-		<PackageReference Include="Microsoft.Extensions.FileProviders.Composite" />
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" />
     <PackageReference Include="NetEscapades.Configuration.Yaml" />
 		<PackageReference Include="Newtonsoft.Json" />
@@ -26,13 +24,9 @@
 		<PackageReference Include="Serilog.Sinks.Async" />
 		<PackageReference Include="Serilog.Sinks.File" />
 		<PackageReference Include="Serilog.Sinks.Console" />
-		<PackageReference Include="System.Private.Uri" />
 
 		<PackageReference Include="System.Security.Cryptography.Pkcs" />
-		<PackageReference Include="System.Text.RegularExpressions" />
 		<PackageReference Include="YamlDotnet" />
-		<PackageReference Include="System.Text.Json" />
-		<PackageReference Include="System.Formats.Asn1" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Update="Utils\version.properties">

--- a/src/EventStore.Core.Tests/Caching/EventNumberCachedTests.cs
+++ b/src/EventStore.Core.Tests/Caching/EventNumberCachedTests.cs
@@ -46,6 +46,8 @@ public class EventNumberCachedTests
 
 		// initialize any underlying data structures (the dictionary in this case)
 		lruCache.Put(123, new EventNumberCached(0, 0));
+		// Avoid charging lazy equality-comparer setup to the measured cache item.
+		lruCache.TryGet(456, out _);
 
 		var mem = MemUsage.Calculate(() =>
 			lruCache.Put(456, new EventNumberCached(10, 123)));

--- a/src/EventStore.Core.Tests/Caching/MetadataCachedTests.cs
+++ b/src/EventStore.Core.Tests/Caching/MetadataCachedTests.cs
@@ -65,6 +65,8 @@ public class MetadataCachedTests
 
 		// initialize any underlying data structures (the dictionary in this case)
 		lruCache.Put(123, CreateMetadataCachedObject());
+		// Avoid charging lazy equality-comparer setup to the measured cache item.
+		lruCache.TryGet(456, out _);
 
 		var mem = MemUsage.Calculate(() =>
 			lruCache.Put(456, CreateMetadataCachedObject()));

--- a/src/EventStore.Core.Tests/Certificates/key_usages.cs
+++ b/src/EventStore.Core.Tests/Certificates/key_usages.cs
@@ -8,8 +8,8 @@ namespace EventStore.Core.Tests.Certificates;
 
 public class key_usages
 {
-	private readonly Oid _serverAuth = Oid.FromOidValue("1.3.6.1.5.5.7.3.1", OidGroup.EnhancedKeyUsage);
-	private readonly Oid _clientAuth = Oid.FromOidValue("1.3.6.1.5.5.7.3.2", OidGroup.EnhancedKeyUsage);
+	private readonly Oid _serverAuth = new("1.3.6.1.5.5.7.3.1");
+	private readonly Oid _clientAuth = new("1.3.6.1.5.5.7.3.2");
 	private const X509KeyUsageFlags DefaultKeyUsages = X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment;
 
 	private static X509Certificate2 GenSut(X509KeyUsageFlags keyUsages, OidCollection extendedKeyUsages)

--- a/src/EventStore.Core.Tests/Certificates/with_certificate_chain_of_length_2.cs
+++ b/src/EventStore.Core.Tests/Certificates/with_certificate_chain_of_length_2.cs
@@ -12,7 +12,7 @@ public class with_certificate_chain_of_length_2 : with_certificates
 		var leaf = CreateCertificate(issuer: false, parent: root);
 
 		//get rid of private keys except for the leaf
-		_root = new X509Certificate2(root.Export(X509ContentType.Cert));
+		_root = X509CertificateLoader.LoadCertificate(root.Export(X509ContentType.Cert));
 		_leaf = leaf;
 	}
 }

--- a/src/EventStore.Core.Tests/Certificates/with_certificate_chain_of_length_3.cs
+++ b/src/EventStore.Core.Tests/Certificates/with_certificate_chain_of_length_3.cs
@@ -16,8 +16,8 @@ public class with_certificate_chain_of_length_3 : with_certificates
 		var leaf = CreateCertificate(issuer: false, parent: intermediate, expired: leafExpired);
 
 		//get rid of private keys except for the leaf
-		_root = new X509Certificate2(root.Export(X509ContentType.Cert));
-		_intermediate = new X509Certificate2(intermediate.Export(X509ContentType.Cert));
+		_root = X509CertificateLoader.LoadCertificate(root.Export(X509ContentType.Cert));
+		_intermediate = X509CertificateLoader.LoadCertificate(intermediate.Export(X509ContentType.Cert));
 		_leaf = leaf;
 	}
 }

--- a/src/EventStore.Core.Tests/Certificates/with_certificate_files.cs
+++ b/src/EventStore.Core.Tests/Certificates/with_certificate_files.cs
@@ -136,7 +136,7 @@ public class with_password_protected_pkcs12_and_separate_key : with_certificate_
 	{
 		_certPath = $"{PathName}/leaf.p12";
 		_keyPath = $"{PathName}/leaf.key";
-		File.WriteAllBytes(_certPath, _leaf.Export(X509ContentType.Pkcs12, Password));
+		File.WriteAllBytes(_certPath, _leaf.ExportToPkcs12(Password));
 		File.WriteAllText(_keyPath, _leaf.PemPrivateKey());
 	}
 
@@ -147,6 +147,32 @@ public class with_password_protected_pkcs12_and_separate_key : with_certificate_
 		Assert.AreEqual(_leaf, certificate);
 		Assert.IsNull(intermediates);
 		Assert.True(certificate.HasPrivateKey);
+	}
+}
+
+public class with_password_protected_pkcs12_and_wrong_separate_key : with_certificate_chain_of_length_1
+{
+	private string _certPath;
+	private string _keyPath;
+	private const string Password = "test$1234";
+
+	[SetUp]
+	public void Setup()
+	{
+		_certPath = $"{PathName}/leaf.p12";
+		_keyPath = $"{PathName}/leaf.key";
+
+		using var wrongKey = RSA.Create();
+		File.WriteAllBytes(_certPath, _leaf.ExportToPkcs12(Password));
+		File.WriteAllText(_keyPath, wrongKey.ExportRSAPrivateKey().PEM("RSA PRIVATE KEY"));
+	}
+
+	[Test]
+	public void cannot_load_certificate()
+	{
+		Assert.Throws<ArgumentException>(() =>
+			CertificateUtils.LoadFromFile(_certPath, _keyPath, Password)
+		);
 	}
 }
 

--- a/src/EventStore.Core.Tests/Certificates/with_certificate_files.cs
+++ b/src/EventStore.Core.Tests/Certificates/with_certificate_files.cs
@@ -125,6 +125,31 @@ public class with_password_protected_pkcs12 : with_certificate_chain_of_length_1
 	}
 }
 
+public class with_password_protected_pkcs12_and_separate_key : with_certificate_chain_of_length_1
+{
+	private string _certPath;
+	private string _keyPath;
+	private const string Password = "test$1234";
+
+	[SetUp]
+	public void Setup()
+	{
+		_certPath = $"{PathName}/leaf.p12";
+		_keyPath = $"{PathName}/leaf.key";
+		File.WriteAllBytes(_certPath, _leaf.Export(X509ContentType.Pkcs12, Password));
+		File.WriteAllText(_keyPath, _leaf.PemPrivateKey());
+	}
+
+	[Test]
+	public void can_load_certificate()
+	{
+		var (certificate, intermediates) = CertificateUtils.LoadFromFile(_certPath, _keyPath, Password);
+		Assert.AreEqual(_leaf, certificate);
+		Assert.IsNull(intermediates);
+		Assert.True(certificate.HasPrivateKey);
+	}
+}
+
 public class with_passwordless_pkcs8_private_key : with_certificate_chain_of_length_1
 {
 	private string _certPath;

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -2,6 +2,7 @@
 	<PropertyGroup>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<NoWarn>$(NoWarn);ASPDEPR004;ASPDEPR008;CA2022</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="EventStore.Client" />
@@ -11,7 +12,6 @@
 		<PackageReference Include="Grpc.HealthCheck" />
 		<PackageReference Include="Grpc.Net.Client" />
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" />
-		<PackageReference Include="Microsoft.CSharp" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="NUnit" />
 		<PackageReference Include="NUnit3TestAdapter" />

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -2,7 +2,6 @@
 	<PropertyGroup>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<NoWarn>$(NoWarn);ASPDEPR004;ASPDEPR008;CA2022</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="EventStore.Client" />

--- a/src/EventStore.Core.Tests/FakePlugin/FakePlugin.csproj
+++ b/src/EventStore.Core.Tests/FakePlugin/FakePlugin.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 </Project>

--- a/src/EventStore.Core.Tests/GlobalSuppressions.cs
+++ b/src/EventStore.Core.Tests/GlobalSuppressions.cs
@@ -1,0 +1,14 @@
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage(
+	"Reliability",
+	"CA2022",
+	Justification = "These storage tests intentionally exercise Stream.Read behavior rather than exact-read helpers.",
+	Scope = "namespaceanddescendants",
+	Target = "~N:EventStore.Core.Tests.TransactionLog")]
+[assembly: SuppressMessage(
+	"Reliability",
+	"CA2022",
+	Justification = "This ignored regression test preserves the historical FileStream.Read behavior it was written for.",
+	Scope = "type",
+	Target = "~T:EventStore.Core.Tests.mono_filestream_bug")]

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -27,6 +27,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using ILogger = Serilog.ILogger;
 using RuntimeInformation = System.Runtime.RuntimeInformation;
 
@@ -58,7 +59,7 @@ public class MiniClusterNode<TLogFormat, TStreamId>
 	public Task AdminUserCreated => _adminUserCreated.Task;
 
 	public VNodeState NodeState = VNodeState.Unknown;
-	private readonly IWebHost _host;
+	private readonly IHost _host;
 
 	private static bool EnableHttps() => !RuntimeInformation.IsOSX;
 
@@ -198,36 +199,40 @@ public class MiniClusterNode<TLogFormat, TStreamId>
 			configuration: inMemConf,
 			expiryStrategy,
 			Guid.NewGuid(), debugIndex);
-		_host = new WebHostBuilder()
-			.UseKestrel(o =>
+		_host = new HostBuilder()
+			.ConfigureWebHost(webHost =>
 			{
-				o.Listen(HttpEndPoint, options =>
-				{
-					if (RuntimeInformation.IsOSX)
+				webHost
+					.UseKestrel(o =>
 					{
-						options.Protocols = HttpProtocols.Http2;
-					}
-					else
-					{
-						options.UseHttps(new HttpsConnectionAdapterOptions
+						o.Listen(HttpEndPoint, options =>
 						{
-							ServerCertificate = serverCertificate,
-							ClientCertificateMode = ClientCertificateMode.AllowCertificate,
-							ClientCertificateValidation = (certificate, chain, sslPolicyErrors) =>
+							if (RuntimeInformation.IsOSX)
 							{
-								var (isValid, error) =
-									ClusterVNode<string>.ValidateClientCertificate(certificate, chain, sslPolicyErrors, () => null, () => trustedRootCertificates);
-								if (!isValid && error != null)
+								options.Protocols = HttpProtocols.Http2;
+							}
+							else
+							{
+								options.UseHttps(new HttpsConnectionAdapterOptions
 								{
-									Log.Error("Client certificate validation error: {e}", error);
-								}
-								return isValid;
+									ServerCertificate = serverCertificate,
+									ClientCertificateMode = ClientCertificateMode.AllowCertificate,
+									ClientCertificateValidation = (certificate, chain, sslPolicyErrors) =>
+									{
+										var (isValid, error) =
+											ClusterVNode<string>.ValidateClientCertificate(certificate, chain, sslPolicyErrors, () => null, () => trustedRootCertificates);
+										if (!isValid && error != null)
+										{
+											Log.Error("Client certificate validation error: {e}", error);
+										}
+										return isValid;
+									}
+								});
 							}
 						});
-					}
-				});
+					})
+					.UseStartup(Node.Startup);
 			})
-			.UseStartup(Node.Startup)
 			.Build();
 	}
 

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -33,6 +33,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using ILogger = Serilog.ILogger;
 using RuntimeInformation = System.Runtime.RuntimeInformation;
 
@@ -62,6 +63,7 @@ public class MiniNode<TLogFormat, TStreamId> : MiniNode, IAsyncDisposable
 	public readonly HttpClient HttpClient;
 	public readonly HttpMessageHandler HttpMessageHandler;
 
+	private readonly IHost _kestrelTestHost;
 	private readonly TestServer _kestrelTestServer;
 	private readonly TaskCompletionSource<bool> _started;
 	private readonly TaskCompletionSource<bool> _adminUserCreated;
@@ -224,36 +226,43 @@ public class MiniNode<TLogFormat, TStreamId> : MiniNode, IAsyncDisposable
 			configureAdditionalNodeServices: services => ConfigureMiniNodeServices(services, newTransforms));
 		Db = Node.Db;
 
-		_kestrelTestServer = new TestServer(new WebHostBuilder()
-			.UseKestrel(o =>
+		_kestrelTestHost = new HostBuilder()
+			.ConfigureWebHost(webHost =>
 			{
-				o.Listen(HttpEndPoint, options =>
-				{
-					if (RuntimeInformation.IsOSX)
+				webHost
+					.UseKestrel(o =>
 					{
-						options.Protocols = HttpProtocols.Http2;
-					}
-					else
-					{
-						options.UseHttps(new HttpsConnectionAdapterOptions
+						o.Listen(HttpEndPoint, options =>
 						{
-							ServerCertificate = ssl_connections.GetServerCertificate(),
-							ClientCertificateMode = ClientCertificateMode.AllowCertificate,
-							ClientCertificateValidation = (certificate, chain, sslPolicyErrors) =>
+							if (RuntimeInformation.IsOSX)
 							{
-								var (isValid, error) =
-									ClusterVNode<string>.ValidateClientCertificate(certificate, chain, sslPolicyErrors, () => null, () => new X509Certificate2Collection(ssl_connections.GetRootCertificate()));
-								if (!isValid && error != null)
+								options.Protocols = HttpProtocols.Http2;
+							}
+							else
+							{
+								options.UseHttps(new HttpsConnectionAdapterOptions
 								{
-									Log.Error("Client certificate validation error: {e}", error);
-								}
-								return isValid;
+									ServerCertificate = ssl_connections.GetServerCertificate(),
+									ClientCertificateMode = ClientCertificateMode.AllowCertificate,
+									ClientCertificateValidation = (certificate, chain, sslPolicyErrors) =>
+									{
+										var (isValid, error) =
+											ClusterVNode<string>.ValidateClientCertificate(certificate, chain, sslPolicyErrors, () => null, () => new X509Certificate2Collection(ssl_connections.GetRootCertificate()));
+										if (!isValid && error != null)
+										{
+											Log.Error("Client certificate validation error: {e}", error);
+										}
+										return isValid;
+									}
+								});
 							}
 						});
-					}
-				});
+					})
+					.UseTestServer()
+					.UseStartup(Node.Startup);
 			})
-			.UseStartup(Node.Startup));
+			.Start();
+		_kestrelTestServer = _kestrelTestHost.GetTestServer();
 		_started = new TaskCompletionSource<bool>();
 		_adminUserCreated = new TaskCompletionSource<bool>();
 		HttpMessageHandler = _kestrelTestServer.CreateHandler();
@@ -344,9 +353,9 @@ public class MiniNode<TLogFormat, TStreamId> : MiniNode, IAsyncDisposable
 
 		StoppingTime.Start();
 
-		_kestrelTestServer.Dispose();
 		HttpMessageHandler.Dispose();
 		HttpClient.Dispose();
+		_kestrelTestHost.Dispose();
 		await Node.StopAsync(TimeSpan.FromSeconds(20));
 
 		if (!keepDb)

--- a/src/EventStore.Core.Tests/Helpers/WebHostBuilderExtensions.cs
+++ b/src/EventStore.Core.Tests/Helpers/WebHostBuilderExtensions.cs
@@ -13,6 +13,7 @@ internal static class WebHostBuilderExtensions
 				.Configure(startup.Configure);
 
 		return builder
-			.ConfigureServices(services => services.AddSingleton(startup));
+			.ConfigureServices(services => startup.ConfigureServices(services))
+			.Configure(startup.Configure);
 	}
 }

--- a/src/EventStore.Core.Tests/Http/HttpProtocols/clear_text_http_multiplexing_middleware.cs
+++ b/src/EventStore.Core.Tests/Http/HttpProtocols/clear_text_http_multiplexing_middleware.cs
@@ -22,7 +22,8 @@ public class Startup : IStartup
 {
 	public IServiceProvider ConfigureServices(IServiceCollection services)
 	{
-		return services.AddRouting().BuildServiceProvider();
+		services.AddRouting();
+		return null;
 	}
 
 	public void Configure(IApplicationBuilder app)

--- a/src/EventStore.Core.Tests/Http/HttpProtocols/clear_text_http_multiplexing_middleware.cs
+++ b/src/EventStore.Core.Tests/Http/HttpProtocols/clear_text_http_multiplexing_middleware.cs
@@ -63,7 +63,9 @@ public class clear_text_http_multiplexing_middleware
 			.Build();
 
 		_host.Start();
-		_endpoint = _host.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>().Addresses.Single();
+		var addressesFeature = _host.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>();
+		_endpoint = addressesFeature?.Addresses.Single()
+			?? throw new InvalidOperationException("IServerAddressesFeature not available after host start.");
 	}
 
 	[TearDown]

--- a/src/EventStore.Core.Tests/Http/HttpProtocols/clear_text_http_multiplexing_middleware.cs
+++ b/src/EventStore.Core.Tests/Http/HttpProtocols/clear_text_http_multiplexing_middleware.cs
@@ -7,10 +7,12 @@ using EventStore.Core.Services.Transport.Http;
 using EventStore.Core.Tests.Helpers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Http.HttpProtocols;
@@ -38,25 +40,29 @@ public class Startup : IStartup
 [TestFixture]
 public class clear_text_http_multiplexing_middleware
 {
-	private IWebHost _host;
+	private IHost _host;
 	private string _endpoint;
 
 	[SetUp]
 	public void SetUp()
 	{
-		_host = new WebHostBuilder()
-			.UseKestrel(server =>
+		_host = new HostBuilder()
+			.ConfigureWebHost(webHost =>
 			{
-				server.Listen(IPAddress.Loopback, 0, listenOptions =>
-				{
-					listenOptions.Use(next => new ClearTextHttpMultiplexingMiddleware(next).OnConnectAsync);
-				});
+				webHost
+					.UseKestrel(server =>
+					{
+						server.Listen(IPAddress.Loopback, 0, listenOptions =>
+						{
+							listenOptions.Use(next => new ClearTextHttpMultiplexingMiddleware(next).OnConnectAsync);
+						});
+					})
+					.UseStartup(new Startup());
 			})
-			.UseStartup(new Startup())
 			.Build();
 
 		_host.Start();
-		_endpoint = _host.ServerFeatures.Get<IServerAddressesFeature>().Addresses.Single();
+		_endpoint = _host.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>().Addresses.Single();
 	}
 
 	[TearDown]

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/rfc_2898_password_hash_algorithm.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/rfc_2898_password_hash_algorithm.cs
@@ -28,6 +28,12 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication
 			}
 
 			[Test]
+			public void prefixes_the_hash_with_the_current_version()
+			{
+				Assert.That(_hash, Does.StartWith("v2$SHA256$600000$"));
+			}
+
+			[Test]
 			public void does_not_verify_incorrect_password()
 			{
 				Assert.That(!_algorithm.Verify(_password.ToUpper(), _hash, _salt));

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/rfc_2898_password_hash_algorithm.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/rfc_2898_password_hash_algorithm.cs
@@ -73,7 +73,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication
 		}
 
 		[TestFixture]
-		public class when_upgrading_the_hashes
+		public class when_verifying_legacy_hashes
 		{
 			private Rfc2898PasswordHashAlgorithm _algorithm;
 			private readonly string _password = "Pa55w0rd!";
@@ -89,15 +89,15 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication
 			}
 
 			[Test]
-			public void old_hashes_should_successfully_verify()
+			public void old_hashes_do_not_verify()
 			{
-				Assert.True(_algorithm.Verify(_password, _hash, _salt));
+				Assert.False(_algorithm.Verify(_password, _hash, _salt));
 			}
 
 			[Test]
-			public void old_hashes_starting_with_v_should_successfully_verify()
+			public void old_hashes_starting_with_v_do_not_verify()
 			{
-				Assert.True(_algorithm.Verify(_password, _hashStartingWithVersionPrefix, _saltForHashStartingWithVersionPrefix));
+				Assert.False(_algorithm.Verify(_password, _hashStartingWithVersionPrefix, _saltForHashStartingWithVersionPrefix));
 			}
 		}
 	}

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/rfc_2898_password_hash_algorithm.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/rfc_2898_password_hash_algorithm.cs
@@ -79,6 +79,8 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication
 			private readonly string _password = "Pa55w0rd!";
 			private readonly string _hash = "HKoq6xw3Oird4KqU4RyoY9aFFRc=";
 			private readonly string _salt = "+6eoSEkays/BOpzGMLE6Uw==";
+			private readonly string _hashStartingWithVersionPrefix = "vYwkAhH8una9mDmclvp9G1UzWb4=";
+			private readonly string _saltForHashStartingWithVersionPrefix = "WVadp2fjEOzN93uhQ2Fp3Q==";
 
 			[SetUp]
 			public void SetUp()
@@ -90,6 +92,12 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication
 			public void old_hashes_should_successfully_verify()
 			{
 				Assert.True(_algorithm.Verify(_password, _hash, _salt));
+			}
+
+			[Test]
+			public void old_hashes_starting_with_v_should_successfully_verify()
+			{
+				Assert.True(_algorithm.Verify(_password, _hashStartingWithVersionPrefix, _saltForHashStartingWithVersionPrefix));
 			}
 		}
 	}

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/rfc_2898_password_hash_algorithm.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/rfc_2898_password_hash_algorithm.cs
@@ -40,6 +40,24 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication
 				Assert.That(!_algorithm.Verify(_password.ToUpper(), _hash, _salt));
 			}
 
+			[TestCase(null, "valid-salt")]
+			[TestCase("valid-hash", null)]
+			[TestCase("", "valid-salt")]
+			[TestCase("valid-hash", "")]
+			public void does_not_verify_missing_hash_material(string hash, string salt)
+			{
+				Assert.False(_algorithm.Verify(_password, hash, salt));
+			}
+
+			[TestCase("v2$SHA256$600000")]
+			[TestCase("v2$SHA256$600000$not-base64")]
+			[TestCase("v2$SHA256$not-a-number$ee1+y7tFN2rFnT6InxyxNuv16Fhq7VGC1nvLzgHm0qU=")]
+			[TestCase("v2$SHA256$599999$ee1+y7tFN2rFnT6InxyxNuv16Fhq7VGC1nvLzgHm0qU=")]
+			public void does_not_verify_malformed_current_hashes(string hash)
+			{
+				Assert.False(_algorithm.Verify(_password, hash, _salt));
+			}
+
 			[Test]
 			public void verifies_hash_with_stored_iteration_count()
 			{

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/rfc_2898_password_hash_algorithm.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/rfc_2898_password_hash_algorithm.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using EventStore.Core.Services.Transport.Http.Authentication;
 using NUnit.Framework;
 
@@ -37,6 +38,24 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication
 			public void does_not_verify_incorrect_password()
 			{
 				Assert.That(!_algorithm.Verify(_password.ToUpper(), _hash, _salt));
+			}
+
+			[Test]
+			public void verifies_hash_with_stored_iteration_count()
+			{
+				var saltData = RandomNumberGenerator.GetBytes(16);
+				var iterations = 600_001;
+				var hashData = Rfc2898DeriveBytes.Pbkdf2(
+					_password,
+					saltData,
+					iterations,
+					HashAlgorithmName.SHA256,
+					32);
+
+				var hash = $"v2$SHA256${iterations}${System.Convert.ToBase64String(hashData)}";
+				var salt = System.Convert.ToBase64String(saltData);
+
+				Assert.That(_algorithm.Verify(_password, hash, salt));
 			}
 		}
 

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connection.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connection.cs
@@ -152,7 +152,7 @@ public class ssl_connections
 		using X509Certificate2 certWithKey = certificate.CopyWithPrivateKey(rsa);
 
 		// recreate the certificate from a PKCS #12 bundle to work around: https://github.com/dotnet/runtime/issues/23749
-		return new X509Certificate2(certWithKey.ExportToPkcs12(), string.Empty, X509KeyStorageFlags.Exportable);
+		return X509CertificateLoader.LoadPkcs12(certWithKey.ExportToPkcs12(), string.Empty, X509KeyStorageFlags.Exportable);
 	}
 
 	private static byte[] LoadResource(string resource)

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/with_intermediate_certificates.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/with_intermediate_certificates.cs
@@ -25,7 +25,7 @@ public class with_intermediate_certificates : with_certificate_chain_of_length_3
 	public void SetUp()
 	{
 		// certificate exported to PKCS #12 due to this issue on Windows: https://github.com/dotnet/runtime/issues/45680
-		_cert = new X509Certificate2(_leaf.ExportToPkcs12());
+		_cert = X509CertificateLoader.LoadPkcs12(_leaf.ExportToPkcs12(), null);
 
 		_clientCertValidator = (_, _, _) => (true, null);
 		_serverEndPoint = new IPEndPoint(IPAddress.Loopback, PortsHelper.GetAvailablePort(IPAddress.Loopback));

--- a/src/EventStore.Core.Tests/Services/VNode/startup_should.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/startup_should.cs
@@ -13,9 +13,11 @@ using EventStore.Core.Configuration.Sources;
 using EventStore.Core.Services.Monitoring;
 using EventStore.Core.Tests.Helpers;
 using EventStore.Core.Tests.Services.Transport.Tcp;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Services.VNode;
@@ -97,10 +99,17 @@ public class startup_should : SpecificationWithDirectory
 			configuration: configuration,
 			configureAdditionalNodeServices: services =>
 				services.Decorate<IReadOnlyList<IClusterVNodeStartupTask>>(
-					startupTasks => [..startupTasks, blockingStartupTask]));
+					startupTasks => [.. startupTasks, blockingStartupTask]));
 
-		using var host = new TestServer(
-			new Microsoft.AspNetCore.Hosting.WebHostBuilder().UseStartup(node.Startup));
+		using var host = new HostBuilder()
+			.ConfigureWebHost(webHost =>
+			{
+				webHost
+					.UseTestServer()
+					.UseStartup(node.Startup);
+			})
+			.Build();
+		await host.StartAsync();
 
 		using var cancellationTokenSource = new CancellationTokenSource();
 		var startTask = node.StartAsync(false, cancellationTokenSource.Token);

--- a/src/EventStore.Core.Tests/Services/VNode/startup_should.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/startup_should.cs
@@ -114,10 +114,17 @@ public class startup_should : SpecificationWithDirectory
 		using var cancellationTokenSource = new CancellationTokenSource();
 		var startTask = node.StartAsync(false, cancellationTokenSource.Token);
 
-		await startupTaskStarted.Task.WithTimeout(TimeSpan.FromSeconds(5));
-		await cancellationTokenSource.CancelAsync();
+		try
+		{
+			await startupTaskStarted.Task.WithTimeout(TimeSpan.FromSeconds(5));
+			await cancellationTokenSource.CancelAsync();
 
-		Assert.That(async () => await startTask, Throws.InstanceOf<OperationCanceledException>());
+			Assert.That(async () => await startTask, Throws.InstanceOf<OperationCanceledException>());
+		}
+		finally
+		{
+			await node.StopAsync(TimeSpan.FromSeconds(20));
+		}
 	}
 
 	private sealed class BlockingStartupTask(TaskCompletionSource<bool> started) : IClusterVNodeStartupTask

--- a/src/EventStore.Core.Tests/TestsInitFixture.cs
+++ b/src/EventStore.Core.Tests/TestsInitFixture.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Runtime;
 using System.Runtime.InteropServices;
 using EventStore.Common.Utils;
@@ -15,7 +14,6 @@ public class TestsInitFixture
 	[OneTimeSetUp]
 	public void SetUp()
 	{
-		ServicePointManager.DefaultConnectionLimit = 1000;
 		LogEnvironmentInfo();
 	}
 

--- a/src/EventStore.Core.XUnit.Tests/EventStore.Core.XUnit.Tests.csproj
+++ b/src/EventStore.Core.XUnit.Tests/EventStore.Core.XUnit.Tests.csproj
@@ -6,7 +6,6 @@
 	<ItemGroup>
 		<PackageReference Include="GitHubActionsTestLogger" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
-		<PackageReference Include="System.Linq.Async" />
 		<PackageReference Include="xunit" />
 		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/EventStore.Core.XUnit.Tests/PluginLoaderTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/PluginLoaderTests.cs
@@ -101,7 +101,7 @@ public class PluginLoaderTests : IAsyncLifetime
 			StartInfo = new ProcessStartInfo
 			{
 				FileName = "dotnet",
-				Arguments = $"publish --configuration {BuildConfiguration} --framework=net8.0 --output {outputFolder.FullName}",
+				Arguments = $"publish --configuration {BuildConfiguration} --framework=net10.0 --output {outputFolder.FullName}",
 				WorkingDirectory = PluginSourceDirectory,
 				UseShellExecute = false,
 				RedirectStandardError = true,

--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageReaderTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/ArchiveStorageReaderTests.cs
@@ -171,7 +171,7 @@ public abstract class ArchiveStorageReaderTests<T> : ArchiveStorageTestsBase<T>
 		await writerSut.StoreChunk(chunk1, Path.GetFileName(chunk1), CancellationToken.None);
 		await writerSut.StoreChunk(chunk1, Path.GetFileName(chunk2), CancellationToken.None);
 
-		var archivedChunks = sut.ListChunks(CancellationToken.None).ToEnumerable();
+		var archivedChunks = await sut.ListChunks(CancellationToken.None).ToArrayAsync(CancellationToken.None);
 		Assert.Equal([
 			Path.GetFileName(chunk0),
 			Path.GetFileName(chunk1),
@@ -189,7 +189,7 @@ public abstract class ArchiveStorageReaderTests<T> : ArchiveStorageTestsBase<T>
 		await writerSut.StoreChunk(chunk, Path.GetFileName(chunk), CancellationToken.None);
 		await writerSut.StoreChunk(chunk, "other-000000.000000", CancellationToken.None);
 
-		var archivedChunks = sut.ListChunks(CancellationToken.None).ToEnumerable();
+		var archivedChunks = await sut.ListChunks(CancellationToken.None).ToArrayAsync(CancellationToken.None);
 		Assert.Equal([Path.GetFileName(chunk)], archivedChunks);
 	}
 }

--- a/src/EventStore.Core/Certificates/CertificateUtils.cs
+++ b/src/EventStore.Core/Certificates/CertificateUtils.cs
@@ -5,20 +5,24 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
-using EventStore.Common.Utils;
 using System.Text;
+using EventStore.Common.Utils;
 using EventStore.Core.Exceptions;
 
-namespace EventStore.Core {
-	public static class CertificateUtils {
+namespace EventStore.Core
+{
+	public static class CertificateUtils
+	{
 		public static X509Certificate2 LoadFromStore(StoreLocation storeLocation, StoreName storeName,
-			string certificateSubjectName, string certificateThumbprint) {
+			string certificateSubjectName, string certificateThumbprint)
+		{
 			var store = new X509Store(storeName, storeLocation);
 			return GetCertificateFromStore(store, certificateSubjectName, certificateThumbprint);
 		}
 
 		public static X509Certificate2 LoadFromStore(StoreName storeName, string certificateSubjectName,
-			string certificateThumbprint) {
+			string certificateThumbprint)
+		{
 			var store = new X509Store(storeName);
 			return GetCertificateFromStore(store, certificateSubjectName, certificateThumbprint);
 		}
@@ -27,43 +31,50 @@ namespace EventStore.Core {
 			(string certificatePath,
 			string password,
 			out X509Certificate2 certificate,
-			out X509Certificate2Collection intermediates) {
-			var pkcs12Info =  Pkcs12Info.Decode(File.ReadAllBytes(certificatePath), out _);
+			out X509Certificate2Collection intermediates)
+		{
+			var pkcs12Info = Pkcs12Info.Decode(File.ReadAllBytes(certificatePath), out _);
 
 			var certs = new X509Certificate2Collection();
 			using var rsa = RSA.Create();
 			var privateKeyFound = false;
 
-			foreach (var safeContents in pkcs12Info.AuthenticatedSafe) {
-				if (safeContents.ConfidentialityMode == Pkcs12ConfidentialityMode.Password) {
+			foreach (var safeContents in pkcs12Info.AuthenticatedSafe)
+			{
+				if (safeContents.ConfidentialityMode == Pkcs12ConfidentialityMode.Password)
+				{
 					safeContents.Decrypt(password);
 				}
 
-				foreach (var bag in safeContents.GetBags()) {
+				foreach (var bag in safeContents.GetBags())
+				{
 					switch (bag)
 					{
 						case Pkcs12CertBag certBag:
 							certs.Add(certBag.GetCertificate());
 							break;
 						case Pkcs12ShroudedKeyBag shroudedKeyBag:
-						{
-							if (privateKeyFound) {
-								throw new Exception("Multiple private keys found");
+							{
+								if (privateKeyFound)
+								{
+									throw new Exception("Multiple private keys found");
+								}
+								var encryptedKey = shroudedKeyBag.EncryptedPkcs8PrivateKey;
+								rsa.ImportEncryptedPkcs8PrivateKey(password.AsSpan(), encryptedKey.Span, out _);
+								privateKeyFound = true;
+								break;
 							}
-							var encryptedKey = shroudedKeyBag.EncryptedPkcs8PrivateKey;
-							rsa.ImportEncryptedPkcs8PrivateKey(password.AsSpan(), encryptedKey.Span, out _);
-							privateKeyFound = true;
-							break;
-						}
 					}
 				}
 			}
 
-			if (certs.Count == 0) {
+			if (certs.Count == 0)
+			{
 				throw new Exception("No certificates found");
 			}
 
-			if (!privateKeyFound) {
+			if (!privateKeyFound)
+			{
 				throw new Exception("No private keys found");
 			}
 
@@ -78,21 +89,27 @@ namespace EventStore.Core {
 		public static (X509Certificate2 certificate, X509Certificate2Collection intermediates) LoadFromFile(
 			string certificatePath,
 			string privateKeyPath,
-			string certificatePassword, string certificatePrivateKeyPassword = null) {
+			string certificatePassword, string certificatePrivateKeyPassword = null)
+		{
 
-			if (string.IsNullOrEmpty(privateKeyPath)) {
+			if (string.IsNullOrEmpty(privateKeyPath))
+			{
 				// no private key file - assume PKCS12 format
 				// the check is done on the private key file since an empty password may still be valid
 
-				try {
+				try
+				{
 					if (TryReadPkcs12CertificateBundle(
 						certificatePath,
 						certificatePassword,
 						out var nodeCertificate,
-						out var intermediateCertificates)) {
+						out var intermediateCertificates))
+					{
 						return (nodeCertificate, intermediateCertificates);
 					}
-				} catch(CryptographicException) {
+				}
+				catch (CryptographicException)
+				{
 					// ignored
 				}
 
@@ -108,7 +125,8 @@ namespace EventStore.Core {
 			var privateKey = Convert.FromBase64String(string.Join(string.Empty, allLines.Skip(1).SkipLast(1)));
 
 			using var rsa = RSA.Create();
-			switch (header) {
+			switch (header)
+			{
 				case "BEGIN PRIVATE KEY":
 					rsa.ImportPkcs8PrivateKey(new ReadOnlySpan<byte>(privateKey), out _);
 					break;
@@ -116,34 +134,42 @@ namespace EventStore.Core {
 					rsa.ImportRSAPrivateKey(new ReadOnlySpan<byte>(privateKey), out _);
 					break;
 				case "BEGIN ENCRYPTED PRIVATE KEY":
-					if (certificatePrivateKeyPassword is null) {
+					if (certificatePrivateKeyPassword is null)
+					{
 						throw new ArgumentException(
 							"A password is required to read the certificate's private key file.");
 					}
-					try {
+					try
+					{
 						rsa.ImportEncryptedPkcs8PrivateKey(new ReadOnlySpan<byte>(Encoding.UTF8.GetBytes(certificatePrivateKeyPassword)), new ReadOnlySpan<byte>(privateKey), out _);
-					} catch (CryptographicException e) {
+					}
+					catch (CryptographicException e)
+					{
 						throw new ArgumentException(
 							"Failed to read the certificate's private key file. The password may be incorrect or the private key may not be an RSA key.", e);
 					}
 					break;
 				default:
 					throw new NotSupportedException($"Unsupported private key file format: {header}");
-					
+
 			}
-			
+
 
 			// assume it's a PEM bundle
 			var certificateBundle = new X509Certificate2Collection();
 			var bundleLoadSucceeded = false;
-			try {
+			try
+			{
 				certificateBundle.ImportFromPemFile(certificatePath);
 				bundleLoadSucceeded = true;
-			} catch {
+			}
+			catch
+			{
 				// ignored
 			}
 
-			if (!bundleLoadSucceeded || certificateBundle.Count == 0) {
+			if (!bundleLoadSucceeded || certificateBundle.Count == 0)
+			{
 				// make a last attempt to open the certificate, leaving the file format guess-work to the library
 				certificateBundle.Add(X509CertificateLoader.LoadCertificateFromFile(certificatePath));
 			}
@@ -158,16 +184,21 @@ namespace EventStore.Core {
 		}
 
 		private static X509Certificate2 GetCertificateFromStore(X509Store store, string certificateSubjectName,
-			string certificateThumbprint) {
-			try {
+			string certificateThumbprint)
+		{
+			try
+			{
 				store.Open(OpenFlags.OpenExistingOnly);
-			} catch (Exception exc) {
+			}
+			catch (Exception exc)
+			{
 				throw new Exception(
 					string.Format("Could not open certificate store '{0}' in location {1}'.", store.Name,
 						store.Location), exc);
 			}
 
-			if (!string.IsNullOrWhiteSpace(certificateThumbprint)) {
+			if (!string.IsNullOrWhiteSpace(certificateThumbprint))
+			{
 				var certificates = store.Certificates.Find(X509FindType.FindByThumbprint, certificateThumbprint, true);
 				if (certificates.Count == 0)
 					throw new Exception($"Could not find valid certificate with thumbprint '{certificateThumbprint}'.");
@@ -179,28 +210,35 @@ namespace EventStore.Core {
 				return certificates[0];
 			}
 
-			if (!string.IsNullOrWhiteSpace(certificateSubjectName)) {
+			if (!string.IsNullOrWhiteSpace(certificateSubjectName))
+			{
 				var certificates =
 					store.Certificates.Find(X509FindType.FindBySubjectName, certificateSubjectName, true);
 				if (certificates.Count == 0)
 					throw new Exception(
 						$"Could not find valid certificate with subject name '{certificateSubjectName}'.");
 
-				if (certificates.Count == 1) {
+				if (certificates.Count == 1)
+				{
 					return certificates[0];
 				}
 
 				// If we get multiple of the same certificate, pick the one which expires last to allow rolling certificates
 				var certs = certificates.GetEnumerator();
 				X509Certificate2 mostRecentCert = null;
-				while (certs.MoveNext()) {
-					if (certs.Current is null) {
+				while (certs.MoveNext())
+				{
+					if (certs.Current is null)
+					{
 						continue;
 					}
 
-					if (mostRecentCert is null) {
+					if (mostRecentCert is null)
+					{
 						mostRecentCert = certs.Current;
-					} else if (certs.Current.NotAfter > mostRecentCert.NotAfter) {
+					}
+					else if (certs.Current.NotAfter > mostRecentCert.NotAfter)
+					{
 						mostRecentCert = certs.Current;
 					}
 				}
@@ -212,17 +250,23 @@ namespace EventStore.Core {
 				"No thumbprint or subject name was specified for a certificate, but a certificate store was specified.");
 		}
 
-		public static IEnumerable<(string fileName,X509Certificate2 certificate)> LoadAllCertificates(string path) {
+		public static IEnumerable<(string fileName, X509Certificate2 certificate)> LoadAllCertificates(string path)
+		{
 			var files = Directory.GetFiles(path);
-			var acceptedExtensions = new[] {".crt", ".cert", ".cer", ".pem", ".der"};
-			foreach (var file in files) {
+			var acceptedExtensions = new[] { ".crt", ".cert", ".cer", ".pem", ".der" };
+			foreach (var file in files)
+			{
 				var fileInfo = new FileInfo(file);
 				var extension = fileInfo.Extension;
-				if (acceptedExtensions.Contains(extension)) {
+				if (acceptedExtensions.Contains(extension))
+				{
 					X509Certificate2 cert;
-					try {
+					try
+					{
 						cert = X509CertificateLoader.LoadCertificate(File.ReadAllBytes(file));
-					} catch (Exception exc) {
+					}
+					catch (Exception exc)
+					{
 						throw new AggregateException($"Error loading certificate file: {file}", exc);
 					}
 					yield return (file, cert);
@@ -230,13 +274,15 @@ namespace EventStore.Core {
 			}
 		}
 
-		public static StoreLocation GetCertificateStoreLocation(string certificateStoreLocation) {
+		public static StoreLocation GetCertificateStoreLocation(string certificateStoreLocation)
+		{
 			if (!Enum.TryParse(certificateStoreLocation, out StoreLocation location))
 				throw new Exception($"Could not find certificate store location '{certificateStoreLocation}'");
 			return location;
 		}
 
-		public static StoreName GetCertificateStoreName(string certificateStoreName) {
+		public static StoreName GetCertificateStoreName(string certificateStoreName)
+		{
 			if (!Enum.TryParse(certificateStoreName, out StoreName name))
 				throw new Exception($"Could not find certificate store name '{certificateStoreName}'");
 			return name;
@@ -244,8 +290,10 @@ namespace EventStore.Core {
 
 		public static X509ChainStatusFlags BuildChain(X509Certificate certificate,
 			X509Certificate2Collection intermediateCerts, X509Certificate2Collection trustedRootCerts,
-			out List<string> statusInformation) {
-			using var chain = new X509Chain {
+			out List<string> statusInformation)
+		{
+			using var chain = new X509Chain
+			{
 				ChainPolicy = {
 					RevocationMode = X509RevocationMode.NoCheck,
 					TrustMode = X509ChainTrustMode.CustomRootTrust,
@@ -253,14 +301,18 @@ namespace EventStore.Core {
 				}
 			};
 
-			if (trustedRootCerts != null) {
-				foreach (var cert in trustedRootCerts) {
+			if (trustedRootCerts != null)
+			{
+				foreach (var cert in trustedRootCerts)
+				{
 					chain.ChainPolicy.CustomTrustStore.Add(cert);
 				}
 			}
 
-			if (intermediateCerts != null) {
-				foreach (var cert in intermediateCerts) {
+			if (intermediateCerts != null)
+			{
+				foreach (var cert in intermediateCerts)
+				{
 					chain.ChainPolicy.ExtraStore.Add(cert);
 				}
 			}
@@ -272,7 +324,8 @@ namespace EventStore.Core {
 
 			var cn = ((X509Certificate2)certificate).GetCommonName();
 
-			foreach (var status in chain.ChainStatus) {
+			foreach (var status in chain.ChainStatus)
+			{
 				chainStatus |= status.Status;
 				statusInformation.Add($"{cn} : {status.StatusInformation}");
 			}
@@ -280,8 +333,10 @@ namespace EventStore.Core {
 			return chainStatus;
 		}
 
-		public static bool IsValidNodeCertificate(X509Certificate2 certificate, out string error) {
-			if (certificate.HasPrivateKey) {
+		public static bool IsValidNodeCertificate(X509Certificate2 certificate, out string error)
+		{
+			if (certificate.HasPrivateKey)
+			{
 				error = null;
 				return true;
 			}
@@ -290,19 +345,23 @@ namespace EventStore.Core {
 			return false;
 		}
 
-		public static bool IsValidIntermediateCertificate(X509Certificate2 certificate, out string error) {
-			if (certificate.SubjectName.Name != certificate.IssuerName.Name) {
+		public static bool IsValidIntermediateCertificate(X509Certificate2 certificate, out string error)
+		{
+			if (certificate.SubjectName.Name != certificate.IssuerName.Name)
+			{
 				error = null;
 				return true;
 			}
 
 			error = $"Certificate with thumbprint '{certificate.Thumbprint}' does not appear to be a valid intermediate certificate " +
-			        $"since it is self-signed (subject = {certificate.SubjectName.Name}, issuer = {certificate.IssuerName.Name}).";
+					$"since it is self-signed (subject = {certificate.SubjectName.Name}, issuer = {certificate.IssuerName.Name}).";
 			return false;
 		}
 
-		public static bool IsValidRootCertificate(X509Certificate2 certificate, out string error) {
-			if (certificate.SubjectName.Name == certificate.IssuerName.Name) {
+		public static bool IsValidRootCertificate(X509Certificate2 certificate, out string error)
+		{
+			if (certificate.SubjectName.Name == certificate.IssuerName.Name)
+			{
 				error = null;
 				return true;
 			}

--- a/src/EventStore.Core/Certificates/CertificateUtils.cs
+++ b/src/EventStore.Core/Certificates/CertificateUtils.cs
@@ -81,7 +81,9 @@ namespace EventStore.Core
 			using var publicCertificate = certs[0];
 			using var publicWithPrivate = publicCertificate.CopyWithPrivateKey(rsa);
 			certs.RemoveAt(0);
-			certificate = X509CertificateLoader.LoadPkcs12(publicWithPrivate.ExportToPkcs12(), null);
+			certificate = X509CertificateLoader.LoadPkcs12(
+				publicWithPrivate.Export(X509ContentType.Pkcs12, string.Empty),
+				string.Empty);
 			intermediates = certs.Count == 0 ? null : certs;
 			return true;
 		}
@@ -170,17 +172,31 @@ namespace EventStore.Core
 
 			if (!bundleLoadSucceeded || certificateBundle.Count == 0)
 			{
-				// make a last attempt to open the certificate, leaving the file format guess-work to the library
-				certificateBundle.Add(X509CertificateLoader.LoadCertificateFromFile(certificatePath));
+				certificateBundle.Add(LoadCertificateFromFile(certificatePath, certificatePassword));
 			}
 
 			using var publicCertificate = certificateBundle[0];
 			using var publicWithPrivate = publicCertificate.CopyWithPrivateKey(rsa);
-			var serverCertificate = X509CertificateLoader.LoadPkcs12(publicWithPrivate.ExportToPkcs12(), null);
+			var serverCertificate = X509CertificateLoader.LoadPkcs12(
+				publicWithPrivate.Export(X509ContentType.Pkcs12, string.Empty),
+				string.Empty);
 			certificateBundle.RemoveAt(0);
 			var intermediates = certificateBundle.Count == 0 ? null : certificateBundle;
 
 			return (serverCertificate, intermediates);
+		}
+
+		private static X509Certificate2 LoadCertificateFromFile(string certificatePath, string certificatePassword)
+		{
+			try
+			{
+				return X509CertificateLoader.LoadCertificateFromFile(certificatePath);
+			}
+			catch (CryptographicException)
+			{
+				using var certificate = X509CertificateLoader.LoadPkcs12FromFile(certificatePath, certificatePassword);
+				return X509CertificateLoader.LoadCertificate(certificate.Export(X509ContentType.Cert));
+			}
 		}
 
 		private static X509Certificate2 GetCertificateFromStore(X509Store store, string certificateSubjectName,

--- a/src/EventStore.Core/Certificates/CertificateUtils.cs
+++ b/src/EventStore.Core/Certificates/CertificateUtils.cs
@@ -70,7 +70,7 @@ namespace EventStore.Core {
 			using var publicCertificate = certs[0];
 			using var publicWithPrivate = publicCertificate.CopyWithPrivateKey(rsa);
 			certs.RemoveAt(0);
-			certificate = new X509Certificate2(publicWithPrivate.ExportToPkcs12());
+			certificate = X509CertificateLoader.LoadPkcs12(publicWithPrivate.ExportToPkcs12(), null);
 			intermediates = certs.Count == 0 ? null : certs;
 			return true;
 		}
@@ -97,7 +97,7 @@ namespace EventStore.Core {
 				}
 
 				// if the above attempt failed, try to load the certificate via the standard constructor
-				var certificate = new X509Certificate2(certificatePath, certificatePassword);
+				var certificate = X509CertificateLoader.LoadPkcs12FromFile(certificatePath, certificatePassword);
 				if (!certificate.HasPrivateKey)
 					throw new NoCertificatePrivateKeyException();
 				return (certificate, null);
@@ -145,12 +145,12 @@ namespace EventStore.Core {
 
 			if (!bundleLoadSucceeded || certificateBundle.Count == 0) {
 				// make a last attempt to open the certificate, leaving the file format guess-work to the library
-				certificateBundle.Add(new X509Certificate2(certificatePath, certificatePassword));
+				certificateBundle.Add(X509CertificateLoader.LoadCertificateFromFile(certificatePath));
 			}
 
 			using var publicCertificate = certificateBundle[0];
 			using var publicWithPrivate = publicCertificate.CopyWithPrivateKey(rsa);
-			var serverCertificate = new X509Certificate2(publicWithPrivate.ExportToPkcs12());
+			var serverCertificate = X509CertificateLoader.LoadPkcs12(publicWithPrivate.ExportToPkcs12(), null);
 			certificateBundle.RemoveAt(0);
 			var intermediates = certificateBundle.Count == 0 ? null : certificateBundle;
 
@@ -221,7 +221,7 @@ namespace EventStore.Core {
 				if (acceptedExtensions.Contains(extension)) {
 					X509Certificate2 cert;
 					try {
-						cert = new X509Certificate2(File.ReadAllBytes(file));
+						cert = X509CertificateLoader.LoadCertificate(File.ReadAllBytes(file));
 					} catch (Exception exc) {
 						throw new AggregateException($"Error loading certificate file: {file}", exc);
 					}

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -25,11 +25,7 @@
 		<PackageReference Include="Quickenshtein" />
 		<PackageReference Include="Scrutor" />
 		<PackageReference Include="Serilog.Sinks.OpenTelemetry" />
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" />
-		<PackageReference Include="System.IO.Pipelines" />
-		<PackageReference Include="System.Linq.Async" />
-		<PackageReference Include="System.Net.Http" />
 		<PackageReference Include="Microsoft.Diagnostics.NETCore.Client" />
 		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" />
 		<PackageReference Include="Microsoft.Data.Sqlite" />
@@ -37,8 +33,6 @@
 		<PackageReference Include="DotNext.IO" />
 		<PackageReference Include="DotNext.Threading" />
 		<PackageReference Include="DotNext.Unsafe" />
-		<PackageReference Include="System.Text.RegularExpressions" />
-		<PackageReference Include="System.Threading.Channels" />
 		<PackageReference Include="TrogonEventStore.Plugins" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/EventStore.Core/Index/PTable.cs
+++ b/src/EventStore.Core/Index/PTable.cs
@@ -3,18 +3,18 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Common.Utils;
 using EventStore.Core.DataStructures;
+using EventStore.Core.DataStructures.ProbabilisticFilter;
 using EventStore.Core.Exceptions;
 using EventStore.Core.TransactionLog.Unbuffered;
 using ILogger = Serilog.ILogger;
-using Range = EventStore.Core.Data.Range;
-using EventStore.Core.DataStructures.ProbabilisticFilter;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
-using System.Threading.Tasks;
 using MD5 = EventStore.Core.Hashing.MD5;
+using Range = EventStore.Core.Data.Range;
 using RuntimeInformation = System.Runtime.RuntimeInformation;
 
 namespace EventStore.Core.Index;
@@ -176,8 +176,8 @@ public partial class PTable : ISearchTable, IDisposable
 			}
 
 			if ((header.Version != PTableVersions.IndexV2) &&
-			    (header.Version != PTableVersions.IndexV3) &&
-			    (header.Version != PTableVersions.IndexV4))
+				(header.Version != PTableVersions.IndexV3) &&
+				(header.Version != PTableVersions.IndexV4))
 				throw new CorruptIndexException(
 					new UnsupportedFileVersionException(_filename, header.Version, Version));
 			_version = header.Version;
@@ -226,7 +226,7 @@ public partial class PTable : ISearchTable, IDisposable
 			}
 
 			long indexEntriesTotalSize = (_size - PTableHeader.Size - _midpointsCacheSize -
-			                              PTableFooter.GetSize(_version) - MD5Size);
+										  PTableFooter.GetSize(_version) - MD5Size);
 
 			if (indexEntriesTotalSize < 0)
 			{
@@ -337,8 +337,9 @@ public partial class PTable : ISearchTable, IDisposable
 			Log.Debug("Disabling Verification of PTable");
 		}
 
-		Stream stream = null;
 		WorkItem workItem = null;
+
+		Stream stream;
 		if (RuntimeInformation.IsUnix)
 		{
 			workItem = GetWorkItem();
@@ -376,7 +377,7 @@ public partial class PTable : ISearchTable, IDisposable
 						//so, we can load them directly from the PTable file
 						Log.Debug("Loading {midpointsCached} cached midpoints from PTable", _midpointsCached);
 						long startOffset = stream.Length - MD5Size - PTableFooter.GetSize(_version) -
-						                   _midpointsCacheSize;
+										   _midpointsCacheSize;
 						stream.Seek(startOffset, SeekOrigin.Begin);
 						for (int k = 0; k < (int)_midpointsCached; k++)
 						{
@@ -746,9 +747,9 @@ public partial class PTable : ISearchTable, IDisposable
 			}
 
 			if (candidateEntry.Stream == stream.Hash &&
-			    candidateEntry.Position < beforePosition &&
-			    candidateEntry.Position > maxBeforePosition &&
-			    await isForThisStream(candidateEntry, token))
+				candidateEntry.Position < beforePosition &&
+				candidateEntry.Position > maxBeforePosition &&
+				await isForThisStream(candidateEntry, token))
 			{
 
 				maxBeforePosition = candidateEntry.Position;
@@ -1415,7 +1416,7 @@ public partial class PTable : ISearchTable, IDisposable
 		// its not in either of the LRU caches. add it to one or the other
 		// so that subsequent calls do not require searching.
 		if (TrySearchForLatestEntry(stream, 0, long.MaxValue, out var latestEntry, out var latestOffset) &&
-		    TrySearchForOldestEntry(stream, 0, long.MaxValue, out var oldestEntry, out var oldestOffset))
+			TrySearchForOldestEntry(stream, 0, long.MaxValue, out var oldestEntry, out var oldestOffset))
 		{
 
 			value = new(

--- a/src/EventStore.Core/Index/PTable.cs
+++ b/src/EventStore.Core/Index/PTable.cs
@@ -380,7 +380,7 @@ public partial class PTable : ISearchTable, IDisposable
 						stream.Seek(startOffset, SeekOrigin.Begin);
 						for (int k = 0; k < (int)_midpointsCached; k++)
 						{
-							stream.Read(buffer, 0, _indexEntrySize);
+							stream.ReadExactly(buffer, 0, _indexEntrySize);
 							IndexEntryKey key;
 							long index;
 							if (_version == PTableVersions.IndexV4)
@@ -423,7 +423,7 @@ public partial class PTable : ISearchTable, IDisposable
 				if (!skipIndexVerify)
 				{
 					stream.Seek(0, SeekOrigin.Begin);
-					stream.Read(buffer, 0, PTableHeader.Size);
+					stream.ReadExactly(buffer, 0, PTableHeader.Size);
 					md5.TransformBlock(buffer, 0, PTableHeader.Size, null, 0);
 				}
 
@@ -437,13 +437,13 @@ public partial class PTable : ISearchTable, IDisposable
 						if (!skipIndexVerify)
 						{
 							ReadUntilWithMd5(PTableHeader.Size + _indexEntrySize * nextIndex, stream, md5);
-							stream.Read(buffer, 0, _indexKeySize);
+							stream.ReadExactly(buffer, 0, _indexKeySize);
 							md5.TransformBlock(buffer, 0, _indexKeySize, null, 0);
 						}
 						else
 						{
 							stream.Seek(PTableHeader.Size + _indexEntrySize * nextIndex, SeekOrigin.Begin);
-							stream.Read(buffer, 0, _indexKeySize);
+							stream.ReadExactly(buffer, 0, _indexKeySize);
 						}
 
 						IndexEntryKey key;
@@ -496,7 +496,7 @@ public partial class PTable : ISearchTable, IDisposable
 					//verify hash (should be at stream.length - MD5Size)
 					md5.TransformFinalBlock(Empty.ByteArray, 0, 0);
 					var fileHash = new byte[MD5Size];
-					stream.Read(fileHash, 0, MD5Size);
+					stream.ReadExactly(fileHash, 0, MD5Size);
 					ValidateHash(md5.Hash, fileHash);
 				}
 
@@ -1036,15 +1036,10 @@ public partial class PTable : ISearchTable, IDisposable
 		lowKeyOut = new IndexEntryKey(ulong.MaxValue, long.MaxValue);
 		highKeyOut = new IndexEntryKey(ulong.MinValue, long.MinValue);
 
-		ReadOnlySpan<Midpoint> midpoints = null;
-		if (_midpoints != null)
-		{
-			midpoints = _midpoints.AsSpan();
-		}
-
-		if (midpoints == null)
+		if (_midpoints == null)
 			return new Range(0, Count - 1);
 
+		var midpoints = _midpoints.AsSpan();
 		long lowerMidpoint = LowerMidpointBound(midpoints, lowKey);
 		long upperMidpoint = UpperMidpointBound(midpoints, highKey);
 

--- a/src/EventStore.Core/Index/PTableConstruction.cs
+++ b/src/EventStore.Core/Index/PTableConstruction.cs
@@ -79,7 +79,7 @@ public partial class PTable
 
 		var sw = Stopwatch.StartNew();
 		using (var fs = new FileStream(filename, FileMode.Create, FileAccess.ReadWrite, FileShare.None,
-			       DefaultSequentialBufferSize, FileOptions.SequentialScan))
+				   DefaultSequentialBufferSize, FileOptions.SequentialScan))
 		{
 
 			var fileSize = GetFileSizeUpToIndexEntries(table.Count, table.Version);
@@ -101,7 +101,7 @@ public partial class PTable
 				var requiredMidpointCount = GetRequiredMidpointCountCached(table.Count, table.Version, cacheDepth);
 				using var midpoints =
 					new UnmanagedMemoryAppendOnlyList<Midpoint>((int)requiredMidpointCount +
-					                                            MidpointsOverflowSafetyNet);
+																MidpointsOverflowSafetyNet);
 
 				var midpointCalculator = new MidpointIndexCalculator(table.Count, requiredMidpointCount);
 				long indexEntry = 0L;
@@ -112,7 +112,7 @@ public partial class PTable
 					AppendRecordTo(bs, buffer, table.Version, rec, indexEntrySize);
 					dumpedEntryCount += 1;
 					if (table.Version >= PTableVersions.IndexV4 &&
-					    indexEntry == midpointCalculator.NextMidpointIndex)
+						indexEntry == midpointCalculator.NextMidpointIndex)
 					{
 						midpoints.Add(new Midpoint(new IndexEntryKey(rec.Stream, rec.Version), indexEntry));
 						midpointCalculator.Advance();
@@ -219,13 +219,13 @@ public partial class PTable
 
 			long dumpedEntryCount = 0;
 			using (var f = new FileStream(outputFile, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None,
-				       DefaultSequentialBufferSize, FileOptions.SequentialScan))
+					   DefaultSequentialBufferSize, FileOptions.SequentialScan))
 			{
 				f.SetLength(fileSizeUpToIndexEntries);
 				f.Seek(0, SeekOrigin.Begin);
 
 				using (var bloomFilter =
-				       ConstructBloomFilter(useBloomFilter, outputFile, tables.Sum(table => table.Count)))
+					   ConstructBloomFilter(useBloomFilter, outputFile, tables.Sum(table => table.Count)))
 				using (var md5 = MD5.Create())
 				using (var cs = new CryptoStream(f, md5, CryptoStreamMode.Write))
 				using (var bs = new BufferedStream(cs, DefaultSequentialBufferSize))
@@ -239,7 +239,7 @@ public partial class PTable
 					var requiredMidpointCount = GetRequiredMidpointCountCached(numIndexEntries, version, cacheDepth);
 					using var midpoints =
 						new UnmanagedMemoryAppendOnlyList<Midpoint>((int)requiredMidpointCount +
-						                                            MidpointsOverflowSafetyNet);
+																	MidpointsOverflowSafetyNet);
 
 					var midpointCalculator = new MidpointIndexCalculator(numIndexEntries, requiredMidpointCount);
 					long indexEntry = 0L;
@@ -252,7 +252,7 @@ public partial class PTable
 						var current = enumerators[idx].Current;
 						AppendRecordTo(bs, buffer, version, current, indexEntrySize);
 						if (version >= PTableVersions.IndexV4 &&
-						    indexEntry == midpointCalculator.NextMidpointIndex)
+							indexEntry == midpointCalculator.NextMidpointIndex)
 						{
 							midpoints.Add(new Midpoint(new IndexEntryKey(current.Stream, current.Version), indexEntry));
 							midpointCalculator.Advance();
@@ -365,13 +365,13 @@ public partial class PTable
 		{
 			long dumpedEntryCount = 0;
 			using (var f = new FileStream(outputFile, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None,
-				       DefaultSequentialBufferSize, FileOptions.SequentialScan))
+					   DefaultSequentialBufferSize, FileOptions.SequentialScan))
 			{
 				f.SetLength(fileSizeUpToIndexEntries);
 				f.Seek(0, SeekOrigin.Begin);
 
 				using (var bloomFilter =
-				       ConstructBloomFilter(useBloomFilter, outputFile, tables.Sum(table => table.Count)))
+					   ConstructBloomFilter(useBloomFilter, outputFile, tables.Sum(table => table.Count)))
 				using (var md5 = MD5.Create())
 				using (var cs = new CryptoStream(f, md5, CryptoStreamMode.Write))
 				using (var bs = new BufferedStream(cs, DefaultSequentialBufferSize))
@@ -386,7 +386,7 @@ public partial class PTable
 						GetRequiredMidpointCountCached(numIndexEntries, version, cacheDepth);
 					using var midpoints =
 						new UnmanagedMemoryAppendOnlyList<Midpoint>((int)requiredMidpointCount +
-						                                            MidpointsOverflowSafetyNet);
+																	MidpointsOverflowSafetyNet);
 
 					var midpointCalculator = new MidpointIndexCalculator(numIndexEntries, requiredMidpointCount);
 					long indexEntry = 0L;
@@ -417,7 +417,7 @@ public partial class PTable
 
 						AppendRecordTo(bs, buffer, version, current, indexEntrySize);
 						if (version >= PTableVersions.IndexV4 &&
-						    indexEntry == midpointCalculator.NextMidpointIndex)
+							indexEntry == midpointCalculator.NextMidpointIndex)
 						{
 							midpoints.Add(new Midpoint(new IndexEntryKey(current.Stream, current.Version),
 								indexEntry));
@@ -520,7 +520,7 @@ public partial class PTable
 		try
 		{
 			using (var f = new FileStream(outputFile, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None,
-				       DefaultSequentialBufferSize, FileOptions.SequentialScan))
+					   DefaultSequentialBufferSize, FileOptions.SequentialScan))
 			{
 				f.SetLength(fileSizeUpToIndexEntries);
 				f.Seek(0, SeekOrigin.Begin);
@@ -832,7 +832,8 @@ public partial class PTable
 	private static int GetDepth(long indexEntriesFileSize, int minDepth)
 	{
 		minDepth = Math.Max(0, Math.Min(minDepth, 28));
-		if ((2L << 28) * 4096L < indexEntriesFileSize) return 28;
+		if ((2L << 28) * 4096L < indexEntriesFileSize)
+			return 28;
 		for (int i = 27; i >= minDepth; i--)
 		{
 			if ((2L << i) * 4096L < indexEntriesFileSize)
@@ -846,8 +847,10 @@ public partial class PTable
 
 	private static int GetRequiredMidpointCount(long numIndexEntries, byte version, int minDepth)
 	{
-		if (numIndexEntries == 0) return 0;
-		if (numIndexEntries == 1) return 2;
+		if (numIndexEntries == 0)
+			return 0;
+		if (numIndexEntries == 1)
+			return 2;
 
 		int indexEntrySize = GetIndexEntrySize(version);
 		var depth = GetDepth(numIndexEntries * indexEntrySize, minDepth);

--- a/src/EventStore.Core/Index/PTableConstruction.cs
+++ b/src/EventStore.Core/Index/PTableConstruction.cs
@@ -727,7 +727,7 @@ public partial class PTable
 			else
 			{
 				fs.Seek(PTableHeader.Size + index * indexEntrySize, SeekOrigin.Begin);
-				fs.Read(buffer, 0, indexKeySize);
+				fs.ReadExactly(buffer, 0, indexKeySize);
 				IndexEntryKey key = new IndexEntryKey(BitConverter.ToUInt64(buffer, 8),
 					BitConverter.ToInt64(buffer, 0));
 				midpoints.Add(new Midpoint(key, index));

--- a/src/EventStore.Core/Index/PTableFooter.cs
+++ b/src/EventStore.Core/Index/PTableFooter.cs
@@ -48,7 +48,7 @@ namespace EventStore.Core.Index {
 					new InvalidFileException("Invalid PTable file."));
 
 			byte[] buffer = new byte[4];
-			stream.Read(buffer, 0, 4);
+			stream.ReadExactly(buffer, 0, 4);
 			uint numMidpointsCached = BitConverter.ToUInt32(buffer, 0);
 
 			return new PTableFooter((byte)version, numMidpointsCached);

--- a/src/EventStore.Core/Index/PTableFooter.cs
+++ b/src/EventStore.Core/Index/PTableFooter.cs
@@ -2,31 +2,37 @@ using System;
 using System.IO;
 using EventStore.Core.Exceptions;
 
-namespace EventStore.Core.Index {
-	public class PTableFooter {
+namespace EventStore.Core.Index
+{
+	public class PTableFooter
+	{
 		private const int Size = 128;
 		public readonly FileType FileType;
 		public readonly byte Version;
 		public readonly uint NumMidpointsCached;
 
-		public static int GetSize(byte version) {
+		public static int GetSize(byte version)
+		{
 			if (version >= PTableVersions.IndexV4)
 				return Size;
 			return 0;
 		}
 
-		public PTableFooter(byte version, uint numMidpointsCached) {
+		public PTableFooter(byte version, uint numMidpointsCached)
+		{
 			FileType = FileType.PTableFile;
 			Version = version;
 			NumMidpointsCached = numMidpointsCached;
 		}
 
-		public byte[] AsByteArray() {
+		public byte[] AsByteArray()
+		{
 			var array = new byte[Size];
 			array[0] = (byte)FileType.PTableFile;
 			array[1] = Version;
 			uint numMidpoints = NumMidpointsCached;
-			for (int i = 0; i < 4; i++) {
+			for (int i = 0; i < 4; i++)
+			{
 				array[i + 2] = (byte)(numMidpoints & 0xFF);
 				numMidpoints >>= 8;
 			}
@@ -34,7 +40,8 @@ namespace EventStore.Core.Index {
 			return array;
 		}
 
-		public static PTableFooter FromStream(Stream stream) {
+		public static PTableFooter FromStream(Stream stream)
+		{
 			var type = stream.ReadByte();
 			if (type != (int)FileType.PTableFile)
 				throw new CorruptIndexException("Corrupted PTable.", new InvalidFileException("Wrong type of PTable."));

--- a/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
+++ b/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
@@ -1,15 +1,16 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
+using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.RequestManager.Managers;
 using EventStore.Core.Services.TimerService;
-using System.Diagnostics;
-using EventStore.Core.Data;
 
-namespace EventStore.Core.Services.RequestManager {
+namespace EventStore.Core.Services.RequestManager
+{
 	public class RequestManagementService :
 		IHandle<SystemMessage.SystemInit>,
 		IHandle<ClientMessage.WriteEvents>,
@@ -27,7 +28,8 @@ namespace EventStore.Core.Services.RequestManager {
 		IHandle<StorageMessage.InvalidTransaction>,
 		IHandle<StorageMessage.StreamDeleted>,
 		IHandle<StorageMessage.RequestManagerTimerTick>,
-		IHandle<SystemMessage.StateChangeMessage> {
+		IHandle<SystemMessage.StateChangeMessage>
+	{
 		private readonly IPublisher _bus;
 		private readonly TimerMessage.Schedule _tickRequestMessage;
 		private readonly Dictionary<Guid, RequestManagerBase> _currentRequests = new Dictionary<Guid, RequestManagerBase>();
@@ -36,12 +38,13 @@ namespace EventStore.Core.Services.RequestManager {
 		private readonly TimeSpan _commitTimeout;
 		private readonly CommitSource _commitSource;
 		private readonly bool _explicitTransactionsSupported;
-		private VNodeState _nodeState;		
+		private VNodeState _nodeState;
 
 		public RequestManagementService(IPublisher bus,
 			TimeSpan prepareTimeout,
 			TimeSpan commitTimeout,
-			bool explicitTransactionsSupported) {
+			bool explicitTransactionsSupported)
+		{
 			Ensure.NotNull(bus, "bus");
 			_bus = bus;
 			_tickRequestMessage = TimerMessage.Schedule.Create(TimeSpan.FromMilliseconds(1000),
@@ -53,8 +56,9 @@ namespace EventStore.Core.Services.RequestManager {
 			_commitSource = new CommitSource();
 			_explicitTransactionsSupported = explicitTransactionsSupported;
 		}
-		
-		public void Handle(ClientMessage.WriteEvents message) {
+
+		public void Handle(ClientMessage.WriteEvents message)
+		{
 			var manager = new WriteEvents(
 								_bus,
 								_commitTimeout,
@@ -71,7 +75,8 @@ namespace EventStore.Core.Services.RequestManager {
 			manager.Start();
 		}
 
-		public void Handle(ClientMessage.DeleteStream message) {
+		public void Handle(ClientMessage.DeleteStream message)
+		{
 			var manager = new DeleteStream(
 								_bus,
 								_commitTimeout,
@@ -88,8 +93,10 @@ namespace EventStore.Core.Services.RequestManager {
 			manager.Start();
 		}
 
-		public void Handle(ClientMessage.TransactionStart message) {
-			if (!_explicitTransactionsSupported) {
+		public void Handle(ClientMessage.TransactionStart message)
+		{
+			if (!_explicitTransactionsSupported)
+			{
 				var reply = new ClientMessage.TransactionStartCompleted(
 					message.CorrelationId,
 					default,
@@ -113,8 +120,10 @@ namespace EventStore.Core.Services.RequestManager {
 			manager.Start();
 		}
 
-		public void Handle(ClientMessage.TransactionWrite message) {
-			if (!_explicitTransactionsSupported) {
+		public void Handle(ClientMessage.TransactionWrite message)
+		{
+			if (!_explicitTransactionsSupported)
+			{
 				var reply = new ClientMessage.TransactionWriteCompleted(
 					message.CorrelationId,
 					default,
@@ -138,8 +147,10 @@ namespace EventStore.Core.Services.RequestManager {
 			manager.Start();
 		}
 
-		public void Handle(ClientMessage.TransactionCommit message) {
-			if (!_explicitTransactionsSupported) {
+		public void Handle(ClientMessage.TransactionCommit message)
+		{
+			if (!_explicitTransactionsSupported)
+			{
 				var reply = new ClientMessage.TransactionCommitCompleted(
 					message.CorrelationId,
 					default,
@@ -162,14 +173,18 @@ namespace EventStore.Core.Services.RequestManager {
 			_currentTimedRequests.Add(message.InternalCorrId, Stopwatch.StartNew());
 			manager.Start();
 		}
-		
-		
-		public void Handle(SystemMessage.StateChangeMessage message) {
-			
-			if (_nodeState == VNodeState.Leader && message.State is not (VNodeState.Leader or VNodeState.ResigningLeader)) {
+
+
+		public void Handle(SystemMessage.StateChangeMessage message)
+		{
+
+			if (_nodeState == VNodeState.Leader && message.State is not (VNodeState.Leader or VNodeState.ResigningLeader))
+			{
 				var keys = _currentRequests.Keys;
-				foreach (var key in keys) {
-					if (_currentRequests.Remove(key, out var manager)) {
+				foreach (var key in keys)
+				{
+					if (_currentRequests.Remove(key, out var manager))
+					{
 						manager.Dispose();
 					}
 				}
@@ -177,35 +192,42 @@ namespace EventStore.Core.Services.RequestManager {
 			_nodeState = message.State;
 		}
 
-		public void Handle(SystemMessage.SystemInit message) {
+		public void Handle(SystemMessage.SystemInit message)
+		{
 			_bus.Publish(_tickRequestMessage);
 		}
 
-		public void Handle(StorageMessage.RequestManagerTimerTick message) {
-			foreach (var currentRequest in _currentRequests) {
+		public void Handle(StorageMessage.RequestManagerTimerTick message)
+		{
+			foreach (var currentRequest in _currentRequests)
+			{
 				currentRequest.Value.Handle(message);
 			}
 			//TODO(clc): if we have become resigning leader should all requests be actively disposed?
-			if (_nodeState == VNodeState.ResigningLeader && _currentRequests.Count == 0) {
+			if (_nodeState == VNodeState.ResigningLeader && _currentRequests.Count == 0)
+			{
 				_bus.Publish(new SystemMessage.RequestQueueDrained());
 			}
 
 			_bus.Publish(_tickRequestMessage);
 		}
 
-		public void Handle(StorageMessage.RequestCompleted message) {
-			if (_currentTimedRequests.TryGetValue(message.CorrelationId, out _)) {
+		public void Handle(StorageMessage.RequestCompleted message)
+		{
+			if (_currentTimedRequests.TryGetValue(message.CorrelationId, out _))
+			{
 				// todo: histogram metric?
 				_currentTimedRequests.Remove(message.CorrelationId);
 			}
 
-			if (!_currentRequests.Remove(message.CorrelationId)) {
+			if (!_currentRequests.Remove(message.CorrelationId))
+			{
 				// noop. RequestManager guarantees not complete twice now.
 				// and we will legitimately get in here when StateChangeMessage removes
 				// entries from _currentRequests
 			}
 		}
-		
+
 		public void Handle(ReplicationTrackingMessage.ReplicatedTo message) => _commitSource.Handle(message);
 		public void Handle(ReplicationTrackingMessage.IndexedTo message) => _commitSource.Handle(message);
 
@@ -215,9 +237,11 @@ namespace EventStore.Core.Services.RequestManager {
 		public void Handle(StorageMessage.WrongExpectedVersion message) => DispatchInternal(message.CorrelationId, message, static (manager, m) => manager.Handle(m));
 		public void Handle(StorageMessage.InvalidTransaction message) => DispatchInternal(message.CorrelationId, message, static (manager, m) => manager.Handle(m));
 		public void Handle(StorageMessage.StreamDeleted message) => DispatchInternal(message.CorrelationId, message, static (manager, m) => manager.Handle(m));
-		
-		private void DispatchInternal<T>(Guid correlationId, T message, Action<RequestManagerBase, T> handle) where T : Message {
-			if (_currentRequests.TryGetValue(correlationId, out var manager)) {
+
+		private void DispatchInternal<T>(Guid correlationId, T message, Action<RequestManagerBase, T> handle) where T : Message
+		{
+			if (_currentRequests.TryGetValue(correlationId, out var manager))
+			{
 				handle(manager, message);
 			}
 		}

--- a/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
+++ b/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
@@ -166,7 +166,7 @@ namespace EventStore.Core.Services.RequestManager {
 		
 		public void Handle(SystemMessage.StateChangeMessage message) {
 			
-			if (_nodeState == VNodeState.Leader && message.State is not VNodeState.Leader or VNodeState.ResigningLeader) {
+			if (_nodeState == VNodeState.Leader && message.State is not (VNodeState.Leader or VNodeState.ResigningLeader)) {
 				var keys = _currentRequests.Keys;
 				foreach (var key in keys) {
 					if (_currentRequests.Remove(key, out var manager)) {

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
@@ -1243,9 +1243,13 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 			{
 				token.ThrowIfCancellationRequested();
 				if (await ReadPrepareInternal(reader, indexEntry.Position, token) is { } prepare &&
-					StreamIdComparer.Equals(prepare.EventStreamId, streamId) &&
-					(!ageThreshold.HasValue || prepare.TimeStamp >= ageThreshold.Value))
+					StreamIdComparer.Equals(prepare.EventStreamId, streamId))
+				{
+					if (ageThreshold.HasValue && prepare.TimeStamp < ageThreshold.Value)
+						break;
+
 					records.Add(await CreateEventRecord(indexEntry.Version, prepare, streamName, token));
+				}
 			}
 
 			return records.ToArray();
@@ -1267,8 +1271,10 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 		var filtered = new List<EventRecord>(array.Length);
 		foreach (var record in array)
 		{
-			if (record.TimeStamp >= ageThreshold.Value)
-				filtered.Add(record);
+			if (record.TimeStamp < ageThreshold.Value)
+				break;
+
+			filtered.Add(record);
 		}
 
 		return filtered.ToArray();

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
@@ -16,7 +16,8 @@ using ILogger = Serilog.ILogger;
 
 namespace EventStore.Core.Services.Storage.ReaderIndex;
 
-public interface IIndexReader<TStreamId> {
+public interface IIndexReader<TStreamId>
+{
 	long CachedStreamInfo { get; }
 	long NotCachedStreamInfo { get; }
 	long HashCollisions { get; }
@@ -46,7 +47,8 @@ public interface IIndexReader<TStreamId> {
 	ValueTask<long> GetStreamLastEventNumber_NoCollisions(ulong stream, Func<ulong, TStreamId> getStreamId, long beforePosition, CancellationToken token);
 }
 
-public abstract class IndexReader {
+public abstract class IndexReader
+{
 	public static string UnspecifiedStreamName => "Unspecified stream name";
 	protected static readonly ILogger Log = Serilog.Log.ForContext<IndexReader>();
 }
@@ -205,7 +207,7 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 		if (_tableIndex.TryGetOneValue(streamId, eventNumber, out var position))
 		{
 			if (await ReadPrepareInternal(reader, position, token) is { } rec &&
-			    StreamIdComparer.Equals(rec.EventStreamId, streamId))
+				StreamIdComparer.Equals(rec.EventStreamId, streamId))
 				return rec;
 
 			foreach (var indexEntry in _tableIndex.GetRange(streamId, eventNumber, eventNumber))
@@ -230,8 +232,8 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 			return null;
 
 		if (result.LogRecord.RecordType is not LogRecordType.Prepare
-		    and not LogRecordType.Stream
-		    and not LogRecordType.EventType)
+			and not LogRecordType.Stream
+			and not LogRecordType.EventType)
 			throw new Exception(string.Format("Incorrect type of log record {0}, expected Prepare record.",
 				result.LogRecord.RecordType));
 		return (IPrepareLogRecord<TStreamId>)result.LogRecord;
@@ -376,7 +378,7 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 			{
 
 				if (await ReadPrepareInternal(reader, indexEntries[i].Position, token) is not { } prepare ||
-				    !StreamIdComparer.Equals(prepare.EventStreamId, streamId))
+					!StreamIdComparer.Equals(prepare.EventStreamId, streamId))
 				{
 					continue;
 				}
@@ -410,7 +412,7 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 			//check high value will be valid, otherwise early return.
 			// this resolves hash collisions itself
 			if (await ReadPrepareInternal(reader, streamId, eventNumber: lastEventNumber, token) is not { } lastEvent ||
-			    lastEvent.TimeStamp < ageThreshold || lastEventNumber < fromEventNumber)
+				lastEvent.TimeStamp < ageThreshold || lastEventNumber < fromEventNumber)
 			{
 				//No events in the stream are < max age, so return an empty set
 				return new IndexReadStreamResult(fromEventNumber, maxCount, IndexReadStreamResult.EmptyRecords,
@@ -473,7 +475,7 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 				for (int i = 0; i < indexEntries.Count; i++)
 				{
 					if (await ReadPrepareInternal(reader, indexEntries[i].Position, token) is not { } prepare ||
-					    !StreamIdComparer.Equals(prepare.EventStreamId, streamId))
+						!StreamIdComparer.Equals(prepare.EventStreamId, streamId))
 						continue;
 
 					if (prepare?.TimeStamp >= ageThreshold)
@@ -525,7 +527,7 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 				for (int i = entries.Count - 1; i >= 0; i--)
 				{
 					if (await ReadPrepareInternal(tfReaderLease, entries[i].Position, token) is { } prepare &&
-					    StreamIdComparer.Equals(prepare.EventStreamId, streamId))
+						StreamIdComparer.Equals(prepare.EventStreamId, streamId))
 						return (entries[i].Version, prepare);
 				}
 
@@ -542,7 +544,7 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 				for (int i = 0; i < entries.Count; i++)
 				{
 					if (await ReadPrepareInternal(tfReaderLease, entries[i].Position, token) is { } prepare &&
-					    StreamIdComparer.Equals(prepare.EventStreamId, streamId))
+						StreamIdComparer.Equals(prepare.EventStreamId, streamId))
 						return (entries[i].Version, prepare);
 				}
 
@@ -747,10 +749,10 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 			.ToArrayAsync(token);
 
 		isEndOfStream = isEndOfStream
-		                || startEventNumber == 0
-		                || (startEventNumber <= lastEventNumber
-		                    && (records.Length is 0 ||
-		                        records[^1].EventNumber != startEventNumber));
+						|| startEventNumber == 0
+						|| (startEventNumber <= lastEventNumber
+							&& (records.Length is 0 ||
+								records[^1].EventNumber != startEventNumber));
 		long nextEventNumber = isEndOfStream ? -1 : Math.Min(startEventNumber - 1, lastEventNumber);
 		return new IndexReadStreamResult(endEventNumber, maxCount, records, metadata,
 			nextEventNumber, lastEventNumber, isEndOfStream);
@@ -1031,8 +1033,8 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 	{
 		// if this is metastream -- check if original stream was deleted, if yes -- metastream is deleted as well
 		if (_systemStreams.IsMetaStream(streamId)
-		    && await GetStreamLastEventNumberCached(reader, _systemStreams.OriginalStreamOf(streamId), token) ==
-		    EventNumber.DeletedStream)
+			&& await GetStreamLastEventNumberCached(reader, _systemStreams.OriginalStreamOf(streamId), token) ==
+			EventNumber.DeletedStream)
 			return EventNumber.DeletedStream;
 
 		var cache = _backend.TryGetStreamLastEventNumber(streamId);
@@ -1076,10 +1078,10 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 		}
 
 		foreach (var indexEntry in _tableIndex.GetRange(streamId, startVersion, long.MaxValue,
-			         limit: _hashCollisionReadLimit + 1))
+					 limit: _hashCollisionReadLimit + 1))
 		{
 			if (await ReadPrepareInternal(reader, indexEntry.Position, token) is { } r &&
-			    StreamIdComparer.Equals(r.EventStreamId, streamId))
+				StreamIdComparer.Equals(r.EventStreamId, streamId))
 			{
 				if (latestVersion is long.MinValue)
 				{

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
@@ -53,6 +53,8 @@ public abstract class IndexReader {
 
 public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 {
+	private readonly record struct IndexedPrepare(long Version, IPrepareLogRecord<TStreamId> Prepare, IndexEntry IndexEntry);
+
 	private static EqualityComparer<TStreamId> StreamIdComparer { get; } = EqualityComparer<TStreamId>.Default;
 
 	public long CachedStreamInfo
@@ -187,13 +189,11 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 	private ValueTask<IPrepareLogRecord<TStreamId>> ReadPrepare(TFReaderLease reader, TStreamId streamId,
 		long eventNumber, CancellationToken token)
 	{
-		var recordsQuery = _tableIndex.GetRange(streamId, eventNumber, eventNumber)
-			.ToAsyncEnumerable()
-			.SelectAwaitWithCancellation(async (x, token) =>
-				new { x.Version, Prepare = await ReadPrepareInternal(reader, x.Position, token) })
-			.Where(x => x.Prepare is not null && StreamIdComparer.Equals(x.Prepare.EventStreamId, streamId))
-			.GroupBy(static x => x.Version)
-			.SelectAwaitWithCancellation(AsyncEnumerable.LastAsync)
+		var recordsQuery = LastByVersion(ReadIndexedPrepares(
+				reader,
+				_tableIndex.GetRange(streamId, eventNumber, eventNumber),
+				streamId,
+				token), token)
 			.Select(static x => x.Prepare);
 
 		return recordsQuery.FirstOrDefaultAsync(token);
@@ -308,20 +308,17 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 					skipIndexScanOnRead, token);
 			}
 
-			var recordsQuery = _tableIndex.GetRange(streamId, startEventNumber, endEventNumber)
-				.ToAsyncEnumerable()
-				.SelectAwaitWithCancellation(async (x, token) =>
-					new { x.Version, Prepare = await ReadPrepareInternal(reader, x.Position, token) })
-				.Where(x => x.Prepare != null && StreamIdComparer.Equals(x.Prepare.EventStreamId, streamId));
+			var recordsQuery = ReadIndexedPrepares(
+				reader,
+				_tableIndex.GetRange(streamId, startEventNumber, endEventNumber),
+				streamId,
+				token);
 			if (!skipIndexScanOnRead)
 			{
-				recordsQuery = recordsQuery.OrderByDescending(x => x.Version)
-					.GroupBy(static x => x.Version).SelectAwaitWithCancellation(AsyncEnumerable.LastAsync);
+				recordsQuery = LastByVersion(recordsQuery.OrderByDescending(static x => x.Version), token);
 			}
 
-			var records = await recordsQuery
-				.Reverse()
-				.SelectAwaitWithCancellation((x, token) => CreateEventRecord(x.Version, x.Prepare, streamName, token))
+			var records = await CreateEventRecords(recordsQuery.Reverse(), streamName, token)
 				.ToArrayAsync(token);
 
 			long nextEventNumber = Math.Min(endEventNumber + 1, lastEventNumber + 1);
@@ -559,25 +556,25 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 		TStreamHandle streamHandle,
 		TFReaderLease reader,
 		long startEventNumber,
-		long endEventNumber);
+		long endEventNumber,
+		CancellationToken token);
 
 	private static IAsyncEnumerable<IndexEntry> ReadIndexEntries_RemoveCollisions(IndexReader<TStreamId> indexReader,
 		TStreamId streamHandle,
 		TFReaderLease reader,
 		long startEventNumber,
-		long endEventNumber)
-		=> indexReader._tableIndex.GetRange(streamHandle, startEventNumber, endEventNumber)
-			.ToAsyncEnumerable()
-			.SelectAwaitWithCancellation(async (x, token) =>
-				new { IndexEntry = x, Prepare = await ReadPrepareInternal(reader, x.Position, token) })
-			.Where(x => x.Prepare is not null && StreamIdComparer.Equals(x.Prepare.EventStreamId, streamHandle))
+		long endEventNumber,
+		CancellationToken token)
+		=> ReadIndexedPrepares(reader, indexReader._tableIndex.GetRange(streamHandle, startEventNumber, endEventNumber),
+				streamHandle, token)
 			.Select(static x => x.IndexEntry);
 
 	private static IAsyncEnumerable<IndexEntry> ReadIndexEntries_NoCollisions(IndexReader<TStreamId> indexReader,
 		ulong streamHandle,
 		TFReaderLease reader,
 		long startEventNumber,
-		long endEventNumber) =>
+		long endEventNumber,
+		CancellationToken token) =>
 		indexReader._tableIndex.GetRange(streamHandle, startEventNumber, endEventNumber).ToAsyncEnumerable();
 
 	public async ValueTask<IndexReadEventInfoResult> ReadEventInfo_KeepDuplicates(TStreamId streamId, long eventNumber,
@@ -730,15 +727,14 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 			startEventNumber = minEventNumber;
 		}
 
-		var recordsQuery = _tableIndex.GetRange(streamId, startEventNumber, endEventNumber)
-			.ToAsyncEnumerable()
-			.SelectAwaitWithCancellation(async (x, token) =>
-				new { x.Version, Prepare = await ReadPrepareInternal(reader, x.Position, token) })
-			.Where(x => x.Prepare is not null && StreamIdComparer.Equals(x.Prepare.EventStreamId, streamId));
+		var recordsQuery = ReadIndexedPrepares(
+			reader,
+			_tableIndex.GetRange(streamId, startEventNumber, endEventNumber),
+			streamId,
+			token);
 		if (!skipIndexScanOnRead)
 		{
-			recordsQuery = recordsQuery.OrderByDescending(static x => x.Version)
-				.GroupBy(x => x.Version).SelectAwaitWithCancellation(AsyncEnumerable.LastAsync);
+			recordsQuery = LastByVersion(recordsQuery.OrderByDescending(static x => x.Version), token);
 		}
 
 		if (metadata.MaxAge.HasValue)
@@ -747,8 +743,7 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 			recordsQuery = recordsQuery.Where(x => x.Prepare.TimeStamp >= ageThreshold);
 		}
 
-		var records = await recordsQuery
-			.SelectAwaitWithCancellation((x, token) => CreateEventRecord(x.Version, x.Prepare, streamName, token))
+		var records = await CreateEventRecords(recordsQuery, streamName, token)
 			.ToArrayAsync(token);
 
 		isEndOfStream = isEndOfStream
@@ -869,7 +864,7 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 		CancellationToken token)
 	{
 
-		var entries = readIndexEntries(this, streamHandle, reader, startEventNumber, endEventNumber);
+		var entries = readIndexEntries(this, streamHandle, reader, startEventNumber, endEventNumber, token);
 		var eventInfos = new List<EventInfo>();
 
 		var prevEntry = new IndexEntry(long.MaxValue, long.MaxValue, long.MaxValue);
@@ -1170,6 +1165,43 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 		string streamName, CancellationToken token)
 	{
 		return CreateEventRecord(version, prepare, streamName, _eventTypes, token);
+	}
+
+	private async IAsyncEnumerable<EventRecord> CreateEventRecords(IAsyncEnumerable<IndexedPrepare> records,
+		string streamName, [EnumeratorCancellation] CancellationToken token)
+	{
+		await foreach (var record in records.WithCancellation(token))
+			yield return await CreateEventRecord(record.Version, record.Prepare, streamName, token);
+	}
+
+	private static async IAsyncEnumerable<IndexedPrepare> ReadIndexedPrepares(TFReaderLease reader,
+		IEnumerable<IndexEntry> indexEntries, TStreamId streamId, [EnumeratorCancellation] CancellationToken token)
+	{
+		foreach (var indexEntry in indexEntries)
+		{
+			token.ThrowIfCancellationRequested();
+			var prepare = await ReadPrepareInternal(reader, indexEntry.Position, token);
+			if (prepare is not null && StreamIdComparer.Equals(prepare.EventStreamId, streamId))
+				yield return new IndexedPrepare(indexEntry.Version, prepare, indexEntry);
+		}
+	}
+
+	private static async IAsyncEnumerable<IndexedPrepare> LastByVersion(IAsyncEnumerable<IndexedPrepare> records,
+		[EnumeratorCancellation] CancellationToken token)
+	{
+		var versions = new List<long>();
+		var recordsByVersion = new Dictionary<long, IndexedPrepare>();
+
+		await foreach (var record in records.WithCancellation(token))
+		{
+			if (!recordsByVersion.ContainsKey(record.Version))
+				versions.Add(record.Version);
+
+			recordsByVersion[record.Version] = record;
+		}
+
+		foreach (var version in versions)
+			yield return recordsByVersion[version];
 	}
 
 	private static async ValueTask<EventRecord> CreateEventRecord(long version, IPrepareLogRecord<TStreamId> prepare,

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
@@ -55,8 +55,6 @@ public abstract class IndexReader
 
 public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 {
-	private readonly record struct IndexedPrepare(long Version, IPrepareLogRecord<TStreamId> Prepare, IndexEntry IndexEntry);
-
 	private static EqualityComparer<TStreamId> StreamIdComparer { get; } = EqualityComparer<TStreamId>.Default;
 
 	public long CachedStreamInfo
@@ -188,17 +186,20 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 			: ReadPrepare(reader, streamId, eventNumber, token);
 	}
 
-	private ValueTask<IPrepareLogRecord<TStreamId>> ReadPrepare(TFReaderLease reader, TStreamId streamId,
+	private async ValueTask<IPrepareLogRecord<TStreamId>> ReadPrepare(TFReaderLease reader, TStreamId streamId,
 		long eventNumber, CancellationToken token)
 	{
-		var recordsQuery = LastByVersion(ReadIndexedPrepares(
-				reader,
-				_tableIndex.GetRange(streamId, eventNumber, eventNumber),
-				streamId,
-				token), token)
-			.Select(static x => x.Prepare);
+		IPrepareLogRecord<TStreamId> prepare = null;
 
-		return recordsQuery.FirstOrDefaultAsync(token);
+		foreach (var indexEntry in _tableIndex.GetRange(streamId, eventNumber, eventNumber))
+		{
+			token.ThrowIfCancellationRequested();
+			if (await ReadPrepareInternal(reader, indexEntry.Position, token) is { } candidate &&
+				StreamIdComparer.Equals(candidate.EventStreamId, streamId))
+				prepare = candidate;
+		}
+
+		return prepare;
 	}
 
 	private async ValueTask<IPrepareLogRecord<TStreamId>> ReadPrepareSkipScan(TFReaderLease reader, TStreamId streamId,
@@ -310,18 +311,15 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 					skipIndexScanOnRead, token);
 			}
 
-			var recordsQuery = ReadIndexedPrepares(
+			var records = await ReadEventRecordsForward(
 				reader,
-				_tableIndex.GetRange(streamId, startEventNumber, endEventNumber),
 				streamId,
+				streamName,
+				startEventNumber,
+				endEventNumber,
+				maxCount,
+				skipIndexScanOnRead,
 				token);
-			if (!skipIndexScanOnRead)
-			{
-				recordsQuery = LastByVersion(recordsQuery.OrderByDescending(static x => x.Version), token);
-			}
-
-			var records = await CreateEventRecords(recordsQuery.Reverse(), streamName, token)
-				.ToArrayAsync(token);
 
 			long nextEventNumber = Math.Min(endEventNumber + 1, lastEventNumber + 1);
 			if (records.Length > 0)
@@ -567,17 +565,41 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 		long startEventNumber,
 		long endEventNumber,
 		CancellationToken token)
-		=> ReadIndexedPrepares(reader, indexReader._tableIndex.GetRange(streamHandle, startEventNumber, endEventNumber),
-				streamHandle, token)
-			.Select(static x => x.IndexEntry);
+	{
+		return ReadIndexEntries_RemoveCollisions(
+			reader,
+			indexReader._tableIndex.GetRange(streamHandle, startEventNumber, endEventNumber),
+			streamHandle,
+			token);
+	}
 
-	private static IAsyncEnumerable<IndexEntry> ReadIndexEntries_NoCollisions(IndexReader<TStreamId> indexReader,
+	private static async IAsyncEnumerable<IndexEntry> ReadIndexEntries_RemoveCollisions(TFReaderLease reader,
+		IEnumerable<IndexEntry> indexEntries,
+		TStreamId streamHandle,
+		[EnumeratorCancellation] CancellationToken token)
+	{
+		foreach (var indexEntry in indexEntries)
+		{
+			token.ThrowIfCancellationRequested();
+			if (await ReadPrepareInternal(reader, indexEntry.Position, token) is { } prepare &&
+				StreamIdComparer.Equals(prepare.EventStreamId, streamHandle))
+				yield return indexEntry;
+		}
+	}
+
+	private static async IAsyncEnumerable<IndexEntry> ReadIndexEntries_NoCollisions(IndexReader<TStreamId> indexReader,
 		ulong streamHandle,
 		TFReaderLease reader,
 		long startEventNumber,
 		long endEventNumber,
-		CancellationToken token) =>
-		indexReader._tableIndex.GetRange(streamHandle, startEventNumber, endEventNumber).ToAsyncEnumerable();
+		[EnumeratorCancellation] CancellationToken token)
+	{
+		foreach (var indexEntry in indexReader._tableIndex.GetRange(streamHandle, startEventNumber, endEventNumber))
+		{
+			token.ThrowIfCancellationRequested();
+			yield return indexEntry;
+		}
+	}
 
 	public async ValueTask<IndexReadEventInfoResult> ReadEventInfo_KeepDuplicates(TStreamId streamId, long eventNumber,
 		CancellationToken token)
@@ -729,24 +751,16 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 			startEventNumber = minEventNumber;
 		}
 
-		var recordsQuery = ReadIndexedPrepares(
+		var records = await ReadEventRecordsBackward(
 			reader,
-			_tableIndex.GetRange(streamId, startEventNumber, endEventNumber),
 			streamId,
+			streamName,
+			startEventNumber,
+			endEventNumber,
+			maxCount,
+			metadata.MaxAge,
+			skipIndexScanOnRead,
 			token);
-		if (!skipIndexScanOnRead)
-		{
-			recordsQuery = LastByVersion(recordsQuery.OrderByDescending(static x => x.Version), token);
-		}
-
-		if (metadata.MaxAge.HasValue)
-		{
-			var ageThreshold = DateTime.UtcNow - metadata.MaxAge.Value;
-			recordsQuery = recordsQuery.Where(x => x.Prepare.TimeStamp >= ageThreshold);
-		}
-
-		var records = await CreateEventRecords(recordsQuery, streamName, token)
-			.ToArrayAsync(token);
 
 		isEndOfStream = isEndOfStream
 						|| startEventNumber == 0
@@ -1169,41 +1183,95 @@ public class IndexReader<TStreamId> : IndexReader, IIndexReader<TStreamId>
 		return CreateEventRecord(version, prepare, streamName, _eventTypes, token);
 	}
 
-	private async IAsyncEnumerable<EventRecord> CreateEventRecords(IAsyncEnumerable<IndexedPrepare> records,
-		string streamName, [EnumeratorCancellation] CancellationToken token)
+	private async ValueTask<EventRecord[]> ReadEventRecordsForward(TFReaderLease reader,
+		TStreamId streamId,
+		string streamName,
+		long startEventNumber,
+		long endEventNumber,
+		int maxCount,
+		bool skipIndexScanOnRead,
+		CancellationToken token)
 	{
-		await foreach (var record in records.WithCancellation(token))
-			yield return await CreateEventRecord(record.Version, record.Prepare, streamName, token);
-	}
+		var indexEntries = _tableIndex.GetRange(streamId, startEventNumber, endEventNumber);
 
-	private static async IAsyncEnumerable<IndexedPrepare> ReadIndexedPrepares(TFReaderLease reader,
-		IEnumerable<IndexEntry> indexEntries, TStreamId streamId, [EnumeratorCancellation] CancellationToken token)
-	{
+		if (skipIndexScanOnRead)
+		{
+			var records = new List<EventRecord>(Math.Min(maxCount, indexEntries.Count));
+			foreach (var indexEntry in indexEntries)
+			{
+				token.ThrowIfCancellationRequested();
+				if (await ReadPrepareInternal(reader, indexEntry.Position, token) is { } prepare &&
+					StreamIdComparer.Equals(prepare.EventStreamId, streamId))
+					records.Add(await CreateEventRecord(indexEntry.Version, prepare, streamName, token));
+			}
+
+			records.Reverse();
+			return records.ToArray();
+		}
+
+		var results = new ResultsDeduplicator(maxCount, skipIndexScanOnRead: false);
 		foreach (var indexEntry in indexEntries)
 		{
 			token.ThrowIfCancellationRequested();
-			var prepare = await ReadPrepareInternal(reader, indexEntry.Position, token);
-			if (prepare is not null && StreamIdComparer.Equals(prepare.EventStreamId, streamId))
-				yield return new IndexedPrepare(indexEntry.Version, prepare, indexEntry);
+			if (await ReadPrepareInternal(reader, indexEntry.Position, token) is { } prepare &&
+				StreamIdComparer.Equals(prepare.EventStreamId, streamId))
+				results.Add(await CreateEventRecord(indexEntry.Version, prepare, streamName, token));
 		}
+
+		var array = results.ProduceArray();
+		Array.Reverse(array);
+		return array;
 	}
 
-	private static async IAsyncEnumerable<IndexedPrepare> LastByVersion(IAsyncEnumerable<IndexedPrepare> records,
-		[EnumeratorCancellation] CancellationToken token)
+	private async ValueTask<EventRecord[]> ReadEventRecordsBackward(TFReaderLease reader,
+		TStreamId streamId,
+		string streamName,
+		long startEventNumber,
+		long endEventNumber,
+		int maxCount,
+		TimeSpan? maxAge,
+		bool skipIndexScanOnRead,
+		CancellationToken token)
 	{
-		var versions = new List<long>();
-		var recordsByVersion = new Dictionary<long, IndexedPrepare>();
+		var indexEntries = _tableIndex.GetRange(streamId, startEventNumber, endEventNumber);
+		var ageThreshold = maxAge.HasValue ? DateTime.UtcNow - maxAge.Value : (DateTime?)null;
 
-		await foreach (var record in records.WithCancellation(token))
+		if (skipIndexScanOnRead)
 		{
-			if (!recordsByVersion.ContainsKey(record.Version))
-				versions.Add(record.Version);
+			var records = new List<EventRecord>(Math.Min(maxCount, indexEntries.Count));
+			foreach (var indexEntry in indexEntries)
+			{
+				token.ThrowIfCancellationRequested();
+				if (await ReadPrepareInternal(reader, indexEntry.Position, token) is { } prepare &&
+					StreamIdComparer.Equals(prepare.EventStreamId, streamId) &&
+					(!ageThreshold.HasValue || prepare.TimeStamp >= ageThreshold.Value))
+					records.Add(await CreateEventRecord(indexEntry.Version, prepare, streamName, token));
+			}
 
-			recordsByVersion[record.Version] = record;
+			return records.ToArray();
 		}
 
-		foreach (var version in versions)
-			yield return recordsByVersion[version];
+		var results = new ResultsDeduplicator(maxCount, skipIndexScanOnRead: false);
+		foreach (var indexEntry in indexEntries)
+		{
+			token.ThrowIfCancellationRequested();
+			if (await ReadPrepareInternal(reader, indexEntry.Position, token) is { } prepare &&
+				StreamIdComparer.Equals(prepare.EventStreamId, streamId))
+				results.Add(await CreateEventRecord(indexEntry.Version, prepare, streamName, token));
+		}
+
+		var array = results.ProduceArray();
+		if (!ageThreshold.HasValue)
+			return array;
+
+		var filtered = new List<EventRecord>(array.Length);
+		foreach (var record in array)
+		{
+			if (record.TimeStamp >= ageThreshold.Value)
+				filtered.Add(record);
+		}
+
+		return filtered.ToArray();
 	}
 
 	private static async ValueTask<EventRecord> CreateEventRecord(long version, IPrepareLogRecord<TStreamId> prepare,

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
@@ -11,8 +11,7 @@ namespace EventStore.Core.Services.Transport.Http.Authentication {
 			var saltData = new byte[SaltSize];
 			RandomNumberGenerator.Fill(saltData);
 			
-			using var rfcBytes = new Rfc2898DeriveBytes(password, saltData, Iterations, HashAlgorithmName.SHA1);
-			var hashData = rfcBytes.GetBytes(HashSize);
+			var hashData = Rfc2898DeriveBytes.Pbkdf2(password, saltData, Iterations, HashAlgorithmName.SHA1, HashSize);
 			hash = System.Convert.ToBase64String(hashData);
 			salt = System.Convert.ToBase64String(saltData);
 		}
@@ -20,8 +19,8 @@ namespace EventStore.Core.Services.Transport.Http.Authentication {
 		public override bool Verify(string password, string hash, string salt) {
 			var saltData = System.Convert.FromBase64String(salt);
 
-			using var rfcBytes = new Rfc2898DeriveBytes(password, saltData, Iterations, HashAlgorithmName.SHA1);
-			var newHash = System.Convert.ToBase64String(rfcBytes.GetBytes(HashSize));
+			var newHash = System.Convert.ToBase64String(
+				Rfc2898DeriveBytes.Pbkdf2(password, saltData, Iterations, HashAlgorithmName.SHA1, HashSize));
 
 			return hash == newHash;
 		}

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
@@ -1,22 +1,26 @@
 using System.Security.Cryptography;
 using EventStore.Core.Authentication.InternalAuthentication;
 
-namespace EventStore.Core.Services.Transport.Http.Authentication {
-	public class Rfc2898PasswordHashAlgorithm : PasswordHashAlgorithm {
+namespace EventStore.Core.Services.Transport.Http.Authentication
+{
+	public class Rfc2898PasswordHashAlgorithm : PasswordHashAlgorithm
+	{
 		private const int HashSize = 20;
 		private const int SaltSize = 16;
 		private const int Iterations = 1000;
-		
-		public override void Hash(string password, out string hash, out string salt) {
+
+		public override void Hash(string password, out string hash, out string salt)
+		{
 			var saltData = new byte[SaltSize];
 			RandomNumberGenerator.Fill(saltData);
-			
+
 			var hashData = Rfc2898DeriveBytes.Pbkdf2(password, saltData, Iterations, HashAlgorithmName.SHA1, HashSize);
 			hash = System.Convert.ToBase64String(hashData);
 			salt = System.Convert.ToBase64String(saltData);
 		}
 
-		public override bool Verify(string password, string hash, string salt) {
+		public override bool Verify(string password, string hash, string salt)
+		{
 			var saltData = System.Convert.FromBase64String(salt);
 
 			var newHash = System.Convert.ToBase64String(

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
@@ -29,6 +29,9 @@ namespace EventStore.Core.Services.Transport.Http.Authentication
 
 		public override bool Verify(string password, string hash, string salt)
 		{
+			if (string.IsNullOrEmpty(hash) || string.IsNullOrEmpty(salt))
+				return false;
+
 			if (!TryParseHash(hash, out var hashAlgorithm, out var iterations, out var expectedHash))
 				return false;
 
@@ -55,6 +58,9 @@ namespace EventStore.Core.Services.Transport.Http.Authentication
 			iterations = CurrentIterations;
 			expectedHash = null;
 
+			if (string.IsNullOrEmpty(hash))
+				return false;
+
 			var parts = hash.Split('$');
 			if (parts.Length != 4 ||
 				parts[0] != Version ||
@@ -68,6 +74,12 @@ namespace EventStore.Core.Services.Transport.Http.Authentication
 
 		private static bool TryReadSalt(string salt, out byte[] saltData)
 		{
+			if (string.IsNullOrEmpty(salt))
+			{
+				saltData = null;
+				return false;
+			}
+
 			try
 			{
 				saltData = System.Convert.FromBase64String(salt);
@@ -83,6 +95,12 @@ namespace EventStore.Core.Services.Transport.Http.Authentication
 
 		private static bool TryReadHash(string hash, int hashSize, out byte[] expectedHash)
 		{
+			if (string.IsNullOrEmpty(hash))
+			{
+				expectedHash = null;
+				return false;
+			}
+
 			try
 			{
 				expectedHash = System.Convert.FromBase64String(hash);

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
@@ -5,10 +5,8 @@ namespace EventStore.Core.Services.Transport.Http.Authentication
 {
 	public class Rfc2898PasswordHashAlgorithm : PasswordHashAlgorithm
 	{
-		private const int LegacyHashSize = 20;
 		private const int HashSize = 32;
 		private const int SaltSize = 16;
-		private const int LegacyIterations = 1000;
 		private const int Iterations = 600_000;
 		private const string Version = "v2";
 		private const string HashAlgorithm = "SHA256";
@@ -33,7 +31,9 @@ namespace EventStore.Core.Services.Transport.Http.Authentication
 			if (!TryParseHash(hash, out var hashAlgorithm, out var iterations, out var expectedHash))
 				return false;
 
-			var saltData = System.Convert.FromBase64String(salt);
+			if (!TryReadSalt(salt, out var saltData))
+				return false;
+
 			var actualHash = Rfc2898DeriveBytes.Pbkdf2(
 				password,
 				saltData,
@@ -50,23 +50,34 @@ namespace EventStore.Core.Services.Transport.Http.Authentication
 			out int iterations,
 			out byte[] expectedHash)
 		{
-			hashAlgorithm = HashAlgorithmName.SHA1;
-			iterations = LegacyIterations;
+			hashAlgorithm = HashAlgorithmName.SHA256;
+			iterations = Iterations;
 			expectedHash = null;
-
-			if (!hash.Contains('$', System.StringComparison.Ordinal))
-				return TryReadHash(hash, LegacyHashSize, out expectedHash);
 
 			var parts = hash.Split('$');
 			if (parts.Length != 4 ||
 				parts[0] != Version ||
 				parts[1] != HashAlgorithm ||
 				!int.TryParse(parts[2], out iterations) ||
-				iterations <= 0)
+				iterations != Iterations)
 				return false;
 
-			hashAlgorithm = HashAlgorithmName.SHA256;
 			return TryReadHash(parts[3], HashSize, out expectedHash);
+		}
+
+		private static bool TryReadSalt(string salt, out byte[] saltData)
+		{
+			try
+			{
+				saltData = System.Convert.FromBase64String(salt);
+			}
+			catch (System.FormatException)
+			{
+				saltData = null;
+				return false;
+			}
+
+			return saltData.Length == SaltSize;
 		}
 
 		private static bool TryReadHash(string hash, int hashSize, out byte[] expectedHash)

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
@@ -5,28 +5,83 @@ namespace EventStore.Core.Services.Transport.Http.Authentication
 {
 	public class Rfc2898PasswordHashAlgorithm : PasswordHashAlgorithm
 	{
-		private const int HashSize = 20;
+		private const int LegacyHashSize = 20;
+		private const int HashSize = 32;
 		private const int SaltSize = 16;
-		private const int Iterations = 1000;
+		private const int LegacyIterations = 1000;
+		private const int Iterations = 600_000;
+		private const string Version = "v2";
+		private const string HashAlgorithm = "SHA256";
 
 		public override void Hash(string password, out string hash, out string salt)
 		{
 			var saltData = new byte[SaltSize];
 			RandomNumberGenerator.Fill(saltData);
 
-			var hashData = Rfc2898DeriveBytes.Pbkdf2(password, saltData, Iterations, HashAlgorithmName.SHA1, HashSize);
-			hash = System.Convert.ToBase64String(hashData);
+			var hashData = Rfc2898DeriveBytes.Pbkdf2(
+				password,
+				saltData,
+				Iterations,
+				HashAlgorithmName.SHA256,
+				HashSize);
+			hash = $"{Version}${HashAlgorithm}${Iterations}${System.Convert.ToBase64String(hashData)}";
 			salt = System.Convert.ToBase64String(saltData);
 		}
 
 		public override bool Verify(string password, string hash, string salt)
 		{
+			if (!TryParseHash(hash, out var hashAlgorithm, out var iterations, out var expectedHash))
+				return false;
+
 			var saltData = System.Convert.FromBase64String(salt);
+			var actualHash = Rfc2898DeriveBytes.Pbkdf2(
+				password,
+				saltData,
+				iterations,
+				hashAlgorithm,
+				expectedHash.Length);
 
-			var newHash = System.Convert.ToBase64String(
-				Rfc2898DeriveBytes.Pbkdf2(password, saltData, Iterations, HashAlgorithmName.SHA1, HashSize));
+			return CryptographicOperations.FixedTimeEquals(expectedHash, actualHash);
+		}
 
-			return hash == newHash;
+		private static bool TryParseHash(
+			string hash,
+			out HashAlgorithmName hashAlgorithm,
+			out int iterations,
+			out byte[] expectedHash)
+		{
+			hashAlgorithm = HashAlgorithmName.SHA1;
+			iterations = LegacyIterations;
+			expectedHash = null;
+
+			if (!hash.StartsWith("v", System.StringComparison.Ordinal))
+				return TryReadHash(hash, LegacyHashSize, out expectedHash);
+
+			var parts = hash.Split('$');
+			if (parts.Length != 4 ||
+				parts[0] != Version ||
+				parts[1] != HashAlgorithm ||
+				!int.TryParse(parts[2], out iterations) ||
+				iterations <= 0)
+				return false;
+
+			hashAlgorithm = HashAlgorithmName.SHA256;
+			return TryReadHash(parts[3], HashSize, out expectedHash);
+		}
+
+		private static bool TryReadHash(string hash, int hashSize, out byte[] expectedHash)
+		{
+			try
+			{
+				expectedHash = System.Convert.FromBase64String(hash);
+			}
+			catch (System.FormatException)
+			{
+				expectedHash = null;
+				return false;
+			}
+
+			return expectedHash.Length == hashSize;
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
@@ -54,7 +54,7 @@ namespace EventStore.Core.Services.Transport.Http.Authentication
 			iterations = LegacyIterations;
 			expectedHash = null;
 
-			if (!hash.StartsWith("v", System.StringComparison.Ordinal))
+			if (!hash.Contains('$', System.StringComparison.Ordinal))
 				return TryReadHash(hash, LegacyHashSize, out expectedHash);
 
 			var parts = hash.Split('$');

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
@@ -7,7 +7,8 @@ namespace EventStore.Core.Services.Transport.Http.Authentication
 	{
 		private const int HashSize = 32;
 		private const int SaltSize = 16;
-		private const int Iterations = 600_000;
+		private const int MinimumIterations = 600_000;
+		private const int CurrentIterations = 600_000;
 		private const string Version = "v2";
 		private const string HashAlgorithm = "SHA256";
 
@@ -19,10 +20,10 @@ namespace EventStore.Core.Services.Transport.Http.Authentication
 			var hashData = Rfc2898DeriveBytes.Pbkdf2(
 				password,
 				saltData,
-				Iterations,
+				CurrentIterations,
 				HashAlgorithmName.SHA256,
 				HashSize);
-			hash = $"{Version}${HashAlgorithm}${Iterations}${System.Convert.ToBase64String(hashData)}";
+			hash = $"{Version}${HashAlgorithm}${CurrentIterations}${System.Convert.ToBase64String(hashData)}";
 			salt = System.Convert.ToBase64String(saltData);
 		}
 
@@ -51,7 +52,7 @@ namespace EventStore.Core.Services.Transport.Http.Authentication
 			out byte[] expectedHash)
 		{
 			hashAlgorithm = HashAlgorithmName.SHA256;
-			iterations = Iterations;
+			iterations = CurrentIterations;
 			expectedHash = null;
 
 			var parts = hash.Split('$');
@@ -59,7 +60,7 @@ namespace EventStore.Core.Services.Transport.Http.Authentication
 				parts[0] != Version ||
 				parts[1] != HashAlgorithm ||
 				!int.TryParse(parts[2], out iterations) ||
-				iterations != Iterations)
+				iterations < MinimumIterations)
 				return false;
 
 			return TryReadHash(parts[3], HashSize, out expectedHash);

--- a/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
+++ b/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
@@ -6,6 +6,5 @@
 		<PackageReference Include="System.ServiceModel.Http" />
 		<PackageReference Include="System.Security.Cryptography.Pkcs" />
 		<PackageReference Include="System.Security.Cryptography.Xml" />
-		<PackageReference Include="System.Formats.Asn1" />
 	</ItemGroup>
 </Project>

--- a/src/EventStore.Projections.Core.XUnit.Tests/EventStore.Projections.Core.XUnit.Tests.csproj
+++ b/src/EventStore.Projections.Core.XUnit.Tests/EventStore.Projections.Core.XUnit.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/EventStore.Projections.Core.XUnit.Tests/Metrics/ProjectionMetricsTests.cs
+++ b/src/EventStore.Projections.Core.XUnit.Tests/Metrics/ProjectionMetricsTests.cs
@@ -98,7 +98,8 @@ public class ProjectionMetricsTests
 		};
 
 	private static ProjectionStatistics ProjectionWithState(ManagedProjectionState state, string status) =>
-		new() {
+		new()
+		{
 			Name = "TestProjection",
 			ProjectionId = 1234,
 			Epoch = -1,

--- a/src/EventStore.Projections.Core.XUnit.Tests/Metrics/ProjectionMetricsTests.cs
+++ b/src/EventStore.Projections.Core.XUnit.Tests/Metrics/ProjectionMetricsTests.cs
@@ -91,8 +91,6 @@ public class ProjectionMetricsTests
 		actualMeasurement =>
 		{
 			Assert.Equal(expectedValue, actualMeasurement.Value);
-			if (actualMeasurement.Tags == null)
-				return;
 
 			Assert.Equal(
 				tags,

--- a/src/EventStore.SourceGenerators.Tests/EventStore.SourceGenerators.Tests.csproj
+++ b/src/EventStore.SourceGenerators.Tests/EventStore.SourceGenerators.Tests.csproj
@@ -31,10 +31,6 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="Newtonsoft.Json" />
 		<PackageReference Include="NuGet.Protocol" />
-		<PackageReference Include="System.Formats.Asn1" />
-		<PackageReference Include="System.Linq.Async" />
-		<PackageReference Include="System.Net.Http" />
-		<PackageReference Include="System.Text.RegularExpressions" />
 		<PackageReference Include="xunit" />
 		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
@@ -345,28 +345,9 @@ public class TcpConnectionSsl : TcpConnectionBase, ITcpConnection
 	private void DisplaySslStreamInfo(SslStream stream)
 	{
 		Log.Information("[S{remoteEndPoint}, L{localEndPoint}]", RemoteEndPoint, LocalEndPoint);
-		Log.Verbose("Cipher: {cipherAlgorithm}", stream.CipherAlgorithm);
 		try
 		{
-			Log.Verbose("Cipher strength: {cipherStrength}", stream.CipherStrength);
-		}
-		catch (NotImplementedException)
-		{
-		}
-
-		Log.Verbose("Hash: {hashAlgorithm}", stream.HashAlgorithm);
-		try
-		{
-			Log.Verbose("Hash strength: {hashStrength}", stream.HashStrength);
-		}
-		catch (NotImplementedException)
-		{
-		}
-
-		Log.Verbose("Key exchange: {keyExchangeAlgorithm}", stream.KeyExchangeAlgorithm);
-		try
-		{
-			Log.Verbose("Key exchange strength: {keyExchangeStrength}", stream.KeyExchangeStrength);
+			Log.Verbose("Cipher suite: {cipherSuite}", stream.NegotiatedCipherSuite);
 		}
 		catch (NotImplementedException)
 		{


### PR DESCRIPTION
- Keeps the runtime/toolchain on the current supported LTS line before the .NET 8 support window closes.
- Reduces compatibility drift across local builds, CI, and container images.