### PR TITLE
fix(docs): correct node priority environment variable

### DIFF
--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -237,7 +237,7 @@ You can control which clones the cluster promotes with the `NodePriority` settin
 |:---------------------|:--------------------------|
 | Command line         | `--node-priority`         |
 | YAML                 | `NodePriority`            |
-| Environment variable | `EVENTSTORE_NODE_PRORITY` |
+| Environment variable | `EVENTSTORE_NODE_PRIORITY` |
 
 **Default**: `0`.
 


### PR DESCRIPTION
- Operators copying the setting name from the cluster guide need the environment variable to be spelled correctly.