### PR TITLE
fix(projections): cover transformed javascript results

### DIFF
--- a/src/EventStore.Projections.Core.Javascript.Tests/EventStore.Projections.Core.Javascript.Tests.csproj
+++ b/src/EventStore.Projections.Core.Javascript.Tests/EventStore.Projections.Core.Javascript.Tests.csproj
@@ -4,21 +4,10 @@
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 	<ItemGroup>
-		<None Remove="Specs\account-balancer.js" />
-		<None Remove="Specs\account-closer.js" />
-		<None Remove="Specs\by-category-spec.json" />
-		<None Remove="Specs\by-category.js" />
-		<None Remove="Specs\event-data.js" />
-		<None Remove="Specs\event-data-spec.json" />
+		<None Remove="Specs\*" />
 	</ItemGroup>
 	<ItemGroup>
-		<EmbeddedResource Include="Specs\account-balancer.js" />
-		<EmbeddedResource Include="Specs\account-closer.js" />
-		<EmbeddedResource Include="Specs\by-category-spec.json" />
-		<EmbeddedResource Include="Specs\by-category.js" />
-		<EmbeddedResource Include="Specs\event-data.js" />
-		<EmbeddedResource Include="Specs\event-data-spec.json" />
-		<EmbeddedResource Include="Specs\account-spec.json" />
+		<EmbeddedResource Include="Specs\*" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="GitHubActionsTestLogger" />

--- a/src/EventStore.Projections.Core.Javascript.Tests/SpecRunner.cs
+++ b/src/EventStore.Projections.Core.Javascript.Tests/SpecRunner.cs
@@ -86,18 +86,30 @@ public class SpecRunner
 						}
 					}
 					var expectedStates = new Dictionary<string, string?>();
+					var expectedResults = new Dictionary<string, string?>();
 					int stateCount = 0;
 					if (e.TryGetProperty("states", out var states))
 					{
 						foreach (var state in states.EnumerateArray())
 						{
 							stateCount++;
+							var partition = state.GetProperty("partition").GetString()!;
 							var expectedStateNode = state.GetProperty("state");
 							var expectedState = expectedStateNode.ValueKind == JsonValueKind.Null ? null : expectedStateNode.GetRawText();
-							if (!expectedStates.TryAdd(state.GetProperty("partition").GetString()!,
-								expectedState))
+							if (!expectedStates.TryAdd(partition, expectedState))
 							{
 								throw new InvalidOperationException("Duplicate state");
+							}
+
+							if (state.TryGetProperty("result", out var expectedResultNode))
+							{
+								var expectedResult = expectedResultNode.ValueKind == JsonValueKind.Null
+									? null
+									: expectedResultNode.GetRawText();
+								if (!expectedResults.TryAdd(partition, expectedResult))
+								{
+									throw new InvalidOperationException("Duplicate result");
+								}
 							}
 						}
 					}
@@ -106,7 +118,18 @@ public class SpecRunner
 						throw new InvalidOperationException("Cannot specify more than 2 states");
 					}
 
-					sequence.Events.Add(new InputEvent(et!, e.GetProperty("data").GetRawText(), e.TryGetProperty("metadata", out var metadata) ? metadata.GetRawText() : null, initializedPartitions, expectedStates, skip, e.TryGetProperty("eventId", out var idElement) && idElement.TryGetGuid(out var id) ? id : Guid.NewGuid()));
+					sequence.Events.Add(
+						new InputEvent(
+							et!,
+							e.GetProperty("data").GetRawText(),
+							e.TryGetProperty("metadata", out var metadata) ? metadata.GetRawText() : null,
+							initializedPartitions,
+							expectedStates,
+							expectedResults,
+							skip,
+							e.TryGetProperty("eventId", out var idElement) && idElement.TryGetGuid(out var id)
+								? id
+								: Guid.NewGuid()));
 				}
 			}
 
@@ -252,6 +275,7 @@ public class SpecRunner
 			yield return For($"{projection} qs.ProcessingLagOption", () => Assert.Equal(expectedDefinition.ProcessingLagOption, definition.ProcessingLagOption));
 			yield return For($"{projection} qs.LimitingCommitPosition", () => Assert.Equal(expectedDefinition.LimitingCommitPosition, definition.LimitingCommitPosition));
 			var partitionedState = new Dictionary<string, string>();
+			var partitionedResult = new Dictionary<string, string>();
 			var sharedStateInitialized = false;
 			var revision = new Dictionary<string, long>();
 			List<EmittedEventEnvelope> actualEmittedEvents = new();
@@ -389,6 +413,11 @@ public class SpecRunner
 									}
 
 									partitionedState[expectedPartition] = newState;
+									if (@event.ExpectedResults.Any())
+									{
+										partitionedResult[expectedPartition] = runner.TransformStateToResult();
+									}
+
 									if (emittedEvents != null && emittedEvents.Length > 0)
 									{
 										actualEmittedEvents.AddRange(emittedEvents);
@@ -417,6 +446,35 @@ public class SpecRunner
 												Assert.NotEmpty(partitionedState[expectedState.Key]);
 												var expected = Sort(expectedState.Value, "expected");
 												var actual = Sort(partitionedState[expectedState.Key], "actual");
+												Assert.Equal(expected.ToString(Formatting.Indented),
+													actual.ToString(Formatting.Indented));
+											}
+										});
+								}
+							}
+							if (@event.ExpectedResults.Any())
+							{
+								foreach (var expectedResult in @event.ExpectedResults)
+								{
+									yield return For(
+										$"result \"{expectedResult.Key}\" exists at {er.EventNumber}@{sequence.Stream}",
+										() => Assert.Contains(expectedResult.Key,
+											(IReadOnlyDictionary<string, string>)partitionedResult));
+									yield return For(
+										$"result \"{expectedResult.Key}\" is correct at {er.EventNumber}@{sequence.Stream}",
+										() =>
+										{
+											if (string.IsNullOrEmpty(expectedResult.Value))
+											{
+												Assert.Null(partitionedResult[expectedResult.Key]);
+											}
+											else
+											{
+												Assert.True(partitionedResult.ContainsKey(expectedResult.Key), $"partition does not contain key {expectedResult.Key}");
+												Assert.NotNull(partitionedResult[expectedResult.Key]);
+												Assert.NotEmpty(partitionedResult[expectedResult.Key]);
+												var expected = Sort(expectedResult.Value, "expected");
+												var actual = Sort(partitionedResult[expectedResult.Key], "actual");
 												Assert.Equal(expected.ToString(Formatting.Indented),
 													actual.ToString(Formatting.Indented));
 											}
@@ -543,16 +601,26 @@ public class SpecRunner
 		public string Metadata { get; }
 		public IReadOnlyList<string> InitializedPartitions { get; }
 		public IReadOnlyDictionary<string, string> ExpectedStates { get; }
+		public IReadOnlyDictionary<string, string> ExpectedResults { get; }
 		public bool Skip { get; }
 		public Guid EventId { get; }
 
-		public InputEvent(string eventType, string body, string metadata, IReadOnlyList<string> initializedPartitions, IReadOnlyDictionary<string, string> expectedStates, bool skip, Guid eventId)
+		public InputEvent(
+			string eventType,
+			string body,
+			string metadata,
+			IReadOnlyList<string> initializedPartitions,
+			IReadOnlyDictionary<string, string> expectedStates,
+			IReadOnlyDictionary<string, string> expectedResults,
+			bool skip,
+			Guid eventId)
 		{
 			EventType = eventType;
 			Body = body;
 			Metadata = metadata;
 			InitializedPartitions = initializedPartitions;
 			ExpectedStates = expectedStates;
+			ExpectedResults = expectedResults;
 			Skip = skip;
 			EventId = eventId;
 		}

--- a/src/EventStore.Projections.Core.Javascript.Tests/Specs/state-with-null-result-spec.json
+++ b/src/EventStore.Projections.Core.Javascript.Tests/Specs/state-with-null-result-spec.json
@@ -1,0 +1,53 @@
+{
+	"projection": "state-with-null-result",
+	"input": [
+		{
+			"streamId": "state-with-null-result",
+			"events": [
+				{
+					"eventType": "tested",
+					"data": {},
+					"metadata": {},
+					"initializedPartitions": [""],
+					"states": [
+						{
+							"partition": "",
+							"state": { "items": [0] },
+							"result": null
+						}
+					]
+				},
+				{
+					"eventType": "tested",
+					"data": {},
+					"metadata": {},
+					"states": [
+						{
+							"partition": "",
+							"state": { "items": [0, 1] },
+							"result": null
+						}
+					]
+				}
+			]
+		}
+	],
+	"output": {
+		"config": {
+			"categories": [],
+			"allStreams": true,
+			"events": ["tested"],
+			"partitioned": false,
+			"definesStateTransform": true,
+			"handlesDeletedNotifications": false,
+			"producesResults": true,
+			"definesFold": true,
+			"resultStreamName": "",
+			"partitionResultStreamNamePattern": null,
+			"$includeLinks": false,
+			"reorderEvents": false,
+			"processingLag": 0,
+			"biState": false
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Javascript.Tests/Specs/state-with-null-result.js
+++ b/src/EventStore.Projections.Core.Javascript.Tests/Specs/state-with-null-result.js
@@ -1,0 +1,6 @@
+fromAll()
+	.when({
+		$init: function () { return { items: [] }; },
+		tested: function (state, event) { state.items[event.sequenceNumber] = event.sequenceNumber; },
+	})
+	.transformBy(function () { return null; });

--- a/src/EventStore.Projections.Core.Javascript.Tests/Specs/with-result-spec.json
+++ b/src/EventStore.Projections.Core.Javascript.Tests/Specs/with-result-spec.json
@@ -1,0 +1,53 @@
+{
+	"projection": "with-result",
+	"input": [
+		{
+			"streamId": "with-result",
+			"events": [
+				{
+					"eventType": "tested",
+					"data": {},
+					"metadata": {},
+					"initializedPartitions": [""],
+					"states": [
+						{
+							"partition": "",
+							"state": { "count": 1 },
+							"result": { "total": 1 }
+						}
+					]
+				},
+				{
+					"eventType": "tested",
+					"data": {},
+					"metadata": {},
+					"states": [
+						{
+							"partition": "",
+							"state": { "count": 2 },
+							"result": { "total": 2 }
+						}
+					]
+				}
+			]
+		}
+	],
+	"output": {
+		"config": {
+			"categories": [],
+			"allStreams": true,
+			"events": ["tested"],
+			"partitioned": false,
+			"definesStateTransform": true,
+			"handlesDeletedNotifications": false,
+			"producesResults": true,
+			"definesFold": true,
+			"resultStreamName": "",
+			"partitionResultStreamNamePattern": null,
+			"$includeLinks": false,
+			"reorderEvents": false,
+			"processingLag": 0,
+			"biState": false
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Javascript.Tests/Specs/with-result.js
+++ b/src/EventStore.Projections.Core.Javascript.Tests/Specs/with-result.js
@@ -1,0 +1,6 @@
+fromAll()
+	.when({
+		$init: function () { return { count: 0 }; },
+		tested: function (state) { state.count++; },
+	})
+	.transformBy(function (state) { return { total: state.count }; });


### PR DESCRIPTION
- Projection JavaScript specs need to catch result-transform regressions, not only state regressions, because operators consume transformed output as the public projection result.