### PR TITLE
chore(build): align project file indentation

### DIFF
--- a/src/EventStore.BufferManagement/EventStore.BufferManagement.csproj
+++ b/src/EventStore.BufferManagement/EventStore.BufferManagement.csproj
@@ -3,6 +3,6 @@
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 	</PropertyGroup>
 	<ItemGroup>
-	  <PackageReference Include="Serilog" />
+		<PackageReference Include="Serilog" />
 	</ItemGroup>
 </Project>

--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -12,7 +12,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" />
-    <PackageReference Include="NetEscapades.Configuration.Yaml" />
+		<PackageReference Include="NetEscapades.Configuration.Yaml" />
 		<PackageReference Include="Newtonsoft.Json" />
 
 		<PackageReference Include="Serilog" />
@@ -29,12 +29,12 @@
 		<PackageReference Include="YamlDotnet" />
 	</ItemGroup>
 	<ItemGroup>
-	  <None Update="Utils\version.properties">
-	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </None>
+		<None Update="Utils\version.properties">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 	<ItemGroup>
-	  <ProjectReference Include="..\EventStore.SystemRuntime\EventStore.SystemRuntime.csproj" />
+		<ProjectReference Include="..\EventStore.SystemRuntime\EventStore.SystemRuntime.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/EventStore.Native/EventStore.Native.csproj
+++ b/src/EventStore.Native/EventStore.Native.csproj
@@ -7,6 +7,6 @@
 		<PackageReference Include="Mono.Posix.NETStandard" />
 	</ItemGroup>
 	<ItemGroup>
-	  <ProjectReference Include="..\EventStore.SystemRuntime\EventStore.SystemRuntime.csproj" />
+		<ProjectReference Include="..\EventStore.SystemRuntime\EventStore.SystemRuntime.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/EventStore.Projections.Core.XUnit.Tests/EventStore.Projections.Core.XUnit.Tests.csproj
+++ b/src/EventStore.Projections.Core.XUnit.Tests/EventStore.Projections.Core.XUnit.Tests.csproj
@@ -1,27 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\EventStore.Core.Tests\EventStore.Core.Tests.csproj" />
-      <ProjectReference Include="..\EventStore.Projections.Core\EventStore.Projections.Core.csproj" />
-    </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\EventStore.Core.Tests\EventStore.Core.Tests.csproj" />
+		<ProjectReference Include="..\EventStore.Projections.Core\EventStore.Projections.Core.csproj" />
+	</ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="coverlet.collector">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="Microsoft.NET.Test.Sdk" />
-      <PackageReference Include="xunit" />
-      <PackageReference Include="xunit.runner.visualstudio">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-    </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
 </Project>

--- a/src/EventStore.SystemRuntime.Tests/EventStore.SystemRuntime.Tests.csproj
+++ b/src/EventStore.SystemRuntime.Tests/EventStore.SystemRuntime.Tests.csproj
@@ -1,34 +1,34 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+	<PropertyGroup>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="coverlet.collector">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.runner.visualstudio">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="GitHubActionsTestLogger">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-    <ItemGroup>
-        <Using Include="Xunit" />
-    </ItemGroup>
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\EventStore.SystemRuntime\EventStore.SystemRuntime.csproj" />
-    </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\EventStore.SystemRuntime\EventStore.SystemRuntime.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/EventStore.SystemRuntime/EventStore.SystemRuntime.csproj
+++ b/src/EventStore.SystemRuntime/EventStore.SystemRuntime.csproj
@@ -7,9 +7,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="JetBrains.Annotations" />
-	  <PackageReference Include="Serilog" />
-	  <PackageReference Include="System.Diagnostics.PerformanceCounter" />
+		<PackageReference Include="JetBrains.Annotations" />
+		<PackageReference Include="Serilog" />
+		<PackageReference Include="System.Diagnostics.PerformanceCounter" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Keeps project files easier to scan while build metadata continues to change.
- Reduces noisy diffs from mixed XML indentation.