### PR TITLE
chore(deps): refresh roslyn tooling

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -35,13 +35,13 @@
     <PackageVersion Include="librdkafka.redist" Version="2.14.1" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <!--
       NOTE: Do not upgrade beyond version 1.1.1
       Newer versions mark 'XUnitVerifier' as obsolete, which breaks existing tests.
     -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.661903" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.2" />


### PR DESCRIPTION
- Keeps compiler tooling aligned with maintained source generator infrastructure.