### PR TITLE
fix(grpc): decouple cluster continuations

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/Cluster.Gossip.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Cluster.Gossip.cs
@@ -11,56 +11,64 @@ using EventStore.Plugins.Authorization;
 using Grpc.Core;
 using Empty = EventStore.Client.Empty;
 
-namespace EventStore.Core.Services.Transport.Grpc.Cluster {
-	partial class Gossip {
-		private readonly IPublisher _bus;
-		private readonly IAuthorizationProvider _authorizationProvider;
-		private readonly string _clusterDns;
-		private readonly IDurationTracker _updateTracker;
-		private readonly IDurationTracker _readTracker;
-		private static readonly Operation ReadOperation = new Operation(Plugins.Authorization.Operations.Node.Gossip.Read);
-		private static readonly Operation UpdateOperation = new Operation(Plugins.Authorization.Operations.Node.Gossip.Update);
+namespace EventStore.Core.Services.Transport.Grpc.Cluster;
 
-		public Gossip(IPublisher bus, IAuthorizationProvider authorizationProvider, string clusterDns,
-			IDurationTracker updateTracker,
-			IDurationTracker readTracker) {
+partial class Gossip
+{
+	private readonly IPublisher _bus;
+	private readonly IAuthorizationProvider _authorizationProvider;
+	private readonly string _clusterDns;
+	private readonly IDurationTracker _updateTracker;
+	private readonly IDurationTracker _readTracker;
+	private static readonly Operation ReadOperation = new Operation(Plugins.Authorization.Operations.Node.Gossip.Read);
+	private static readonly Operation UpdateOperation = new Operation(Plugins.Authorization.Operations.Node.Gossip.Update);
 
-			_bus = bus;
-			_authorizationProvider = authorizationProvider ?? throw new ArgumentNullException(nameof(authorizationProvider));
-			_clusterDns = clusterDns;
-			_updateTracker = updateTracker;
-			_readTracker = readTracker;
+	public Gossip(IPublisher bus, IAuthorizationProvider authorizationProvider, string clusterDns,
+		IDurationTracker updateTracker,
+		IDurationTracker readTracker)
+	{
+
+		_bus = bus;
+		_authorizationProvider = authorizationProvider ?? throw new ArgumentNullException(nameof(authorizationProvider));
+		_clusterDns = clusterDns;
+		_updateTracker = updateTracker;
+		_readTracker = readTracker;
+	}
+
+	public override async Task<ClusterInfo> Update(GossipRequest request, ServerCallContext context)
+	{
+		var user = context.GetHttpContext().User;
+		if (!await _authorizationProvider.CheckAccessAsync(user, UpdateOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
 		}
+		var clusterInfo = EventStore.Core.Cluster.ClusterInfo.FromGrpcClusterInfo(request.Info, _clusterDns);
+		var tcs = new TaskCompletionSource<ClusterInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var duration = _updateTracker.Start();
+		_bus.Publish(new GossipMessage.GossipReceived(new CallbackEnvelope(msg => GossipResponse(msg, tcs, duration)),
+			clusterInfo, new DnsEndPoint(request.Server.Address, (int)request.Server.Port).WithClusterDns(_clusterDns)));
+		return await tcs.Task;
+	}
 
-		public override async Task<ClusterInfo> Update(GossipRequest request, ServerCallContext context) {
-			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, UpdateOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
-			}
-			var clusterInfo = EventStore.Core.Cluster.ClusterInfo.FromGrpcClusterInfo(request.Info, _clusterDns);
-			var tcs = new TaskCompletionSource<ClusterInfo>();
-			var duration = _updateTracker.Start();
-			_bus.Publish(new GossipMessage.GossipReceived(new CallbackEnvelope(msg => GossipResponse(msg, tcs, duration)),
-				clusterInfo, new DnsEndPoint(request.Server.Address, (int)request.Server.Port).WithClusterDns(_clusterDns)));
-			return await tcs.Task;
+	public override async Task<ClusterInfo> Read(Empty request, ServerCallContext context)
+	{
+		var user = context.GetHttpContext().User;
+		if (!await _authorizationProvider.CheckAccessAsync(user, ReadOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
 		}
+		var tcs = new TaskCompletionSource<ClusterInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var duration = _readTracker.Start();
+		_bus.Publish(new GossipMessage.ReadGossip(new CallbackEnvelope(msg => GossipResponse(msg, tcs, duration))));
+		return await tcs.Task;
+	}
 
-		public override async Task<ClusterInfo> Read(Empty request, ServerCallContext context) {
-			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, ReadOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
-			}
-			var tcs = new TaskCompletionSource<ClusterInfo>();
-			var duration = _readTracker.Start();
-			_bus.Publish(new GossipMessage.ReadGossip(new CallbackEnvelope(msg => GossipResponse(msg, tcs, duration))));
-			return await tcs.Task;
-		}
-
-		private void GossipResponse(Message msg, TaskCompletionSource<ClusterInfo> tcs, Duration duration) {
-			if (msg is GossipMessage.SendGossip received) {
-				tcs.TrySetResult(EventStore.Core.Cluster.ClusterInfo.ToGrpcClusterInfo(received.ClusterInfo));
-				duration.Dispose();
-			}
+	private void GossipResponse(Message msg, TaskCompletionSource<ClusterInfo> tcs, Duration duration)
+	{
+		if (msg is GossipMessage.SendGossip received)
+		{
+			tcs.TrySetResult(EventStore.Core.Cluster.ClusterInfo.ToGrpcClusterInfo(received.ClusterInfo));
+			duration.Dispose();
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/Gossip.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Gossip.Read.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using EventStore.Client.Gossip;
 using EventStore.Client;
+using EventStore.Client.Gossip;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Metrics;
@@ -11,41 +11,50 @@ using Grpc.Core;
 using ClusterInfo = EventStore.Client.Gossip.ClusterInfo;
 using MemberInfo = EventStore.Client.Gossip.MemberInfo;
 
-namespace EventStore.Core.Services.Transport.Grpc {
-	partial class Gossip {
-		private static readonly Operation ReadOperation = new Operation(Plugins.Authorization.Operations.Node.Gossip.ClientRead);
-		public override async Task<ClusterInfo> Read(Empty request, ServerCallContext context) {
-			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, ReadOperation, context.CancellationToken)) {
-				throw RpcExceptions.AccessDenied();
-			}
-			var tcs = new TaskCompletionSource<ClusterInfo>();
-			var duration = _tracker.Start();
-			_bus.Publish(new GossipMessage.ClientGossip(new CallbackEnvelope(msg => GossipResponse(msg, tcs, duration))));;
-			return await tcs.Task;
-		}
+namespace EventStore.Core.Services.Transport.Grpc;
 
-		private void GossipResponse(Message msg, TaskCompletionSource<ClusterInfo> tcs, Duration duration) {
-			if (msg is GossipMessage.SendClientGossip received) {
-				tcs.TrySetResult(ToGrpcClusterInfo(received.ClusterInfo));
-				duration.Dispose();
-			}
+partial class Gossip
+{
+	private static readonly Operation ReadOperation = new Operation(Plugins.Authorization.Operations.Node.Gossip.ClientRead);
+	public override async Task<ClusterInfo> Read(Empty request, ServerCallContext context)
+	{
+		var user = context.GetHttpContext().User;
+		if (!await _authorizationProvider.CheckAccessAsync(user, ReadOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
 		}
+		var tcs = new TaskCompletionSource<ClusterInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var duration = _tracker.Start();
+		_bus.Publish(new GossipMessage.ClientGossip(new CallbackEnvelope(msg => GossipResponse(msg, tcs, duration))));
+		;
+		return await tcs.Task;
+	}
 
-		private ClusterInfo ToGrpcClusterInfo(Core.Cluster.ClientClusterInfo cluster) {
-			var members = Array.ConvertAll(cluster.Members, x => new MemberInfo {
-				InstanceId = Uuid.FromGuid(x.InstanceId).ToDto(),
-				TimeStamp = x.TimeStamp.ToTicksSinceEpoch(),
-				State = (MemberInfo.Types.VNodeState)x.State,
-				IsAlive = x.IsAlive,
-				HttpEndPoint = new EndPoint{
-					Address = x.HttpEndPointIp,
-					Port = (uint)x.HttpEndPointPort
-				}
-			}).ToArray();
-			var info = new ClusterInfo();
-			info.Members.AddRange(members);
-			return info;
+	private void GossipResponse(Message msg, TaskCompletionSource<ClusterInfo> tcs, Duration duration)
+	{
+		if (msg is GossipMessage.SendClientGossip received)
+		{
+			tcs.TrySetResult(ToGrpcClusterInfo(received.ClusterInfo));
+			duration.Dispose();
 		}
+	}
+
+	private ClusterInfo ToGrpcClusterInfo(Core.Cluster.ClientClusterInfo cluster)
+	{
+		var members = Array.ConvertAll(cluster.Members, x => new MemberInfo
+		{
+			InstanceId = Uuid.FromGuid(x.InstanceId).ToDto(),
+			TimeStamp = x.TimeStamp.ToTicksSinceEpoch(),
+			State = (MemberInfo.Types.VNodeState)x.State,
+			IsAlive = x.IsAlive,
+			HttpEndPoint = new EndPoint
+			{
+				Address = x.HttpEndPointIp,
+				Port = (uint)x.HttpEndPointPort
+			}
+		}).ToArray();
+		var info = new ClusterInfo();
+		info.Members.AddRange(members);
+		return info;
 	}
 }


### PR DESCRIPTION
- Cluster replies should not run request continuations inline on the callback path.