### PR TITLE
chore(docs): label readme command fences

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,38 @@
+<!-- markdownlint-disable MD033 MD041 -->
 <p align="center">
   <a href="https://www.trogondb.com/">
     <img src="./trogon-logo.png" width="240px" alt="TrogonDB" />
   </a>
 </p>
+<!-- markdownlint-enable MD033 MD041 -->
 
 # TrogonDB
 
-TrogonDB is the event-native database, where business events are immutably stored and streamed. Designed for event-sourced, event-driven, and microservices architectures
+TrogonDB is the event-native database, where business events are immutably stored
+and streamed. Designed for event-sourced, event-driven, and microservices
+architectures.
 
-- [What is TrogonDB ](#what-is-trogondb)
+- [What is TrogonDB](#what-is-trogondb)
 - [Documentation](#docs)
-- [Getting started with TrogonDB ](#getting-started-with-trogondb)
+- [Getting started with TrogonDB](#getting-started-with-trogondb)
 - [Client libraries](#client-libraries)
-- [Deployment](#deployment)
 - [Communities](#communities)
 - [Building TrogonDB](#building-trogondb)
 
 ## What is TrogonDB
 
-TrogonDB is a new category of operational database that has evolved from the Event Sourcing community. Powered by the state-transition data model, events are stored with the context of why they have happened. Providing flexible, real-time data insights in the language your business understands.
+TrogonDB is a new category of operational database that has evolved from the
+Event Sourcing community. Powered by the state-transition data model, events are
+stored with the context of why they have happened. Providing flexible, real-time
+data insights in the language your business understands.
 
 Download the [latest version](https://www.trogondb.com/downloads).
 For more product information visit [the website](https://www.trogondb.com/TrogonDB).
 
 ## Docs
 
-For guidance on installation, development, deployment, and administration, see the [User Documentation](https://developers.trogondb.com/).
+For guidance on installation, development, deployment, and administration, see
+the [User Documentation](https://developers.trogondb.com/).
 
 ## Getting started with TrogonDB
 
@@ -33,18 +40,21 @@ Follow the [getting started guide](https://developers.trogondb.com/latest.html).
 
 ## Getting started with Event Store Cloud
 
-Event Store can manage TrogonDB for you, so you don't have to run your own clusters.
-See the online documentation: [Getting started with Event Store Cloud](https://developers.trogondb.com/cloud/).
+Event Store can manage TrogonDB for you, so you don't have to run your own
+clusters.
+See the online documentation:
+[Getting started with Event Store Cloud](https://developers.trogondb.com/cloud/).
 
 ## Client libraries
 
-This guide shows you how to get started with TrogonDB by setting up an instance or cluster and configuring it.
+This guide shows you how to get started with TrogonDB by setting up an instance
+or cluster and configuring it.
 
 TrogonDB supported gRPC clients
 
 - Python: [pyeventsourcing/esdbclient](https://pypi.org/project/esdbclient/)
 - Node.js (javascript/typescript): [EventStore/EventStore-Client-NodeJS](https://github.com/EventStore/EventStore-Client-NodeJS)
-- Java: [(EventStore/TrogonDB-Client-Java](https://github.com/EventStore/TrogonDB-Client-Java)
+- Java: [EventStore/TrogonDB-Client-Java](https://github.com/EventStore/TrogonDB-Client-Java)
 - .NET: [EventStore/EventStore-Client-Dotnet](https://github.com/EventStore/EventStore-Client-Dotnet)
 - Go: [EventStore/EventStore-Client-Go](https://github.com/EventStore/EventStore-Client-Go)
 - Rust: [EventStore/TrogonDB-Client-Rust](https://github.com/EventStore/TrogonDB-Client-Rust)
@@ -61,31 +71,35 @@ Community supported gRPC clients
 
 ## Building TrogonDB
 
-TrogonDB is written in a mixture of C# and JavaScript. It can run on Windows, Linux and macOS (using Docker) using the .NET Core runtime.
+TrogonDB is written in a mixture of C# and JavaScript. It can run on Windows,
+Linux and macOS using Docker and the .NET runtime.
 
-**Prerequisites**
+### Prerequisites
 
 - [.NET SDK 10.0](https://dotnet.microsoft.com/download/dotnet/10.0)
 
-Once you've installed the prerequisites for your system, you can launch a `Release` build of EventStore as follows:
+Once you've installed the prerequisites for your system, you can launch a
+`Release` build of EventStore as follows:
 
-```
+```bash
 dotnet build -c Release src
 ```
 
-The build scripts: `build.sh` and `build.ps1` are also available for Linux and Windows respectively to simplify the build process.
+The build scripts: `build.sh` and `build.ps1` are also available for Linux and
+Windows respectively to simplify the build process.
 
 To start a single node, you can then run:
 
-```
-dotnet ./src/EventStore.ClusterNode/bin/x64/Release/net10.0/EventStore.ClusterNode.dll --dev --db ./tmp/data --index ./tmp/index --log ./tmp/log
+```bash
+node="./src/EventStore.ClusterNode/bin/x64/Release/net10.0/EventStore.ClusterNode.dll"
+dotnet "$node" --dev --db ./tmp/data --index ./tmp/index --log ./tmp/log
 ```
 
 ### Running the tests
 
 You can launch the tests as follows:
 
-```
+```bash
 dotnet test src/EventStore.sln
 ```
 
@@ -93,7 +107,7 @@ dotnet test src/EventStore.sln
 
 You can also build a Docker image by running the command:
 
-```
+```bash
 docker build --tag myeventstore . \
 --build-arg CONTAINER_RUNTIME={container-runtime}
 --build-arg RUNTIME={runtime}
@@ -107,7 +121,10 @@ docker build --tag myeventstore . \
 --build-arg RUNTIME=linux-x64
 ```
 
-**_Note:_** Because of the [Docker issue](https://github.com/moby/buildkit/issues/1900), if you're building a Docker image on Windows, you may need to set the `DOCKER_BUILDKIT=0` environment variable. For instance, running in PowerShell:
+**_Note:_** Because of the
+[Docker issue](https://github.com/moby/buildkit/issues/1900), if you're building
+a Docker image on Windows, you may need to set the `DOCKER_BUILDKIT=0`
+environment variable. For instance, running in PowerShell:
 
 ```powershell
 $env:DOCKER_BUILDKIT=0; docker build --tag myeventstore . `
@@ -124,6 +141,6 @@ Currently, we support the following configurations:
 
 You can verify the built image by running:
 
-```
+```bash
 docker run --rm myeventstore --insecure --what-if
 ```


### PR DESCRIPTION
- README command examples should satisfy Markdown linting without reviewers having to rediscover the same fence-language warning.
- Labeled fences make the setup commands easier to scan in rendered documentation.