### PR TITLE
fix(tests): generate log records with utc timestamps

### DIFF
--- a/src/EventStore.Core.Tests/Services/Storage/WriteEventsToIndexScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/WriteEventsToIndexScenario.cs
@@ -50,7 +50,7 @@ public abstract class WriteEventsToIndexScenario<TLogFormat, TStreamId> : Specif
 				eventType,
 				new byte[0],
 				new byte[0],
-				DateTime.Now,
+					DateTime.UtcNow,
 				PrepareFlags.IsCommitted
 			)
 		};
@@ -91,7 +91,7 @@ public abstract class WriteEventsToIndexScenario<TLogFormat, TStreamId> : Specif
 					eventTypes[i],
 					new byte[0],
 					new byte[0],
-					DateTime.Now
+					DateTime.UtcNow
 			));
 		}
 
@@ -100,7 +100,7 @@ public abstract class WriteEventsToIndexScenario<TLogFormat, TStreamId> : Specif
 
 	public CommitLogRecord CreateCommitLogRecord(long logPosition, long transactionPosition, long firstEventNumber)
 	{
-		return new CommitLogRecord(logPosition, Guid.NewGuid(), transactionPosition, DateTime.Now, 0);
+		return new CommitLogRecord(logPosition, Guid.NewGuid(), transactionPosition, DateTime.UtcNow, 0);
 	}
 
 	public void WriteToDB(IEnumerable<IPrepareLogRecord<TStreamId>> prepares)

--- a/src/EventStore.Core.XUnit.Tests/Authorization/StreamBasedAuthPolicyRegistryTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Authorization/StreamBasedAuthPolicyRegistryTests.cs
@@ -10,8 +10,8 @@ using EventStore.Common.Exceptions;
 using EventStore.Core.Authorization;
 using EventStore.Core.Authorization.AuthorizationPolicies;
 using EventStore.Core.Bus;
-using EventStore.Core.Messages;
 using EventStore.Core.Data;
+using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services;
 using EventStore.Core.TransactionLog.LogRecords;
@@ -415,7 +415,7 @@ public class StreamBasedAuthPolicyRegistryTests
 			transactionOffset: 0,
 			SystemStreams.AuthorizationPolicyRegistryStream,
 			eventStreamIdSize: null,
-			expectedVersion: eventNumber, DateTime.Now, PrepareFlags.Data,
+			expectedVersion: eventNumber, DateTime.UtcNow, PrepareFlags.Data,
 			eventType, eventTypeSize: null, data, ReadOnlyMemory<byte>.Empty);
 		var eventRecord = new EventRecord(eventNumber, prepare, SystemStreams.AuthorizationPolicyRegistryStream,
 			eventType);

--- a/src/EventStore.Core.XUnit.Tests/Index/IndexTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Index/IndexTrackerTests.cs
@@ -46,7 +46,7 @@ public class IndexTrackerTests : IDisposable
 
 	private static PrepareLogRecord CreatePrepare()
 	{
-		return new PrepareLogRecord(42, Guid.NewGuid(), Guid.NewGuid(), 42, 42, "tests", null, 42, DateTime.Now,
+		return new PrepareLogRecord(42, Guid.NewGuid(), Guid.NewGuid(), 42, 42, "tests", null, 42, DateTime.UtcNow,
 			PrepareFlags.Data, "type-test", null, Array.Empty<byte>(), Array.Empty<byte>());
 	}
 

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkTrackerTests.cs
@@ -174,17 +174,17 @@ public class TFChunkTrackerTests : IDisposable
 
 	private static PrepareLogRecord CreatePrepare(byte[] data, byte[] meta, long logPosition = 42)
 	{
-		return new PrepareLogRecord(logPosition, Guid.NewGuid(), Guid.NewGuid(), 42, 42, "tests", null, 42, DateTime.Now,
+		return new PrepareLogRecord(logPosition, Guid.NewGuid(), Guid.NewGuid(), 42, 42, "tests", null, 42, DateTime.UtcNow,
 			PrepareFlags.Data, "type-test", null, data, meta);
 	}
 
 	private static SystemLogRecord CreateSystemRecord()
 	{
-		return new SystemLogRecord(42, DateTime.Now, SystemRecordType.Epoch, SystemRecordSerialization.Binary, Array.Empty<byte>());
+		return new SystemLogRecord(42, DateTime.UtcNow, SystemRecordType.Epoch, SystemRecordSerialization.Binary, Array.Empty<byte>());
 	}
 
 	private static CommitLogRecord CreateCommit()
 	{
-		return new CommitLogRecord(42, Guid.NewGuid(), 42, DateTime.Now, 42);
+		return new CommitLogRecord(42, Guid.NewGuid(), 42, DateTime.UtcNow, 42);
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/PrepareLogRecordViewTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/PrepareLogRecordViewTests.cs
@@ -17,7 +17,7 @@ public class PrepareLogRecordViewTests
 	private const int TransactionOffset = 321;
 	private const string EventStreamId = "test_stream";
 	private const long ExpectedVersion = 789;
-	private readonly DateTime _timestamp = DateTime.Now;
+	private readonly DateTime _timestamp = new(DateTime.UtcNow.Ticks);
 	private const PrepareFlags Flags = PrepareFlags.SingleWrite;
 	private const string EventType = "test_event_type";
 	private readonly byte[] _data = { 0xDE, 0XAD, 0xC0, 0XDE };

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/SizeOnDiskTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/SizeOnDiskTests.cs
@@ -32,7 +32,7 @@ public class SizeOnDiskTests
 				eventStreamId: theString,
 				eventStreamIdSize: null,
 				expectedVersion: 789,
-				timeStamp: DateTime.Now,
+					timeStamp: DateTime.UtcNow,
 				flags: PrepareFlags.SingleWrite,
 				eventType: theString,
 				eventTypeSize: null,
@@ -45,12 +45,12 @@ public class SizeOnDiskTests
 			logPosition: 123,
 			correlationId: Guid.NewGuid(),
 			transactionPosition: 456,
-			timeStamp: DateTime.Now,
+				timeStamp: DateTime.UtcNow,
 			firstEventNumber: 789,
 			commitRecordVersion: 1);
 
 		static SystemLogRecord CreateSystemLogRecord() => new(logPosition: 123,
-			timeStamp: DateTime.Now,
+				timeStamp: DateTime.UtcNow,
 			systemRecordType: SystemRecordType.Epoch,
 			systemRecordSerialization: SystemRecordSerialization.Binary,
 			data: [0xDE, 0XAD, 0xC0, 0XDE]);

--- a/src/EventStore.Projections.Core.Javascript.Tests/Integration/SubsystemScenario.cs
+++ b/src/EventStore.Projections.Core.Javascript.Tests/Integration/SubsystemScenario.cs
@@ -343,7 +343,7 @@ public abstract class SubsystemScenario : IHandle<Message>, IAsyncLifetime
 					flags |= PrepareFlags.TransactionEnd;
 
 				var record = new EventRecord(revision, position, message.CorrelationId,
-					current.EventId, _all.Count, i, message.EventStreamId, -1, DateTime.Now,
+					current.EventId, _all.Count, i, message.EventStreamId, -1, DateTime.UtcNow,
 					flags, current.EventType, current.Data, current.Metadata);
 				if (current.EventType == SystemEventTypes.LinkTo)
 				{


### PR DESCRIPTION
- Keep test-generated log records stable across local timezone boundaries.
- Reduce timestamp-kind drift in storage and projection fixtures that behave like event data.