### PR TITLE
chore(deps): refresh in-memory logging sink

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -73,7 +73,7 @@
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageVersion Include="Serilog.Sinks.InMemory" Version="0.16.0" />
+    <PackageVersion Include="Serilog.Sinks.InMemory" Version="2.0.0" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Serilog.Sinks.TextWriter" Version="3.0.0" />
     <PackageVersion Include="SharpDotYaml.Extensions.Configuration" Version="0.4.0" />


### PR DESCRIPTION
- Keeps test logging support aligned with the maintained sink package.