### PR TITLE
fix(runtime): tolerate missing linux io stats

### DIFF
--- a/src/EventStore.SystemRuntime.Tests/ProcessStatsTests.cs
+++ b/src/EventStore.SystemRuntime.Tests/ProcessStatsTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO;
 
 namespace EventStore.SystemRuntime.Tests;
 
@@ -39,6 +40,16 @@ public class ProcessStatsTests
 			writtenBytes: 0,
 			readOps: 0,
 			writeOps: 0), result);
+	}
+
+	[Fact]
+	public void linux_reader_returns_default_when_proc_io_file_is_missing()
+	{
+		var missingPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "io");
+
+		var result = ProcessStats.GetDiskIoLinux(missingPath);
+
+		Assert.Equal(default, result);
 	}
 
 	[Fact]

--- a/src/EventStore.SystemRuntime/Diagnostics/ProcessStats.cs
+++ b/src/EventStore.SystemRuntime/Diagnostics/ProcessStats.cs
@@ -32,18 +32,7 @@ public static class ProcessStats
 		};
 
 		static DiskIoData GetDiskIoLinux(Process process)
-		{
-			var procIoFile = $"/proc/{process.Id}/io";
-
-			try
-			{
-				return ParseLinuxDiskIo(File.ReadLines(procIoFile));
-			}
-			catch (Exception ex)
-			{
-				throw new ApplicationException("Failed to get Linux process I/O info", ex);
-			}
-		}
+			=> ProcessStats.GetDiskIoLinux($"/proc/{process.Id}/io");
 
 		static DiskIoData GetDiskIoOsx(Process process) =>
 			OsxNative.IO.GetDiskIo(process.Id);
@@ -54,6 +43,23 @@ public static class ProcessStats
 
 	public static DiskIoData GetDiskIo() =>
 		GetDiskIo(Process.GetCurrentProcess());
+
+	internal static DiskIoData GetDiskIoLinux(string procIoFile)
+	{
+		if (!File.Exists(procIoFile))
+		{
+			return default;
+		}
+
+		try
+		{
+			return ParseLinuxDiskIo(File.ReadLines(procIoFile));
+		}
+		catch (Exception ex)
+		{
+			throw new ApplicationException("Failed to get Linux process I/O info", ex);
+		}
+	}
 
 	internal static DiskIoData ParseLinuxDiskIo(IEnumerable<string> lines)
 	{


### PR DESCRIPTION
- Some Linux kernels can omit process I/O stats, and monitoring should keep serving default counters instead of failing the runtime stats path.