### PR TITLE
fix(projections): report missing native handler types

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/Management/ProjectionStateHandlerFactoryTests.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/Management/ProjectionStateHandlerFactoryTests.cs
@@ -1,0 +1,20 @@
+using System;
+using EventStore.Projections.Core.Services.Management;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.Management;
+
+[TestFixture]
+public class ProjectionStateHandlerFactoryTests
+{
+	[Test]
+	public void missing_native_handler_type_reports_the_requested_type()
+	{
+		var factory = new ProjectionStateHandlerFactory(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+
+		var ex = Assert.Throws<NotSupportedException>(() =>
+			factory.Create("native:EventStore.Projections.Core.MissingProjectionHandler", "", false, null));
+
+		Assert.That(ex.Message, Does.Contain("EventStore.Projections.Core.MissingProjectionHandler"));
+	}
+}

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionStateHandlerFactory.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionStateHandlerFactory.cs
@@ -49,11 +49,15 @@ public class ProjectionStateHandlerFactory
 				var type = Type.GetType(rest);
 				if (type == null)
 				{
-					//TODO: explicitly list all the assemblies to look for handlers
 					type =
 						AppDomain.CurrentDomain.GetAssemblies()
 							.Select(v => v.GetType(rest))
 							.FirstOrDefault(v => v != null);
+				}
+
+				if (type == null)
+				{
+					throw new NotSupportedException($"Could not find projection handler type \"{rest}\".");
 				}
 
 				var handler = Activator.CreateInstance(type, source, logger);


### PR DESCRIPTION
- Operators need the original projection handler identity when startup fails so the configuration problem can be corrected without chasing a generic reflection failure.