### PR TITLE
fix(test): decouple mininode continuations

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -51,8 +51,8 @@ public class MiniClusterNode<TLogFormat, TStreamId>
 	public TFChunkDb Db => Node.Db;
 	private readonly string _dbPath;
 	private readonly bool _isReadOnlyReplica;
-	private readonly TaskCompletionSource<bool> _started = new();
-	private readonly TaskCompletionSource<bool> _adminUserCreated = new();
+	private readonly TaskCompletionSource<bool> _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+	private readonly TaskCompletionSource<bool> _adminUserCreated = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
 	public Task Started => _started.Task;
 	public Task AdminUserCreated => _adminUserCreated.Task;

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -265,8 +265,8 @@ public class MiniNode<TLogFormat, TStreamId> : MiniNode, IAsyncDisposable
 			})
 			.Start();
 		_kestrelTestServer = _kestrelTestHost.GetTestServer();
-		_started = new TaskCompletionSource<bool>();
-		_adminUserCreated = new TaskCompletionSource<bool>();
+		_started = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+		_adminUserCreated = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 		HttpMessageHandler = _kestrelTestServer.CreateHandler();
 		HttpClient = new HttpClient(HttpMessageHandler)
 		{


### PR DESCRIPTION
- Mini-cluster tests should not let await continuations run inline on node lifecycle callback paths, because that makes callback latency and test scheduling influence each other under load.