### PR TITLE
fix(test): serialize scavenge scenario fixtures

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Sqlite/SqliteDbPerTest.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Sqlite/SqliteDbPerTest.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace EventStore.Core.XUnit.Tests.Scavenge.Sqlite;
 
+[Collection("ScavengeScenarioTests")]
 public class SqliteDbPerTest<T> : IAsyncLifetime
 {
 	protected SqliteDbFixture<T> Fixture { get; }


### PR DESCRIPTION
- ARM64 runners can starve background index work when several scavenge scenario fixtures execute at once.
- Keeping those fixtures in one test collection protects master from architecture-specific timing noise without changing production shutdown behavior.