### PR TITLE
fix(docs): repair docker build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ You can also build a Docker image by running the command:
 
 ```bash
 docker build --tag myeventstore . \
---build-arg CONTAINER_RUNTIME={container-runtime}
+--build-arg CONTAINER_RUNTIME={container-runtime} \
 --build-arg RUNTIME={runtime}
 ```
 


### PR DESCRIPTION
- Prevents the generic image build example from failing when copied directly.
- Keeps the documented command consistent with the working concrete example below it.