### PR TITLE
chore(deps): refresh kafka native runtime

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="Grpc.Tools" Version="2.80.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageVersion Include="Jint" Version="4.9.0" />
-    <PackageVersion Include="librdkafka.redist" Version="2.5.3" />
+    <PackageVersion Include="librdkafka.redist" Version="2.14.1" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />


### PR DESCRIPTION
- Keeps the native Kafka dependency aligned with maintained runtime fixes.