### PR TITLE
chore(deps): update grpc streams client

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="DotNext.Threading" Version="5.22.0" />
     <PackageVersion Include="DotNext.Unsafe" Version="5.22.0" />
     <PackageVersion Include="EventStore.Client" Version="21.2.0" />
-    <PackageVersion Include="EventStore.Client.Grpc.Streams" Version="23.3.3" />
+    <PackageVersion Include="EventStore.Client.Grpc.Streams" Version="23.3.9" />
     <!--Version 8 and beyond are free for open-source projects and non-commercial use, but commercial use requires a paid license-->
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <PackageVersion Include="FluentStorage.AWS" Version="5.5.0" />


### PR DESCRIPTION
- gRPC client dependencies should stay aligned with the current runtime baseline.
- Patch-level dependency drift should be reduced before larger transport work continues.