### PR TITLE
feat(otel): trace outbound node calls

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -61,6 +61,7 @@
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
     <PackageVersion Include="Quickenshtein" Version="1.5.1" />
     <PackageVersion Include="Scrutor" Version="5.1.2" />
     <PackageVersion Include="Serilog" Version="4.3.0" />

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -263,7 +263,7 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 		IConfiguration configuration)
 	{
 		meterOptions
-			.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("eventstore"))
+			.SetResourceBuilder(CreateResourceBuilder())
 			.AddMeter(metricsConfiguration.Meters)
 			.AddView(i =>
 			{
@@ -345,17 +345,23 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 		TracerProviderBuilder tracerOptions,
 		IConfiguration configuration)
 	{
-		tracerOptions.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("eventstore"));
+		tracerOptions.SetResourceBuilder(CreateResourceBuilder());
 
 		if (!configuration.OtlpTracesEnabled())
 			return;
 
 		tracerOptions
 			.AddAspNetCoreInstrumentation()
+			.AddHttpClientInstrumentation()
 			.AddOtlpExporter(exporterOptions => configuration.BindOtlpExporterOptions(
 				OpenTelemetryConfiguration.OtlpTracesOtlpPrefix,
 				exporterOptions));
 	}
+
+	private static ResourceBuilder CreateResourceBuilder() =>
+		ResourceBuilder.CreateDefault().AddService(
+			serviceName: "eventstore",
+			serviceVersion: VersionInfo.Version);
 
 	public void Handle(SystemMessage.SystemReady _) => _nodeHealthState.MarkReady();
 

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -22,6 +22,7 @@
 		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Http" />
 		<PackageReference Include="Quickenshtein" />
 		<PackageReference Include="Scrutor" />
 		<PackageReference Include="Serilog.Sinks.OpenTelemetry" />


### PR DESCRIPTION
- Native telemetry should cover outbound node-to-node dependencies when trace export is enabled.
- Metrics and traces should carry consistent service identity for collector-side correlation.