### PR TITLE
fix(storage): harden ongoing chunk flush writes

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,10 +6,10 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
-    <PackageVersion Include="DotNext" Version="5.22.0" />
-    <PackageVersion Include="DotNext.IO" Version="5.22.0" />
-    <PackageVersion Include="DotNext.Threading" Version="5.22.0" />
-    <PackageVersion Include="DotNext.Unsafe" Version="5.22.0" />
+    <PackageVersion Include="DotNext" Version="5.26.3" />
+    <PackageVersion Include="DotNext.IO" Version="5.26.3" />
+    <PackageVersion Include="DotNext.Threading" Version="5.26.3" />
+    <PackageVersion Include="DotNext.Unsafe" Version="5.26.2" />
     <PackageVersion Include="EventStore.Client" Version="21.2.0" />
     <PackageVersion Include="EventStore.Client.Grpc.Streams" Version="23.3.9" />
     <!--Version 8 and beyond are free for open-source projects and non-commercial use, but commercial use requires a paid license-->

--- a/src/EventStore.Core.Tests/TransactionLog/WhenOpeningExistingOngoingTfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/WhenOpeningExistingOngoingTfchunk.cs
@@ -14,17 +14,24 @@ public class WhenOpeningExistingOngoingTfchunk : SpecificationWithFilePerTestFix
 {
 	private TFChunk _chunk;
 	private TFChunk _testChunk;
+	private long _nextLogPosition;
 
 	[OneTimeSetUp]
 	public override async Task TestFixtureSetUp()
 	{
 		await base.TestFixtureSetUp();
 		_chunk = await TFChunkHelper.CreateNewChunk(Filename, chunkSize: 10 * 1024);
+		var seedResult = await _chunk.TryAppend(
+			new CommitLogRecord(0, Guid.NewGuid(), 0, DateTime.UtcNow, 0),
+			CancellationToken.None);
+		Assert.IsTrue(seedResult.Success);
+		Assert.Greater(seedResult.NewPosition, 0);
+		_nextLogPosition = seedResult.NewPosition;
 		_chunk.TryClose();
 		_testChunk = await TFChunk.FromOngoingFile(
 			fileSystem: TFChunkHelper.CreateLocalFileSystem(Filename),
 			filename: Filename,
-			writePosition: 0,
+			writePosition: (int)_nextLogPosition,
 			unbuffered: false,
 			writethrough: false,
 			reduceFileCachePressure: false,
@@ -60,7 +67,7 @@ public class WhenOpeningExistingOngoingTfchunk : SpecificationWithFilePerTestFix
 		await _testChunk.Flush(CancellationToken.None);
 
 		var result = await _testChunk.TryAppend(
-			new CommitLogRecord(0, Guid.NewGuid(), 0, DateTime.UtcNow, 0),
+			new CommitLogRecord(_nextLogPosition, Guid.NewGuid(), 0, DateTime.UtcNow, 0),
 			CancellationToken.None);
 
 		Assert.IsTrue(result.Success);

--- a/src/EventStore.Core.Tests/TransactionLog/WhenOpeningExistingOngoingTfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/WhenOpeningExistingOngoingTfchunk.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Transforms;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog;
+
+[TestFixture]
+public class WhenOpeningExistingOngoingTfchunk : SpecificationWithFilePerTestFixture
+{
+	private TFChunk _chunk;
+	private TFChunk _testChunk;
+
+	[OneTimeSetUp]
+	public override async Task TestFixtureSetUp()
+	{
+		await base.TestFixtureSetUp();
+		_chunk = await TFChunkHelper.CreateNewChunk(Filename, chunkSize: 10 * 1024);
+		_chunk.TryClose();
+		_testChunk = await TFChunk.FromOngoingFile(
+			fileSystem: TFChunkHelper.CreateLocalFileSystem(Filename),
+			filename: Filename,
+			writePosition: 0,
+			unbuffered: false,
+			writethrough: false,
+			reduceFileCachePressure: false,
+			tracker: new TFChunkTracker.NoOp(),
+			asyncIO: false,
+			getTransformFactory: DbTransformManager.Default.GetFactoryForExistingChunk,
+			token: CancellationToken.None);
+	}
+
+	[OneTimeTearDown]
+	public override void TestFixtureTearDown()
+	{
+		_chunk.Dispose();
+		_testChunk.Dispose();
+		base.TestFixtureTearDown();
+	}
+
+	[Test]
+	public void the_chunk_is_cached()
+	{
+		Assert.IsTrue(_testChunk.IsCached);
+	}
+
+	[Test]
+	public void the_chunk_is_not_readonly()
+	{
+		Assert.IsFalse(_testChunk.IsReadOnly);
+	}
+
+	[Test]
+	public async Task can_flush_and_then_write()
+	{
+		await _testChunk.Flush(CancellationToken.None);
+
+		var result = await _testChunk.TryAppend(
+			new CommitLogRecord(0, Guid.NewGuid(), 0, DateTime.UtcNow, 0),
+			CancellationToken.None);
+
+		Assert.IsTrue(result.Success);
+	}
+}

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
@@ -10,18 +10,19 @@ using EventStore.Core.Data;
 using EventStore.Core.Exceptions;
 using EventStore.Core.LogAbstraction;
 using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
 using EventStore.Core.Services.Storage.InMemory;
 using EventStore.Core.Services.Storage.ReaderIndex;
-using EventStore.Core.TransactionLog.Checkpoint;
-using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
 using EventStore.Core.Services.TimerService;
-using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using ILogger = Serilog.ILogger;
+using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
 
 namespace EventStore.Core.Services.Storage;
 
-public abstract class StorageReaderWorker {
+public abstract class StorageReaderWorker
+{
 	protected static readonly ILogger Log = Serilog.Log.ForContext<StorageReaderWorker>();
 }
 
@@ -46,6 +47,7 @@ public class StorageReaderWorker<TStreamId> :
 	private readonly IReadOnlyCheckpoint _writerCheckpoint;
 	private readonly IInMemoryStreamReader _memoryStreamReader;
 	private readonly int _queueId;
+	private readonly CancellationTokenMultiplexer _tokenMultiplexer = new();
 	private static readonly char[] LinkToSeparator = { '@' };
 	private const int MaxPageSize = 4096;
 	private DateTime? _lastExpireTime;
@@ -88,19 +90,15 @@ public class StorageReaderWorker<TStreamId> :
 			return;
 		}
 
-		var cts = token.LinkTo(msg.CancellationToken);
+		using var cts = Multiplex(ref token, msg.CancellationToken);
 		try
 		{
 			var ev = await ReadEvent(msg, token);
 			msg.Envelope.ReplyWith(ev);
 		}
-		catch (OperationCanceledException ex) when (ex.CancellationToken == cts?.Token)
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token)
 		{
 			throw new OperationCanceledException(null, ex, cts.CancellationOrigin);
-		}
-		finally
-		{
-			cts?.Dispose();
 		}
 	}
 
@@ -128,20 +126,16 @@ public class StorageReaderWorker<TStreamId> :
 		}
 
 		ClientMessage.ReadStreamEventsForwardCompleted res;
-		var cts = token.LinkTo(msg.CancellationToken);
+		using var cts = Multiplex(ref token, msg.CancellationToken);
 		try
 		{
 			res = SystemStreams.IsInMemoryStream(msg.EventStreamId)
 				? _memoryStreamReader.ReadForwards(msg)
 				: await ReadStreamEventsForward(msg, token);
 		}
-		catch (OperationCanceledException ex) when (ex.CancellationToken == cts?.Token)
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token)
 		{
 			throw new OperationCanceledException(null, ex, cts.CancellationOrigin);
-		}
-		finally
-		{
-			cts?.Dispose();
 		}
 
 		switch (res.Result)
@@ -187,7 +181,7 @@ public class StorageReaderWorker<TStreamId> :
 			return;
 		}
 
-		var cts = token.LinkTo(msg.CancellationToken);
+		using var cts = Multiplex(ref token, msg.CancellationToken);
 		try
 		{
 			var res = SystemStreams.IsInMemoryStream(msg.EventStreamId)
@@ -196,13 +190,9 @@ public class StorageReaderWorker<TStreamId> :
 
 			msg.Envelope.ReplyWith(res);
 		}
-		catch (OperationCanceledException ex) when (ex.CancellationToken == cts?.Token)
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token)
 		{
 			throw new OperationCanceledException(null, ex, cts.CancellationOrigin);
-		}
-		finally
-		{
-			cts?.Dispose();
 		}
 	}
 
@@ -246,7 +236,7 @@ public class StorageReaderWorker<TStreamId> :
 				break;
 			case ReadAllResult.NotModified:
 				if (msg.LongPollTimeout.HasValue && res.IsEndOfStream &&
-				    res.CurrentPos.CommitPosition > res.TfLastCommitPosition)
+					res.CurrentPos.CommitPosition > res.TfLastCommitPosition)
 				{
 					_publisher.Publish(new SubscriptionMessage.PollStream(
 						SubscriptionsService.AllStreamsSubscriptionId, res.TfLastCommitPosition, null,
@@ -323,7 +313,7 @@ public class StorageReaderWorker<TStreamId> :
 				break;
 			case FilteredReadAllResult.NotModified:
 				if (msg.LongPollTimeout.HasValue && res.IsEndOfStream &&
-				    res.CurrentPos.CommitPosition > res.TfLastCommitPosition)
+					res.CurrentPos.CommitPosition > res.TfLastCommitPosition)
 				{
 					_publisher.Publish(new SubscriptionMessage.PollStream(
 						SubscriptionsService.AllStreamsSubscriptionId, res.TfLastCommitPosition, null,
@@ -373,7 +363,7 @@ public class StorageReaderWorker<TStreamId> :
 				break;
 			case FilteredReadAllResult.NotModified:
 				if (msg.LongPollTimeout.HasValue && res.IsEndOfStream &&
-				    res.CurrentPos.CommitPosition > res.TfLastCommitPosition)
+					res.CurrentPos.CommitPosition > res.TfLastCommitPosition)
 				{
 					_publisher.Publish(new SubscriptionMessage.PollStream(
 						SubscriptionsService.AllStreamsSubscriptionId, res.TfLastCommitPosition, null,
@@ -397,7 +387,7 @@ public class StorageReaderWorker<TStreamId> :
 		StorageMessage.EffectiveStreamAclRequest msg, CancellationToken token)
 	{
 		Message reply;
-		var cts = token.LinkTo(msg.CancellationToken);
+		using var cts = Multiplex(ref token, msg.CancellationToken);
 
 		try
 		{
@@ -408,13 +398,9 @@ public class StorageReaderWorker<TStreamId> :
 		{
 			reply = new StorageMessage.OperationCancelledMessage(msg.CancellationToken);
 		}
-		catch (OperationCanceledException ex) when (ex.CancellationToken == cts?.Token)
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token)
 		{
 			throw new OperationCanceledException(null, ex, cts.CancellationOrigin);
-		}
-		finally
-		{
-			cts?.Dispose();
 		}
 
 		msg.Envelope.ReplyWith(reply);
@@ -434,9 +420,9 @@ public class StorageReaderWorker<TStreamId> :
 			if (record is null)
 				return NoData(msg, ReadEventResult.AccessDenied);
 			if (result.Result is ReadEventResult.NoStream or ReadEventResult.NotFound &&
-			    _systemStreams.IsMetaStream(streamId) &&
-			    result.OriginalStreamExists.HasValue &&
-			    result.OriginalStreamExists.Value)
+				_systemStreams.IsMetaStream(streamId) &&
+				result.OriginalStreamExists.HasValue &&
+				result.OriginalStreamExists.Value)
 			{
 				return NoData(msg, ReadEventResult.Success);
 			}
@@ -466,7 +452,7 @@ public class StorageReaderWorker<TStreamId> :
 			var streamName = msg.EventStreamId;
 			var streamId = _readIndex.GetStreamId(msg.EventStreamId);
 			if (msg.ValidationStreamVersion.HasValue &&
-			    await _readIndex.GetStreamLastEventNumber(streamId, token) == msg.ValidationStreamVersion)
+				await _readIndex.GetStreamLastEventNumber(streamId, token) == msg.ValidationStreamVersion)
 				return NoData(msg, ReadStreamResult.NotModified, lastIndexPosition,
 					msg.ValidationStreamVersion.Value);
 
@@ -504,7 +490,7 @@ public class StorageReaderWorker<TStreamId> :
 			var streamName = msg.EventStreamId;
 			var streamId = _readIndex.GetStreamId(msg.EventStreamId);
 			if (msg.ValidationStreamVersion.HasValue &&
-			    await _readIndex.GetStreamLastEventNumber(streamId, token) == msg.ValidationStreamVersion)
+				await _readIndex.GetStreamLastEventNumber(streamId, token) == msg.ValidationStreamVersion)
 				return NoData(msg, ReadStreamResult.NotModified, lastIndexedPosition,
 					msg.ValidationStreamVersion.Value);
 
@@ -967,7 +953,7 @@ public class StorageReaderWorker<TStreamId> :
 	async ValueTask IAsyncHandle<StorageMessage.StreamIdFromTransactionIdRequest>.HandleAsync(
 		StorageMessage.StreamIdFromTransactionIdRequest message, CancellationToken token)
 	{
-		var cts = token.LinkTo(message.CancellationToken);
+		using var cts = Multiplex(ref token, message.CancellationToken);
 		Message reply;
 		try
 		{
@@ -979,15 +965,20 @@ public class StorageReaderWorker<TStreamId> :
 		{
 			reply = new StorageMessage.OperationCancelledMessage(message.CancellationToken);
 		}
-		catch (OperationCanceledException ex) when (ex.CancellationToken == cts?.Token)
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token)
 		{
 			throw new OperationCanceledException(null, ex, cts.CancellationOrigin);
 		}
-		finally
-		{
-			cts?.Dispose();
-		}
 
 		message.Envelope.ReplyWith(reply);
+	}
+
+	private CancellationTokenMultiplexer.Scope Multiplex(
+		ref CancellationToken token,
+		CancellationToken cancellationToken)
+	{
+		var scope = _tokenMultiplexer.Combine([token, cancellationToken]);
+		token = scope.Token;
+		return scope;
 	}
 }


### PR DESCRIPTION
- Prevent active chunk recovery from depending on stale buffered-stream behavior during flush-before-write paths.
- Keep storage reader cancellation propagation aligned with supported dependency APIs instead of obsolete token linking.