### PR TITLE
chore(deps): update build metadata tooling

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="GitInfo" Version="3.3.5">
+    <PackageVersion Include="GitInfo" Version="3.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageVersion>


### PR DESCRIPTION
- Build metadata generation should stay compatible with the current runtime baseline.
- Keeping build tooling current reduces dependency drift around release diagnostics.