### PR TITLE
fix(config): guard removed first-level auth option

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
@@ -50,6 +50,16 @@ public class ClusterVNodeOptionsTests
 	}
 
 	[Fact]
+	public void removed_first_level_http_authorization_option_is_unknown()
+	{
+		var options = GetOptions("--disable-first-level-http-authorization true");
+
+		var (key, value) = options.Unknown.Options[0];
+		Assert.Equal("DisableFirstLevelHttpAuthorization", key);
+		Assert.Equal("", value);
+	}
+
+	[Fact]
 	public void valid_parameters()
 	{
 		var options = GetOptions("--cluster-size 3");


### PR DESCRIPTION
- Removed security switches should fail loudly so stale configuration cannot create a false sense of protection.