### PR TITLE
chore(deps): update benchmark tooling

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="DotNext" Version="5.22.0" />
     <PackageVersion Include="DotNext.IO" Version="5.22.0" />


### PR DESCRIPTION
- Benchmark tooling should stay compatible with the current runtime baseline.
- Isolating benchmark dependency drift keeps production changes easier to review.