### PR TITLE
chore(deps): update script engine

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Grpc.Net.Client" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.80.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
-    <PackageVersion Include="Jint" Version="4.4.0" />
+    <PackageVersion Include="Jint" Version="4.8.0" />
     <PackageVersion Include="librdkafka.redist" Version="2.5.3" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />


### PR DESCRIPTION
- Projection scripting dependencies should stay current with the runtime baseline.
- Keeping the scripting engine current reduces dependency drift around projection maintenance.