### PR TITLE
chore(deps): refresh scrutor

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -63,7 +63,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageVersion Include="Quickenshtein" Version="1.5.1" />
-    <PackageVersion Include="Scrutor" Version="5.1.2" />
+    <PackageVersion Include="Scrutor" Version="7.0.0" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />


### PR DESCRIPTION
- Keeps dependency scanning infrastructure aligned with the maintained package line.