### PR TITLE
chore(runtime): keep failures deterministic

### DIFF
--- a/src/EventStore.Core.Tests/ClientAPI/catch_up_subscription_handles_errors.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/catch_up_subscription_handles_errors.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -21,7 +20,7 @@ namespace EventStore.Core.Tests.ClientAPI;
 [TestFixture, Category("ClientAPI"), Category("LongRunning")]
 public class catch_up_subscription_handles_errors
 {
-	private static readonly int TimeoutMs = Debugger.IsAttached ? Timeout.Infinite : 2000;
+	private const int TimeoutMs = 2000;
 	private FakeEventStoreConnection _connection;
 	private IList<ResolvedEvent> _raisedEvents;
 	private bool _liveProcessingStarted;

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/GrpcSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/GrpcSpecification.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -123,9 +122,7 @@ public abstract class GrpcSpecification<TLogFormat, TStreamId>
 
 	protected CallOptions GetCallOptions((string userName, string password) credentials = default) =>
 		new(credentials: GetCredentials(credentials == default ? DefaultCredentials : credentials),
-			deadline: Debugger.IsAttached
-				? DateTime.UtcNow.AddDays(1)
-				: new DateTime?());
+			deadline: null);
 
 	private static CallCredentials GetCredentials((string userName, string password) credentials) =>
 		credentials == default ? null : CallCredentialsFromUser(credentials);

--- a/src/EventStore.Core.Tests/TaskExtensions.cs
+++ b/src/EventStore.Core.Tests/TaskExtensions.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using DotNext;
-using static System.Threading.Timeout;
 
 namespace EventStore.Core.Tests;
 
@@ -14,11 +13,6 @@ public static class TaskExtensions
 		[CallerLineNumber] int sourceLineNumber = 0)
 	{
 		Debug.Assert(task is not null);
-
-		if (Debugger.IsAttached)
-		{
-			timeout = InfiniteTimeSpan;
-		}
 
 		await task
 			.WaitAsync(timeout)
@@ -43,12 +37,6 @@ public static class TaskExtensions
 		[CallerMemberName] string memberName = "", [CallerFilePath] string sourceFilePath = "",
 		[CallerLineNumber] int sourceLineNumber = 0)
 	{
-
-		if (Debugger.IsAttached)
-		{
-			timeout = InfiniteTimeSpan;
-		}
-
 		await task.As<Task>()
 			.WaitAsync(timeout)
 			.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
@@ -1,20 +1,19 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Index;
-using EventStore.Core.Messages;
 using EventStore.Core.LogAbstraction;
+using EventStore.Core.Messages;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.LogRecords;
-using ILogger = Serilog.ILogger;
 using EventStore.LogCommon;
+using ILogger = Serilog.ILogger;
 
 namespace EventStore.Core.Services.Storage.ReaderIndex;
 
@@ -125,30 +124,30 @@ public class IndexCommitter<TStreamId>(
 					case LogRecordType.Stream:
 					case LogRecordType.EventType:
 					case LogRecordType.Prepare:
-					{
-						var prepare = (IPrepareLogRecord<TStreamId>)result.LogRecord;
-						if (prepare.Flags.HasAnyOf(PrepareFlags.IsCommitted))
 						{
-							if (prepare.Flags.HasAnyOf(PrepareFlags.SingleWrite))
+							var prepare = (IPrepareLogRecord<TStreamId>)result.LogRecord;
+							if (prepare.Flags.HasAnyOf(PrepareFlags.IsCommitted))
 							{
-								await Commit(commitedPrepares, false, false, token);
-								commitedPrepares.Clear();
-								await Commit([prepare], result.Eof, false, token);
-							}
-							else
-							{
-								if (prepare.Flags.HasAnyOf(PrepareFlags.Data | PrepareFlags.StreamDelete))
-									commitedPrepares.Add(prepare);
-								if (prepare.Flags.HasAnyOf(PrepareFlags.TransactionEnd))
+								if (prepare.Flags.HasAnyOf(PrepareFlags.SingleWrite))
 								{
-									await Commit(commitedPrepares, result.Eof, false, token);
+									await Commit(commitedPrepares, false, false, token);
 									commitedPrepares.Clear();
+									await Commit([prepare], result.Eof, false, token);
+								}
+								else
+								{
+									if (prepare.Flags.HasAnyOf(PrepareFlags.Data | PrepareFlags.StreamDelete))
+										commitedPrepares.Add(prepare);
+									if (prepare.Flags.HasAnyOf(PrepareFlags.TransactionEnd))
+									{
+										await Commit(commitedPrepares, result.Eof, false, token);
+										commitedPrepares.Clear();
+									}
 								}
 							}
-						}
 
-						break;
-					}
+							break;
+						}
 					case LogRecordType.Commit:
 						await Commit((CommitLogRecord)result.LogRecord, result.Eof, false, token);
 						break;
@@ -286,7 +285,7 @@ public class IndexCommitter<TStreamId>(
 				: commit.FirstEventNumber + prepare.TransactionOffset;
 
 			if (new TFPos(commit.LogPosition, prepare.LogPosition) >
-			    new TFPos(_persistedCommitPos, _persistedPreparePos))
+				new TFPos(_persistedCommitPos, _persistedPreparePos))
 			{
 				indexEntries.Add(new IndexKey<TStreamId>(streamId, eventNumber, prepare.LogPosition));
 				prepares.Add(prepare);
@@ -403,14 +402,14 @@ public class IndexCommitter<TStreamId>(
 			}
 
 			if (prepare.LogPosition < lastIndexedPosition ||
-			    (prepare.LogPosition == lastIndexedPosition && !_indexRebuild))
+				(prepare.LogPosition == lastIndexedPosition && !_indexRebuild))
 				continue; // already committed
 
 			eventNumber =
 				prepare.ExpectedVersion + 1; /* for committed prepare expected version is always explicit */
 
 			if (new TFPos(prepare.LogPosition, prepare.LogPosition) >
-			    new TFPos(_persistedCommitPos, _persistedPreparePos))
+				new TFPos(_persistedCommitPos, _persistedPreparePos))
 			{
 				indexEntries.Add(new IndexKey<TStreamId>(streamId, eventNumber, prepare.LogPosition));
 				prepares.Add(prepare);
@@ -512,13 +511,10 @@ public class IndexCommitter<TStreamId>(
 		long lastEventNumber = await indexReader.GetStreamLastEventNumber(streamId, token);
 		if (newEventNumber != lastEventNumber + 1)
 		{
-			if (Debugger.IsAttached)
-				Debugger.Break();
-			else
-				throw new Exception(
-					string.Format(
-						"Commit invariant violation: new event number {0} does not correspond to current stream version {1}.\n"
-						+ "Stream ID: {2}.\nCommit: {3}.", newEventNumber, lastEventNumber, streamId, commit));
+			throw new Exception(
+				string.Format(
+					"Commit invariant violation: new event number {0} does not correspond to current stream version {1}.\n"
+					+ "Stream ID: {2}.\nCommit: {3}.", newEventNumber, lastEventNumber, streamId, commit));
 		}
 	}
 
@@ -536,15 +532,12 @@ public class IndexCommitter<TStreamId>(
 				var prepare = prepares[prepareIndex];
 				IPrepareLogRecord<TStreamId> indexedPrepare = await GetPrepare(reader, indexEntry.Position, token);
 				if (indexedPrepare != null &&
-				    StreamIdComparer.Equals(indexedPrepare.EventStreamId, prepare.EventStreamId))
+					StreamIdComparer.Equals(indexedPrepare.EventStreamId, prepare.EventStreamId))
 				{
-					if (Debugger.IsAttached)
-						Debugger.Break();
-					else
-						throw new Exception(
-							string.Format("Trying to add duplicate event #{0} to stream {1} \nCommit: {2}\n"
-							              + "Prepare: {3}\nIndexed prepare: {4}.",
-								indexEntry.Version, prepare.EventStreamId, commit, prepare, indexedPrepare));
+					throw new Exception(
+						string.Format("Trying to add duplicate event #{0} to stream {1} \nCommit: {2}\n"
+									  + "Prepare: {3}\nIndexed prepare: {4}.",
+							indexEntry.Version, prepare.EventStreamId, commit, prepare, indexedPrepare));
 				}
 			}
 		}

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexWriter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexWriter.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -471,10 +470,6 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId>
 				commitInfo.StreamId,
 				x =>
 				{
-					if (!Debugger.IsAttached)
-						Debugger.Launch();
-					else
-						Debugger.Break();
 					throw new Exception(string.Format("CommitInfo for stream '{0}' is not present!", x));
 				},
 				(streamId, oldVersion) => oldVersion,
@@ -485,10 +480,6 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId>
 					_systemStreams.OriginalStreamOf(commitInfo.StreamId),
 					x =>
 					{
-						if (!Debugger.IsAttached)
-							Debugger.Launch();
-						else
-							Debugger.Break();
 						throw new Exception(string.Format(
 							"Original stream CommitInfo for meta-stream '{0}' is not present!",
 							_systemStreams.MetaStreamOf(x)));

--- a/src/EventStore.MicroBenchmarks/Program.cs
+++ b/src/EventStore.MicroBenchmarks/Program.cs
@@ -14,8 +14,7 @@ internal class Program
 {
 	static void Main(string[] args)
 	{
-		var config = System.Diagnostics.Debugger.IsAttached ? new DebugBuildConfig() { } : DefaultConfig.Instance;
-		BenchmarkRunner.Run<ProjectionSerializationBenchmarks>(config, args);
+		BenchmarkRunner.Run<ProjectionSerializationBenchmarks>(DefaultConfig.Instance, args);
 	}
 }
 

--- a/src/EventStore.Projections.Core.Javascript.Tests/Integration/ProjectionRuntimeScenario.cs
+++ b/src/EventStore.Projections.Core.Javascript.Tests/Integration/ProjectionRuntimeScenario.cs
@@ -24,7 +24,7 @@ public abstract class ProjectionRuntimeScenario : SubsystemScenario
 	static readonly IConfiguration EmptyConfiguration = new ConfigurationBuilder().AddInMemoryCollection().Build();
 
 	protected ProjectionRuntimeScenario() : base(CreateRuntime, "$et",
-		new CancellationTokenSource(System.Diagnostics.Debugger.IsAttached ? 5 * 60 * 1000 : 5 * 1000).Token)
+		new CancellationTokenSource(5 * 1000).Token)
 	{
 
 	}

--- a/src/EventStore.Projections.Core.Tests/ProjectionManagementTestClient.cs
+++ b/src/EventStore.Projections.Core.Tests/ProjectionManagementTestClient.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -24,7 +23,8 @@ internal sealed class ProjectionManagementTestClient : IDisposable
 	{
 		_channel = GrpcChannel.ForAddress(
 			new Uri($"https://{endpoint}"),
-			new GrpcChannelOptions {
+			new GrpcChannelOptions
+			{
 				HttpHandler = httpHandler
 			});
 		_client = new ProjectionGrpc.ProjectionsClient(_channel);
@@ -35,16 +35,20 @@ internal sealed class ProjectionManagementTestClient : IDisposable
 		_ownedHttpClient = httpClient;
 		_channel = GrpcChannel.ForAddress(
 			httpClient.BaseAddress ?? new Uri($"https://{endpoint}"),
-			new GrpcChannelOptions {
+			new GrpcChannelOptions
+			{
 				HttpClient = httpClient
 			});
 		_client = new ProjectionGrpc.ProjectionsClient(_channel);
 	}
 
 	public Task CreateContinuous(string name, string query, bool emitEnabled = false, bool trackEmittedStreams = false) =>
-		_client.CreateAsync(new CreateReq {
-			Options = new CreateReq.Types.Options {
-				Continuous = new CreateReq.Types.Options.Types.Continuous {
+		_client.CreateAsync(new CreateReq
+		{
+			Options = new CreateReq.Types.Options
+			{
+				Continuous = new CreateReq.Types.Options.Types.Continuous
+				{
 					Name = name,
 					EmitEnabled = emitEnabled,
 					TrackEmittedStreams = trackEmittedStreams
@@ -54,8 +58,10 @@ internal sealed class ProjectionManagementTestClient : IDisposable
 		}, GetCallOptions()).ResponseAsync;
 
 	public Task CreateOneTime(string query, string name = null) =>
-		_client.CreateAsync(new CreateReq {
-			Options = new CreateReq.Types.Options {
+		_client.CreateAsync(new CreateReq
+		{
+			Options = new CreateReq.Types.Options
+			{
 				OneTime = new ClientEmpty(),
 				Name = name ?? string.Empty,
 				Query = query
@@ -63,9 +69,12 @@ internal sealed class ProjectionManagementTestClient : IDisposable
 		}, GetCallOptions()).ResponseAsync;
 
 	public Task CreateTransient(string name, string query) =>
-		_client.CreateAsync(new CreateReq {
-			Options = new CreateReq.Types.Options {
-				Transient = new CreateReq.Types.Options.Types.Transient {
+		_client.CreateAsync(new CreateReq
+		{
+			Options = new CreateReq.Types.Options
+			{
+				Transient = new CreateReq.Types.Options.Types.Transient
+				{
 					Name = name
 				},
 				Query = query
@@ -73,30 +82,38 @@ internal sealed class ProjectionManagementTestClient : IDisposable
 		}, GetCallOptions()).ResponseAsync;
 
 	public Task Enable(string name) =>
-		_client.EnableAsync(new EnableReq {
-			Options = new EnableReq.Types.Options {
+		_client.EnableAsync(new EnableReq
+		{
+			Options = new EnableReq.Types.Options
+			{
 				Name = name
 			}
 		}, GetCallOptions()).ResponseAsync;
 
 	public Task Disable(string name, bool writeCheckpoint = true) =>
-		_client.DisableAsync(new DisableReq {
-			Options = new DisableReq.Types.Options {
+		_client.DisableAsync(new DisableReq
+		{
+			Options = new DisableReq.Types.Options
+			{
 				Name = name,
 				WriteCheckpoint = writeCheckpoint
 			}
 		}, GetCallOptions()).ResponseAsync;
 
 	public Task Abort(string name) =>
-		_client.AbortAsync(new AbortReq {
-			Options = new AbortReq.Types.Options {
+		_client.AbortAsync(new AbortReq
+		{
+			Options = new AbortReq.Types.Options
+			{
 				Name = name
 			}
 		}, GetCallOptions()).ResponseAsync;
 
 	public Task UpdateQuery(string name, string query) =>
-		_client.UpdateAsync(new UpdateReq {
-			Options = new UpdateReq.Types.Options {
+		_client.UpdateAsync(new UpdateReq
+		{
+			Options = new UpdateReq.Types.Options
+			{
 				Name = name,
 				Query = query
 			}
@@ -106,7 +123,8 @@ internal sealed class ProjectionManagementTestClient : IDisposable
 		StatisticsReq.Types.Options options,
 		CancellationToken cancellationToken = default)
 	{
-		using var call = _client.Statistics(new StatisticsReq {
+		using var call = _client.Statistics(new StatisticsReq
+		{
 			Options = options
 		}, GetCallOptions(TimeSpan.FromSeconds(20)));
 
@@ -120,17 +138,20 @@ internal sealed class ProjectionManagementTestClient : IDisposable
 	}
 
 	public Task<IReadOnlyList<StatisticsResp.Types.Details>> StatisticsAll(CancellationToken cancellationToken = default) =>
-		Statistics(new StatisticsReq.Types.Options {
+		Statistics(new StatisticsReq.Types.Options
+		{
 			All = new ClientEmpty()
 		}, cancellationToken);
 
 	public Task<IReadOnlyList<StatisticsResp.Types.Details>> StatisticsOneTime(CancellationToken cancellationToken = default) =>
-		Statistics(new StatisticsReq.Types.Options {
+		Statistics(new StatisticsReq.Types.Options
+		{
 			OneTime = new ClientEmpty()
 		}, cancellationToken);
 
 	public Task<IReadOnlyList<StatisticsResp.Types.Details>> StatisticsContinuous(CancellationToken cancellationToken = default) =>
-		Statistics(new StatisticsReq.Types.Options {
+		Statistics(new StatisticsReq.Types.Options
+		{
 			Continuous = new ClientEmpty()
 		}, cancellationToken);
 
@@ -142,7 +163,8 @@ internal sealed class ProjectionManagementTestClient : IDisposable
 
 	private static CallOptions GetCallOptions(TimeSpan? deadline = null)
 	{
-		var credentials = CallCredentials.FromInterceptor((_, metadata) => {
+		var credentials = CallCredentials.FromInterceptor((_, metadata) =>
+		{
 			metadata.Add("authorization",
 				$"Basic {Convert.ToBase64String(Encoding.ASCII.GetBytes("admin:changeit"))}");
 			return Task.CompletedTask;
@@ -150,10 +172,8 @@ internal sealed class ProjectionManagementTestClient : IDisposable
 
 		return new CallOptions(
 			credentials: credentials,
-			deadline: Debugger.IsAttached
-				? DateTime.UtcNow.AddDays(1)
-				: deadline is { } value
-					? DateTime.UtcNow.Add(value)
-					: null);
+			deadline: deadline is { } value
+				? DateTime.UtcNow.Add(value)
+				: null);
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/grpc_service/ProjectionManagementParityTests.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/grpc_service/ProjectionManagementParityTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -37,14 +36,18 @@ public class ProjectionManagementParityTests<TLogFormat, TStreamId> : Specificat
 	{
 		_channel = GrpcChannel.ForAddress(
 			new Uri($"https://{_node.HttpEndPoint}"),
-			new GrpcChannelOptions {
+			new GrpcChannelOptions
+			{
 				HttpHandler = _node.HttpMessageHandler
 			});
 		_client = new Client.Projections.Projections.ProjectionsClient(_channel);
 
-		await _client.CreateAsync(new CreateReq {
-			Options = new CreateReq.Types.Options {
-				Continuous = new CreateReq.Types.Options.Types.Continuous {
+		await _client.CreateAsync(new CreateReq
+		{
+			Options = new CreateReq.Types.Options
+			{
+				Continuous = new CreateReq.Types.Options.Types.Continuous
+				{
 					Name = ProjectionName,
 					EmitEnabled = true,
 					TrackEmittedStreams = true
@@ -53,8 +56,10 @@ public class ProjectionManagementParityTests<TLogFormat, TStreamId> : Specificat
 			}
 		}, GetCallOptions());
 
-		await _client.CreateAsync(new CreateReq {
-			Options = new CreateReq.Types.Options {
+		await _client.CreateAsync(new CreateReq
+		{
+			Options = new CreateReq.Types.Options
+			{
 				OneTime = new EventStore.Client.Empty(),
 				Enabled = false,
 				Name = DisabledOneTimeProjectionName,
@@ -65,9 +70,12 @@ public class ProjectionManagementParityTests<TLogFormat, TStreamId> : Specificat
 			}
 		}, GetCallOptions());
 
-		await _client.CreateAsync(new CreateReq {
-			Options = new CreateReq.Types.Options {
-				Transient = new CreateReq.Types.Options.Types.Transient {
+		await _client.CreateAsync(new CreateReq
+		{
+			Options = new CreateReq.Types.Options
+			{
+				Transient = new CreateReq.Types.Options.Types.Transient
+				{
 					Name = TransientProjectionName
 				},
 				Query = $"fromStream(\"{DebugStream}\").when({{$any:function(s,e){{return s;}}}});"
@@ -80,28 +88,36 @@ public class ProjectionManagementParityTests<TLogFormat, TStreamId> : Specificat
 
 	public override async Task When()
 	{
-		_query = await _client.GetQueryAsync(new GetQueryReq {
-			Options = new GetQueryReq.Types.Options {
+		_query = await _client.GetQueryAsync(new GetQueryReq
+		{
+			Options = new GetQueryReq.Types.Options
+			{
 				Name = ProjectionName
 			}
 		}, GetCallOptions());
 
-		_disabledOneTimeQuery = await _client.GetQueryAsync(new GetQueryReq {
-			Options = new GetQueryReq.Types.Options {
+		_disabledOneTimeQuery = await _client.GetQueryAsync(new GetQueryReq
+		{
+			Options = new GetQueryReq.Types.Options
+			{
 				Name = DisabledOneTimeProjectionName
 			}
 		}, GetCallOptions());
 
-		_initialConfig = await _client.GetConfigAsync(new GetConfigReq {
-			Options = new GetConfigReq.Types.Options {
+		_initialConfig = await _client.GetConfigAsync(new GetConfigReq
+		{
+			Options = new GetConfigReq.Types.Options
+			{
 				Name = ProjectionName
 			}
 		}, GetCallOptions());
 
 		await WaitForStatus(ProjectionName, "Faulted");
 
-		await _client.UpdateConfigAsync(new UpdateConfigReq {
-			Options = new UpdateConfigReq.Types.Options {
+		await _client.UpdateConfigAsync(new UpdateConfigReq
+		{
+			Options = new UpdateConfigReq.Types.Options
+			{
 				Name = ProjectionName,
 				EmitEnabled = _initialConfig.Details.EmitEnabled,
 				TrackEmittedStreams = _initialConfig.Details.TrackEmittedStreams,
@@ -115,15 +131,20 @@ public class ProjectionManagementParityTests<TLogFormat, TStreamId> : Specificat
 			}
 		}, GetCallOptions());
 
-		_updatedConfig = await _client.GetConfigAsync(new GetConfigReq {
-			Options = new GetConfigReq.Types.Options {
+		_updatedConfig = await _client.GetConfigAsync(new GetConfigReq
+		{
+			Options = new GetConfigReq.Types.Options
+			{
 				Name = ProjectionName
 			}
 		}, GetCallOptions());
 
-		_feedPage = await _client.ReadEventsAsync(new ReadEventsReq {
-			Options = new ReadEventsReq.Types.Options {
-				QuerySourcesJson = new QuerySourcesDefinition {
+		_feedPage = await _client.ReadEventsAsync(new ReadEventsReq
+		{
+			Options = new ReadEventsReq.Types.Options
+			{
+				QuerySourcesJson = new QuerySourcesDefinition
+				{
 					Streams = new[] { DebugStream },
 					AllEvents = true
 				}.ToJson(),
@@ -132,14 +153,18 @@ public class ProjectionManagementParityTests<TLogFormat, TStreamId> : Specificat
 			}
 		}, GetCallOptions());
 
-		await _client.AbortAsync(new AbortReq {
-			Options = new AbortReq.Types.Options {
+		await _client.AbortAsync(new AbortReq
+		{
+			Options = new AbortReq.Types.Options
+			{
 				Name = TransientProjectionName
 			}
 		}, GetCallOptions());
 
-		_allNonTransientStatistics = await ReadStatisticsAsync(new StatisticsReq {
-			Options = new StatisticsReq.Types.Options {
+		_allNonTransientStatistics = await ReadStatisticsAsync(new StatisticsReq
+		{
+			Options = new StatisticsReq.Types.Options
+			{
 				AllNonTransient = new EventStore.Client.Empty()
 			}
 		});
@@ -203,7 +228,8 @@ public class ProjectionManagementParityTests<TLogFormat, TStreamId> : Specificat
 
 	private static CallOptions GetCallOptions(TimeSpan? deadline = null)
 	{
-		var credentials = CallCredentials.FromInterceptor((_, metadata) => {
+		var credentials = CallCredentials.FromInterceptor((_, metadata) =>
+		{
 			metadata.Add("authorization",
 				$"Basic {Convert.ToBase64String(Encoding.ASCII.GetBytes("admin:changeit"))}");
 			return Task.CompletedTask;
@@ -211,19 +237,19 @@ public class ProjectionManagementParityTests<TLogFormat, TStreamId> : Specificat
 
 		return new CallOptions(
 			credentials: credentials,
-			deadline: Debugger.IsAttached
-				? DateTime.UtcNow.AddDays(1)
-				: deadline is { } value
-					? DateTime.UtcNow.Add(value)
-					: null);
+			deadline: deadline is { } value
+				? DateTime.UtcNow.Add(value)
+				: null);
 	}
 
 	private async Task WaitForStatus(string projectionName, string expectedStatus)
 	{
 		for (var attempt = 0; attempt < 40; attempt++)
 		{
-			using var statistics = _client.Statistics(new StatisticsReq {
-				Options = new StatisticsReq.Types.Options {
+			using var statistics = _client.Statistics(new StatisticsReq
+			{
+				Options = new StatisticsReq.Types.Options
+				{
 					Name = projectionName
 				}
 			}, GetCallOptions(TimeSpan.FromSeconds(10)));

--- a/src/EventStore.Projections.Core.Tests/Services/grpc_service/ProjectionsStatisticsTests.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/grpc_service/ProjectionsStatisticsTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,14 +26,18 @@ public class ProjectionsStatisticsTests<TLogFormat, TStreamId> : SpecificationWi
 	{
 		_channel = GrpcChannel.ForAddress(
 			new Uri($"https://{_node.HttpEndPoint}"),
-			new GrpcChannelOptions {
+			new GrpcChannelOptions
+			{
 				HttpHandler = _node.HttpMessageHandler
 			});
 		_client = new Client.Projections.Projections.ProjectionsClient(_channel);
 
-		await _client.CreateAsync(new CreateReq {
-			Options = new CreateReq.Types.Options {
-				Continuous = new CreateReq.Types.Options.Types.Continuous {
+		await _client.CreateAsync(new CreateReq
+		{
+			Options = new CreateReq.Types.Options
+			{
+				Continuous = new CreateReq.Types.Options.Types.Continuous
+				{
 					Name = "faulted-projection",
 					EmitEnabled = false,
 					TrackEmittedStreams = false
@@ -43,9 +46,12 @@ public class ProjectionsStatisticsTests<TLogFormat, TStreamId> : SpecificationWi
 			}
 		}, GetCallOptions());
 
-		await _client.CreateAsync(new CreateReq {
-			Options = new CreateReq.Types.Options {
-				Continuous = new CreateReq.Types.Options.Types.Continuous {
+		await _client.CreateAsync(new CreateReq
+		{
+			Options = new CreateReq.Types.Options
+			{
+				Continuous = new CreateReq.Types.Options.Types.Continuous
+				{
 					Name = "running-projection",
 					EmitEnabled = false,
 					TrackEmittedStreams = false
@@ -57,7 +63,8 @@ public class ProjectionsStatisticsTests<TLogFormat, TStreamId> : SpecificationWi
 
 	public override async Task When()
 	{
-		for (var attempt = 0; attempt < 20; attempt++) {
+		for (var attempt = 0; attempt < 20; attempt++)
+		{
 			try
 			{
 				(_faultedProjection, _runningProjection) = await ReadStatisticsAsync();
@@ -106,8 +113,10 @@ public class ProjectionsStatisticsTests<TLogFormat, TStreamId> : SpecificationWi
 		return base.TestFixtureTearDown();
 	}
 
-	private static CallOptions GetCallOptions(TimeSpan? deadline = null) {
-		var credentials = CallCredentials.FromInterceptor((_, metadata) => {
+	private static CallOptions GetCallOptions(TimeSpan? deadline = null)
+	{
+		var credentials = CallCredentials.FromInterceptor((_, metadata) =>
+		{
 			metadata.Add("authorization",
 				$"Basic {Convert.ToBase64String(Encoding.ASCII.GetBytes("admin:changeit"))}");
 			return Task.CompletedTask;
@@ -115,11 +124,9 @@ public class ProjectionsStatisticsTests<TLogFormat, TStreamId> : SpecificationWi
 
 		return new CallOptions(
 			credentials: credentials,
-			deadline: Debugger.IsAttached
-				? DateTime.UtcNow.AddDays(1)
-				: deadline is { } value
-					? DateTime.UtcNow.Add(value)
-					: null);
+			deadline: deadline is { } value
+				? DateTime.UtcNow.Add(value)
+				: null);
 	}
 
 	private async Task<(StatisticsResp.Types.Details faultedProjection, StatisticsResp.Types.Details runningProjection)>
@@ -128,13 +135,16 @@ public class ProjectionsStatisticsTests<TLogFormat, TStreamId> : SpecificationWi
 		StatisticsResp.Types.Details faultedProjection = null;
 		StatisticsResp.Types.Details runningProjection = null;
 
-		using var statistics = _client.Statistics(new StatisticsReq {
-			Options = new StatisticsReq.Types.Options {
+		using var statistics = _client.Statistics(new StatisticsReq
+		{
+			Options = new StatisticsReq.Types.Options
+			{
 				All = new Empty()
 			}
 		}, GetCallOptions(StatisticsCallDeadline));
 
-		while (await statistics.ResponseStream.MoveNext(CancellationToken.None)) {
+		while (await statistics.ResponseStream.MoveNext(CancellationToken.None))
+		{
 			var details = statistics.ResponseStream.Current.Details;
 			if (details.Name == "faulted-projection")
 				faultedProjection = details;

--- a/src/EventStore.Projections.Core/Services/Interpreted/JintProjectionStateHandler.cs
+++ b/src/EventStore.Projections.Core/Services/Interpreted/JintProjectionStateHandler.cs
@@ -485,8 +485,6 @@ namespace EventStore.Projections.Core.Services.Interpreted
 			{
 				if (_sw.Elapsed - _start >= _timeout)
 				{
-					if (Debugger.IsAttached)
-						return;
 					var action = _executing ? "execute" : "compile";
 					throw new TimeoutException($"Projection script took too long to {action} (took: {_sw.Elapsed - _start:c}, allowed: {_timeout:c}");
 				}

--- a/src/EventStore.TestClient/Commands/RunTestScenarios/ScenarioBase.cs
+++ b/src/EventStore.TestClient/Commands/RunTestScenarios/ScenarioBase.cs
@@ -290,7 +290,6 @@ internal abstract class ScenarioBase : IScenario
 	{
 		if (streams.Length == 0)
 		{
-			Debugger.Break();
 			throw new Exception("Streams shouldn't be empty.");
 		}
 
@@ -440,8 +439,7 @@ internal abstract class ScenarioBase : IScenario
 			}
 			else
 			{
-				Process temp;
-				if (TryGetProcessById(processId, out temp))
+				if (TryGetProcessById(processId, out _))
 					Log.Error(
 						"Process {processId} did not report about exit in time and is still present in processes list.",
 						processId);


### PR DESCRIPTION
- Runtime and test behavior should not depend on debugger attachment.
- Failure and timeout paths should stay deterministic in every environment.