### PR TITLE
fix(grpc): decouple subscription continuations

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Create.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Create.cs
@@ -1,69 +1,80 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using EventStore.Core.Messages;
-using EventStore.Core.Messaging;
 using EventStore.Client.PersistentSubscriptions;
 using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Services.Transport.Common;
 using EventStore.Plugins.Authorization;
 using Grpc.Core;
-using static EventStore.Core.Messages.ClientMessage.CreatePersistentSubscriptionToStreamCompleted;
 using static EventStore.Core.Messages.ClientMessage.CreatePersistentSubscriptionToAllCompleted;
-using StreamOptionOneofCase = EventStore.Client.PersistentSubscriptions.CreateReq.Types.Options.StreamOptionOneofCase;
-using RevisionOptionOneofCase = EventStore.Client.PersistentSubscriptions.CreateReq.Types.StreamOptions.RevisionOptionOneofCase;
+using static EventStore.Core.Messages.ClientMessage.CreatePersistentSubscriptionToStreamCompleted;
 using AllOptionOneofCase = EventStore.Client.PersistentSubscriptions.CreateReq.Types.AllOptions.AllOptionOneofCase;
+using RevisionOptionOneofCase = EventStore.Client.PersistentSubscriptions.CreateReq.Types.StreamOptions.RevisionOptionOneofCase;
+using StreamOptionOneofCase = EventStore.Client.PersistentSubscriptions.CreateReq.Types.Options.StreamOptionOneofCase;
 
-namespace EventStore.Core.Services.Transport.Grpc {
-	internal partial class PersistentSubscriptions {
-		private static readonly Operation CreateOperation = new Operation(Plugins.Authorization.Operations.Subscriptions.Create);
+namespace EventStore.Core.Services.Transport.Grpc;
 
-		public override async Task<CreateResp> Create(CreateReq request, ServerCallContext context) {
-			var createPersistentSubscriptionSource = new TaskCompletionSource<CreateResp>();
-			var settings = request.Options.Settings;
-			var correlationId = Guid.NewGuid();
+internal partial class PersistentSubscriptions
+{
+	private static readonly Operation CreateOperation = new Operation(Plugins.Authorization.Operations.Subscriptions.Create);
 
-			var user = context.GetHttpContext().User;
-			
-			if (!await _authorizationProvider.CheckAccessAsync(user,
-				CreateOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
-			}
+	public override async Task<CreateResp> Create(CreateReq request, ServerCallContext context)
+	{
+		var createPersistentSubscriptionSource = new TaskCompletionSource<CreateResp>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var settings = request.Options.Settings;
+		var correlationId = Guid.NewGuid();
 
-			ValidateCreateSettings(settings);
+		var user = context.GetHttpContext().User;
 
-			string streamId = null;
-			string consumerStrategy = null;
-			if (string.IsNullOrEmpty(settings.ConsumerStrategy)) { /*for backwards compatibility*/
-			#pragma warning disable 612
-				consumerStrategy = settings.NamedConsumerStrategy.ToString();
-			#pragma warning restore 612
+		if (!await _authorizationProvider.CheckAccessAsync(user,
+			CreateOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
 
-			} else {
-				consumerStrategy = settings.ConsumerStrategy;
-			}
+		ValidateCreateSettings(settings);
 
-			switch (request.Options.StreamOptionCase)
-			{
-				case StreamOptionOneofCase.Stream:
-				case StreamOptionOneofCase.None: /*for backwards compatibility*/
+		string streamId = null;
+		string consumerStrategy = null;
+		if (string.IsNullOrEmpty(settings.ConsumerStrategy))
+		{ /*for backwards compatibility*/
+#pragma warning disable 612
+			consumerStrategy = settings.NamedConsumerStrategy.ToString();
+#pragma warning restore 612
+
+		}
+		else
+		{
+			consumerStrategy = settings.ConsumerStrategy;
+		}
+
+		switch (request.Options.StreamOptionCase)
+		{
+			case StreamOptionOneofCase.Stream:
+			case StreamOptionOneofCase.None: /*for backwards compatibility*/
 				{
 					StreamRevision startRevision;
 
-					if (request.Options.StreamOptionCase == StreamOptionOneofCase.Stream) {
+					if (request.Options.StreamOptionCase == StreamOptionOneofCase.Stream)
+					{
 						streamId = request.Options.Stream.StreamIdentifier;
-						startRevision = request.Options.Stream.RevisionOptionCase switch {
+						startRevision = request.Options.Stream.RevisionOptionCase switch
+						{
 							RevisionOptionOneofCase.Revision => new StreamRevision(request.Options.Stream.Revision),
 							RevisionOptionOneofCase.Start => StreamRevision.Start,
 							RevisionOptionOneofCase.End => StreamRevision.End,
 							_ => throw RpcExceptions.InvalidArgument(request.Options.Stream.RevisionOptionCase)
 						};
-					} else { /*for backwards compatibility*/
-						#pragma warning disable 612
+					}
+					else
+					{ /*for backwards compatibility*/
+#pragma warning disable 612
 						streamId = request.Options.StreamIdentifier;
 						startRevision = new StreamRevision(request.Options.Settings.Revision);
-						#pragma warning restore 612
+#pragma warning restore 612
 					}
 
 					_publisher.Publish(
@@ -75,7 +86,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 							request.Options.GroupName,
 							settings.ResolveLinks,
 							startRevision.ToInt64(),
-							settings.MessageTimeoutCase switch {
+							settings.MessageTimeoutCase switch
+							{
 								CreateReq.Types.Settings.MessageTimeoutOneofCase.MessageTimeoutMs => settings
 									.MessageTimeoutMs,
 								CreateReq.Types.Settings.MessageTimeoutOneofCase.MessageTimeoutTicks => (int)TimeSpan
@@ -87,7 +99,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 							settings.HistoryBufferSize,
 							settings.LiveBufferSize,
 							settings.ReadBatchSize,
-							settings.CheckpointAfterCase switch {
+							settings.CheckpointAfterCase switch
+							{
 								CreateReq.Types.Settings.CheckpointAfterOneofCase.CheckpointAfterMs => settings
 									.CheckpointAfterMs,
 								CreateReq.Types.Settings.CheckpointAfterOneofCase.CheckpointAfterTicks => (int)TimeSpan
@@ -101,160 +114,174 @@ namespace EventStore.Core.Services.Transport.Grpc {
 							user));
 					break;
 				}
-				case StreamOptionOneofCase.All:
-					var startPosition = request.Options.All.AllOptionCase switch {
-						AllOptionOneofCase.Position => new Position(
-							request.Options.All.Position.CommitPosition,
-							request.Options.All.Position.PreparePosition),
-						AllOptionOneofCase.Start => Position.Start,
-						AllOptionOneofCase.End => Position.End,
-						_ => throw RpcExceptions.InvalidArgument(request.Options.All.AllOptionCase)
-					};
-					var filter = request.Options.All.FilterOptionCase switch {
-						CreateReq.Types.AllOptions.FilterOptionOneofCase.NoFilter => null,
-						CreateReq.Types.AllOptions.FilterOptionOneofCase.Filter => ConvertToEventFilter(true,
-							request.Options.All.Filter),
-						CreateReq.Types.AllOptions.FilterOptionOneofCase.None => null,
-						_ => throw RpcExceptions.InvalidArgument(request.Options.All.FilterOptionCase)
-					};
-
-					streamId = SystemStreams.AllStream;
-					_publisher.Publish(
-						new ClientMessage.CreatePersistentSubscriptionToAll(
-							correlationId,
-							correlationId,
-							new CallbackEnvelope(HandleCreatePersistentSubscriptionCompleted),
-							request.Options.GroupName,
-							filter,
-							settings.ResolveLinks,
-							new TFPos(
-								startPosition.ToInt64().commitPosition,
-								startPosition.ToInt64().preparePosition
-							),
-							settings.MessageTimeoutCase switch {
-								CreateReq.Types.Settings.MessageTimeoutOneofCase.MessageTimeoutMs => settings
-									.MessageTimeoutMs,
-								CreateReq.Types.Settings.MessageTimeoutOneofCase.MessageTimeoutTicks => (int)TimeSpan
-									.FromTicks(settings.MessageTimeoutTicks).TotalMilliseconds,
-								_ => 0
-							},
-							settings.ExtraStatistics,
-							settings.MaxRetryCount,
-							settings.HistoryBufferSize,
-							settings.LiveBufferSize,
-							settings.ReadBatchSize,
-							settings.CheckpointAfterCase switch {
-								CreateReq.Types.Settings.CheckpointAfterOneofCase.CheckpointAfterMs => settings
-									.CheckpointAfterMs,
-								CreateReq.Types.Settings.CheckpointAfterOneofCase.CheckpointAfterTicks => (int)TimeSpan
-									.FromTicks(settings.CheckpointAfterTicks).TotalMilliseconds,
-								_ => 0
-							},
-							settings.MinCheckpointCount,
-							settings.MaxCheckpointCount,
-							settings.MaxSubscriberCount,
-							consumerStrategy,
-							user));
-					break;
-				default:
-					throw new InvalidOperationException();
-			}
-			IEventFilter ConvertToEventFilter(bool isAllStream, CreateReq.Types.AllOptions.Types.FilterOptions filter) =>
-				filter.FilterCase switch {
-					CreateReq.Types.AllOptions.Types.FilterOptions.FilterOneofCase.EventType => (
-						string.IsNullOrEmpty(filter.EventType.Regex)
-							? EventFilter.EventType.Prefixes(isAllStream, filter.EventType.Prefix.ToArray())
-							: EventFilter.EventType.Regex(isAllStream, filter.EventType.Regex)),
-					CreateReq.Types.AllOptions.Types.FilterOptions.FilterOneofCase.StreamIdentifier => (
-						string.IsNullOrEmpty(filter.StreamIdentifier.Regex)
-							? EventFilter.StreamName.Prefixes(isAllStream, filter.StreamIdentifier.Prefix.ToArray())
-							: EventFilter.StreamName.Regex(isAllStream, filter.StreamIdentifier.Regex)),
-					_ => throw RpcExceptions.InvalidArgument(filter.FilterCase)
+			case StreamOptionOneofCase.All:
+				var startPosition = request.Options.All.AllOptionCase switch
+				{
+					AllOptionOneofCase.Position => new Position(
+						request.Options.All.Position.CommitPosition,
+						request.Options.All.Position.PreparePosition),
+					AllOptionOneofCase.Start => Position.Start,
+					AllOptionOneofCase.End => Position.End,
+					_ => throw RpcExceptions.InvalidArgument(request.Options.All.AllOptionCase)
+				};
+				var filter = request.Options.All.FilterOptionCase switch
+				{
+					CreateReq.Types.AllOptions.FilterOptionOneofCase.NoFilter => null,
+					CreateReq.Types.AllOptions.FilterOptionOneofCase.Filter => ConvertToEventFilter(true,
+						request.Options.All.Filter),
+					CreateReq.Types.AllOptions.FilterOptionOneofCase.None => null,
+					_ => throw RpcExceptions.InvalidArgument(request.Options.All.FilterOptionCase)
 				};
 
-			static void ValidateCreateSettings(CreateReq.Types.Settings settings) {
-				if (settings is null)
-					throw RpcExceptions.InvalidArgument("Subscription settings are required.");
+				streamId = SystemStreams.AllStream;
+				_publisher.Publish(
+					new ClientMessage.CreatePersistentSubscriptionToAll(
+						correlationId,
+						correlationId,
+						new CallbackEnvelope(HandleCreatePersistentSubscriptionCompleted),
+						request.Options.GroupName,
+						filter,
+						settings.ResolveLinks,
+						new TFPos(
+							startPosition.ToInt64().commitPosition,
+							startPosition.ToInt64().preparePosition
+						),
+						settings.MessageTimeoutCase switch
+						{
+							CreateReq.Types.Settings.MessageTimeoutOneofCase.MessageTimeoutMs => settings
+								.MessageTimeoutMs,
+							CreateReq.Types.Settings.MessageTimeoutOneofCase.MessageTimeoutTicks => (int)TimeSpan
+								.FromTicks(settings.MessageTimeoutTicks).TotalMilliseconds,
+							_ => 0
+						},
+						settings.ExtraStatistics,
+						settings.MaxRetryCount,
+						settings.HistoryBufferSize,
+						settings.LiveBufferSize,
+						settings.ReadBatchSize,
+						settings.CheckpointAfterCase switch
+						{
+							CreateReq.Types.Settings.CheckpointAfterOneofCase.CheckpointAfterMs => settings
+								.CheckpointAfterMs,
+							CreateReq.Types.Settings.CheckpointAfterOneofCase.CheckpointAfterTicks => (int)TimeSpan
+								.FromTicks(settings.CheckpointAfterTicks).TotalMilliseconds,
+							_ => 0
+						},
+						settings.MinCheckpointCount,
+						settings.MaxCheckpointCount,
+						settings.MaxSubscriberCount,
+						consumerStrategy,
+						user));
+				break;
+			default:
+				throw new InvalidOperationException();
+		}
+		IEventFilter ConvertToEventFilter(bool isAllStream, CreateReq.Types.AllOptions.Types.FilterOptions filter) =>
+			filter.FilterCase switch
+			{
+				CreateReq.Types.AllOptions.Types.FilterOptions.FilterOneofCase.EventType => (
+					string.IsNullOrEmpty(filter.EventType.Regex)
+						? EventFilter.EventType.Prefixes(isAllStream, filter.EventType.Prefix.ToArray())
+						: EventFilter.EventType.Regex(isAllStream, filter.EventType.Regex)),
+				CreateReq.Types.AllOptions.Types.FilterOptions.FilterOneofCase.StreamIdentifier => (
+					string.IsNullOrEmpty(filter.StreamIdentifier.Regex)
+						? EventFilter.StreamName.Prefixes(isAllStream, filter.StreamIdentifier.Prefix.ToArray())
+						: EventFilter.StreamName.Regex(isAllStream, filter.StreamIdentifier.Regex)),
+				_ => throw RpcExceptions.InvalidArgument(filter.FilterCase)
+			};
 
-				if (settings.HistoryBufferSize <= 0)
-					throw RpcExceptions.InvalidArgument($"Buffer Size ({settings.HistoryBufferSize}) must be positive");
+		static void ValidateCreateSettings(CreateReq.Types.Settings settings)
+		{
+			if (settings is null)
+				throw RpcExceptions.InvalidArgument("Subscription settings are required.");
 
-				if (settings.LiveBufferSize <= 0)
-					throw RpcExceptions.InvalidArgument($"Live Buffer Size ({settings.LiveBufferSize}) must be positive");
+			if (settings.HistoryBufferSize <= 0)
+				throw RpcExceptions.InvalidArgument($"Buffer Size ({settings.HistoryBufferSize}) must be positive");
 
-				if (settings.ReadBatchSize <= 0)
-					throw RpcExceptions.InvalidArgument($"Read Batch Size ({settings.ReadBatchSize}) must be positive");
+			if (settings.LiveBufferSize <= 0)
+				throw RpcExceptions.InvalidArgument($"Live Buffer Size ({settings.LiveBufferSize}) must be positive");
 
-				if (settings.HistoryBufferSize <= settings.ReadBatchSize)
-					throw RpcExceptions.InvalidArgument(
-						$"BufferSize ({settings.HistoryBufferSize}) must be larger than ReadBatchSize ({settings.ReadBatchSize})");
+			if (settings.ReadBatchSize <= 0)
+				throw RpcExceptions.InvalidArgument($"Read Batch Size ({settings.ReadBatchSize}) must be positive");
+
+			if (settings.HistoryBufferSize <= settings.ReadBatchSize)
+				throw RpcExceptions.InvalidArgument(
+					$"BufferSize ({settings.HistoryBufferSize}) must be larger than ReadBatchSize ({settings.ReadBatchSize})");
+		}
+
+		return await createPersistentSubscriptionSource.Task;
+
+		void HandleCreatePersistentSubscriptionCompleted(Message message)
+		{
+			if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex))
+			{
+				createPersistentSubscriptionSource.TrySetException(ex);
+				return;
 			}
 
-			return await createPersistentSubscriptionSource.Task;
-
-			void HandleCreatePersistentSubscriptionCompleted(Message message) {
-				if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
-					createPersistentSubscriptionSource.TrySetException(ex);
-					return;
+			if (streamId != SystemStreams.AllStream)
+			{
+				if (message is ClientMessage.CreatePersistentSubscriptionToStreamCompleted completed)
+				{
+					switch (completed.Result)
+					{
+						case CreatePersistentSubscriptionToStreamResult.Success:
+							createPersistentSubscriptionSource.TrySetResult(new CreateResp());
+							return;
+						case CreatePersistentSubscriptionToStreamResult.Fail:
+							createPersistentSubscriptionSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
+									completed.Reason));
+							return;
+						case CreatePersistentSubscriptionToStreamResult.AlreadyExists:
+							createPersistentSubscriptionSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionExists(streamId, request.Options.GroupName));
+							return;
+						case CreatePersistentSubscriptionToStreamResult.AccessDenied:
+							createPersistentSubscriptionSource.TrySetException(RpcExceptions.AccessDenied());
+							return;
+						default:
+							createPersistentSubscriptionSource.TrySetException(
+								RpcExceptions.UnknownError(completed.Result));
+							return;
+					}
 				}
 
-				if (streamId != SystemStreams.AllStream) {
-					if (message is ClientMessage.CreatePersistentSubscriptionToStreamCompleted completed) {
-						switch (completed.Result) {
-							case CreatePersistentSubscriptionToStreamResult.Success:
-								createPersistentSubscriptionSource.TrySetResult(new CreateResp());
-								return;
-							case CreatePersistentSubscriptionToStreamResult.Fail:
-								createPersistentSubscriptionSource.TrySetException(
-									RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
-										completed.Reason));
-								return;
-							case CreatePersistentSubscriptionToStreamResult.AlreadyExists:
-								createPersistentSubscriptionSource.TrySetException(
-									RpcExceptions.PersistentSubscriptionExists(streamId, request.Options.GroupName));
-								return;
-							case CreatePersistentSubscriptionToStreamResult.AccessDenied:
-								createPersistentSubscriptionSource.TrySetException(RpcExceptions.AccessDenied());
-								return;
-							default:
-								createPersistentSubscriptionSource.TrySetException(
-									RpcExceptions.UnknownError(completed.Result));
-								return;
-						}
+				createPersistentSubscriptionSource.TrySetException(
+					RpcExceptions.UnknownMessage<ClientMessage.CreatePersistentSubscriptionToStreamCompleted>(
+						message));
+			}
+			else
+			{
+				if (message is ClientMessage.CreatePersistentSubscriptionToAllCompleted completedAll)
+				{
+					switch (completedAll.Result)
+					{
+						case CreatePersistentSubscriptionToAllResult.Success:
+							createPersistentSubscriptionSource.TrySetResult(new CreateResp());
+							return;
+						case CreatePersistentSubscriptionToAllResult.Fail:
+							createPersistentSubscriptionSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
+									completedAll.Reason));
+							return;
+						case CreatePersistentSubscriptionToAllResult.AlreadyExists:
+							createPersistentSubscriptionSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionExists(streamId, request.Options.GroupName));
+							return;
+						case CreatePersistentSubscriptionToAllResult.AccessDenied:
+							createPersistentSubscriptionSource.TrySetException(RpcExceptions.AccessDenied());
+							return;
+						default:
+							createPersistentSubscriptionSource.TrySetException(
+								RpcExceptions.UnknownError(completedAll.Result));
+							return;
 					}
-
-					createPersistentSubscriptionSource.TrySetException(
-						RpcExceptions.UnknownMessage<ClientMessage.CreatePersistentSubscriptionToStreamCompleted>(
-							message));
-				} else {
-					if (message is ClientMessage.CreatePersistentSubscriptionToAllCompleted completedAll) {
-						switch (completedAll.Result) {
-							case CreatePersistentSubscriptionToAllResult.Success:
-								createPersistentSubscriptionSource.TrySetResult(new CreateResp());
-								return;
-							case CreatePersistentSubscriptionToAllResult.Fail:
-								createPersistentSubscriptionSource.TrySetException(
-									RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
-										completedAll.Reason));
-								return;
-							case CreatePersistentSubscriptionToAllResult.AlreadyExists:
-								createPersistentSubscriptionSource.TrySetException(
-									RpcExceptions.PersistentSubscriptionExists(streamId, request.Options.GroupName));
-								return;
-							case CreatePersistentSubscriptionToAllResult.AccessDenied:
-								createPersistentSubscriptionSource.TrySetException(RpcExceptions.AccessDenied());
-								return;
-							default:
-								createPersistentSubscriptionSource.TrySetException(
-									RpcExceptions.UnknownError(completedAll.Result));
-								return;
-						}
-					}
-
-					createPersistentSubscriptionSource.TrySetException(
-						RpcExceptions.UnknownMessage<ClientMessage.CreatePersistentSubscriptionToAllCompleted>(
-							message));
 				}
+
+				createPersistentSubscriptionSource.TrySetException(
+					RpcExceptions.UnknownMessage<ClientMessage.CreatePersistentSubscriptionToAllCompleted>(
+						message));
 			}
 		}
 	}

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Delete.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Delete.cs
@@ -1,34 +1,38 @@
 using System;
 using System.Threading.Tasks;
+using EventStore.Client.PersistentSubscriptions;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Client.PersistentSubscriptions;
 using EventStore.Plugins.Authorization;
 using Grpc.Core;
-using static EventStore.Core.Messages.ClientMessage.DeletePersistentSubscriptionToStreamCompleted;
 using static EventStore.Core.Messages.ClientMessage.DeletePersistentSubscriptionToAllCompleted;
+using static EventStore.Core.Messages.ClientMessage.DeletePersistentSubscriptionToStreamCompleted;
 using StreamOptionOneofCase = EventStore.Client.PersistentSubscriptions.DeleteReq.Types.Options.StreamOptionOneofCase;
 
-namespace EventStore.Core.Services.Transport.Grpc {
-	internal partial class PersistentSubscriptions {
-		private static readonly Operation DeleteOperation = new Operation(Plugins.Authorization.Operations.Subscriptions.Delete);
-		public override async Task<DeleteResp> Delete(DeleteReq request, ServerCallContext context) {
-			
-			var createPersistentSubscriptionSource = new TaskCompletionSource<DeleteResp>();
-			var correlationId = Guid.NewGuid();
+namespace EventStore.Core.Services.Transport.Grpc;
 
-			var user = context.GetHttpContext().User;
+internal partial class PersistentSubscriptions
+{
+	private static readonly Operation DeleteOperation = new Operation(Plugins.Authorization.Operations.Subscriptions.Delete);
+	public override async Task<DeleteResp> Delete(DeleteReq request, ServerCallContext context)
+	{
 
-			if (!await _authorizationProvider.CheckAccessAsync(user,
-				DeleteOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
-			}
+		var createPersistentSubscriptionSource = new TaskCompletionSource<DeleteResp>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var correlationId = Guid.NewGuid();
 
-			string streamId = null;
+		var user = context.GetHttpContext().User;
 
-			switch (request.Options.StreamOptionCase)
-			{
-				case StreamOptionOneofCase.StreamIdentifier:
+		if (!await _authorizationProvider.CheckAccessAsync(user,
+			DeleteOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+
+		string streamId = null;
+
+		switch (request.Options.StreamOptionCase)
+		{
+			case StreamOptionOneofCase.StreamIdentifier:
 				{
 					streamId = request.Options.StreamIdentifier;
 					_publisher.Publish(new ClientMessage.DeletePersistentSubscriptionToStream(
@@ -40,84 +44,92 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						user));
 					break;
 				}
-				case StreamOptionOneofCase.All:
-					streamId = SystemStreams.AllStream;
-					_publisher.Publish(new ClientMessage.DeletePersistentSubscriptionToAll(
-						correlationId,
-						correlationId,
-						new CallbackEnvelope(HandleDeletePersistentSubscriptionCompleted),
-						request.Options.GroupName,
-						user));
-					break;
-				default:
-					throw new InvalidOperationException();
+			case StreamOptionOneofCase.All:
+				streamId = SystemStreams.AllStream;
+				_publisher.Publish(new ClientMessage.DeletePersistentSubscriptionToAll(
+					correlationId,
+					correlationId,
+					new CallbackEnvelope(HandleDeletePersistentSubscriptionCompleted),
+					request.Options.GroupName,
+					user));
+				break;
+			default:
+				throw new InvalidOperationException();
+		}
+
+		return await createPersistentSubscriptionSource.Task;
+
+		void HandleDeletePersistentSubscriptionCompleted(Message message)
+		{
+			if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex))
+			{
+				createPersistentSubscriptionSource.TrySetException(ex);
+				return;
 			}
 
-			return await createPersistentSubscriptionSource.Task;
-
-			void HandleDeletePersistentSubscriptionCompleted(Message message) {
-				if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
-					createPersistentSubscriptionSource.TrySetException(ex);
-					return;
-				}
-
-				if (streamId != SystemStreams.AllStream) {
-					if (message is ClientMessage.DeletePersistentSubscriptionToStreamCompleted completed) {
-						switch (completed.Result) {
-							case DeletePersistentSubscriptionToStreamResult.Success:
-								createPersistentSubscriptionSource.TrySetResult(new DeleteResp());
-								return;
-							case DeletePersistentSubscriptionToStreamResult.Fail:
-								createPersistentSubscriptionSource.TrySetException(
-									RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
-										completed.Reason));
-								return;
-							case DeletePersistentSubscriptionToStreamResult.DoesNotExist:
-								createPersistentSubscriptionSource.TrySetException(
-									RpcExceptions.PersistentSubscriptionDoesNotExist(streamId,
-										request.Options.GroupName));
-								return;
-							case DeletePersistentSubscriptionToStreamResult.AccessDenied:
-								createPersistentSubscriptionSource.TrySetException(RpcExceptions.AccessDenied());
-								return;
-							default:
-								createPersistentSubscriptionSource.TrySetException(
-									RpcExceptions.UnknownError(completed.Result));
-								return;
-						}
+			if (streamId != SystemStreams.AllStream)
+			{
+				if (message is ClientMessage.DeletePersistentSubscriptionToStreamCompleted completed)
+				{
+					switch (completed.Result)
+					{
+						case DeletePersistentSubscriptionToStreamResult.Success:
+							createPersistentSubscriptionSource.TrySetResult(new DeleteResp());
+							return;
+						case DeletePersistentSubscriptionToStreamResult.Fail:
+							createPersistentSubscriptionSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
+									completed.Reason));
+							return;
+						case DeletePersistentSubscriptionToStreamResult.DoesNotExist:
+							createPersistentSubscriptionSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionDoesNotExist(streamId,
+									request.Options.GroupName));
+							return;
+						case DeletePersistentSubscriptionToStreamResult.AccessDenied:
+							createPersistentSubscriptionSource.TrySetException(RpcExceptions.AccessDenied());
+							return;
+						default:
+							createPersistentSubscriptionSource.TrySetException(
+								RpcExceptions.UnknownError(completed.Result));
+							return;
 					}
-					createPersistentSubscriptionSource.TrySetException(
-						RpcExceptions.UnknownMessage<ClientMessage.DeletePersistentSubscriptionToStreamCompleted>(message));
-				} else {
-					if (message is ClientMessage.DeletePersistentSubscriptionToAllCompleted completedAll) {
-						switch (completedAll.Result) {
-							case DeletePersistentSubscriptionToAllResult.Success:
-								createPersistentSubscriptionSource.TrySetResult(new DeleteResp());
-								return;
-							case DeletePersistentSubscriptionToAllResult.Fail:
-								createPersistentSubscriptionSource.TrySetException(
-									RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
-										completedAll.Reason));
-								return;
-							case DeletePersistentSubscriptionToAllResult.DoesNotExist:
-								createPersistentSubscriptionSource.TrySetException(
-									RpcExceptions.PersistentSubscriptionDoesNotExist(streamId,
-										request.Options.GroupName));
-								return;
-							case DeletePersistentSubscriptionToAllResult.AccessDenied:
-								createPersistentSubscriptionSource.TrySetException(RpcExceptions.AccessDenied());
-								return;
-							default:
-								createPersistentSubscriptionSource.TrySetException(
-									RpcExceptions.UnknownError(completedAll.Result));
-								return;
-						}
-					}
-					createPersistentSubscriptionSource.TrySetException(
-						RpcExceptions.UnknownMessage<ClientMessage.DeletePersistentSubscriptionToAllCompleted>(message));
 				}
-
+				createPersistentSubscriptionSource.TrySetException(
+					RpcExceptions.UnknownMessage<ClientMessage.DeletePersistentSubscriptionToStreamCompleted>(message));
 			}
+			else
+			{
+				if (message is ClientMessage.DeletePersistentSubscriptionToAllCompleted completedAll)
+				{
+					switch (completedAll.Result)
+					{
+						case DeletePersistentSubscriptionToAllResult.Success:
+							createPersistentSubscriptionSource.TrySetResult(new DeleteResp());
+							return;
+						case DeletePersistentSubscriptionToAllResult.Fail:
+							createPersistentSubscriptionSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
+									completedAll.Reason));
+							return;
+						case DeletePersistentSubscriptionToAllResult.DoesNotExist:
+							createPersistentSubscriptionSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionDoesNotExist(streamId,
+									request.Options.GroupName));
+							return;
+						case DeletePersistentSubscriptionToAllResult.AccessDenied:
+							createPersistentSubscriptionSource.TrySetException(RpcExceptions.AccessDenied());
+							return;
+						default:
+							createPersistentSubscriptionSource.TrySetException(
+								RpcExceptions.UnknownError(completedAll.Result));
+							return;
+					}
+				}
+				createPersistentSubscriptionSource.TrySetException(
+					RpcExceptions.UnknownMessage<ClientMessage.DeletePersistentSubscriptionToAllCompleted>(message));
+			}
+
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Info.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Info.cs
@@ -8,224 +8,245 @@ using EventStore.Core.Messaging;
 using EventStore.Plugins.Authorization;
 using Grpc.Core;
 
-namespace EventStore.Core.Services.Transport.Grpc {
-	internal partial class PersistentSubscriptions {
-		private static readonly Operation GetInfoOperation = new Operation(Plugins.Authorization.Operations.Subscriptions.Statistics);
-		public override async Task<GetInfoResp> GetInfo(GetInfoReq request, ServerCallContext context) {
-			var getPersistentSubscriptionInfoSource = new TaskCompletionSource<GetInfoResp>();
+namespace EventStore.Core.Services.Transport.Grpc;
 
-			var user = context.GetHttpContext().User;
+internal partial class PersistentSubscriptions
+{
+	private static readonly Operation GetInfoOperation = new Operation(Plugins.Authorization.Operations.Subscriptions.Statistics);
+	public override async Task<GetInfoResp> GetInfo(GetInfoReq request, ServerCallContext context)
+	{
+		var getPersistentSubscriptionInfoSource = new TaskCompletionSource<GetInfoResp>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-			if (!await _authorizationProvider.CheckAccessAsync(user,
-				GetInfoOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
-			}
+		var user = context.GetHttpContext().User;
 
-			string streamId = request.Options.StreamOptionCase switch {
-				GetInfoReq.Types.Options.StreamOptionOneofCase.All => "$all",
-				GetInfoReq.Types.Options.StreamOptionOneofCase.StreamIdentifier => request.Options.StreamIdentifier,
-				_ => throw new InvalidOperationException()
-			};
-
-			_publisher.Publish(new MonitoringMessage.GetPersistentSubscriptionStats(
-				new CallbackEnvelope(HandleGetPersistentSubscriptionStatsCompleted),
-				streamId,
-				request.Options.GroupName));
-			return await getPersistentSubscriptionInfoSource.Task;
-
-			void HandleGetPersistentSubscriptionStatsCompleted(Message message) {
-				if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
-					getPersistentSubscriptionInfoSource.TrySetException(ex);
-					return;
-				}
-
-				if (message is MonitoringMessage.GetPersistentSubscriptionStatsCompleted completed) {
-					switch (completed.Result) {
-						case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success:
-							var getInfoResp = new GetInfoResp {
-								SubscriptionInfo = ParseSubscriptionInfo(completed.SubscriptionStats.First())
-							};
-							getPersistentSubscriptionInfoSource.TrySetResult(getInfoResp);
-							return;
-						case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotFound:
-							getPersistentSubscriptionInfoSource.TrySetException(
-								RpcExceptions.PersistentSubscriptionDoesNotExist(streamId,
-									request.Options.GroupName));
-							return;
-						case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotReady:
-							getPersistentSubscriptionInfoSource.TrySetException(
-								RpcExceptions.ServerNotReady());
-							return;
-						case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Fail:
-							getPersistentSubscriptionInfoSource.TrySetException(
-								RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
-									completed.ErrorString));
-							return;
-						default:
-							getPersistentSubscriptionInfoSource.TrySetException(
-								RpcExceptions.UnknownError(completed.Result));
-							return;
-					}
-				}
-				getPersistentSubscriptionInfoSource.TrySetException(
-					RpcExceptions.UnknownMessage<MonitoringMessage.GetPersistentSubscriptionStatsCompleted>(
-						message));
-			}
+		if (!await _authorizationProvider.CheckAccessAsync(user,
+			GetInfoOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
 		}
 
-		public override async Task<ListResp> List(ListReq request, ServerCallContext context) {
-			var listPersistentSubscriptionsSource =
-				new TaskCompletionSource<ListResp>(TaskCreationOptions.RunContinuationsAsynchronously);
+		string streamId = request.Options.StreamOptionCase switch
+		{
+			GetInfoReq.Types.Options.StreamOptionOneofCase.All => "$all",
+			GetInfoReq.Types.Options.StreamOptionOneofCase.StreamIdentifier => request.Options.StreamIdentifier,
+			_ => throw new InvalidOperationException()
+		};
 
-			var user = context.GetHttpContext().User;
+		_publisher.Publish(new MonitoringMessage.GetPersistentSubscriptionStats(
+			new CallbackEnvelope(HandleGetPersistentSubscriptionStatsCompleted),
+			streamId,
+			request.Options.GroupName));
+		return await getPersistentSubscriptionInfoSource.Task;
 
-			if (!await _authorizationProvider.CheckAccessAsync(user,
-				GetInfoOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
+		void HandleGetPersistentSubscriptionStatsCompleted(Message message)
+		{
+			if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex))
+			{
+				getPersistentSubscriptionInfoSource.TrySetException(ex);
+				return;
 			}
 
-			var options = request.Options ?? new ListReq.Types.Options();
-			var listOptionCase = options.ListOptionCase == ListReq.Types.Options.ListOptionOneofCase.None
-				? ListReq.Types.Options.ListOptionOneofCase.ListAllSubscriptions
-				: options.ListOptionCase;
-
-			var hasPaging = options.HasOffset || options.HasCount;
-			if (options.HasOffset && options.Offset < 0)
-				throw new RpcException(new Status(StatusCode.InvalidArgument, "offset must be a non-negative integer"));
-			if (options.HasCount && options.Count < 1)
-				throw new RpcException(new Status(StatusCode.InvalidArgument, "count must be a positive integer"));
-			if (hasPaging && !(options.HasOffset && options.HasCount))
-				throw new RpcException(new Status(StatusCode.InvalidArgument, "offset and count must be provided together"));
-			if (hasPaging &&
-				listOptionCase != ListReq.Types.Options.ListOptionOneofCase.ListAllSubscriptions)
-				throw new RpcException(new Status(StatusCode.InvalidArgument,
-					"offset and count are only supported when listing all subscriptions"));
-
-			var streamId = string.Empty;
-			switch (listOptionCase) {
-				case ListReq.Types.Options.ListOptionOneofCase.ListAllSubscriptions:
-					var envelope = new CallbackEnvelope(HandleListSubscriptionsCompleted);
-					_publisher.Publish(hasPaging
-						? new MonitoringMessage.GetAllPersistentSubscriptionStats(
-							envelope,
-							options.Offset,
-							options.Count)
-						: new MonitoringMessage.GetAllPersistentSubscriptionStats(envelope));
-					break;
-				case ListReq.Types.Options.ListOptionOneofCase.ListForStream:
-					var listForStream = options.ListForStream;
-					if (listForStream is null)
-						throw new RpcException(new Status(StatusCode.InvalidArgument, "list_for_stream must be provided"));
-					streamId = listForStream.StreamOptionCase switch {
-						ListReq.Types.StreamOption.StreamOptionOneofCase.All => "$all",
-						ListReq.Types.StreamOption.StreamOptionOneofCase.Stream => listForStream.Stream,
-						_ => throw new RpcException(new Status(StatusCode.InvalidArgument, "stream option must be provided"))
-					};
-					_publisher.Publish(new MonitoringMessage.GetStreamPersistentSubscriptionStats(
-						new CallbackEnvelope(HandleListSubscriptionsCompleted),
-						streamId
-					));
-					break;
-				default:
-					throw new InvalidOperationException();
-			}
-
-			return await listPersistentSubscriptionsSource.Task.WaitAsync(context.CancellationToken);
-
-			void HandleListSubscriptionsCompleted(Message message) {
-				if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
-					listPersistentSubscriptionsSource.TrySetException(ex);
-					return;
+			if (message is MonitoringMessage.GetPersistentSubscriptionStatsCompleted completed)
+			{
+				switch (completed.Result)
+				{
+					case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success:
+						var getInfoResp = new GetInfoResp
+						{
+							SubscriptionInfo = ParseSubscriptionInfo(completed.SubscriptionStats.First())
+						};
+						getPersistentSubscriptionInfoSource.TrySetResult(getInfoResp);
+						return;
+					case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotFound:
+						getPersistentSubscriptionInfoSource.TrySetException(
+							RpcExceptions.PersistentSubscriptionDoesNotExist(streamId,
+								request.Options.GroupName));
+						return;
+					case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotReady:
+						getPersistentSubscriptionInfoSource.TrySetException(
+							RpcExceptions.ServerNotReady());
+						return;
+					case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Fail:
+						getPersistentSubscriptionInfoSource.TrySetException(
+							RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
+								completed.ErrorString));
+						return;
+					default:
+						getPersistentSubscriptionInfoSource.TrySetException(
+							RpcExceptions.UnknownError(completed.Result));
+						return;
 				}
-
-				if (message is MonitoringMessage.GetPersistentSubscriptionStatsCompleted completed) {
-					switch (completed.Result) {
-						case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success:
-							var listResp = new ListResp();
-							listResp.Subscriptions.AddRange(
-								completed.SubscriptionStats.Select(ParseSubscriptionInfo)
-							);
-							listResp.Offset = completed.RequestedOffset;
-							listResp.Count = completed.RequestedCount == int.MaxValue
-								? listResp.Subscriptions.Count
-								: completed.RequestedCount;
-							listResp.Total = completed.Total;
-							listPersistentSubscriptionsSource.TrySetResult(listResp);
-							return;
-						case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotFound:
-							listPersistentSubscriptionsSource.TrySetException(
-								RpcExceptions.PersistentSubscriptionDoesNotExist(streamId, ""));
-							return;
-						case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotReady:
-							listPersistentSubscriptionsSource.TrySetException(
-								RpcExceptions.ServerNotReady());
-							return;
-						case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Fail:
-							listPersistentSubscriptionsSource.TrySetException(
-								RpcExceptions.PersistentSubscriptionFailed(streamId, "", completed.ErrorString));
-							return;
-						default:
-							listPersistentSubscriptionsSource.TrySetException(
-								RpcExceptions.UnknownError(completed.Result));
-							return;
-					}
-				}
-				listPersistentSubscriptionsSource.TrySetException(
-					RpcExceptions.UnknownMessage<MonitoringMessage.GetPersistentSubscriptionStatsCompleted>(
-						message));
 			}
+			getPersistentSubscriptionInfoSource.TrySetException(
+				RpcExceptions.UnknownMessage<MonitoringMessage.GetPersistentSubscriptionStatsCompleted>(
+					message));
+		}
+	}
+
+	public override async Task<ListResp> List(ListReq request, ServerCallContext context)
+	{
+		var listPersistentSubscriptionsSource =
+			new TaskCompletionSource<ListResp>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		var user = context.GetHttpContext().User;
+
+		if (!await _authorizationProvider.CheckAccessAsync(user,
+			GetInfoOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
 		}
 
-		private SubscriptionInfo ParseSubscriptionInfo(MonitoringMessage.PersistentSubscriptionInfo input) {
-			var connectionInfo = new List<SubscriptionInfo.Types.ConnectionInfo>();
-			foreach (var conn in input.Connections) {
-				var connInfo = new SubscriptionInfo.Types.ConnectionInfo {
-					From = conn.From,
-					Username = conn.Username,
-					AverageItemsPerSecond = conn.AverageItemsPerSecond,
-					TotalItems = conn.TotalItems,
-					CountSinceLastMeasurement = conn.CountSinceLastMeasurement,
-					AvailableSlots = conn.AvailableSlots,
-					InFlightMessages = conn.InFlightMessages,
-					ConnectionName = conn.ConnectionName
+		var options = request.Options ?? new ListReq.Types.Options();
+		var listOptionCase = options.ListOptionCase == ListReq.Types.Options.ListOptionOneofCase.None
+			? ListReq.Types.Options.ListOptionOneofCase.ListAllSubscriptions
+			: options.ListOptionCase;
+
+		var hasPaging = options.HasOffset || options.HasCount;
+		if (options.HasOffset && options.Offset < 0)
+			throw new RpcException(new Status(StatusCode.InvalidArgument, "offset must be a non-negative integer"));
+		if (options.HasCount && options.Count < 1)
+			throw new RpcException(new Status(StatusCode.InvalidArgument, "count must be a positive integer"));
+		if (hasPaging && !(options.HasOffset && options.HasCount))
+			throw new RpcException(new Status(StatusCode.InvalidArgument, "offset and count must be provided together"));
+		if (hasPaging &&
+			listOptionCase != ListReq.Types.Options.ListOptionOneofCase.ListAllSubscriptions)
+			throw new RpcException(new Status(StatusCode.InvalidArgument,
+				"offset and count are only supported when listing all subscriptions"));
+
+		var streamId = string.Empty;
+		switch (listOptionCase)
+		{
+			case ListReq.Types.Options.ListOptionOneofCase.ListAllSubscriptions:
+				var envelope = new CallbackEnvelope(HandleListSubscriptionsCompleted);
+				_publisher.Publish(hasPaging
+					? new MonitoringMessage.GetAllPersistentSubscriptionStats(
+						envelope,
+						options.Offset,
+						options.Count)
+					: new MonitoringMessage.GetAllPersistentSubscriptionStats(envelope));
+				break;
+			case ListReq.Types.Options.ListOptionOneofCase.ListForStream:
+				var listForStream = options.ListForStream;
+				if (listForStream is null)
+					throw new RpcException(new Status(StatusCode.InvalidArgument, "list_for_stream must be provided"));
+				streamId = listForStream.StreamOptionCase switch
+				{
+					ListReq.Types.StreamOption.StreamOptionOneofCase.All => "$all",
+					ListReq.Types.StreamOption.StreamOptionOneofCase.Stream => listForStream.Stream,
+					_ => throw new RpcException(new Status(StatusCode.InvalidArgument, "stream option must be provided"))
 				};
-				connInfo.ObservedMeasurements.AddRange(
-					conn.ObservedMeasurements.Select(x => new SubscriptionInfo.Types.Measurement
-						{Key = x.Key, Value = x.Value}));
-				connectionInfo.Add(connInfo);
+				_publisher.Publish(new MonitoringMessage.GetStreamPersistentSubscriptionStats(
+					new CallbackEnvelope(HandleListSubscriptionsCompleted),
+					streamId
+				));
+				break;
+			default:
+				throw new InvalidOperationException();
+		}
+
+		return await listPersistentSubscriptionsSource.Task.WaitAsync(context.CancellationToken);
+
+		void HandleListSubscriptionsCompleted(Message message)
+		{
+			if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex))
+			{
+				listPersistentSubscriptionsSource.TrySetException(ex);
+				return;
 			}
 
-			var subscriptionInfo = new SubscriptionInfo {
-				EventSource = input.EventSource,
-				GroupName = input.GroupName,
-				Status = input.Status,
-				AveragePerSecond = input.AveragePerSecond,
-				TotalItems = input.TotalItems,
-				CountSinceLastMeasurement = input.CountSinceLastMeasurement,
-				LastCheckpointedEventPosition = input.LastCheckpointedEventPosition ?? string.Empty,
-				LastKnownEventPosition = input.LastKnownEventPosition ?? string.Empty,
-				ResolveLinkTos = input.ResolveLinktos,
-				StartFrom = input.StartFrom,
-				MessageTimeoutMilliseconds = input.MessageTimeoutMilliseconds,
-				ExtraStatistics = input.ExtraStatistics,
-				MaxRetryCount = input.MaxRetryCount,
-				LiveBufferSize = input.LiveBufferSize,
-				BufferSize = input.BufferSize,
-				ReadBatchSize = input.ReadBatchSize,
-				CheckPointAfterMilliseconds = input.CheckPointAfterMilliseconds,
-				MinCheckPointCount = input.MinCheckPointCount,
-				MaxCheckPointCount = input.MaxCheckPointCount,
-				ReadBufferCount = input.ReadBufferCount,
-				LiveBufferCount = input.LiveBufferCount,
-				RetryBufferCount = input.RetryBufferCount,
-				TotalInFlightMessages = input.TotalInFlightMessages,
-				OutstandingMessagesCount = input.OutstandingMessagesCount,
-				NamedConsumerStrategy = input.NamedConsumerStrategy,
-				MaxSubscriberCount = input.MaxSubscriberCount,
-				ParkedMessageCount = input.ParkedMessageCount,
-			};
-			subscriptionInfo.Connections.AddRange(connectionInfo);
-			return subscriptionInfo;
+			if (message is MonitoringMessage.GetPersistentSubscriptionStatsCompleted completed)
+			{
+				switch (completed.Result)
+				{
+					case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success:
+						var listResp = new ListResp();
+						listResp.Subscriptions.AddRange(
+							completed.SubscriptionStats.Select(ParseSubscriptionInfo)
+						);
+						listResp.Offset = completed.RequestedOffset;
+						listResp.Count = completed.RequestedCount == int.MaxValue
+							? listResp.Subscriptions.Count
+							: completed.RequestedCount;
+						listResp.Total = completed.Total;
+						listPersistentSubscriptionsSource.TrySetResult(listResp);
+						return;
+					case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotFound:
+						listPersistentSubscriptionsSource.TrySetException(
+							RpcExceptions.PersistentSubscriptionDoesNotExist(streamId, ""));
+						return;
+					case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotReady:
+						listPersistentSubscriptionsSource.TrySetException(
+							RpcExceptions.ServerNotReady());
+						return;
+					case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Fail:
+						listPersistentSubscriptionsSource.TrySetException(
+							RpcExceptions.PersistentSubscriptionFailed(streamId, "", completed.ErrorString));
+						return;
+					default:
+						listPersistentSubscriptionsSource.TrySetException(
+							RpcExceptions.UnknownError(completed.Result));
+						return;
+				}
+			}
+			listPersistentSubscriptionsSource.TrySetException(
+				RpcExceptions.UnknownMessage<MonitoringMessage.GetPersistentSubscriptionStatsCompleted>(
+					message));
 		}
+	}
+
+	private SubscriptionInfo ParseSubscriptionInfo(MonitoringMessage.PersistentSubscriptionInfo input)
+	{
+		var connectionInfo = new List<SubscriptionInfo.Types.ConnectionInfo>();
+		foreach (var conn in input.Connections)
+		{
+			var connInfo = new SubscriptionInfo.Types.ConnectionInfo
+			{
+				From = conn.From,
+				Username = conn.Username,
+				AverageItemsPerSecond = conn.AverageItemsPerSecond,
+				TotalItems = conn.TotalItems,
+				CountSinceLastMeasurement = conn.CountSinceLastMeasurement,
+				AvailableSlots = conn.AvailableSlots,
+				InFlightMessages = conn.InFlightMessages,
+				ConnectionName = conn.ConnectionName
+			};
+			connInfo.ObservedMeasurements.AddRange(
+				conn.ObservedMeasurements.Select(x => new SubscriptionInfo.Types.Measurement
+				{ Key = x.Key, Value = x.Value }));
+			connectionInfo.Add(connInfo);
+		}
+
+		var subscriptionInfo = new SubscriptionInfo
+		{
+			EventSource = input.EventSource,
+			GroupName = input.GroupName,
+			Status = input.Status,
+			AveragePerSecond = input.AveragePerSecond,
+			TotalItems = input.TotalItems,
+			CountSinceLastMeasurement = input.CountSinceLastMeasurement,
+			LastCheckpointedEventPosition = input.LastCheckpointedEventPosition ?? string.Empty,
+			LastKnownEventPosition = input.LastKnownEventPosition ?? string.Empty,
+			ResolveLinkTos = input.ResolveLinktos,
+			StartFrom = input.StartFrom,
+			MessageTimeoutMilliseconds = input.MessageTimeoutMilliseconds,
+			ExtraStatistics = input.ExtraStatistics,
+			MaxRetryCount = input.MaxRetryCount,
+			LiveBufferSize = input.LiveBufferSize,
+			BufferSize = input.BufferSize,
+			ReadBatchSize = input.ReadBatchSize,
+			CheckPointAfterMilliseconds = input.CheckPointAfterMilliseconds,
+			MinCheckPointCount = input.MinCheckPointCount,
+			MaxCheckPointCount = input.MaxCheckPointCount,
+			ReadBufferCount = input.ReadBufferCount,
+			LiveBufferCount = input.LiveBufferCount,
+			RetryBufferCount = input.RetryBufferCount,
+			TotalInFlightMessages = input.TotalInFlightMessages,
+			OutstandingMessagesCount = input.OutstandingMessagesCount,
+			NamedConsumerStrategy = input.NamedConsumerStrategy,
+			MaxSubscriberCount = input.MaxSubscriberCount,
+			ParkedMessageCount = input.ParkedMessageCount,
+		};
+		subscriptionInfo.Connections.AddRange(connectionInfo);
+		return subscriptionInfo;
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
@@ -20,287 +20,336 @@ using Serilog;
 using static EventStore.Core.Messages.ClientMessage.PersistentSubscriptionNackEvents;
 using UUID = EventStore.Client.UUID;
 
-namespace EventStore.Core.Services.Transport.Grpc {
-	internal partial class PersistentSubscriptions {
-		private static readonly Operation ProcessMessagesOperation = new Operation(Plugins.Authorization.Operations.Subscriptions.ProcessMessages);
-		public override async Task Read(IAsyncStreamReader<ReadReq> requestStream,
-			IServerStreamWriter<ReadResp> responseStream, ServerCallContext context) {
-			if (!await requestStream.MoveNext()) {
-				return;
-			}
+namespace EventStore.Core.Services.Transport.Grpc;
 
-			if (requestStream.Current.ContentCase != ReadReq.ContentOneofCase.Options) {
+internal partial class PersistentSubscriptions
+{
+	private static readonly Operation ProcessMessagesOperation = new Operation(Plugins.Authorization.Operations.Subscriptions.ProcessMessages);
+	public override async Task Read(IAsyncStreamReader<ReadReq> requestStream,
+		IServerStreamWriter<ReadResp> responseStream, ServerCallContext context)
+	{
+		if (!await requestStream.MoveNext())
+		{
+			return;
+		}
+
+		if (requestStream.Current.ContentCase != ReadReq.ContentOneofCase.Options)
+		{
+			throw new InvalidOperationException();
+		}
+
+		var options = requestStream.Current.Options;
+		var user = context.GetHttpContext().User;
+
+		string streamId = null;
+		switch (options.StreamOptionCase)
+		{
+			case ReadReq.Types.Options.StreamOptionOneofCase.StreamIdentifier:
+				streamId = options.StreamIdentifier;
+				break;
+			case ReadReq.Types.Options.StreamOptionOneofCase.All:
+				streamId = SystemStreams.AllStream;
+				break;
+			default:
 				throw new InvalidOperationException();
-			}
+		}
 
-			var options = requestStream.Current.Options;
-			var user = context.GetHttpContext().User;
+		if (!await _authorizationProvider.CheckAccessAsync(user,
+			ProcessMessagesOperation.WithParameter(Plugins.Authorization.Operations.Subscriptions.Parameters.StreamId(streamId)), context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+		var connectionName =
+			context.RequestHeaders.FirstOrDefault(x => x.Key == Constants.Headers.ConnectionName)?.Value ??
+			"<unknown>";
+		var correlationId = Guid.NewGuid();
+		var uuidOptionsCase = options.UuidOption.ContentCase;
 
-			string streamId = null;
-			switch (options.StreamOptionCase) {
-				case ReadReq.Types.Options.StreamOptionOneofCase.StreamIdentifier:
-					streamId = options.StreamIdentifier;
-					break;
-				case ReadReq.Types.Options.StreamOptionOneofCase.All:
-					streamId = SystemStreams.AllStream;
-					break;
-				default:
-					throw new InvalidOperationException();
-			}
+		var enumerator = new PersistentStreamSubscriptionEnumerator(correlationId, connectionName,
+			_publisher, streamId, options.GroupName, options.BufferSize, user, context.CancellationToken);
+		await using var _ = enumerator;
 
-			if (!await _authorizationProvider.CheckAccessAsync(user,
-				ProcessMessagesOperation.WithParameter(Plugins.Authorization.Operations.Subscriptions.Parameters.StreamId(streamId)), context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
-			}
-			var connectionName =
-				context.RequestHeaders.FirstOrDefault(x => x.Key == Constants.Headers.ConnectionName)?.Value ??
-				"<unknown>";
-			var correlationId = Guid.NewGuid();
-			var uuidOptionsCase = options.UuidOption.ContentCase;
+		var subscriptionId = await enumerator.Started;
 
-			var enumerator = new PersistentStreamSubscriptionEnumerator(correlationId, connectionName,
-				_publisher, streamId, options.GroupName, options.BufferSize, user, context.CancellationToken);
-			await using var _ = enumerator;
+		var read = ValueTask.CompletedTask;
+		var cts = new CancellationTokenSource();
+		try
+		{
+			read = PumpRequestStream(cts.Token);
 
-			var subscriptionId = await enumerator.Started;
+			await responseStream.WriteAsync(new ReadResp
+			{
+				SubscriptionConfirmation = new ReadResp.Types.SubscriptionConfirmation
+				{
+					SubscriptionId = subscriptionId
+				}
+			});
 
-			var read = ValueTask.CompletedTask;
-			var cts = new CancellationTokenSource();
-			try {
-				read = PumpRequestStream(cts.Token);
-
-				await responseStream.WriteAsync(new ReadResp {
-					SubscriptionConfirmation = new ReadResp.Types.SubscriptionConfirmation {
-						SubscriptionId = subscriptionId
-					}
+			while (await enumerator.MoveNextAsync())
+			{
+				await responseStream.WriteAsync(new ReadResp
+				{
+					Event = ConvertToReadEvent(enumerator.Current)
 				});
-
-				while (await enumerator.MoveNextAsync()) {
-					await responseStream.WriteAsync(new ReadResp {
-						Event = ConvertToReadEvent(enumerator.Current)
-					});
-				}
-			} catch (IOException) {
-				Log.Information("Subscription {correlationId} to {subscriptionId} disposed. The request stream was closed.", correlationId, subscriptionId);
-			} finally {
-				// make sure we stop reading the request stream before leaving this method
-				cts.Cancel();
-				await read;
 			}
+		}
+		catch (IOException)
+		{
+			Log.Information("Subscription {correlationId} to {subscriptionId} disposed. The request stream was closed.", correlationId, subscriptionId);
+		}
+		finally
+		{
+			// make sure we stop reading the request stream before leaving this method
+			cts.Cancel();
+			await read;
+		}
 
-			async ValueTask PumpRequestStream(CancellationToken token) {
-				try {
-					await requestStream.ForEachAsync(HandleAckNack, token);
-				} catch {
-				}
+		async ValueTask PumpRequestStream(CancellationToken token)
+		{
+			try
+			{
+				await requestStream.ForEachAsync(HandleAckNack, token);
 			}
-
-			ValueTask HandleAckNack(ReadReq request) {
-				_publisher.Publish(request.ContentCase switch {
-					ReadReq.ContentOneofCase.Ack => new ClientMessage.PersistentSubscriptionAckEvents(
-						correlationId, correlationId, new NoopEnvelope(), subscriptionId,
-						request.Ack.Ids.Select(id => Uuid.FromDto(id).ToGuid()).ToArray(), user),
-					ReadReq.ContentOneofCase.Nack =>
-					new ClientMessage.PersistentSubscriptionNackEvents(
-						correlationId, correlationId, new NoopEnvelope(), subscriptionId,
-						request.Nack.Reason, request.Nack.Action switch {
-							ReadReq.Types.Nack.Types.Action.Unknown => NakAction.Unknown,
-							ReadReq.Types.Nack.Types.Action.Park => NakAction.Park,
-							ReadReq.Types.Nack.Types.Action.Retry => NakAction.Retry,
-							ReadReq.Types.Nack.Types.Action.Skip => NakAction.Skip,
-							ReadReq.Types.Nack.Types.Action.Stop => NakAction.Stop,
-							_ => throw RpcExceptions.InvalidArgument(request.Nack.Action)
-						},
-						request.Nack.Ids.Select(id => Uuid.FromDto(id).ToGuid()).ToArray(), user),
-					_ => throw RpcExceptions.InvalidArgument(request.ContentCase)
-				});
-
-				return new ValueTask(Task.CompletedTask);
-			}
-
-			ReadResp.Types.ReadEvent.Types.RecordedEvent ConvertToRecordedEvent(EventRecord e, long? commitPosition,
-				long? preparePosition) {
-				if (e == null) return null;
-				var position = Position.FromInt64(commitPosition ?? -1, preparePosition ?? -1);
-				return new ReadResp.Types.ReadEvent.Types.RecordedEvent {
-					Id = uuidOptionsCase switch {
-						ReadReq.Types.Options.Types.UUIDOption.ContentOneofCase.String => new UUID {
-							String = e.EventId.ToString()
-						},
-						_ => Uuid.FromGuid(e.EventId).ToDto()
-					},
-					StreamIdentifier = e.EventStreamId,
-					StreamRevision = StreamRevision.FromInt64(e.EventNumber),
-					CommitPosition = position.CommitPosition,
-					PreparePosition = position.PreparePosition,
-					Metadata = {
-						[Constants.Metadata.Type] = e.EventType,
-						[Constants.Metadata.Created] = e.TimeStamp.ToTicksSinceEpoch().ToString(),
-						[Constants.Metadata.ContentType] = e.IsJson
-							? Constants.Metadata.ContentTypes.ApplicationJson
-							: Constants.Metadata.ContentTypes.ApplicationOctetStream
-					},
-					Data = ByteString.CopyFrom(e.Data.Span),
-					CustomMetadata = ByteString.CopyFrom(e.Metadata.Span)
-				};
-			}
-
-			ReadResp.Types.ReadEvent ConvertToReadEvent((ResolvedEvent, int) _) {
-				var (e, retryCount) = _;
-				var readEvent = new ReadResp.Types.ReadEvent {
-					Link = ConvertToRecordedEvent(e.Link,
-						e.OriginalPosition?.CommitPosition,
-						e.OriginalPosition?.PreparePosition),
-					Event = ConvertToRecordedEvent(e.Event,
-						e.OriginalPosition?.CommitPosition,
-						e.OriginalPosition?.PreparePosition),
-					RetryCount = retryCount
-				};
-				if (e.OriginalPosition.HasValue) {
-					var position = Position.FromInt64(
-						e.OriginalPosition.Value.CommitPosition,
-						e.OriginalPosition.Value.PreparePosition);
-					readEvent.CommitPosition = position.CommitPosition;
-				} else {
-					readEvent.NoPosition = new Empty();
-				}
-
-				return readEvent;
+			catch
+			{
 			}
 		}
 
-		private class PersistentStreamSubscriptionEnumerator
-			: IAsyncEnumerator<(ResolvedEvent resolvedEvent, int retryCount)> {
-			private readonly TaskCompletionSource<string> _subscriptionIdSource;
-			private readonly IPublisher _publisher;
-			private readonly Guid _correlationId;
-			private readonly ClaimsPrincipal _user;
-			private readonly CancellationToken _cancellationToken;
-			private readonly Channel<(ResolvedEvent, int)> _channel;
+		ValueTask HandleAckNack(ReadReq request)
+		{
+			_publisher.Publish(request.ContentCase switch
+			{
+				ReadReq.ContentOneofCase.Ack => new ClientMessage.PersistentSubscriptionAckEvents(
+					correlationId, correlationId, new NoopEnvelope(), subscriptionId,
+					request.Ack.Ids.Select(id => Uuid.FromDto(id).ToGuid()).ToArray(), user),
+				ReadReq.ContentOneofCase.Nack =>
+				new ClientMessage.PersistentSubscriptionNackEvents(
+					correlationId, correlationId, new NoopEnvelope(), subscriptionId,
+					request.Nack.Reason, request.Nack.Action switch
+					{
+						ReadReq.Types.Nack.Types.Action.Unknown => NakAction.Unknown,
+						ReadReq.Types.Nack.Types.Action.Park => NakAction.Park,
+						ReadReq.Types.Nack.Types.Action.Retry => NakAction.Retry,
+						ReadReq.Types.Nack.Types.Action.Skip => NakAction.Skip,
+						ReadReq.Types.Nack.Types.Action.Stop => NakAction.Stop,
+						_ => throw RpcExceptions.InvalidArgument(request.Nack.Action)
+					},
+					request.Nack.Ids.Select(id => Uuid.FromDto(id).ToGuid()).ToArray(), user),
+				_ => throw RpcExceptions.InvalidArgument(request.ContentCase)
+			});
 
-			private (ResolvedEvent, int) _current;
+			return new ValueTask(Task.CompletedTask);
+		}
 
-			public (ResolvedEvent resolvedEvent, int retryCount) Current => _current;
-			public Task<string> Started => _subscriptionIdSource.Task;
+		ReadResp.Types.ReadEvent.Types.RecordedEvent ConvertToRecordedEvent(EventRecord e, long? commitPosition,
+			long? preparePosition)
+		{
+			if (e == null)
+				return null;
+			var position = Position.FromInt64(commitPosition ?? -1, preparePosition ?? -1);
+			return new ReadResp.Types.ReadEvent.Types.RecordedEvent
+			{
+				Id = uuidOptionsCase switch
+				{
+					ReadReq.Types.Options.Types.UUIDOption.ContentOneofCase.String => new UUID
+					{
+						String = e.EventId.ToString()
+					},
+					_ => Uuid.FromGuid(e.EventId).ToDto()
+				},
+				StreamIdentifier = e.EventStreamId,
+				StreamRevision = StreamRevision.FromInt64(e.EventNumber),
+				CommitPosition = position.CommitPosition,
+				PreparePosition = position.PreparePosition,
+				Metadata = {
+					[Constants.Metadata.Type] = e.EventType,
+					[Constants.Metadata.Created] = e.TimeStamp.ToTicksSinceEpoch().ToString(),
+					[Constants.Metadata.ContentType] = e.IsJson
+						? Constants.Metadata.ContentTypes.ApplicationJson
+						: Constants.Metadata.ContentTypes.ApplicationOctetStream
+				},
+				Data = ByteString.CopyFrom(e.Data.Span),
+				CustomMetadata = ByteString.CopyFrom(e.Metadata.Span)
+			};
+		}
 
-			public PersistentStreamSubscriptionEnumerator(Guid correlationId,
-				string connectionName,
-				IPublisher publisher,
-				string streamName,
-				string groupName,
-				int bufferSize,
-				ClaimsPrincipal user,
-				CancellationToken cancellationToken) {
-				if (connectionName == null) {
-					throw new ArgumentNullException(nameof(connectionName));
-				}
-				if (publisher == null) {
-					throw new ArgumentNullException(nameof(publisher));
-				}
+		ReadResp.Types.ReadEvent ConvertToReadEvent((ResolvedEvent, int) _)
+		{
+			var (e, retryCount) = _;
+			var readEvent = new ReadResp.Types.ReadEvent
+			{
+				Link = ConvertToRecordedEvent(e.Link,
+					e.OriginalPosition?.CommitPosition,
+					e.OriginalPosition?.PreparePosition),
+				Event = ConvertToRecordedEvent(e.Event,
+					e.OriginalPosition?.CommitPosition,
+					e.OriginalPosition?.PreparePosition),
+				RetryCount = retryCount
+			};
+			if (e.OriginalPosition.HasValue)
+			{
+				var position = Position.FromInt64(
+					e.OriginalPosition.Value.CommitPosition,
+					e.OriginalPosition.Value.PreparePosition);
+				readEvent.CommitPosition = position.CommitPosition;
+			}
+			else
+			{
+				readEvent.NoPosition = new Empty();
+			}
 
-				if (streamName == null) {
-					throw new ArgumentNullException(nameof(streamName));
-				}
+			return readEvent;
+		}
+	}
 
-				if (groupName == null) {
-					throw new ArgumentNullException(nameof(groupName));
-				}
+	private class PersistentStreamSubscriptionEnumerator
+		: IAsyncEnumerator<(ResolvedEvent resolvedEvent, int retryCount)>
+	{
+		private readonly TaskCompletionSource<string> _subscriptionIdSource;
+		private readonly IPublisher _publisher;
+		private readonly Guid _correlationId;
+		private readonly ClaimsPrincipal _user;
+		private readonly CancellationToken _cancellationToken;
+		private readonly Channel<(ResolvedEvent, int)> _channel;
 
-				if (correlationId == Guid.Empty) {
-					throw new ArgumentException($"{nameof(correlationId)} should be non empty.", nameof(correlationId));
-				}
+		private (ResolvedEvent, int) _current;
 
-				_correlationId = correlationId;
-				_publisher = publisher;
-				_subscriptionIdSource = new TaskCompletionSource<string>();
-				_user = user;
-				_cancellationToken = cancellationToken;
-				_channel = Channel.CreateBounded<(ResolvedEvent, int)>(new BoundedChannelOptions(bufferSize) {
-					SingleReader = true,
-					SingleWriter = false,
-					FullMode = BoundedChannelFullMode.DropWrite
-				});
+		public (ResolvedEvent resolvedEvent, int retryCount) Current => _current;
+		public Task<string> Started => _subscriptionIdSource.Task;
 
-				var semaphore = new SemaphoreSlim(1, 1);
+		public PersistentStreamSubscriptionEnumerator(Guid correlationId,
+			string connectionName,
+			IPublisher publisher,
+			string streamName,
+			string groupName,
+			int bufferSize,
+			ClaimsPrincipal user,
+			CancellationToken cancellationToken)
+		{
+			if (connectionName == null)
+			{
+				throw new ArgumentNullException(nameof(connectionName));
+			}
+			if (publisher == null)
+			{
+				throw new ArgumentNullException(nameof(publisher));
+			}
 
-				switch(streamName) {
-					case SystemStreams.AllStream:
-						publisher.Publish(new ClientMessage.ConnectToPersistentSubscriptionToAll(correlationId,
-							correlationId,
-							new ContinuationEnvelope(OnMessage, semaphore, _cancellationToken), correlationId,
-							connectionName,
-							groupName, bufferSize, string.Empty, user));
-						break;
-					default:
-						publisher.Publish(new ClientMessage.ConnectToPersistentSubscriptionToStream(correlationId,
-							correlationId,
-							new ContinuationEnvelope(OnMessage, semaphore, _cancellationToken), correlationId,
-							connectionName,
-							groupName, streamName, bufferSize, string.Empty, user));
-						break;
-				}
+			if (streamName == null)
+			{
+				throw new ArgumentNullException(nameof(streamName));
+			}
 
-				async Task OnMessage(Message message, CancellationToken ct) {
-					if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
-						_subscriptionIdSource.TrySetException(ex);
-						return;
-					}
-					
-					switch (message) {
-						case ClientMessage.SubscriptionDropped dropped:
-							switch (dropped.Reason) {
-								case SubscriptionDropReason.AccessDenied:
-									Fail(RpcExceptions.AccessDenied());
-									return;
-								case SubscriptionDropReason.NotFound:
-								case SubscriptionDropReason.PersistentSubscriptionDeleted:
-									Fail(RpcExceptions.PersistentSubscriptionDoesNotExist(streamName, groupName));
-									return;
-								case SubscriptionDropReason.SubscriberMaxCountReached:
-									Fail(RpcExceptions.PersistentSubscriptionMaximumSubscribersReached(streamName,
-										groupName));
-									return;
-								case SubscriptionDropReason.Unsubscribed:
-									Fail(RpcExceptions.PersistentSubscriptionDropped(streamName, groupName));
-									return;
-								default:
-									Fail(RpcExceptions.UnknownError(dropped.Reason));
-									return;
-							}
-						case ClientMessage.PersistentSubscriptionConfirmation confirmation:
-							_subscriptionIdSource.TrySetResult(confirmation.SubscriptionId);
-							return;
-						case ClientMessage.PersistentSubscriptionStreamEventAppeared appeared:
-							await _channel.Writer.WriteAsync((appeared.Event, appeared.RetryCount), ct);
-							return;
-						default:
-							Fail(RpcExceptions
-								.UnknownMessage<ClientMessage.PersistentSubscriptionConfirmation>(message));
-							return;
-					}
-				}
+			if (groupName == null)
+			{
+				throw new ArgumentNullException(nameof(groupName));
+			}
 
-				void Fail(Exception ex) {
-					_channel.Writer.TryComplete(ex);
+			if (correlationId == Guid.Empty)
+			{
+				throw new ArgumentException($"{nameof(correlationId)} should be non empty.", nameof(correlationId));
+			}
+
+			_correlationId = correlationId;
+			_publisher = publisher;
+			_subscriptionIdSource = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+			_user = user;
+			_cancellationToken = cancellationToken;
+			_channel = Channel.CreateBounded<(ResolvedEvent, int)>(new BoundedChannelOptions(bufferSize)
+			{
+				SingleReader = true,
+				SingleWriter = false,
+				FullMode = BoundedChannelFullMode.DropWrite
+			});
+
+			var semaphore = new SemaphoreSlim(1, 1);
+
+			switch (streamName)
+			{
+				case SystemStreams.AllStream:
+					publisher.Publish(new ClientMessage.ConnectToPersistentSubscriptionToAll(correlationId,
+						correlationId,
+						new ContinuationEnvelope(OnMessage, semaphore, _cancellationToken), correlationId,
+						connectionName,
+						groupName, bufferSize, string.Empty, user));
+					break;
+				default:
+					publisher.Publish(new ClientMessage.ConnectToPersistentSubscriptionToStream(correlationId,
+						correlationId,
+						new ContinuationEnvelope(OnMessage, semaphore, _cancellationToken), correlationId,
+						connectionName,
+						groupName, streamName, bufferSize, string.Empty, user));
+					break;
+			}
+
+			async Task OnMessage(Message message, CancellationToken ct)
+			{
+				if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex))
+				{
 					_subscriptionIdSource.TrySetException(ex);
+					return;
+				}
+
+				switch (message)
+				{
+					case ClientMessage.SubscriptionDropped dropped:
+						switch (dropped.Reason)
+						{
+							case SubscriptionDropReason.AccessDenied:
+								Fail(RpcExceptions.AccessDenied());
+								return;
+							case SubscriptionDropReason.NotFound:
+							case SubscriptionDropReason.PersistentSubscriptionDeleted:
+								Fail(RpcExceptions.PersistentSubscriptionDoesNotExist(streamName, groupName));
+								return;
+							case SubscriptionDropReason.SubscriberMaxCountReached:
+								Fail(RpcExceptions.PersistentSubscriptionMaximumSubscribersReached(streamName,
+									groupName));
+								return;
+							case SubscriptionDropReason.Unsubscribed:
+								Fail(RpcExceptions.PersistentSubscriptionDropped(streamName, groupName));
+								return;
+							default:
+								Fail(RpcExceptions.UnknownError(dropped.Reason));
+								return;
+						}
+					case ClientMessage.PersistentSubscriptionConfirmation confirmation:
+						_subscriptionIdSource.TrySetResult(confirmation.SubscriptionId);
+						return;
+					case ClientMessage.PersistentSubscriptionStreamEventAppeared appeared:
+						await _channel.Writer.WriteAsync((appeared.Event, appeared.RetryCount), ct);
+						return;
+					default:
+						Fail(RpcExceptions
+							.UnknownMessage<ClientMessage.PersistentSubscriptionConfirmation>(message));
+						return;
 				}
 			}
 
-			public ValueTask DisposeAsync() {
-				_publisher.Publish(new ClientMessage.UnsubscribeFromStream(Guid.NewGuid(), _correlationId,
-					new NoopEnvelope(), _user));
-				_channel.Writer.TryComplete();
-				return new ValueTask(Task.CompletedTask);
+			void Fail(Exception ex)
+			{
+				_channel.Writer.TryComplete(ex);
+				_subscriptionIdSource.TrySetException(ex);
+			}
+		}
+
+		public ValueTask DisposeAsync()
+		{
+			_publisher.Publish(new ClientMessage.UnsubscribeFromStream(Guid.NewGuid(), _correlationId,
+				new NoopEnvelope(), _user));
+			_channel.Writer.TryComplete();
+			return new ValueTask(Task.CompletedTask);
+		}
+
+		public async ValueTask<bool> MoveNextAsync()
+		{
+			if (!await _channel.Reader.WaitToReadAsync(_cancellationToken))
+			{
+				return false;
 			}
 
-			public async ValueTask<bool> MoveNextAsync() {
-				if (!await _channel.Reader.WaitToReadAsync(_cancellationToken)) {
-					return false;
-				}
-
-				_current = await _channel.Reader.ReadAsync(_cancellationToken);
-				return true;
-			}
+			_current = await _channel.Reader.ReadAsync(_cancellationToken);
+			return true;
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.ReplayParked.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.ReplayParked.cs
@@ -6,78 +6,87 @@ using EventStore.Core.Messaging;
 using EventStore.Plugins.Authorization;
 using Grpc.Core;
 
-namespace EventStore.Core.Services.Transport.Grpc {
-	internal partial class PersistentSubscriptions {
-		private static readonly Operation ReplayParkedOperation = new Operation(Plugins.Authorization.Operations.Subscriptions.ReplayParked);
-		public override async Task<ReplayParkedResp> ReplayParked(ReplayParkedReq request, ServerCallContext context) {
-			var replayParkedMessagesSource = new TaskCompletionSource<ReplayParkedResp>();
-			var correlationId = Guid.NewGuid();
+namespace EventStore.Core.Services.Transport.Grpc;
 
-			var user = context.GetHttpContext().User;
+internal partial class PersistentSubscriptions
+{
+	private static readonly Operation ReplayParkedOperation = new Operation(Plugins.Authorization.Operations.Subscriptions.ReplayParked);
+	public override async Task<ReplayParkedResp> ReplayParked(ReplayParkedReq request, ServerCallContext context)
+	{
+		var replayParkedMessagesSource = new TaskCompletionSource<ReplayParkedResp>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var correlationId = Guid.NewGuid();
 
-			if (!await _authorizationProvider.CheckAccessAsync(user,
-				ReplayParkedOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
+		var user = context.GetHttpContext().User;
+
+		if (!await _authorizationProvider.CheckAccessAsync(user,
+			ReplayParkedOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+
+		string streamId = request.Options.StreamOptionCase switch
+		{
+			ReplayParkedReq.Types.Options.StreamOptionOneofCase.All => "$all",
+			ReplayParkedReq.Types.Options.StreamOptionOneofCase.StreamIdentifier => request.Options.StreamIdentifier,
+			_ => throw new InvalidOperationException()
+		};
+
+		long? stopAt = request.Options.StopAtOptionCase switch
+		{
+			ReplayParkedReq.Types.Options.StopAtOptionOneofCase.StopAt => request.Options.StopAt,
+			ReplayParkedReq.Types.Options.StopAtOptionOneofCase.NoLimit => null,
+			_ => throw new InvalidOperationException()
+		};
+
+		_publisher.Publish(new ClientMessage.ReplayParkedMessages(
+			correlationId,
+			correlationId,
+			new CallbackEnvelope(HandleReplayParkedMessagesCompleted),
+			streamId,
+			request.Options.GroupName,
+			stopAt,
+			user));
+		return await replayParkedMessagesSource.Task;
+
+		void HandleReplayParkedMessagesCompleted(Message message)
+		{
+			if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex))
+			{
+				replayParkedMessagesSource.TrySetException(ex);
+				return;
 			}
 
-			string streamId = request.Options.StreamOptionCase switch {
-				ReplayParkedReq.Types.Options.StreamOptionOneofCase.All => "$all",
-				ReplayParkedReq.Types.Options.StreamOptionOneofCase.StreamIdentifier => request.Options.StreamIdentifier,
-				_ => throw new InvalidOperationException()
-			};
+			if (message is ClientMessage.ReplayMessagesReceived completed)
+			{
+				switch (completed.Result)
+				{
+					case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Success:
+						replayParkedMessagesSource.TrySetResult(new ReplayParkedResp());
+						return;
+					case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.DoesNotExist:
+						replayParkedMessagesSource.TrySetException(
+							RpcExceptions.PersistentSubscriptionDoesNotExist(streamId,
+								request.Options.GroupName));
+						return;
+					case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.AccessDenied:
+						replayParkedMessagesSource.TrySetException(
+							RpcExceptions.AccessDenied());
+						return;
+					case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Fail:
+						replayParkedMessagesSource.TrySetException(
+							RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
+								completed.Reason));
+						return;
 
-			long? stopAt = request.Options.StopAtOptionCase switch {
-				ReplayParkedReq.Types.Options.StopAtOptionOneofCase.StopAt => request.Options.StopAt,
-				ReplayParkedReq.Types.Options.StopAtOptionOneofCase.NoLimit => null,
-				_ => throw new InvalidOperationException()
-			};
-
-			_publisher.Publish(new ClientMessage.ReplayParkedMessages(
-				correlationId,
-				correlationId,
-				new CallbackEnvelope(HandleReplayParkedMessagesCompleted),
-				streamId,
-				request.Options.GroupName,
-				stopAt,
-				user));
-			return await replayParkedMessagesSource.Task;
-
-			void HandleReplayParkedMessagesCompleted(Message message) {
-				if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
-					replayParkedMessagesSource.TrySetException(ex);
-					return;
+					default:
+						replayParkedMessagesSource.TrySetException(
+							RpcExceptions.UnknownError(completed.Result));
+						return;
 				}
-
-				if (message is ClientMessage.ReplayMessagesReceived completed) {
-					switch (completed.Result) {
-						case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Success:
-							replayParkedMessagesSource.TrySetResult(new ReplayParkedResp());
-							return;
-						case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.DoesNotExist:
-							replayParkedMessagesSource.TrySetException(
-								RpcExceptions.PersistentSubscriptionDoesNotExist(streamId,
-									request.Options.GroupName));
-							return;
-						case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.AccessDenied:
-							replayParkedMessagesSource.TrySetException(
-								RpcExceptions.AccessDenied());
-							return;
-						case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Fail:
-							replayParkedMessagesSource.TrySetException(
-								RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
-									completed.Reason));
-							return;
-
-						default:
-							replayParkedMessagesSource.TrySetException(
-								RpcExceptions.UnknownError(completed.Result));
-							return;
-					}
-				}
-				replayParkedMessagesSource.TrySetException(
-					RpcExceptions.UnknownMessage<ClientMessage.ReplayMessagesReceived>(
-						message));
 			}
+			replayParkedMessagesSource.TrySetException(
+				RpcExceptions.UnknownMessage<ClientMessage.ReplayMessagesReceived>(
+					message));
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.RestartSubsystem.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.RestartSubsystem.cs
@@ -6,45 +6,51 @@ using EventStore.Core.Messaging;
 using EventStore.Plugins.Authorization;
 using Grpc.Core;
 
-namespace EventStore.Core.Services.Transport.Grpc {
-	internal partial class PersistentSubscriptions {
-		private static readonly Operation RestartOperation = new Operation(Plugins.Authorization.Operations.Subscriptions.Restart);
+namespace EventStore.Core.Services.Transport.Grpc;
 
-		public override async Task<Empty> RestartSubsystem(Empty request, ServerCallContext context) {
-			var restartSubsystemSource = new TaskCompletionSource<Empty>();
+internal partial class PersistentSubscriptions
+{
+	private static readonly Operation RestartOperation = new Operation(Plugins.Authorization.Operations.Subscriptions.Restart);
 
-			var user = context.GetHttpContext().User;
+	public override async Task<Empty> RestartSubsystem(Empty request, ServerCallContext context)
+	{
+		var restartSubsystemSource = new TaskCompletionSource<Empty>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-			if (!await _authorizationProvider.CheckAccessAsync(user,
-				RestartOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
+		var user = context.GetHttpContext().User;
+
+		if (!await _authorizationProvider.CheckAccessAsync(user,
+			RestartOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+
+		_publisher.Publish(new SubscriptionMessage.PersistentSubscriptionsRestart(
+			new CallbackEnvelope(HandleRestartSubsystemCompleted)));
+		return await restartSubsystemSource.Task;
+
+		void HandleRestartSubsystemCompleted(Message message)
+		{
+			if (message is ClientMessage.NotHandled notHandled &&
+				RpcExceptions.TryHandleNotHandled(notHandled, out var ex))
+			{
+				restartSubsystemSource.TrySetException(ex);
+				return;
 			}
 
-			_publisher.Publish(new SubscriptionMessage.PersistentSubscriptionsRestart(
-				new CallbackEnvelope(HandleRestartSubsystemCompleted)));
-			return await restartSubsystemSource.Task;
-
-			void HandleRestartSubsystemCompleted(Message message) {
-				if (message is ClientMessage.NotHandled notHandled &&
-				    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
-					restartSubsystemSource.TrySetException(ex);
+			switch (message)
+			{
+				case SubscriptionMessage.PersistentSubscriptionsRestarting _:
+					restartSubsystemSource.TrySetResult(new Empty());
 					return;
-				}
-
-				switch (message) {
-					case SubscriptionMessage.PersistentSubscriptionsRestarting _:
-						restartSubsystemSource.TrySetResult(new Empty());
-						return;
-					case SubscriptionMessage.InvalidPersistentSubscriptionsRestart fail:
-						restartSubsystemSource.TrySetException(
-							RpcExceptions.PersistentSubscriptionFailed("", "",
-								$"Persistent Subscriptions cannot be restarted as it is in the wrong state."));
-						return;
-					default:
-						restartSubsystemSource.TrySetException(
-							RpcExceptions.UnknownMessage<SubscriptionMessage.PersistentSubscriptionsRestarting>(message));
-						return;
-				}
+				case SubscriptionMessage.InvalidPersistentSubscriptionsRestart fail:
+					restartSubsystemSource.TrySetException(
+						RpcExceptions.PersistentSubscriptionFailed("", "",
+							$"Persistent Subscriptions cannot be restarted as it is in the wrong state."));
+					return;
+				default:
+					restartSubsystemSource.TrySetException(
+						RpcExceptions.UnknownMessage<SubscriptionMessage.PersistentSubscriptionsRestarting>(message));
+					return;
 			}
 		}
 	}

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Update.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Update.cs
@@ -1,63 +1,74 @@
 using System;
 using System.Threading.Tasks;
-using EventStore.Core.Messages;
-using EventStore.Core.Messaging;
 using EventStore.Client.PersistentSubscriptions;
 using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
 using EventStore.Core.Services.Transport.Common;
 using EventStore.Plugins.Authorization;
 using Grpc.Core;
-using StreamOptionOneofCase = EventStore.Client.PersistentSubscriptions.UpdateReq.Types.Options.StreamOptionOneofCase;
-using RevisionOptionOneofCase = EventStore.Client.PersistentSubscriptions.UpdateReq.Types.StreamOptions.RevisionOptionOneofCase;
 using AllOptionOneofCase = EventStore.Client.PersistentSubscriptions.UpdateReq.Types.AllOptions.AllOptionOneofCase;
+using RevisionOptionOneofCase = EventStore.Client.PersistentSubscriptions.UpdateReq.Types.StreamOptions.RevisionOptionOneofCase;
+using StreamOptionOneofCase = EventStore.Client.PersistentSubscriptions.UpdateReq.Types.Options.StreamOptionOneofCase;
 
-namespace EventStore.Core.Services.Transport.Grpc {
-	internal partial class PersistentSubscriptions {
-		private static readonly Operation UpdateOperation = new Operation(Plugins.Authorization.Operations.Subscriptions.Update);
-		public override async Task<UpdateResp> Update(UpdateReq request, ServerCallContext context) {
-			var updatePersistentSubscriptionSource = new TaskCompletionSource<UpdateResp>();
-			var settings = request.Options.Settings;
-			var correlationId = Guid.NewGuid();
+namespace EventStore.Core.Services.Transport.Grpc;
 
-			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user,
-				UpdateOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
-			}
+internal partial class PersistentSubscriptions
+{
+	private static readonly Operation UpdateOperation = new Operation(Plugins.Authorization.Operations.Subscriptions.Update);
+	public override async Task<UpdateResp> Update(UpdateReq request, ServerCallContext context)
+	{
+		var updatePersistentSubscriptionSource = new TaskCompletionSource<UpdateResp>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var settings = request.Options.Settings;
+		var correlationId = Guid.NewGuid();
 
-			ValidateUpdateSettings(settings);
+		var user = context.GetHttpContext().User;
+		if (!await _authorizationProvider.CheckAccessAsync(user,
+			UpdateOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
 
-			string consumerStrategy;
-			if (string.IsNullOrEmpty(settings.ConsumerStrategy)) { /*for backwards compatibility*/
-				#pragma warning disable 612
-				consumerStrategy = settings.NamedConsumerStrategy.ToString();
-				#pragma warning restore 612
-			} else {
-				consumerStrategy = settings.ConsumerStrategy;
-			}
+		ValidateUpdateSettings(settings);
 
-			string streamId = null;
+		string consumerStrategy;
+		if (string.IsNullOrEmpty(settings.ConsumerStrategy))
+		{ /*for backwards compatibility*/
+#pragma warning disable 612
+			consumerStrategy = settings.NamedConsumerStrategy.ToString();
+#pragma warning restore 612
+		}
+		else
+		{
+			consumerStrategy = settings.ConsumerStrategy;
+		}
 
-			switch (request.Options.StreamOptionCase)
-			{
-				case StreamOptionOneofCase.Stream:
-				case StreamOptionOneofCase.None: /*for backwards compatibility*/
+		string streamId = null;
+
+		switch (request.Options.StreamOptionCase)
+		{
+			case StreamOptionOneofCase.Stream:
+			case StreamOptionOneofCase.None: /*for backwards compatibility*/
 				{
 					StreamRevision startRevision;
 
-					if (request.Options.StreamOptionCase == StreamOptionOneofCase.Stream) {
+					if (request.Options.StreamOptionCase == StreamOptionOneofCase.Stream)
+					{
 						streamId = request.Options.Stream.StreamIdentifier;
-						startRevision = request.Options.Stream.RevisionOptionCase switch {
+						startRevision = request.Options.Stream.RevisionOptionCase switch
+						{
 							RevisionOptionOneofCase.Revision => new StreamRevision(request.Options.Stream.Revision),
 							RevisionOptionOneofCase.Start => StreamRevision.Start,
 							RevisionOptionOneofCase.End => StreamRevision.End,
 							_ => throw RpcExceptions.InvalidArgument(request.Options.Stream.RevisionOptionCase)
 						};
-					} else { /*for backwards compatibility*/
-						#pragma warning disable 612
+					}
+					else
+					{ /*for backwards compatibility*/
+#pragma warning disable 612
 						streamId = request.Options.StreamIdentifier;
 						startRevision = new StreamRevision(request.Options.Settings.Revision);
-						#pragma warning restore 612
+#pragma warning restore 612
 					}
 
 					_publisher.Publish(new ClientMessage.UpdatePersistentSubscriptionToStream(
@@ -68,7 +79,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						request.Options.GroupName,
 						settings.ResolveLinks,
 						startRevision.ToInt64(),
-						settings.MessageTimeoutCase switch {
+						settings.MessageTimeoutCase switch
+						{
 							UpdateReq.Types.Settings.MessageTimeoutOneofCase.MessageTimeoutMs => settings.MessageTimeoutMs,
 							UpdateReq.Types.Settings.MessageTimeoutOneofCase.MessageTimeoutTicks => (int)TimeSpan
 								.FromTicks(settings.MessageTimeoutTicks).TotalMilliseconds,
@@ -79,7 +91,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						settings.HistoryBufferSize,
 						settings.LiveBufferSize,
 						settings.ReadBatchSize,
-						settings.CheckpointAfterCase switch {
+						settings.CheckpointAfterCase switch
+						{
 							UpdateReq.Types.Settings.CheckpointAfterOneofCase.CheckpointAfterMs => settings.CheckpointAfterMs,
 							UpdateReq.Types.Settings.CheckpointAfterOneofCase.CheckpointAfterTicks => (int)TimeSpan
 								.FromTicks(settings.CheckpointAfterTicks).TotalMilliseconds,
@@ -92,145 +105,157 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						user));
 					break;
 				}
-				case StreamOptionOneofCase.All:
-					var startPosition = request.Options.All.AllOptionCase switch {
-						AllOptionOneofCase.Position => new Position(
-							request.Options.All.Position.CommitPosition,
-							request.Options.All.Position.PreparePosition),
-						AllOptionOneofCase.Start => Position.Start,
-						AllOptionOneofCase.End => Position.End,
-						_ => throw new InvalidOperationException()
-					};
+			case StreamOptionOneofCase.All:
+				var startPosition = request.Options.All.AllOptionCase switch
+				{
+					AllOptionOneofCase.Position => new Position(
+						request.Options.All.Position.CommitPosition,
+						request.Options.All.Position.PreparePosition),
+					AllOptionOneofCase.Start => Position.Start,
+					AllOptionOneofCase.End => Position.End,
+					_ => throw new InvalidOperationException()
+				};
 
-					streamId = SystemStreams.AllStream;
+				streamId = SystemStreams.AllStream;
 
-					_publisher.Publish(new ClientMessage.UpdatePersistentSubscriptionToAll(
-						correlationId,
-						correlationId,
-						new CallbackEnvelope(HandleUpdatePersistentSubscriptionCompleted),
-						request.Options.GroupName,
-						settings.ResolveLinks,
-						new TFPos(
-							startPosition.ToInt64().commitPosition,
-							startPosition.ToInt64().preparePosition
-						),
-						settings.MessageTimeoutCase switch {
-							UpdateReq.Types.Settings.MessageTimeoutOneofCase.MessageTimeoutMs => settings.MessageTimeoutMs,
-							UpdateReq.Types.Settings.MessageTimeoutOneofCase.MessageTimeoutTicks => (int)TimeSpan
-								.FromTicks(settings.MessageTimeoutTicks).TotalMilliseconds,
-							_ => 0
-						},
-						settings.ExtraStatistics,
-						settings.MaxRetryCount,
-						settings.HistoryBufferSize,
-						settings.LiveBufferSize,
-						settings.ReadBatchSize,
-						settings.CheckpointAfterCase switch {
-							UpdateReq.Types.Settings.CheckpointAfterOneofCase.CheckpointAfterMs => settings.CheckpointAfterMs,
-							UpdateReq.Types.Settings.CheckpointAfterOneofCase.CheckpointAfterTicks => (int)TimeSpan
-								.FromTicks(settings.CheckpointAfterTicks).TotalMilliseconds,
-							_ => 0
-						},
-						settings.MinCheckpointCount,
-						settings.MaxCheckpointCount,
-						settings.MaxSubscriberCount,
-						consumerStrategy,
-						user));
-					break;
-				default:
-					throw new InvalidOperationException();
+				_publisher.Publish(new ClientMessage.UpdatePersistentSubscriptionToAll(
+					correlationId,
+					correlationId,
+					new CallbackEnvelope(HandleUpdatePersistentSubscriptionCompleted),
+					request.Options.GroupName,
+					settings.ResolveLinks,
+					new TFPos(
+						startPosition.ToInt64().commitPosition,
+						startPosition.ToInt64().preparePosition
+					),
+					settings.MessageTimeoutCase switch
+					{
+						UpdateReq.Types.Settings.MessageTimeoutOneofCase.MessageTimeoutMs => settings.MessageTimeoutMs,
+						UpdateReq.Types.Settings.MessageTimeoutOneofCase.MessageTimeoutTicks => (int)TimeSpan
+							.FromTicks(settings.MessageTimeoutTicks).TotalMilliseconds,
+						_ => 0
+					},
+					settings.ExtraStatistics,
+					settings.MaxRetryCount,
+					settings.HistoryBufferSize,
+					settings.LiveBufferSize,
+					settings.ReadBatchSize,
+					settings.CheckpointAfterCase switch
+					{
+						UpdateReq.Types.Settings.CheckpointAfterOneofCase.CheckpointAfterMs => settings.CheckpointAfterMs,
+						UpdateReq.Types.Settings.CheckpointAfterOneofCase.CheckpointAfterTicks => (int)TimeSpan
+							.FromTicks(settings.CheckpointAfterTicks).TotalMilliseconds,
+						_ => 0
+					},
+					settings.MinCheckpointCount,
+					settings.MaxCheckpointCount,
+					settings.MaxSubscriberCount,
+					consumerStrategy,
+					user));
+				break;
+			default:
+				throw new InvalidOperationException();
+		}
+
+		return await updatePersistentSubscriptionSource.Task;
+
+		void HandleUpdatePersistentSubscriptionCompleted(Message message)
+		{
+			if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex))
+			{
+				updatePersistentSubscriptionSource.TrySetException(ex);
+				return;
 			}
 
-			return await updatePersistentSubscriptionSource.Task;
-
-			void HandleUpdatePersistentSubscriptionCompleted(Message message) {
-				if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
-					updatePersistentSubscriptionSource.TrySetException(ex);
-					return;
-				}
-
-				if (streamId != SystemStreams.AllStream) {
-					if (message is ClientMessage.UpdatePersistentSubscriptionToStreamCompleted completed) {
-						switch (completed.Result) {
-							case ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
-								.UpdatePersistentSubscriptionToStreamResult.Success:
-								updatePersistentSubscriptionSource.TrySetResult(new UpdateResp());
-								return;
-							case ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
-								.UpdatePersistentSubscriptionToStreamResult.Fail:
-								updatePersistentSubscriptionSource.TrySetException(
-									RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
-										completed.Reason));
-								return;
-							case ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
-								.UpdatePersistentSubscriptionToStreamResult
-								.AccessDenied:
-								updatePersistentSubscriptionSource.TrySetException(RpcExceptions.AccessDenied());
-								return;
-							case ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
-								.UpdatePersistentSubscriptionToStreamResult.DoesNotExist:
-								updatePersistentSubscriptionSource.TrySetException(
-									RpcExceptions.PersistentSubscriptionDoesNotExist(streamId, request.Options.GroupName));
-								return;
-							default:
-								updatePersistentSubscriptionSource.TrySetException(
-									RpcExceptions.UnknownError(completed.Result));
-								return;
-						}
+			if (streamId != SystemStreams.AllStream)
+			{
+				if (message is ClientMessage.UpdatePersistentSubscriptionToStreamCompleted completed)
+				{
+					switch (completed.Result)
+					{
+						case ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
+							.UpdatePersistentSubscriptionToStreamResult.Success:
+							updatePersistentSubscriptionSource.TrySetResult(new UpdateResp());
+							return;
+						case ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
+							.UpdatePersistentSubscriptionToStreamResult.Fail:
+							updatePersistentSubscriptionSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
+									completed.Reason));
+							return;
+						case ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
+							.UpdatePersistentSubscriptionToStreamResult
+							.AccessDenied:
+							updatePersistentSubscriptionSource.TrySetException(RpcExceptions.AccessDenied());
+							return;
+						case ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
+							.UpdatePersistentSubscriptionToStreamResult.DoesNotExist:
+							updatePersistentSubscriptionSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionDoesNotExist(streamId, request.Options.GroupName));
+							return;
+						default:
+							updatePersistentSubscriptionSource.TrySetException(
+								RpcExceptions.UnknownError(completed.Result));
+							return;
 					}
-					updatePersistentSubscriptionSource.TrySetException(
-						RpcExceptions.UnknownMessage<ClientMessage.UpdatePersistentSubscriptionToStreamCompleted>(message));
-				} else {
-					if (message is ClientMessage.UpdatePersistentSubscriptionToAllCompleted completedAll) {
-						switch (completedAll.Result) {
-							case ClientMessage.UpdatePersistentSubscriptionToAllCompleted
-								.UpdatePersistentSubscriptionToAllResult.Success:
-								updatePersistentSubscriptionSource.TrySetResult(new UpdateResp());
-								return;
-							case ClientMessage.UpdatePersistentSubscriptionToAllCompleted
-								.UpdatePersistentSubscriptionToAllResult.Fail:
-								updatePersistentSubscriptionSource.TrySetException(
-									RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
-										completedAll.Reason));
-								return;
-							case ClientMessage.UpdatePersistentSubscriptionToAllCompleted
-								.UpdatePersistentSubscriptionToAllResult
-								.AccessDenied:
-								updatePersistentSubscriptionSource.TrySetException(RpcExceptions.AccessDenied());
-								return;
-							case ClientMessage.UpdatePersistentSubscriptionToAllCompleted
-								.UpdatePersistentSubscriptionToAllResult.DoesNotExist:
-								updatePersistentSubscriptionSource.TrySetException(
-									RpcExceptions.PersistentSubscriptionDoesNotExist(streamId, request.Options.GroupName));
-								return;
-							default:
-								updatePersistentSubscriptionSource.TrySetException(
-									RpcExceptions.UnknownError(completedAll.Result));
-								return;
-						}
-					}
-					updatePersistentSubscriptionSource.TrySetException(
-						RpcExceptions.UnknownMessage<ClientMessage.UpdatePersistentSubscriptionToAllCompleted>(message));
 				}
+				updatePersistentSubscriptionSource.TrySetException(
+					RpcExceptions.UnknownMessage<ClientMessage.UpdatePersistentSubscriptionToStreamCompleted>(message));
 			}
-
-			static void ValidateUpdateSettings(UpdateReq.Types.Settings settings) {
-				if (settings is null)
-					throw RpcExceptions.InvalidArgument("Subscription settings are required.");
-
-				if (settings.HistoryBufferSize <= 0)
-					throw RpcExceptions.InvalidArgument($"Buffer Size ({settings.HistoryBufferSize}) must be positive");
-
-				if (settings.LiveBufferSize <= 0)
-					throw RpcExceptions.InvalidArgument($"Live Buffer Size ({settings.LiveBufferSize}) must be positive");
-
-				if (settings.ReadBatchSize <= 0)
-					throw RpcExceptions.InvalidArgument($"Read Batch Size ({settings.ReadBatchSize}) must be positive");
-
-				if (settings.HistoryBufferSize <= settings.ReadBatchSize)
-					throw RpcExceptions.InvalidArgument(
-						$"BufferSize ({settings.HistoryBufferSize}) must be larger than ReadBatchSize ({settings.ReadBatchSize})");
+			else
+			{
+				if (message is ClientMessage.UpdatePersistentSubscriptionToAllCompleted completedAll)
+				{
+					switch (completedAll.Result)
+					{
+						case ClientMessage.UpdatePersistentSubscriptionToAllCompleted
+							.UpdatePersistentSubscriptionToAllResult.Success:
+							updatePersistentSubscriptionSource.TrySetResult(new UpdateResp());
+							return;
+						case ClientMessage.UpdatePersistentSubscriptionToAllCompleted
+							.UpdatePersistentSubscriptionToAllResult.Fail:
+							updatePersistentSubscriptionSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
+									completedAll.Reason));
+							return;
+						case ClientMessage.UpdatePersistentSubscriptionToAllCompleted
+							.UpdatePersistentSubscriptionToAllResult
+							.AccessDenied:
+							updatePersistentSubscriptionSource.TrySetException(RpcExceptions.AccessDenied());
+							return;
+						case ClientMessage.UpdatePersistentSubscriptionToAllCompleted
+							.UpdatePersistentSubscriptionToAllResult.DoesNotExist:
+							updatePersistentSubscriptionSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionDoesNotExist(streamId, request.Options.GroupName));
+							return;
+						default:
+							updatePersistentSubscriptionSource.TrySetException(
+								RpcExceptions.UnknownError(completedAll.Result));
+							return;
+					}
+				}
+				updatePersistentSubscriptionSource.TrySetException(
+					RpcExceptions.UnknownMessage<ClientMessage.UpdatePersistentSubscriptionToAllCompleted>(message));
 			}
+		}
+
+		static void ValidateUpdateSettings(UpdateReq.Types.Settings settings)
+		{
+			if (settings is null)
+				throw RpcExceptions.InvalidArgument("Subscription settings are required.");
+
+			if (settings.HistoryBufferSize <= 0)
+				throw RpcExceptions.InvalidArgument($"Buffer Size ({settings.HistoryBufferSize}) must be positive");
+
+			if (settings.LiveBufferSize <= 0)
+				throw RpcExceptions.InvalidArgument($"Live Buffer Size ({settings.LiveBufferSize}) must be positive");
+
+			if (settings.ReadBatchSize <= 0)
+				throw RpcExceptions.InvalidArgument($"Read Batch Size ({settings.ReadBatchSize}) must be positive");
+
+			if (settings.HistoryBufferSize <= settings.ReadBatchSize)
+				throw RpcExceptions.InvalidArgument(
+					$"BufferSize ({settings.HistoryBufferSize}) must be larger than ReadBatchSize ({settings.ReadBatchSize})");
 		}
 	}
 }


### PR DESCRIPTION
- Persistent-subscription replies should not run request continuations inline on the callback path.