### PR TITLE
fix(test): stabilize cluster auth fixtures

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/MiniNodeLogging.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNodeLogging.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using Serilog;
 using Serilog.Core;
 using Serilog.Core.Enrichers;
+using Serilog.Events;
 using Serilog.Formatting.Display;
 using Serilog.Sinks.InMemory;
 
@@ -12,13 +13,18 @@ namespace EventStore.Core.Tests.Helpers;
 
 public static class MiniNodeLogging
 {
+	// A shared sink captures cluster callbacks that can write outside the test context.
+	private static readonly object SinkLock = new();
+	private static InMemorySink _inMemorySink = new();
 
-	private static readonly ILogger _logger = new LoggerConfiguration()
+	private static ILogger _logger = CreateLogger(_inMemorySink);
+
+	private static ILogger CreateLogger(InMemorySink sink) => new LoggerConfiguration()
 		.Enrich.WithProcessId()
 		.Enrich.WithThreadId()
 		.Enrich.FromLogContext()
 		.MinimumLevel.Debug()
-		.WriteTo.InMemory()
+		.WriteTo.Sink(sink)
 		.CreateLogger();
 
 	private const string Template =
@@ -26,7 +32,13 @@ public static class MiniNodeLogging
 
 	public static void Setup()
 	{
-		Serilog.Log.Logger = _logger;
+		lock (SinkLock)
+		{
+			_inMemorySink.Dispose();
+			_inMemorySink = new InMemorySink();
+			_logger = CreateLogger(_inMemorySink);
+			Serilog.Log.Logger = _logger;
+		}
 	}
 
 	public static void WriteLogs()
@@ -36,9 +48,15 @@ public static class MiniNodeLogging
 		var sb = new StringBuilder(256);
 		var f = new MessageTemplateTextFormatter(Template);
 		using var tw = new StringWriter(sb);
-		using var snapshot = InMemorySink.Instance.Snapshot();
+		LogEvent[] logEvents;
 
-		foreach (var e in snapshot.LogEvents.ToList())
+		lock (SinkLock)
+		{
+			using var snapshot = _inMemorySink.Snapshot();
+			logEvents = snapshot.LogEvents.ToArray();
+		}
+
+		foreach (var e in logEvents)
 		{
 			sb.Clear();
 			f.Format(e, tw);
@@ -50,7 +68,12 @@ public static class MiniNodeLogging
 
 	public static void Clear()
 	{
-		Serilog.Log.Logger = Logger.None;
-		InMemorySink.Instance.Dispose();
+		lock (SinkLock)
+		{
+			Serilog.Log.Logger = Logger.None;
+			_logger = Logger.None;
+			_inMemorySink.Dispose();
+			_inMemorySink = new InMemorySink();
+		}
 	}
 }

--- a/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
+++ b/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
@@ -9,6 +9,7 @@ using EventStore.Core.Data;
 using EventStore.Core.Tests.Helpers;
 using EventStore.Plugins.Subsystems;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 
 namespace EventStore.Core.Tests.Integration;
 
@@ -121,7 +122,7 @@ public abstract class specification_with_cluster<TLogFormat, TStreamId> : Specif
 		}
 		catch (TimeoutException ex)
 		{
-			if (_nodes.Select(x => x.Started).Count() < 2)
+			if (_nodes.Count(x => x.Started.IsCompletedSuccessfully) < 2)
 			{
 				MiniNodeLogging.WriteLogs();
 				throw new TimeoutException($"Cluster nodes did not start. Statuses: {_nodes[0].NodeState}/{_nodes[1].NodeState}/{_nodes[2].NodeState}", ex);
@@ -134,6 +135,8 @@ public abstract class specification_with_cluster<TLogFormat, TStreamId> : Specif
 			onFail: MiniNodeLogging.WriteLogs,
 			msg: "Waiting for leader timed out!");
 
+		await GetLeader().AdminUserCreated.WithTimeout(TimeSpan.FromMinutes(2), onFail: MiniNodeLogging.WriteLogs);
+
 		//flaky: most tests only need 1 follower, waiting for 2 causes timeouts
 		AssertEx.IsOrBecomesTrue(() =>
 				_nodes.Any(x => x.NodeState is VNodeState.Follower or VNodeState.ReadOnlyReplica),
@@ -144,7 +147,15 @@ public abstract class specification_with_cluster<TLogFormat, TStreamId> : Specif
 		_conn = CreateConnection();
 		await _conn.ConnectAsync();
 
-		await Given().WithTimeout(GivenTimeout, onFail: MiniNodeLogging.WriteLogs);
+		try
+		{
+			await Given().WithTimeout(GivenTimeout);
+		}
+		catch
+		{
+			MiniNodeLogging.WriteLogs();
+			throw;
+		}
 	}
 
 	protected virtual IEventStoreConnection CreateConnection() =>
@@ -163,6 +174,15 @@ public abstract class specification_with_cluster<TLogFormat, TStreamId> : Specif
 		PathName, index, endpoints.InternalTcp,
 		endpoints.ExternalTcp, endpoints.HttpEndPoint,
 		subsystems: Array.Empty<ISubsystem>(), gossipSeeds: gossipSeeds);
+
+	[TearDown]
+	public void AfterEachTest()
+	{
+		if (TestContext.CurrentContext.Result.Outcome.Status is TestStatus.Failed)
+		{
+			MiniNodeLogging.WriteLogs();
+		}
+	}
 
 	[OneTimeTearDown]
 	public override async Task TestFixtureTearDown()

--- a/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
+++ b/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
@@ -35,7 +35,7 @@ public class when_restarting_one_node_at_a_time<TLogFormat, TStreamId> : specifi
 				},
 				i == 0 ? InitialStabilizationTimeout : RestartTimeout,
 				$"Cluster did not stabilize before restart iteration {i + 1}",
-				MiniNodeLogging.WriteLogs);
+				WriteClusterLogs);
 
 			var restartedNodeIndex = SelectRestartNode(restartedNodes, restartLeader: i == RestartCount - 1);
 			restartedNodes[restartedNodeIndex] = true;
@@ -53,7 +53,7 @@ public class when_restarting_one_node_at_a_time<TLogFormat, TStreamId> : specifi
 				},
 				RestartTimeout,
 				$"Remaining cluster did not stabilize after shutting down node {restartedNodeIndex}",
-				MiniNodeLogging.WriteLogs);
+				WriteClusterLogs);
 
 			var node = CreateNode(restartedNodeIndex, _nodeEndpoints[restartedNodeIndex], GossipSeedsFor(restartedNodeIndex));
 			node.Start();
@@ -68,8 +68,14 @@ public class when_restarting_one_node_at_a_time<TLogFormat, TStreamId> : specifi
 				},
 				RestartTimeout,
 				$"Cluster did not stabilize after restarting node {restartedNodeIndex}",
-				MiniNodeLogging.WriteLogs);
+				WriteClusterLogs);
 		}
+	}
+
+	private void WriteClusterLogs()
+	{
+		TestContext.Error.WriteLine($"Cluster states: {string.Join(", ", _nodes.Select(x => x.NodeState))}");
+		MiniNodeLogging.WriteLogs();
 	}
 
 	private int SelectRestartNode(bool[] restartedNodes, bool restartLeader)

--- a/src/EventStore.Core.XUnit.Tests/xunit.runner.json
+++ b/src/EventStore.Core.XUnit.Tests/xunit.runner.json
@@ -1,4 +1,5 @@
 {
 	"$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+	"parallelAlgorithm": "conservative",
 	"maxParallelThreads": -1
 }


### PR DESCRIPTION
- Cluster authentication tests should wait for the leader to be ready before follower-forwarded requests assert authorization behavior.
- Failed mini-cluster runs should leave enough diagnostic context to debug CI flakes without rerunning blindly.
- xUnit should use the current concurrency defaults now that the runner supports the safer scheduling algorithm.