### PR TITLE
chore(deps): update otel http instrumentation

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -61,7 +61,7 @@
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageVersion Include="Quickenshtein" Version="1.5.1" />
     <PackageVersion Include="Scrutor" Version="5.1.2" />
     <PackageVersion Include="Serilog" Version="4.3.1" />


### PR DESCRIPTION
- Keeping HTTP client instrumentation current reduces drift in the observability pipeline.
- Small patch updates are safer to land independently while the telemetry surface keeps moving.