### PR TITLE
chore(deps): update servicemodel package

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -82,7 +82,7 @@
     <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="10.0.7" />
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.7" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
-    <PackageVersion Include="System.ServiceModel.Http" Version="6.2.0" />
+    <PackageVersion Include="System.ServiceModel.Http" Version="10.0.652802" />
     <PackageVersion Include="TrogonEventStore.Plugins" Version="24.10.9" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
- Compatibility dependencies should stay aligned with the current runtime baseline.
- Reducing drift in compatibility shims keeps URI-template behavior easier to maintain.