### PR TITLE
chore(style): align namespace preference

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -30,9 +30,9 @@ dotnet_diagnostic.IDE0011.severity = error
 # disable hint to use primary constructor
 dotnet_diagnostic.IDE0290.severity = none
 
-# use file-scoped namespaces
-csharp_style_namespace_declarations = file_scoped
-dotnet_diagnostic.IDE0161.severity = error
+# keep namespace style aligned with the existing codebase
+csharp_style_namespace_declarations = block_scoped
+dotnet_diagnostic.IDE0161.severity = none
 
 # use ValueTasks correctly
 dotnet_diagnostic.CA2012.severity = error


### PR DESCRIPTION
- Style verification should not pressure the repository toward a namespace migration that has not been intentionally chosen.
- Keeping the configured preference aligned with the existing codebase makes future formatting checks useful instead of noisy.