### PR TITLE
fix(storage): guard failed seq read eof state

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/read_results_should.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/read_results_should.cs
@@ -1,0 +1,20 @@
+using EventStore.Core.TransactionLog;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog;
+
+[TestFixture]
+public class read_results_should
+{
+	[Test]
+	public void report_eof_for_failed_sequential_reads()
+	{
+		Assert.Multiple(() =>
+		{
+			Assert.False(SeqReadResult.Failure.Success);
+			Assert.True(SeqReadResult.Failure.Eof);
+			Assert.AreEqual(-1, SeqReadResult.Failure.RecordPrePosition);
+			Assert.AreEqual(-1, SeqReadResult.Failure.RecordPostPosition);
+		});
+	}
+}


### PR DESCRIPTION
- Transaction-log readers rely on the failed-read sentinel to stop cleanly, so the EOF contract needs an executable guard against accidental regression.