### PR TITLE
chore(docs): singularize community heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ architectures.
 - [Documentation](#docs)
 - [Getting started with TrogonDB](#getting-started-with-trogondb)
 - [Client libraries](#client-libraries)
-- [Communities](#communities)
+- [Community](#community)
 - [Building TrogonDB](#building-trogondb)
 
 ## What is TrogonDB
@@ -65,7 +65,7 @@ Community supported gRPC clients
 - Elixir: [NFIBrokerage/spear](https://github.com/NFIBrokerage/spear)
 - Ruby: [yousty/event_store_client](https://github.com/yousty/event_store_client)
 
-## Communities
+## Community
 
 - [Discord](https://discord.gg/aPXg6p7TH5)
 


### PR DESCRIPTION
- Keeps the README navigation aligned with the single community entry it exposes.
- Removes a tiny polish issue from the first page new contributors see.