### PR TITLE
fix(projections): identify unwrap envelope work

### DIFF
--- a/src/EventStore.Projections.Core/Messaging/PublishToWrapEnvelop.cs
+++ b/src/EventStore.Projections.Core/Messaging/PublishToWrapEnvelop.cs
@@ -6,16 +6,18 @@ namespace EventStore.Projections.Core.Messaging;
 class PublishToWrapEnvelop : IEnvelope
 {
 	private readonly IPublisher _publisher;
-	private readonly IEnvelope _nestedEnevelop;
+	private readonly IEnvelope _nestedEnvelope;
+	private readonly string _extraInformation;
 
-	public PublishToWrapEnvelop(IPublisher publisher, IEnvelope nestedEnevelop)
+	public PublishToWrapEnvelop(IPublisher publisher, IEnvelope nestedEnvelope, string extraInformation)
 	{
 		_publisher = publisher;
-		_nestedEnevelop = nestedEnevelop;
+		_nestedEnvelope = nestedEnvelope;
+		_extraInformation = extraInformation;
 	}
 
 	public void ReplyWith<T>(T message) where T : Message
 	{
-		_publisher.Publish(new UnwrapEnvelopeMessage(() => _nestedEnevelop.ReplyWith(message)));
+		_publisher.Publish(new UnwrapEnvelopeMessage(() => _nestedEnvelope.ReplyWith(message), _extraInformation));
 	}
 }

--- a/src/EventStore.Projections.Core/Messaging/UnwrapEnvelopeMessage.cs
+++ b/src/EventStore.Projections.Core/Messaging/UnwrapEnvelopeMessage.cs
@@ -8,14 +8,21 @@ namespace EventStore.Projections.Core.Messaging;
 public partial class UnwrapEnvelopeMessage : Message
 {
 	private readonly Action _action;
+	private readonly string _extraInformation;
 
-	public UnwrapEnvelopeMessage(Action action)
+	public UnwrapEnvelopeMessage(Action action, string extraInformation)
 	{
 		_action = action;
+		_extraInformation = extraInformation;
 	}
 
 	public Action Action
 	{
 		get { return _action; }
+	}
+
+	public override string ToString()
+	{
+		return $"{base.ToString()}, Extra Information: {_extraInformation}";
 	}
 }

--- a/src/EventStore.Projections.Core/Services/Processing/MultiStream/MultiStreamEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/MultiStream/MultiStreamEventReader.cs
@@ -108,7 +108,7 @@ public class MultiStreamEventReader : EventReader,
 			_publisher.Publish(
 				TimerMessage.Schedule.Create(
 					TimeSpan.FromMilliseconds(250), _publisher,
-					new UnwrapEnvelopeMessage(ProcessBuffers2)));
+					new UnwrapEnvelopeMessage(ProcessBuffers2, nameof(ProcessBuffers2))));
 		}
 
 		foreach (var stream in _streams)

--- a/src/EventStore.Projections.Core/Services/Processing/Phases/EventSubscriptionBasedProjectionProcessingPhase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Phases/EventSubscriptionBasedProjectionProcessingPhase.cs
@@ -170,7 +170,9 @@ public abstract partial class EventSubscriptionBasedProjectionProcessingPhase : 
 			TimerMessage.Schedule.Create(
 				_updateInterval,
 				_inutQueueEnvelope,
-				new UnwrapEnvelopeMessage(MarkTicketReceivedAndUpdateStatistics)));
+				new UnwrapEnvelopeMessage(
+					MarkTicketReceivedAndUpdateStatistics,
+					nameof(MarkTicketReceivedAndUpdateStatistics))));
 	}
 
 	private void MarkTicketReceivedAndUpdateStatistics()

--- a/src/EventStore.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
@@ -20,19 +20,22 @@ public class RequestResponseQueueForwarder(IPublisher inputQueue, IPublisher ext
 	public void Handle(ClientMessage.ReadEvent msg) =>
 		externalRequestQueue.Publish(
 			new ClientMessage.ReadEvent(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(inputQueue, msg.Envelope),
+				msg.InternalCorrId, msg.CorrelationId,
+				new PublishToWrapEnvelop(inputQueue, msg.Envelope, nameof(ClientMessage.ReadEvent)),
 				msg.EventStreamId, msg.EventNumber, msg.ResolveLinkTos, msg.RequireLeader, msg.User));
 
 	public void Handle(ClientMessage.WriteEvents msg) =>
 		externalRequestQueue.Publish(
 			new ClientMessage.WriteEvents(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(inputQueue, msg.Envelope), true,
+				msg.InternalCorrId, msg.CorrelationId,
+				new PublishToWrapEnvelop(inputQueue, msg.Envelope, nameof(ClientMessage.WriteEvents)), true,
 				msg.EventStreamId, msg.ExpectedVersion, msg.Events, msg.User));
 
 	public void Handle(ClientMessage.DeleteStream msg) =>
 		externalRequestQueue.Publish(
 			new ClientMessage.DeleteStream(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(inputQueue, msg.Envelope), true,
+				msg.InternalCorrId, msg.CorrelationId,
+				new PublishToWrapEnvelop(inputQueue, msg.Envelope, nameof(ClientMessage.DeleteStream)), true,
 				msg.EventStreamId, msg.ExpectedVersion, msg.HardDelete, msg.User));
 
 	// Historically, message forwarding here has discarded the original Expiration value,
@@ -45,7 +48,8 @@ public class RequestResponseQueueForwarder(IPublisher inputQueue, IPublisher ext
 	public void Handle(ClientMessage.ReadStreamEventsBackward msg) =>
 		externalRequestQueue.Publish(
 			new ClientMessage.ReadStreamEventsBackward(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(inputQueue, msg.Envelope),
+				msg.InternalCorrId, msg.CorrelationId,
+				new PublishToWrapEnvelop(inputQueue, msg.Envelope, nameof(ClientMessage.ReadStreamEventsBackward)),
 				msg.EventStreamId, msg.FromEventNumber, msg.MaxCount, msg.ResolveLinkTos, msg.RequireLeader,
 				msg.ValidationStreamVersion, msg.User,
 				expires: msg.Expires == DateTime.MaxValue ? msg.Expires : null));
@@ -53,7 +57,8 @@ public class RequestResponseQueueForwarder(IPublisher inputQueue, IPublisher ext
 	public void Handle(ClientMessage.ReadStreamEventsForward msg) =>
 		externalRequestQueue.Publish(
 			new ClientMessage.ReadStreamEventsForward(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(inputQueue, msg.Envelope),
+				msg.InternalCorrId, msg.CorrelationId,
+				new PublishToWrapEnvelop(inputQueue, msg.Envelope, nameof(ClientMessage.ReadStreamEventsForward)),
 				msg.EventStreamId, msg.FromEventNumber, msg.MaxCount, msg.ResolveLinkTos, msg.RequireLeader,
 				msg.ValidationStreamVersion, msg.User, replyOnExpired: false,
 				expires: msg.Expires == DateTime.MaxValue ? msg.Expires : null));
@@ -61,7 +66,8 @@ public class RequestResponseQueueForwarder(IPublisher inputQueue, IPublisher ext
 	public void Handle(ClientMessage.ReadAllEventsForward msg) =>
 		externalRequestQueue.Publish(
 			new ClientMessage.ReadAllEventsForward(
-				msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(inputQueue, msg.Envelope),
+				msg.InternalCorrId, msg.CorrelationId,
+				new PublishToWrapEnvelop(inputQueue, msg.Envelope, nameof(ClientMessage.ReadAllEventsForward)),
 				msg.CommitPosition, msg.PreparePosition, msg.MaxCount, msg.ResolveLinkTos, msg.RequireLeader,
 				msg.ValidationTfLastCommitPosition, msg.User, replyOnExpired: false));
 


### PR DESCRIPTION
- Slow queue diagnostics need to identify the projection callback being resumed so operators can distinguish reader, checkpoint, and statistics delays.