### PR TITLE
chore(deps): update support packages

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="Grpc.HealthCheck" Version="2.64.0" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.64.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.65.0" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageVersion Include="Jint" Version="4.4.0" />
     <PackageVersion Include="librdkafka.redist" Version="2.5.3" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
@@ -52,7 +52,7 @@
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.24" />
     <PackageVersion Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageVersion Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NuGet.Protocol" Version="6.7.1" />
     <PackageVersion Include="NUnit" Version="3.14.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
@@ -75,7 +75,7 @@
     <PackageVersion Include="Serilog.Sinks.InMemory" Version="0.16.0" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.1.1" />
     <PackageVersion Include="Serilog.Sinks.TextWriter" Version="3.0.0" />
-    <PackageVersion Include="SharpDotYaml.Extensions.Configuration" Version="0.3.1" />
+    <PackageVersion Include="SharpDotYaml.Extensions.Configuration" Version="0.4.0" />
     <PackageVersion Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.21216.1" />
     <PackageVersion Include="System.ComponentModel.Composition" Version="10.0.7" />
     <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="10.0.7" />


### PR DESCRIPTION
- Runtime support dependencies should keep pace with the current platform baseline.
- Small dependency drift should be handled before it becomes tangled with larger runtime work.