### PR TITLE
fix(grpc): decouple projection continuations

### DIFF
--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Abort.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Abort.cs
@@ -14,7 +14,7 @@ internal partial class ProjectionManagement
 
 	public override async Task<AbortResp> Abort(AbortReq request, ServerCallContext context)
 	{
-		var abortSource = new TaskCompletionSource<bool>();
+		var abortSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 		using var cancellationRegistration =
 			context.CancellationToken.Register(() => abortSource.TrySetCanceled(context.CancellationToken));
 		var name = request.Options.Name;

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Config.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Config.cs
@@ -15,7 +15,7 @@ internal partial class ProjectionManagement
 
 	public override async Task<GetConfigResp> GetConfig(GetConfigReq request, ServerCallContext context)
 	{
-		var configSource = new TaskCompletionSource<ProjectionManagementMessage.ProjectionConfig>();
+		var configSource = new TaskCompletionSource<ProjectionManagementMessage.ProjectionConfig>(TaskCreationOptions.RunContinuationsAsynchronously);
 		using var getConfigCancellationRegistration =
 			context.CancellationToken.Register(() => configSource.TrySetCanceled(context.CancellationToken));
 		var name = request.Options.Name;
@@ -33,7 +33,8 @@ internal partial class ProjectionManagement
 			new ProjectionManagementMessage.RunAs(user)));
 
 		var config = await configSource.Task;
-		var details = new GetConfigResp.Types.Details {
+		var details = new GetConfigResp.Types.Details
+		{
 			EmitEnabled = config.EmitEnabled,
 			TrackEmittedStreams = config.TrackEmittedStreams,
 			CheckpointAfterMs = config.CheckpointAfterMs,
@@ -48,7 +49,8 @@ internal partial class ProjectionManagement
 			details.ProjectionExecutionTimeout = projectionExecutionTimeout;
 		}
 
-		return new GetConfigResp {
+		return new GetConfigResp
+		{
 			Details = details
 		};
 
@@ -71,7 +73,7 @@ internal partial class ProjectionManagement
 
 	public override async Task<UpdateConfigResp> UpdateConfig(UpdateConfigReq request, ServerCallContext context)
 	{
-		var updateSource = new TaskCompletionSource<bool>();
+		var updateSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 		using var updateConfigCancellationRegistration =
 			context.CancellationToken.Register(() => updateSource.TrySetCanceled(context.CancellationToken));
 		var options = request.Options;

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Create.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Create.cs
@@ -16,7 +16,7 @@ internal partial class ProjectionManagement
 
 	public override async Task<CreateResp> Create(CreateReq request, ServerCallContext context)
 	{
-		var createdSource = new TaskCompletionSource<bool>();
+		var createdSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 		var options = request.Options;
 
 		var user = context.GetHttpContext().User;

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Delete.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Delete.cs
@@ -13,7 +13,7 @@ internal partial class ProjectionManagement
 	private static readonly Operation DeleteOperation = new Operation(Operations.Projections.Delete);
 	public override async Task<DeleteResp> Delete(DeleteReq request, ServerCallContext context)
 	{
-		var deletedSource = new TaskCompletionSource<bool>();
+		var deletedSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 		var options = request.Options;
 
 		var user = context.GetHttpContext().User;

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Disable.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Disable.cs
@@ -13,7 +13,7 @@ internal partial class ProjectionManagement
 	private static readonly Operation DisableOperation = new Operation(Operations.Projections.Disable);
 	public override async Task<DisableResp> Disable(DisableReq request, ServerCallContext context)
 	{
-		var disableSource = new TaskCompletionSource<bool>();
+		var disableSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		var options = request.Options;
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Enable.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Enable.cs
@@ -13,7 +13,7 @@ internal partial class ProjectionManagement
 	private static readonly Operation EnableOperation = new Operation(Operations.Projections.Enable);
 	public override async Task<EnableResp> Enable(EnableReq request, ServerCallContext context)
 	{
-		var enableSource = new TaskCompletionSource<bool>();
+		var enableSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		var options = request.Options;
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Query.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Query.cs
@@ -14,7 +14,7 @@ internal partial class ProjectionManagement
 
 	public override async Task<GetQueryResp> GetQuery(GetQueryReq request, ServerCallContext context)
 	{
-		var querySource = new TaskCompletionSource<ProjectionManagementMessage.ProjectionQuery>();
+		var querySource = new TaskCompletionSource<ProjectionManagementMessage.ProjectionQuery>(TaskCreationOptions.RunContinuationsAsynchronously);
 		using var cancellationRegistration =
 			context.CancellationToken.Register(() => querySource.TrySetCanceled(context.CancellationToken));
 		var name = request.Options.Name;
@@ -32,7 +32,8 @@ internal partial class ProjectionManagement
 			new ProjectionManagementMessage.RunAs(user)));
 
 		var query = await querySource.Task;
-		var details = new GetQueryResp.Types.Details {
+		var details = new GetQueryResp.Types.Details
+		{
 			Name = query.Name ?? string.Empty,
 			Query = query.Query ?? string.Empty,
 			EmitEnabled = query.EmitEnabled,
@@ -50,7 +51,8 @@ internal partial class ProjectionManagement
 			details.CheckpointsEnabled = checkpointsEnabled;
 		}
 
-		return new GetQueryResp {
+		return new GetQueryResp
+		{
 			Details = details
 		};
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.ReadEvents.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.ReadEvents.cs
@@ -20,7 +20,7 @@ internal partial class ProjectionManagement
 
 	public override async Task<ReadEventsResp> ReadEvents(ReadEventsReq request, ServerCallContext context)
 	{
-		var readSource = new TaskCompletionSource<FeedReaderMessage.FeedPage>();
+		var readSource = new TaskCompletionSource<FeedReaderMessage.FeedPage>(TaskCreationOptions.RunContinuationsAsynchronously);
 		using var cancellationRegistration =
 			context.CancellationToken.Register(() => readSource.TrySetCanceled(context.CancellationToken));
 		var options = request.Options;
@@ -50,7 +50,8 @@ internal partial class ProjectionManagement
 			throw RpcExceptions.AccessDenied();
 		}
 
-		var details = new ReadEventsResp.Types.Details {
+		var details = new ReadEventsResp.Types.Details
+		{
 			CorrelationId = page.CorrelationId.ToString("D"),
 			ReaderPositionJson = page.LastReaderPosition.ToJsonRaw().ToString()
 		};
@@ -58,7 +59,8 @@ internal partial class ProjectionManagement
 		foreach (var taggedEvent in page.Events)
 		{
 			var resolvedEvent = taggedEvent.ResolvedEvent;
-			details.Events.Add(new ReadEventsResp.Types.Details.Types.Event {
+			details.Events.Add(new ReadEventsResp.Types.Details.Types.Event
+			{
 				EventStreamId = resolvedEvent.EventStreamId ?? string.Empty,
 				EventNumber = resolvedEvent.EventSequenceNumber,
 				EventType = resolvedEvent.EventType ?? string.Empty,
@@ -70,7 +72,8 @@ internal partial class ProjectionManagement
 			});
 		}
 
-		return new ReadEventsResp {
+		return new ReadEventsResp
+		{
 			Details = details
 		};
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Reset.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Reset.cs
@@ -13,7 +13,7 @@ internal partial class ProjectionManagement
 	private static readonly Operation ResetOperation = new Operation(Operations.Projections.Reset);
 	public override async Task<ResetResp> Reset(ResetReq request, ServerCallContext context)
 	{
-		var resetSource = new TaskCompletionSource<bool>();
+		var resetSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		var options = request.Options;
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.RestartSubsystem.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.RestartSubsystem.cs
@@ -14,7 +14,7 @@ internal partial class ProjectionManagement
 
 	public override async Task<Empty> RestartSubsystem(Empty empty, ServerCallContext context)
 	{
-		var restart = new TaskCompletionSource<bool>();
+		var restart = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 		var envelope = new CallbackEnvelope(OnMessage);
 
 		var user = context.GetHttpContext().User;

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Result.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Result.cs
@@ -23,7 +23,7 @@ internal partial class ProjectionManagement
 			throw RpcExceptions.AccessDenied();
 		}
 
-		var resultSource = new TaskCompletionSource<Value>();
+		var resultSource = new TaskCompletionSource<Value>(TaskCreationOptions.RunContinuationsAsynchronously);
 		var options = request.Options;
 
 		var name = options.Name;
@@ -74,7 +74,7 @@ internal partial class ProjectionManagement
 		{
 			throw RpcExceptions.AccessDenied();
 		}
-		var resultSource = new TaskCompletionSource<Value>();
+		var resultSource = new TaskCompletionSource<Value>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		var options = request.Options;
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Statistics.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Statistics.cs
@@ -22,7 +22,7 @@ internal partial class ProjectionManagement
 			throw RpcExceptions.AccessDenied();
 		}
 
-		var statsSource = new TaskCompletionSource<ProjectionStatistics[]>();
+		var statsSource = new TaskCompletionSource<ProjectionStatistics[]>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		var options = request.Options;
 		var name = string.IsNullOrEmpty(options.Name) ? null : options.Name;

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Update.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Update.cs
@@ -15,7 +15,7 @@ internal partial class ProjectionManagement
 	private static readonly Operation UpdateOperation = new Operation(Operations.Projections.Update);
 	public override async Task<UpdateResp> Update(UpdateReq request, ServerCallContext context)
 	{
-		var updatedSource = new TaskCompletionSource<bool>();
+		var updatedSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 		var options = request.Options;
 
 		var user = context.GetHttpContext().User;


### PR DESCRIPTION
- Projection replies should not run request continuations inline on the callback path.