### PR TITLE
chore(ci): drop obsolete netcoreapp31 setup

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -27,10 +27,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Install netcoreapp3.1
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 3.1.x
       - name: Install net10.0
         uses: actions/setup-dotnet@v5
         with:


### PR DESCRIPTION
- Retired runtimes should not remain in the shared build path once the repository is built by the current supported SDK.
- Keeping the build image lean reduces CI startup work and avoids carrying unsupported runtime assumptions forward.