### PR TITLE
chore(repo): trim config whitespace

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ COPYRIGHT="Copyright 2021 Event Store Ltd. All rights reserved."
 CONFIGURATION="Release"
 NET_FRAMEWORK="net10.0"
 
-function usage() {    
+function usage() {
 cat <<EOF
 Usage:
   $0 [<version=0.0.0.0>] [<configuration=Debug|Release>]

--- a/dev-env/clean-docker.sh
+++ b/dev-env/clean-docker.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-docker container stop $(docker container list -qa) 
+docker container stop $(docker container list -qa)
 docker rmi -f $(docker images -qa)
 if [ "$1" = "-v" ];
 then

--- a/dev-env/rm-cont.sh
+++ b/dev-env/rm-cont.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-docker container stop $(docker container list -qa) 
-docker container rm -f $(docker container list -qa) 
+docker container stop $(docker container list -qa)
+docker container rm -f $(docker container list -qa)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - volumes-provisioner
 
   esdb-node1:
-    build: 
+    build:
       context: ./
       secrets:
         - nuget_auth_token
@@ -49,7 +49,7 @@ services:
       - cert-gen
 
   esdb-node2:
-    build: 
+    build:
       context: ./
       secrets:
         - nuget_auth_token
@@ -74,7 +74,7 @@ services:
       - cert-gen
 
   esdb-node3:
-    build: 
+    build:
       context: ./
       secrets:
         - nuget_auth_token

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -77,7 +77,7 @@ dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
 dotnet_naming_symbols.static_fields.applicable_kinds   = field
 dotnet_naming_symbols.static_fields.required_modifiers = static
 
-dotnet_naming_style.static_prefix_style.capitalization = pascal_case 
+dotnet_naming_style.static_prefix_style.capitalization = pascal_case
 
 # internal and private fields should be _camelCase
 dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
@@ -88,7 +88,7 @@ dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
 dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
 
 dotnet_naming_style.camel_case_underscore_style.required_prefix = _
-dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case 
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
 
 # Code style defaults
 dotnet_sort_system_directives_first = true


### PR DESCRIPTION
- Keep repository maintenance files aligned with the whitespace rules they define.