### PR TITLE
fix(ci): restore stable grpc tooling

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="Grpc.Core" Version="2.46.6" />
     <PackageVersion Include="Grpc.HealthCheck" Version="2.76.0" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.76.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.80.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageVersion Include="Jint" Version="4.8.0" />
     <PackageVersion Include="librdkafka.redist" Version="2.5.3" />


### PR DESCRIPTION
- The ARM64 CI build needs a protoc tool package that does not crash on the hosted runner.
- Keeping the tooling package aligned with the runtime gRPC package line restores a safer build baseline.