### PR TITLE
fix(subscriptions): isolate pinned client identity

### DIFF
--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
@@ -515,4 +515,38 @@ public class PinnedConsumerStrategyTests
 
 		Assert.That(streamBuffer.BufferCount, Is.EqualTo(0));
 	}
+
+	[Test]
+	public void reconnect_with_reused_correlation_id_routes_pinned_stream_to_live_client()
+	{
+		var correlationId = Guid.NewGuid();
+		var client1Envelope = new FakeEnvelope();
+		var client2Envelope = new FakeEnvelope();
+		var reader = new FakeCheckpointReader();
+		const string subsctiptionStream = "$ce-streamName";
+		var sub = new Core.Services.PersistentSubscription.PersistentSubscription(
+			PersistentSubscriptionToStreamParamsBuilder.CreateFor(subsctiptionStream, "groupName")
+				.WithEventLoader(new FakeStreamReader())
+				.WithCheckpointReader(reader)
+				.WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
+				.WithMessageParker(new FakeMessageParker())
+				.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
+				.StartFromCurrent());
+		reader.Load(null);
+
+		var firstConnectionId = Guid.NewGuid();
+		sub.AddClient(correlationId, firstConnectionId, "connection-1", client1Envelope, 10, "foo", "bar");
+		var firstEventId = Guid.NewGuid();
+		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(firstEventId, "type", "streamName-1", 0));
+
+		Assert.That(client1Envelope.Replies.Count, Is.EqualTo(1));
+
+		sub.AcknowledgeMessagesProcessed(correlationId, new[] { firstEventId });
+		Assert.IsTrue(sub.RemoveClientByConnectionId(firstConnectionId));
+		sub.AddClient(correlationId, Guid.NewGuid(), "connection-2", client2Envelope, 10, "foo", "bar");
+		sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 1));
+
+		Assert.That(client1Envelope.Replies.Count, Is.EqualTo(1));
+		Assert.That(client2Envelope.Replies.Count, Is.EqualTo(1));
+	}
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnablePersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnablePersistentSubscriptionConsumerStrategy.cs
@@ -1,103 +1,116 @@
-namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
+
+using Common.Utils;
+using Data;
+using Index.Hashes;
+using PinnedState;
+
+public abstract class PinnablePersistentSubscriptionConsumerStrategy : IPersistentSubscriptionConsumerStrategy
 {
-	using Common.Utils;
-	using Data;
-	using Index.Hashes;
-	using PinnedState;
+	private IHasher<string> _hash;
+	protected static readonly char LinkToSeparator = '@';
+	private readonly PinnedConsumerState _state = new PinnedConsumerState();
+	private readonly object _stateLock = new object();
 
-	public abstract class PinnablePersistentSubscriptionConsumerStrategy : IPersistentSubscriptionConsumerStrategy {
-		private IHasher<string> _hash;
-		protected static readonly char LinkToSeparator = '@';
-		private readonly PinnedConsumerState _state = new PinnedConsumerState();
-		private readonly object _stateLock = new object();
+	public PinnablePersistentSubscriptionConsumerStrategy(IHasher<string> streamHasher)
+	{
+		_hash = streamHasher;
+	}
 
-		public PinnablePersistentSubscriptionConsumerStrategy(IHasher<string> streamHasher) {
-			_hash = streamHasher;
-		}
+	public abstract string Name { get; }
 
-		public abstract string Name { get; }
-
-		public int AvailableCapacity {
-			get {
-				if (_state == null)
-					return 0;
-
-				return _state.AvailableCapacity;
-			}
-		}
-
-		public void ClientAdded(PersistentSubscriptionClient client) {
-			lock (_stateLock) {
-				var newNode = new Node(client);
-
-				_state.AddNode(newNode);
-
-				client.EventConfirmed += OnEventRemoved;
-			}
-		}
-
-		public void ClientRemoved(PersistentSubscriptionClient client) {
-			var nodeId = client.CorrelationId;
-
-			client.EventConfirmed -= OnEventRemoved;
-
-			_state.DisconnectNode(nodeId);
-		}
-
-		public ConsumerPushResult PushMessageToClient(OutstandingMessage message) {
-			if (_state == null) {
-				return ConsumerPushResult.NoMoreCapacity;
-			}
-
-			if (_state.AvailableCapacity == 0) {
-				return ConsumerPushResult.NoMoreCapacity;
-			}
-
-
-			uint bucket = GetAssignmentId(message.ResolvedEvent);
-
-			if (_state.Assignments[bucket].State != BucketAssignment.BucketState.Assigned) {
-				_state.AssignBucket(bucket);
-			}
-
-			if (!_state.Assignments[bucket].Node.Client.Push(message)) {
-				return ConsumerPushResult.Skipped;
-			}
-
-			_state.RecordEventSent(bucket);
-			return ConsumerPushResult.Sent;
-		}
-
-		private void OnEventRemoved(PersistentSubscriptionClient client, ResolvedEvent ev) {
-			var assignmentId = GetAssignmentId(ev);
-			_state.EventRemoved(client.CorrelationId, assignmentId);
-		}
-
-		private uint GetAssignmentId(ResolvedEvent ev) {
-			string sourceStreamId = GetAssignmentSourceId(ev);
-
-			return _hash.Hash(sourceStreamId) % (uint)_state.Assignments.Length;
-		}
-
-		protected abstract string GetAssignmentSourceId(ResolvedEvent ev);
-
-		protected string GetSourceStreamId(ResolvedEvent ev)
+	public int AvailableCapacity
+	{
+		get
 		{
-			var eventRecord = ev.Event ?? ev.Link; // Unresolved link just use the link
+			if (_state == null)
+				return 0;
 
-			string sourceStreamId = eventRecord.EventStreamId;
-
-			if (eventRecord.EventType == SystemEventTypes.LinkTo) // Unresolved link.
-			{
-				sourceStreamId = Helper.UTF8NoBom.GetString(eventRecord.Data.Span);
-				int separatorIndex = sourceStreamId.IndexOf(LinkToSeparator);
-				if (separatorIndex != -1)
-				{
-					sourceStreamId = sourceStreamId.Substring(separatorIndex + 1);
-				}
-			}
-
-			return sourceStreamId;
+			return _state.AvailableCapacity;
 		}
+	}
+
+	public void ClientAdded(PersistentSubscriptionClient client)
+	{
+		lock (_stateLock)
+		{
+			var newNode = new Node(client);
+
+			_state.AddNode(newNode);
+
+			client.EventConfirmed += OnEventRemoved;
+		}
+	}
+
+	public void ClientRemoved(PersistentSubscriptionClient client)
+	{
+		var nodeId = client.InstanceId;
+
+		client.EventConfirmed -= OnEventRemoved;
+
+		_state.DisconnectNode(nodeId);
+	}
+
+	public ConsumerPushResult PushMessageToClient(OutstandingMessage message)
+	{
+		if (_state == null)
+		{
+			return ConsumerPushResult.NoMoreCapacity;
+		}
+
+		if (_state.AvailableCapacity == 0)
+		{
+			return ConsumerPushResult.NoMoreCapacity;
+		}
+
+
+		uint bucket = GetAssignmentId(message.ResolvedEvent);
+
+		if (_state.Assignments[bucket].State != BucketAssignment.BucketState.Assigned)
+		{
+			_state.AssignBucket(bucket);
+		}
+
+		if (!_state.Assignments[bucket].Node.Client.Push(message))
+		{
+			return ConsumerPushResult.Skipped;
+		}
+
+		_state.RecordEventSent(bucket);
+		return ConsumerPushResult.Sent;
+	}
+
+	private void OnEventRemoved(PersistentSubscriptionClient client, ResolvedEvent ev)
+	{
+		var assignmentId = GetAssignmentId(ev);
+		_state.EventRemoved(client.InstanceId, assignmentId);
+	}
+
+	private uint GetAssignmentId(ResolvedEvent ev)
+	{
+		string sourceStreamId = GetAssignmentSourceId(ev);
+
+		return _hash.Hash(sourceStreamId) % (uint)_state.Assignments.Length;
+	}
+
+	protected abstract string GetAssignmentSourceId(ResolvedEvent ev);
+
+	protected string GetSourceStreamId(ResolvedEvent ev)
+	{
+		var eventRecord = ev.Event ?? ev.Link; // Unresolved link just use the link
+
+		string sourceStreamId = eventRecord.EventStreamId;
+
+		if (eventRecord.EventType == SystemEventTypes.LinkTo) // Unresolved link.
+		{
+			sourceStreamId = Helper.UTF8NoBom.GetString(eventRecord.Data.Span);
+			int separatorIndex = sourceStreamId.IndexOf(LinkToSeparator);
+			if (separatorIndex != -1)
+			{
+				sourceStreamId = sourceStreamId.Substring(separatorIndex + 1);
+			}
+		}
+
+		return sourceStreamId;
 	}
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedState/Node.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedState/Node.cs
@@ -1,58 +1,66 @@
 using System;
 
-namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy.PinnedState {
-	internal class Node {
-		internal enum NodeState {
-			Connected,
-			Disconnected
-		}
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy.PinnedState;
 
-		public Node() {
-		}
-
-		public Node(Guid connectionId, Guid nodeId, string host, int port, NodeState state,
-			PersistentSubscriptionClient client, int maximumInFlightMessages, int assignmentCount) {
-			ConnectionId = connectionId;
-			NodeId = nodeId;
-			Host = host;
-			Port = port;
-			State = state;
-			Client = client;
-			MaximumInFlightMessages = maximumInFlightMessages;
-			AssignmentCount = assignmentCount;
-		}
-
-		public Node(PersistentSubscriptionClient client) {
-			Client = client;
-			ConnectionId = client.ConnectionId;
-			NodeId = client.CorrelationId;
-
-			var portSplit = client.From.IndexOf(':');
-			if (portSplit == -1) {
-				Host = client.From;
-			} else {
-				Host = client.From.Substring(0, portSplit);
-				Port = Int32.Parse(client.From.Substring(portSplit + 1));
-			}
-
-			State = NodeState.Connected;
-			MaximumInFlightMessages = client.MaximumInFlightMessages;
-		}
-
-		public Guid ConnectionId { get; set; }
-
-		public Guid NodeId { get; set; }
-
-		public string Host { get; set; }
-
-		public int Port { get; set; }
-
-		public NodeState State { get; set; }
-
-		public PersistentSubscriptionClient Client { get; set; }
-
-		public int MaximumInFlightMessages { get; set; }
-
-		public int AssignmentCount { get; set; }
+internal class Node
+{
+	internal enum NodeState
+	{
+		Connected,
+		Disconnected
 	}
+
+	public Node()
+	{
+	}
+
+	public Node(Guid connectionId, Guid nodeId, string host, int port, NodeState state,
+		PersistentSubscriptionClient client, int maximumInFlightMessages, int assignmentCount)
+	{
+		ConnectionId = connectionId;
+		NodeId = nodeId;
+		Host = host;
+		Port = port;
+		State = state;
+		Client = client;
+		MaximumInFlightMessages = maximumInFlightMessages;
+		AssignmentCount = assignmentCount;
+	}
+
+	public Node(PersistentSubscriptionClient client)
+	{
+		Client = client;
+		ConnectionId = client.ConnectionId;
+		NodeId = client.InstanceId;
+
+		var portSplit = client.From.IndexOf(':');
+		if (portSplit == -1)
+		{
+			Host = client.From;
+		}
+		else
+		{
+			Host = client.From.Substring(0, portSplit);
+			Port = Int32.Parse(client.From.Substring(portSplit + 1));
+		}
+
+		State = NodeState.Connected;
+		MaximumInFlightMessages = client.MaximumInFlightMessages;
+	}
+
+	public Guid ConnectionId { get; set; }
+
+	public Guid NodeId { get; set; }
+
+	public string Host { get; set; }
+
+	public int Port { get; set; }
+
+	public NodeState State { get; set; }
+
+	public PersistentSubscriptionClient Client { get; set; }
+
+	public int MaximumInFlightMessages { get; set; }
+
+	public int AssignmentCount { get; set; }
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClient.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClient.cs
@@ -6,130 +6,153 @@ using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 
-namespace EventStore.Core.Services.PersistentSubscription {
-	public class PersistentSubscriptionClient {
-		public readonly int MaximumInFlightMessages;
+namespace EventStore.Core.Services.PersistentSubscription;
 
-		private readonly Guid _correlationId;
-		private readonly Guid _connectionId;
-		private readonly string _connectionName;
-		private readonly IEnvelope _envelope;
-		private int _allowedMessages;
-		public readonly string Username;
-		public readonly string From;
-		private long _totalItems;
-		private readonly RequestStatistics _extraStatistics;
-		private readonly Dictionary<Guid, OutstandingMessage> _unconfirmedEvents = new Dictionary<Guid, OutstandingMessage>();
+public class PersistentSubscriptionClient
+{
+	public readonly int MaximumInFlightMessages;
 
-		public PersistentSubscriptionClient(Guid correlationId,
-			Guid connectionId,
-			string connectionName,
-			IEnvelope envelope,
-			int inFlightMessages,
-			string username,
-			string from,
-			Stopwatch watch,
-			bool extraStatistics) {
-			_correlationId = correlationId;
-			_connectionId = connectionId;
-			_connectionName = connectionName;
-			_envelope = envelope;
-			_allowedMessages = inFlightMessages;
-			Username = username;
-			From = @from;
-			MaximumInFlightMessages = inFlightMessages;
-			if (extraStatistics) {
-				_extraStatistics = new RequestStatistics(watch, 1000);
-			}
+	private readonly Guid _correlationId;
+	private readonly Guid _connectionId;
+	private readonly string _connectionName;
+	private readonly IEnvelope _envelope;
+	private int _allowedMessages;
+	public readonly string Username;
+	public readonly string From;
+	private long _totalItems;
+	private readonly RequestStatistics _extraStatistics;
+	private readonly Dictionary<Guid, OutstandingMessage> _unconfirmedEvents = new Dictionary<Guid, OutstandingMessage>();
+
+	public PersistentSubscriptionClient(Guid correlationId,
+		Guid connectionId,
+		string connectionName,
+		IEnvelope envelope,
+		int inFlightMessages,
+		string username,
+		string from,
+		Stopwatch watch,
+		bool extraStatistics)
+	{
+		_correlationId = correlationId;
+		_connectionId = connectionId;
+		_connectionName = connectionName;
+		_envelope = envelope;
+		_allowedMessages = inFlightMessages;
+		Username = username;
+		From = @from;
+		MaximumInFlightMessages = inFlightMessages;
+		if (extraStatistics)
+		{
+			_extraStatistics = new RequestStatistics(watch, 1000);
 		}
+	}
 
-		/// <summary>
-		/// Raised whenever an in-flight event has been confirmed. This could be because of ack, nak, timeout or disconnection.
-		/// </summary>
-		public event Action<PersistentSubscriptionClient, ResolvedEvent> EventConfirmed;
+	/// <summary>
+	/// Raised whenever an in-flight event has been confirmed. This could be because of ack, nak, timeout or disconnection.
+	/// </summary>
+	public event Action<PersistentSubscriptionClient, ResolvedEvent> EventConfirmed;
 
-		public int InflightMessages {
-			get { return _unconfirmedEvents.Count; }
-		}
+	public int InflightMessages
+	{
+		get { return _unconfirmedEvents.Count; }
+	}
 
-		public int AvailableSlots {
-			get { return _allowedMessages; }
-		}
+	public int AvailableSlots
+	{
+		get { return _allowedMessages; }
+	}
 
-		public Guid ConnectionId {
-			get { return _connectionId; }
-		}
+	public Guid InstanceId { get; } = Guid.NewGuid();
 
-		public string ConnectionName {
-			get { return _connectionName; }
-		}
+	public Guid ConnectionId
+	{
+		get { return _connectionId; }
+	}
 
-		public long TotalItems {
-			get { return _totalItems; }
-		}
+	public string ConnectionName
+	{
+		get { return _connectionName; }
+	}
 
-		public long LastTotalItems { get; set; }
+	public long TotalItems
+	{
+		get { return _totalItems; }
+	}
 
-		public Guid CorrelationId {
-			get { return _correlationId; }
-		}
+	public long LastTotalItems { get; set; }
 
-		internal bool RemoveFromProcessing(Guid[] processedEventIds) {
-			bool removedAny = false;
-			foreach (var processedEventId in processedEventIds) {
-				if (_extraStatistics != null)
-					_extraStatistics.EndOperation(processedEventId);
-				OutstandingMessage ev;
-				if (!_unconfirmedEvents.TryGetValue(processedEventId, out ev)) continue;
-				_unconfirmedEvents.Remove(processedEventId);
-				removedAny = true;
-				_allowedMessages++;
-				OnEventConfirmed(ev);
-			}
+	public Guid CorrelationId
+	{
+		get { return _correlationId; }
+	}
 
-			return removedAny;
-		}
-
-		public bool Push(OutstandingMessage message) {
-			if (!CanSend()) {
-				return false;
-			}
-
-			var evnt = message.ResolvedEvent;
-			_allowedMessages--;
-			Interlocked.Increment(ref _totalItems);
+	internal bool RemoveFromProcessing(Guid[] processedEventIds)
+	{
+		bool removedAny = false;
+		foreach (var processedEventId in processedEventIds)
+		{
 			if (_extraStatistics != null)
-				_extraStatistics.StartOperation(evnt.OriginalEvent.EventId);
-
-			_envelope.ReplyWith(
-				new ClientMessage.PersistentSubscriptionStreamEventAppeared(CorrelationId, evnt, message.RetryCount));
-			if (!_unconfirmedEvents.ContainsKey(evnt.OriginalEvent.EventId)) {
-				_unconfirmedEvents.Add(evnt.OriginalEvent.EventId, message);
-			}
-
-			return true;
+				_extraStatistics.EndOperation(processedEventId);
+			OutstandingMessage ev;
+			if (!_unconfirmedEvents.TryGetValue(processedEventId, out ev))
+				continue;
+			_unconfirmedEvents.Remove(processedEventId);
+			removedAny = true;
+			_allowedMessages++;
+			OnEventConfirmed(ev);
 		}
 
-		public IEnumerable<OutstandingMessage> GetUnconfirmedEvents() {
-			return _unconfirmedEvents.Values;
+		return removedAny;
+	}
+
+	public bool Push(OutstandingMessage message)
+	{
+		if (!CanSend())
+		{
+			return false;
 		}
 
-		internal void SendDropNotification() {
-			_envelope.ReplyWith(
-				new ClientMessage.SubscriptionDropped(CorrelationId, SubscriptionDropReason.Unsubscribed));
+		var evnt = message.ResolvedEvent;
+		_allowedMessages--;
+		Interlocked.Increment(ref _totalItems);
+		if (_extraStatistics != null)
+			_extraStatistics.StartOperation(evnt.OriginalEvent.EventId);
+
+		_envelope.ReplyWith(
+			new ClientMessage.PersistentSubscriptionStreamEventAppeared(CorrelationId, evnt, message.RetryCount));
+		if (!_unconfirmedEvents.ContainsKey(evnt.OriginalEvent.EventId))
+		{
+			_unconfirmedEvents.Add(evnt.OriginalEvent.EventId, message);
 		}
 
-		internal ObservedTimingMeasurement GetExtraStats() {
-			return _extraStatistics == null ? null : _extraStatistics.GetMeasurementDetails();
-		}
+		return true;
+	}
 
-		private bool CanSend() {
-			return AvailableSlots > 0;
-		}
+	public IEnumerable<OutstandingMessage> GetUnconfirmedEvents()
+	{
+		return _unconfirmedEvents.Values;
+	}
 
-		private void OnEventConfirmed(OutstandingMessage ev) {
-			var handler = EventConfirmed;
-			if (handler != null) handler(this, ev.ResolvedEvent);
-		}
+	internal void SendDropNotification()
+	{
+		_envelope.ReplyWith(
+			new ClientMessage.SubscriptionDropped(CorrelationId, SubscriptionDropReason.Unsubscribed));
+	}
+
+	internal ObservedTimingMeasurement GetExtraStats()
+	{
+		return _extraStatistics == null ? null : _extraStatistics.GetMeasurementDetails();
+	}
+
+	private bool CanSend()
+	{
+		return AvailableSlots > 0;
+	}
+
+	private void OnEventConfirmed(OutstandingMessage ev)
+	{
+		var handler = EventConfirmed;
+		if (handler != null)
+			handler(this, ev.ResolvedEvent);
 	}
 }


### PR DESCRIPTION
- Prevent reconnects from leaving pinned buckets tied to a stale client identity.
- Keep pinned subscription routing tied to live server-owned client instances instead of reusable protocol correlation values.