### PR TITLE
chore(deps): refresh grpc and projection runtime packages

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -24,14 +24,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="Google.Protobuf" Version="3.34.1" />
-    <PackageVersion Include="Grpc.AspNetCore" Version="2.76.0" />
-    <PackageVersion Include="Grpc.AspNetCore.HealthChecks" Version="2.76.0" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.80.0" />
+    <PackageVersion Include="Grpc.AspNetCore.HealthChecks" Version="2.80.0" />
     <PackageVersion Include="Grpc.Core" Version="2.46.6" />
-    <PackageVersion Include="Grpc.HealthCheck" Version="2.76.0" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.76.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
+    <PackageVersion Include="Grpc.HealthCheck" Version="2.80.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.80.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
-    <PackageVersion Include="Jint" Version="4.8.0" />
+    <PackageVersion Include="Jint" Version="4.9.0" />
     <PackageVersion Include="librdkafka.redist" Version="2.5.3" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />


### PR DESCRIPTION
- Keep transport and projection dependencies current without taking major-version migration risk.
- Reduce dependency drift in the gRPC path while larger breaking upgrades remain separate.