### PR TITLE
chore(docs): fix stale link targets

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Find out [what's new](whatsnew.md) in this release to get details on new feature
 
 ## Getting started
 
-Check the [getting started guide](/getting-started.md) for resources on the principles of EventStoreDB, Event Sourcing, database installation guidelines and choosing a client SDK.
+Check the [installation guide](installation.md) for database setup and first-run guidance.
 
 ## Support
 
@@ -54,7 +54,7 @@ When developing software that uses EventStoreDB, we recommend using one of the o
 - Go: [EventStore/EventStore-Client-Go](https://github.com/EventStore/EventStore-Client-Go)
 - Rust: [EventStore/EventStoreDB-Client-Rust](https://github.com/EventStore/EventStoreDB-Client-Rust)
 
-Read more in the [gRPC clients documentation](@clients/grpc/README.md).
+Use the official SDK documentation for language-specific gRPC client guidance.
 
 #### Community developed clients
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -51,7 +51,7 @@ If your network setup requires any kind of IP address, DNS name and port transla
 
 ### Keep-alive pings
 
-The reliability of the connection between the client application and database is crucial for the stability of the solution. If the network is not stable or has some periodic issues, the client may drop the connection. Stability is essential for the [stream subscriptions](@clients/grpc/subscriptions.md) where a client is listening to database notifications. Having an existing connection open when an app resumes activity allows for the initial gRPC calls to be made quickly, without any delay caused by the reestablished connection.
+The reliability of the connection between the client application and database is crucial for the stability of the solution. If the network is not stable or has some periodic issues, the client may drop the connection. Stability is essential for stream subscriptions where a client is listening to database notifications. Having an existing connection open when an app resumes activity allows for the initial gRPC calls to be made quickly, without any delay caused by the reestablished connection.
 
 EventStoreDB supports the built-in gRPC mechanism for keeping the connection alive. If the other side does not acknowledge the ping within a certain period, the connection will be closed. Note that pings are only necessary when there's no activity on the connection.
 
@@ -443,4 +443,3 @@ When the plugin starts, you should see a log similar to the following:
 ```
 [11212, 1,18:44:34.070,INF] "TcpApi" "24.6.0.0" plugin enabled.
 ```
-

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -72,7 +72,7 @@ A 10x improvement has been observed in testing.
 
 ### X.509 authentication in client APIs <Badge type="warning" text="Commercial" vertical="middle" />
 
-Refer to the [clients documentation](@clients/grpc/authentication.md) for instructions on how to enable and use X.509 certificates with the EventStoreDB clients.
+Refer to the [user certificate documentation](security.md#connecting-with-a-user-certificate) for instructions on how to enable and use X.509 certificates with EventStoreDB clients.
 
 ### Metrics support for Linux, FreeBSD, OSX
 


### PR DESCRIPTION
- Broken documentation links make local builds noisy and hide future regressions.
- Keeping the links within the committed docs tree makes the site easier to validate after the HTTP surface cleanup.