### PR TITLE
chore(testclient): remove stale warning suppressions

### DIFF
--- a/src/EventStore.TestClient/EventStore.TestClient.csproj
+++ b/src/EventStore.TestClient/EventStore.TestClient.csproj
@@ -4,9 +4,6 @@
 		<OutputType>Exe</OutputType>
 		<GenerateSupportedRuntime>false</GenerateSupportedRuntime>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-		<NoWarn>1701;1702;1591</NoWarn>
-	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="EventStore.Client" />
 		<PackageReference Include="EventStore.Client.Grpc.Streams" />


### PR DESCRIPTION
- Keeps the test client honest under the repository warning policy.
- Removes old suppression state that is no longer needed by the current toolchain.