### PR TITLE
chore(docs): ignore generated site output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ _dotCover.*
 */es-logs
 
 node_modules
+docs/.vuepress/dist/
 test_results
 
 # Mac


### PR DESCRIPTION
- Docs builds should not leave generated site artifacts sitting in the worktree after local verification.