### PR TITLE
chore(core): trim redundant configuration parentheses

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -331,7 +331,7 @@ public class ClusterVNode<TStreamId> :
 			out var workerThreadsCount);
 
 		var trackers = new Trackers();
-		var metricsConfiguration = MetricsConfiguration.Get((configuration));
+		var metricsConfiguration = MetricsConfiguration.Get(configuration);
 		MetricsBootstrapper.Bootstrap(metricsConfiguration, dbConfig, trackers);
 
 		Db = new TFChunkDb(


### PR DESCRIPTION
- Keeps startup wiring straightforward while observability configuration continues to evolve.
- Removes a tiny readability papercut from a high-traffic initialization path.