### PR TITLE
chore(deps): track javascript package roots

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,33 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "monthly"
+      time: "10:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      docs:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/src/EventStore.ClusterNode"
+    schedule:
+      interval: "monthly"
+      time: "10:30"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      node-ui:
+        patterns:
+          - "*"


### PR DESCRIPTION
- JavaScript dependency alerts should become routine monthly maintenance instead of manual security cleanup.
- Tracking the docs and node UI package roots keeps package update ownership aligned with the existing Dependabot cadence.