### PR TITLE
chore(deps): align qodana license overrides

### DIFF
--- a/src/qodana.yaml
+++ b/src/qodana.yaml
@@ -30,7 +30,7 @@ profile:
 
 dependencyOverrides:
   - name: "OpenTelemetry.Exporter.Prometheus.AspNetCore"
-    version: "1.4.0-rc.1"
+    version: "1.15.3-beta.1"
     licenses:
       - key: "Apache-2.0"
         url: "https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/LICENSE.TXT"


### PR DESCRIPTION
- Keeps dependency license metadata aligned with the package version actually used by the build.