### PR TITLE
chore(runtime): enable server garbage collection

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,7 +110,7 @@ $ eventstored --what-if
 [68443, 1,17:38:39.186,INF] "OS ARCHITECTURE:"        X64 
 [68443, 1,17:38:39.207,INF] "OS:"                     Linux ("Unix 5.19.0.1025")
 [68443, 1,17:38:39.210,INF] "RUNTIME:"                ".NET 6.0.21/e40b3abf1" (64-bit)
-[68443, 1,17:38:39.211,INF] "GC:"                     "3 GENERATIONS" "IsServerGC: False" "Latency Mode: Interactive"
+[68443, 1,17:38:39.211,INF] "GC:"                     "3 GENERATIONS" "IsServerGC: True" "Latency Mode: Interactive"
 [68443, 1,17:38:39.212,INF] "LOGS:"                   "/var/log/eventstore"
 [68443, 1,17:38:39.251,INF] 
 MODIFIED OPTIONS:

--- a/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
+++ b/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
@@ -4,8 +4,11 @@
 		<OutputType>Exe</OutputType>
 		<ApplicationIcon>app2.ico</ApplicationIcon>
 		<GenerateSupportedRuntime>false</GenerateSupportedRuntime>
-		<ServerGarbageCollection>false</ServerGarbageCollection>
+		<ServerGarbageCollection>true</ServerGarbageCollection>
 	</PropertyGroup>
+	<ItemGroup>
+		<RuntimeHostConfigurationOption Include="System.GC.HeapHardLimitPercent" Value="60" />
+	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="SharpDotYaml.Extensions.Configuration" />
 		<PackageReference Include="System.ComponentModel.Composition" />


### PR DESCRIPTION
- Production nodes need predictable garbage-collection behavior and a bounded managed heap budget so memory pressure is less likely to become an availability incident.