### PR TITLE
chore(build): remove unused mac property

### DIFF
--- a/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
+++ b/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
@@ -54,10 +54,4 @@
 		<None Update="ui-assets\js\stream-browser.js" CopyToOutputDirectory="PreserveNewest" />
 		<None Update="ui-assets\js\ui-auth.js" CopyToOutputDirectory="PreserveNewest" />
 	</ItemGroup>
-	<!-- TODO(jen20): Investigate which of these are correct -->
-	<PropertyGroup>
-		<IsMac>false</IsMac>
-		<IsMac Condition="('$(OS)' == 'Unix') And (Exists ('/Library/Frameworks'))">true</IsMac>
-	</PropertyGroup>
-
 </Project>

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -47,9 +47,4 @@
 	<ItemGroup>
 		<EmbeddedResource Include="Services\Jint\Serialization\big_state.json" />
 	</ItemGroup>
-	<!-- TODO(jen20): Decide what is correct here -->
-	<PropertyGroup>
-		<IsMac>false</IsMac>
-		<IsMac Condition="'$(OS)' == 'Unix' And Exists ('/Library/Frameworks')">true</IsMac>
-	</PropertyGroup>
 </Project>


### PR DESCRIPTION
- Removes stale build-only state that no longer influences any target.
- Keeps project files easier to audit as the build surface keeps shrinking.