### PR TITLE
fix(grpc): decouple user continuations

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/Users.ChangePassword.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.ChangePassword.cs
@@ -1,44 +1,50 @@
 using System.Threading.Tasks;
+using EventStore.Client.Users;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Client.Users;
 using EventStore.Plugins.Authorization;
 using Grpc.Core;
 
-namespace EventStore.Core.Services.Transport.Grpc {
-	internal partial class Users {
-		private static readonly Operation ChangePasswordOperation = new Operation(Plugins.Authorization.Operations.Users.ChangePassword);
-		public override async Task<ChangePasswordResp> ChangePassword(ChangePasswordReq request,
-			ServerCallContext context) {
-			var options = request.Options;
+namespace EventStore.Core.Services.Transport.Grpc;
 
-			var user = context.GetHttpContext().User;
-			var changePasswordOperation = ChangePasswordOperation;
-			if (options?.LoginName != null) {
-				changePasswordOperation =
-					changePasswordOperation.WithParameter(
-						Plugins.Authorization.Operations.Users.Parameters.User(options.LoginName));
-			}
-			if (!await _authorizationProvider.CheckAccessAsync(user, changePasswordOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
-			}
-			var changePasswordSource = new TaskCompletionSource<bool>();
+internal partial class Users
+{
+	private static readonly Operation ChangePasswordOperation = new Operation(Plugins.Authorization.Operations.Users.ChangePassword);
+	public override async Task<ChangePasswordResp> ChangePassword(ChangePasswordReq request,
+		ServerCallContext context)
+	{
+		var options = request.Options;
 
-			var envelope = new CallbackEnvelope(OnMessage);
+		var user = context.GetHttpContext().User;
+		var changePasswordOperation = ChangePasswordOperation;
+		if (options?.LoginName != null)
+		{
+			changePasswordOperation =
+				changePasswordOperation.WithParameter(
+					Plugins.Authorization.Operations.Users.Parameters.User(options.LoginName));
+		}
+		if (!await _authorizationProvider.CheckAccessAsync(user, changePasswordOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+		var changePasswordSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-			_publisher.Publish(new UserManagementMessage.ChangePassword(envelope, user, options.LoginName,
-				options.CurrentPassword,
-				options.NewPassword));
+		var envelope = new CallbackEnvelope(OnMessage);
 
-			await changePasswordSource.Task.WaitAsync(context.CancellationToken);
+		_publisher.Publish(new UserManagementMessage.ChangePassword(envelope, user, options.LoginName,
+			options.CurrentPassword,
+			options.NewPassword));
 
-			return new ChangePasswordResp();
+		await changePasswordSource.Task.WaitAsync(context.CancellationToken);
 
-			void OnMessage(Message message) {
-				if (HandleErrors(options.LoginName, message, changePasswordSource)) return;
+		return new ChangePasswordResp();
 
-				changePasswordSource.TrySetResult(true);
-			}
+		void OnMessage(Message message)
+		{
+			if (HandleErrors(options.LoginName, message, changePasswordSource))
+				return;
+
+			changePasswordSource.TrySetResult(true);
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.Create.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.Create.cs
@@ -1,38 +1,43 @@
 using System.Linq;
 using System.Threading.Tasks;
+using EventStore.Client.Users;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Client.Users;
 using EventStore.Plugins.Authorization;
 using Grpc.Core;
 
-namespace EventStore.Core.Services.Transport.Grpc {
-	internal partial class Users {
-		private static readonly Operation CreateOperation = new Operation(Plugins.Authorization.Operations.Users.Create);
-		public override async Task<CreateResp> Create(CreateReq request, ServerCallContext context) {
-			var options = request.Options;
+namespace EventStore.Core.Services.Transport.Grpc;
 
-			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, CreateOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
-			}
-			var createSource = new TaskCompletionSource<bool>();
+internal partial class Users
+{
+	private static readonly Operation CreateOperation = new Operation(Plugins.Authorization.Operations.Users.Create);
+	public override async Task<CreateResp> Create(CreateReq request, ServerCallContext context)
+	{
+		var options = request.Options;
 
-			var envelope = new CallbackEnvelope(OnMessage);
+		var user = context.GetHttpContext().User;
+		if (!await _authorizationProvider.CheckAccessAsync(user, CreateOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+		var createSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-			_publisher.Publish(new UserManagementMessage.Create(envelope, user, options.LoginName, options.FullName,
-				options.Groups.ToArray(),
-				options.Password));
+		var envelope = new CallbackEnvelope(OnMessage);
 
-			await createSource.Task.WaitAsync(context.CancellationToken);
+		_publisher.Publish(new UserManagementMessage.Create(envelope, user, options.LoginName, options.FullName,
+			options.Groups.ToArray(),
+			options.Password));
 
-			return new CreateResp();
+		await createSource.Task.WaitAsync(context.CancellationToken);
 
-			void OnMessage(Message message) {
-				if (HandleErrors(options.LoginName, message, createSource)) return;
+		return new CreateResp();
 
-				createSource.TrySetResult(true);
-			}
+		void OnMessage(Message message)
+		{
+			if (HandleErrors(options.LoginName, message, createSource))
+				return;
+
+			createSource.TrySetResult(true);
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.Current.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.Current.cs
@@ -5,41 +5,49 @@ using EventStore.Core.Messaging;
 using EventStore.Plugins.Authorization;
 using Grpc.Core;
 
-namespace EventStore.Core.Services.Transport.Grpc {
-	internal partial class Users {
-		private static readonly Operation CurrentUserOperation =
-			new Operation(Plugins.Authorization.Operations.Users.CurrentUser);
+namespace EventStore.Core.Services.Transport.Grpc;
 
-		public override async Task<CurrentResp> Current(CurrentReq request, ServerCallContext context) {
-			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, CurrentUserOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
-			}
+internal partial class Users
+{
+	private static readonly Operation CurrentUserOperation =
+		new Operation(Plugins.Authorization.Operations.Users.CurrentUser);
 
-			var loginName = user?.Identity?.Name;
-			if (string.IsNullOrWhiteSpace(loginName)) {
-				throw RpcExceptions.AccessDenied();
-			}
+	public override async Task<CurrentResp> Current(CurrentReq request, ServerCallContext context)
+	{
+		var user = context.GetHttpContext().User;
+		if (!await _authorizationProvider.CheckAccessAsync(user, CurrentUserOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
 
-			var detailsSource = new TaskCompletionSource<UserManagementMessage.UserData>();
-			var envelope = new CallbackEnvelope(OnMessage);
-			_publisher.Publish(new UserManagementMessage.Get(envelope, user, loginName));
+		var loginName = user?.Identity?.Name;
+		if (string.IsNullOrWhiteSpace(loginName))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
 
-			return new CurrentResp {
-				UserDetails = ToUserDetails(await detailsSource.Task.WaitAsync(context.CancellationToken))
-			};
+		var detailsSource = new TaskCompletionSource<UserManagementMessage.UserData>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var envelope = new CallbackEnvelope(OnMessage);
+		_publisher.Publish(new UserManagementMessage.Get(envelope, user, loginName));
 
-			void OnMessage(Message message) {
-				if (HandleErrors(loginName, message, detailsSource)) return;
+		return new CurrentResp
+		{
+			UserDetails = ToUserDetails(await detailsSource.Task.WaitAsync(context.CancellationToken))
+		};
 
-				switch (message) {
-					case UserManagementMessage.UserDetailsResult userDetails:
-						detailsSource.TrySetResult(userDetails.Data);
-						break;
-					default:
-						detailsSource.TrySetException(RpcExceptions.UnknownError(1));
-						break;
-				}
+		void OnMessage(Message message)
+		{
+			if (HandleErrors(loginName, message, detailsSource))
+				return;
+
+			switch (message)
+			{
+				case UserManagementMessage.UserDetailsResult userDetails:
+					detailsSource.TrySetResult(userDetails.Data);
+					break;
+				default:
+					detailsSource.TrySetException(RpcExceptions.UnknownError(1));
+					break;
 			}
 		}
 	}

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.Delete.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.Delete.cs
@@ -1,35 +1,40 @@
 using System.Threading.Tasks;
+using EventStore.Client.Users;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Client.Users;
 using EventStore.Plugins.Authorization;
 using Grpc.Core;
 
-namespace EventStore.Core.Services.Transport.Grpc {
-	internal partial class Users {
-		private static readonly Operation DeleteOperation = new Operation(Plugins.Authorization.Operations.Users.Delete);
-		public override async Task<DeleteResp> Delete(DeleteReq request, ServerCallContext context) {
-			var options = request.Options;
+namespace EventStore.Core.Services.Transport.Grpc;
 
-			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, DeleteOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
-			}
-			var deleteSource = new TaskCompletionSource<bool>();
+internal partial class Users
+{
+	private static readonly Operation DeleteOperation = new Operation(Plugins.Authorization.Operations.Users.Delete);
+	public override async Task<DeleteResp> Delete(DeleteReq request, ServerCallContext context)
+	{
+		var options = request.Options;
 
-			var envelope = new CallbackEnvelope(OnMessage);
+		var user = context.GetHttpContext().User;
+		if (!await _authorizationProvider.CheckAccessAsync(user, DeleteOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+		var deleteSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-			_publisher.Publish(new UserManagementMessage.Delete(envelope, user, options.LoginName));
+		var envelope = new CallbackEnvelope(OnMessage);
 
-			await deleteSource.Task.WaitAsync(context.CancellationToken);
+		_publisher.Publish(new UserManagementMessage.Delete(envelope, user, options.LoginName));
 
-			return new DeleteResp();
+		await deleteSource.Task.WaitAsync(context.CancellationToken);
 
-			void OnMessage(Message message) {
-				if (HandleErrors(options.LoginName, message, deleteSource)) return;
+		return new DeleteResp();
 
-				deleteSource.TrySetResult(true);
-			}
+		void OnMessage(Message message)
+		{
+			if (HandleErrors(options.LoginName, message, deleteSource))
+				return;
+
+			deleteSource.TrySetResult(true);
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.Details.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.Details.cs
@@ -1,70 +1,79 @@
 using System.Threading.Tasks;
 using EventStore.Client;
+using EventStore.Client.Users;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Client.Users;
 using EventStore.Plugins.Authorization;
 using Grpc.Core;
 
-namespace EventStore.Core.Services.Transport.Grpc {
-	internal partial class Users {
-		private static readonly Operation ReadOperation = new Operation(Plugins.Authorization.Operations.Users.Read);
-		private static readonly Operation ListOperation = new Operation(Plugins.Authorization.Operations.Users.List);
-		public override async Task Details(DetailsReq request, IServerStreamWriter<DetailsResp> responseStream,
-			ServerCallContext context) {
-			var options = request.Options;
-			var loginName = options?.LoginName;
+namespace EventStore.Core.Services.Transport.Grpc;
 
-			var user = context.GetHttpContext().User;
-			var operation = string.IsNullOrWhiteSpace(loginName)
-				? ListOperation
-				: ReadOperation.WithParameter(Plugins.Authorization.Operations.Users.Parameters.User(loginName));
-			if (!await _authorizationProvider.CheckAccessAsync(user, operation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
-			}
-			var detailsSource = new TaskCompletionSource<UserManagementMessage.UserData[]>();
+internal partial class Users
+{
+	private static readonly Operation ReadOperation = new Operation(Plugins.Authorization.Operations.Users.Read);
+	private static readonly Operation ListOperation = new Operation(Plugins.Authorization.Operations.Users.List);
+	public override async Task Details(DetailsReq request, IServerStreamWriter<DetailsResp> responseStream,
+		ServerCallContext context)
+	{
+		var options = request.Options;
+		var loginName = options?.LoginName;
 
-			var envelope = new CallbackEnvelope(OnMessage);
+		var user = context.GetHttpContext().User;
+		var operation = string.IsNullOrWhiteSpace(loginName)
+			? ListOperation
+			: ReadOperation.WithParameter(Plugins.Authorization.Operations.Users.Parameters.User(loginName));
+		if (!await _authorizationProvider.CheckAccessAsync(user, operation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+		var detailsSource = new TaskCompletionSource<UserManagementMessage.UserData[]>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-			_publisher.Publish(string.IsNullOrWhiteSpace(loginName)
-				? (Message)new UserManagementMessage.GetAll(envelope, user)
-				: new UserManagementMessage.Get(envelope, user, loginName));
+		var envelope = new CallbackEnvelope(OnMessage);
 
-			var details = await detailsSource.Task.WaitAsync(context.CancellationToken);
+		_publisher.Publish(string.IsNullOrWhiteSpace(loginName)
+			? (Message)new UserManagementMessage.GetAll(envelope, user)
+			: new UserManagementMessage.Get(envelope, user, loginName));
 
-			foreach (var detail in details) {
-				await responseStream.WriteAsync(new DetailsResp {
-					UserDetails = ToUserDetails(detail)
-				});
-			}
+		var details = await detailsSource.Task.WaitAsync(context.CancellationToken);
 
-			void OnMessage(Message message) {
-				if (HandleErrors(loginName, message, detailsSource)) return;
-
-				switch (message) {
-					case UserManagementMessage.UserDetailsResult userDetails:
-						detailsSource.TrySetResult(new[] {userDetails.Data});
-						break;
-					case UserManagementMessage.AllUserDetailsResult allUserDetails:
-						detailsSource.TrySetResult(allUserDetails.Data);
-						break;
-					default:
-						detailsSource.TrySetException(RpcExceptions.UnknownError(1));
-						break;
-				}
-			}
+		foreach (var detail in details)
+		{
+			await responseStream.WriteAsync(new DetailsResp
+			{
+				UserDetails = ToUserDetails(detail)
+			});
 		}
 
-		private static DetailsResp.Types.UserDetails ToUserDetails(UserManagementMessage.UserData detail) =>
-			new() {
-				Disabled = detail.Disabled,
-				Groups = {detail.Groups},
-				FullName = detail.FullName,
-				LoginName = detail.LoginName,
-				LastUpdated = detail.DateLastUpdated.HasValue
-					? new DetailsResp.Types.UserDetails.Types.DateTime
-						{TicksSinceEpoch = detail.DateLastUpdated.Value.UtcDateTime.ToTicksSinceEpoch()}
-					: null
-			};
+		void OnMessage(Message message)
+		{
+			if (HandleErrors(loginName, message, detailsSource))
+				return;
+
+			switch (message)
+			{
+				case UserManagementMessage.UserDetailsResult userDetails:
+					detailsSource.TrySetResult(new[] { userDetails.Data });
+					break;
+				case UserManagementMessage.AllUserDetailsResult allUserDetails:
+					detailsSource.TrySetResult(allUserDetails.Data);
+					break;
+				default:
+					detailsSource.TrySetException(RpcExceptions.UnknownError(1));
+					break;
+			}
+		}
 	}
+
+	private static DetailsResp.Types.UserDetails ToUserDetails(UserManagementMessage.UserData detail) =>
+		new()
+		{
+			Disabled = detail.Disabled,
+			Groups = { detail.Groups },
+			FullName = detail.FullName,
+			LoginName = detail.LoginName,
+			LastUpdated = detail.DateLastUpdated.HasValue
+				? new DetailsResp.Types.UserDetails.Types.DateTime
+				{ TicksSinceEpoch = detail.DateLastUpdated.Value.UtcDateTime.ToTicksSinceEpoch() }
+				: null
+		};
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.Disable.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.Disable.cs
@@ -1,35 +1,40 @@
 using System.Threading.Tasks;
+using EventStore.Client.Users;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Client.Users;
 using EventStore.Plugins.Authorization;
 using Grpc.Core;
 
-namespace EventStore.Core.Services.Transport.Grpc {
-	internal partial class Users {
-		private static readonly Operation DisableOperation = new Operation(Plugins.Authorization.Operations.Users.Disable);
-		public override async Task<DisableResp> Disable(DisableReq request, ServerCallContext context) {
-			var options = request.Options;
+namespace EventStore.Core.Services.Transport.Grpc;
 
-			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, DisableOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
-			}
-			var disableSource = new TaskCompletionSource<bool>();
+internal partial class Users
+{
+	private static readonly Operation DisableOperation = new Operation(Plugins.Authorization.Operations.Users.Disable);
+	public override async Task<DisableResp> Disable(DisableReq request, ServerCallContext context)
+	{
+		var options = request.Options;
 
-			var envelope = new CallbackEnvelope(OnMessage);
+		var user = context.GetHttpContext().User;
+		if (!await _authorizationProvider.CheckAccessAsync(user, DisableOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+		var disableSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-			_publisher.Publish(new UserManagementMessage.Disable(envelope, user, options.LoginName));
+		var envelope = new CallbackEnvelope(OnMessage);
 
-			await disableSource.Task.WaitAsync(context.CancellationToken);
+		_publisher.Publish(new UserManagementMessage.Disable(envelope, user, options.LoginName));
 
-			return new DisableResp();
+		await disableSource.Task.WaitAsync(context.CancellationToken);
 
-			void OnMessage(Message message) {
-				if (HandleErrors(options.LoginName, message, disableSource)) return;
+		return new DisableResp();
 
-				disableSource.TrySetResult(true);
-			}
+		void OnMessage(Message message)
+		{
+			if (HandleErrors(options.LoginName, message, disableSource))
+				return;
+
+			disableSource.TrySetResult(true);
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.Enable.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.Enable.cs
@@ -1,35 +1,40 @@
 using System.Threading.Tasks;
+using EventStore.Client.Users;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Client.Users;
 using EventStore.Plugins.Authorization;
 using Grpc.Core;
 
-namespace EventStore.Core.Services.Transport.Grpc {
-	internal partial class Users {
-		private static readonly Operation EnableOperation = new Operation(Plugins.Authorization.Operations.Users.Enable);
-		public override async Task<EnableResp> Enable(EnableReq request, ServerCallContext context) {
-			var options = request.Options;
+namespace EventStore.Core.Services.Transport.Grpc;
 
-			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, EnableOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
-			}
-			var enableSource = new TaskCompletionSource<bool>();
+internal partial class Users
+{
+	private static readonly Operation EnableOperation = new Operation(Plugins.Authorization.Operations.Users.Enable);
+	public override async Task<EnableResp> Enable(EnableReq request, ServerCallContext context)
+	{
+		var options = request.Options;
 
-			var envelope = new CallbackEnvelope(OnMessage);
+		var user = context.GetHttpContext().User;
+		if (!await _authorizationProvider.CheckAccessAsync(user, EnableOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+		var enableSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-			_publisher.Publish(new UserManagementMessage.Enable(envelope, user, options.LoginName));
+		var envelope = new CallbackEnvelope(OnMessage);
 
-			await enableSource.Task.WaitAsync(context.CancellationToken);
+		_publisher.Publish(new UserManagementMessage.Enable(envelope, user, options.LoginName));
 
-			return new EnableResp();
+		await enableSource.Task.WaitAsync(context.CancellationToken);
 
-			void OnMessage(Message message) {
-				if (HandleErrors(options.LoginName, message, enableSource)) return;
+		return new EnableResp();
 
-				enableSource.TrySetResult(true);
-			}
+		void OnMessage(Message message)
+		{
+			if (HandleErrors(options.LoginName, message, enableSource))
+				return;
+
+			enableSource.TrySetResult(true);
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.ResetPassword.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.ResetPassword.cs
@@ -1,37 +1,42 @@
 using System.Threading.Tasks;
+using EventStore.Client.Users;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Client.Users;
 using EventStore.Plugins.Authorization;
 using Grpc.Core;
 
-namespace EventStore.Core.Services.Transport.Grpc {
-	internal partial class Users {
-		private static readonly Operation ResetOperation = new Operation(Plugins.Authorization.Operations.Users.ResetPassword);
-		public override async Task<ResetPasswordResp> ResetPassword(ResetPasswordReq request,
-			ServerCallContext context) {
-			var options = request.Options;
+namespace EventStore.Core.Services.Transport.Grpc;
 
-			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, ResetOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
-			}
-			var resetPasswordSource = new TaskCompletionSource<bool>();
+internal partial class Users
+{
+	private static readonly Operation ResetOperation = new Operation(Plugins.Authorization.Operations.Users.ResetPassword);
+	public override async Task<ResetPasswordResp> ResetPassword(ResetPasswordReq request,
+		ServerCallContext context)
+	{
+		var options = request.Options;
 
-			var envelope = new CallbackEnvelope(OnMessage);
+		var user = context.GetHttpContext().User;
+		if (!await _authorizationProvider.CheckAccessAsync(user, ResetOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+		var resetPasswordSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-			_publisher.Publish(
-				new UserManagementMessage.ResetPassword(envelope, user, options.LoginName, options.NewPassword));
+		var envelope = new CallbackEnvelope(OnMessage);
 
-			await resetPasswordSource.Task.WaitAsync(context.CancellationToken);
+		_publisher.Publish(
+			new UserManagementMessage.ResetPassword(envelope, user, options.LoginName, options.NewPassword));
 
-			return new ResetPasswordResp();
+		await resetPasswordSource.Task.WaitAsync(context.CancellationToken);
 
-			void OnMessage(Message message) {
-				if (HandleErrors(options.LoginName, message, resetPasswordSource)) return;
+		return new ResetPasswordResp();
 
-				resetPasswordSource.TrySetResult(true);
-			}
+		void OnMessage(Message message)
+		{
+			if (HandleErrors(options.LoginName, message, resetPasswordSource))
+				return;
+
+			resetPasswordSource.TrySetResult(true);
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.Update.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.Update.cs
@@ -1,38 +1,43 @@
 using System.Linq;
 using System.Threading.Tasks;
+using EventStore.Client.Users;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Client.Users;
 using EventStore.Plugins.Authorization;
 using Grpc.Core;
 
-namespace EventStore.Core.Services.Transport.Grpc {
-	internal partial class Users {
-		private static readonly Operation UpdateOperation = new Operation(Plugins.Authorization.Operations.Users.Update);
-		
-		public override async Task<UpdateResp> Update(UpdateReq request, ServerCallContext context) {
-			var options = request.Options;
+namespace EventStore.Core.Services.Transport.Grpc;
 
-			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, UpdateOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
-			}
-			var updateSource = new TaskCompletionSource<bool>();
+internal partial class Users
+{
+	private static readonly Operation UpdateOperation = new Operation(Plugins.Authorization.Operations.Users.Update);
 
-			var envelope = new CallbackEnvelope(OnMessage);
+	public override async Task<UpdateResp> Update(UpdateReq request, ServerCallContext context)
+	{
+		var options = request.Options;
 
-			_publisher.Publish(new UserManagementMessage.Update(envelope, user, options.LoginName, options.FullName,
-				options.Groups.ToArray()));
+		var user = context.GetHttpContext().User;
+		if (!await _authorizationProvider.CheckAccessAsync(user, UpdateOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+		var updateSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-			await updateSource.Task.WaitAsync(context.CancellationToken);
+		var envelope = new CallbackEnvelope(OnMessage);
 
-			return new UpdateResp();
+		_publisher.Publish(new UserManagementMessage.Update(envelope, user, options.LoginName, options.FullName,
+			options.Groups.ToArray()));
 
-			void OnMessage(Message message) {
-				if (HandleErrors(options.LoginName, message, updateSource)) return;
+		await updateSource.Task.WaitAsync(context.CancellationToken);
 
-				updateSource.TrySetResult(true);
-			}
+		return new UpdateResp();
+
+		void OnMessage(Message message)
+		{
+			if (HandleErrors(options.LoginName, message, updateSource))
+				return;
+
+			updateSource.TrySetResult(true);
 		}
 	}
 }


### PR DESCRIPTION
- User-management replies should not run request continuations inline on the callback path.