### PR TITLE
fix(tests): reduce async timing flakes

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/GetInfoTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/GetInfoTests.cs
@@ -781,9 +781,9 @@ public class GetInfoTests
 
 		for (int i = 0; resp.Subscriptions.Any(s => s.Status != "Live"); i++)
 		{
-			Assert.AreNotEqual(5, i, "Reached too many retries to get all subscriptions live!");
+			Assert.AreNotEqual(20, i, "Reached too many retries to get all subscriptions live!");
 
-			await Task.Delay(500);
+			await Task.Delay(1000);
 			resp = await GetSubscriptions();
 		}
 

--- a/src/EventStore.Core.XUnit.Tests/Authorization/StreamBasedAuthPolicyRegistryTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Authorization/StreamBasedAuthPolicyRegistryTests.cs
@@ -10,8 +10,8 @@ using EventStore.Common.Exceptions;
 using EventStore.Core.Authorization;
 using EventStore.Core.Authorization.AuthorizationPolicies;
 using EventStore.Core.Bus;
-using EventStore.Core.Messages;
 using EventStore.Core.Data;
+using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services;
 using EventStore.Core.TransactionLog.LogRecords;
@@ -35,7 +35,7 @@ public class StreamBasedAuthPolicyRegistryTests
 		PropertyNamingPolicy = JsonNamingPolicy.CamelCase
 	};
 
-	private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+	private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
 
 	private StreamBasedAuthorizationPolicyRegistry CreateSut(
 		FakePolicySelectorPlugin[] plugins, AuthorizationPolicySettings defaultSettings,


### PR DESCRIPTION
- Give asynchronous subscription and authorization propagation room to settle under slower CI load.
- Reduce false negatives from timing-sensitive tests without changing production behavior.