### PR TITLE
fix(storage): wake readers after empty transaction eof

### DIFF
--- a/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_committer_service_commits_empty_transaction_at_end_of_log.cs
+++ b/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_committer_service_commits_empty_transaction_at_end_of_log.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading.Tasks;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.Checkpoint;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.IndexCommitter;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class when_index_committer_service_commits_empty_transaction_at_end_of_log<TLogFormat, TStreamId> : with_index_committer_service<TLogFormat, TStreamId>
+{
+	private readonly Guid _correlationId = Guid.NewGuid();
+	private readonly long _logPrePosition = 4000;
+	private readonly long _logPostPosition = 4001;
+
+	public override Task TestFixtureSetUp()
+	{
+		ReplicationCheckpoint = new InMemoryCheckpoint(0);
+		return base.TestFixtureSetUp();
+	}
+
+	public override void Given() { }
+
+	public override void When()
+	{
+		WriterCheckpoint.Write(_logPostPosition);
+		WriterCheckpoint.Flush();
+
+		Service.AddPendingPrepare(_logPrePosition, [], _logPostPosition);
+		Service.Handle(new StorageMessage.CommitAck(_correlationId, _logPrePosition, _logPrePosition, 0, 0));
+
+		ReplicationCheckpoint.Write(_logPostPosition);
+		ReplicationCheckpoint.Flush();
+		Service.Handle(new ReplicationTrackingMessage.ReplicatedTo(_logPostPosition));
+	}
+
+	[Test]
+	public void commit_replicated_message_should_have_been_published()
+	{
+		AssertEx.IsOrBecomesTrue(() => 1 == CommitReplicatedMgs.Count);
+	}
+
+	[Test]
+	public void index_written_message_should_have_been_published()
+	{
+		AssertEx.IsOrBecomesTrue(() => 1 == IndexWrittenMgs.Count);
+	}
+
+	[Test]
+	public void tf_eof_notification_should_have_been_published()
+	{
+		AssertEx.IsOrBecomesTrue(() => 1 == TfEofAtNonCommitRecordMgs.Count);
+	}
+}

--- a/src/EventStore.Core.Tests/Services/IndexCommitter/with_index_committer_service.cs
+++ b/src/EventStore.Core.Tests/Services/IndexCommitter/with_index_committer_service.cs
@@ -26,6 +26,7 @@ public abstract class with_index_committer_service<TLogFormat, TStreamId>
 	protected SynchronousScheduler Publisher = new("publisher");
 	protected ConcurrentQueue<StorageMessage.CommitIndexed> CommitReplicatedMgs = new ConcurrentQueue<StorageMessage.CommitIndexed>();
 	protected ConcurrentQueue<ReplicationTrackingMessage.IndexedTo> IndexWrittenMgs = new ConcurrentQueue<ReplicationTrackingMessage.IndexedTo>();
+	protected ConcurrentQueue<StorageMessage.TfEofAtNonCommitRecord> TfEofAtNonCommitRecordMgs = new();
 
 	protected IndexCommitterService<TStreamId> Service;
 	protected FakeIndexCommitter<TStreamId> IndexCommitter;
@@ -43,6 +44,7 @@ public abstract class with_index_committer_service<TLogFormat, TStreamId>
 		await Service.Init(0, CancellationToken.None);
 		Publisher.Subscribe(new AdHocHandler<StorageMessage.CommitIndexed>(m => CommitReplicatedMgs.Enqueue(m)));
 		Publisher.Subscribe(new AdHocHandler<ReplicationTrackingMessage.IndexedTo>(m => IndexWrittenMgs.Enqueue(m)));
+		Publisher.Subscribe(new AdHocHandler<StorageMessage.TfEofAtNonCommitRecord>(m => TfEofAtNonCommitRecordMgs.Enqueue(m)));
 		Publisher.Subscribe<ReplicationTrackingMessage.ReplicatedTo>(Service);
 		Given();
 
@@ -61,7 +63,7 @@ public abstract class with_index_committer_service<TLogFormat, TStreamId>
 	{
 		postPosition = postPosition == -1 ? transactionPosition : postPosition;
 		var prepare = CreatePrepare(transactionPosition, transactionPosition);
-		Service.AddPendingPrepare(new[] { prepare }, postPosition);
+		Service.AddPendingPrepare(transactionPosition, new[] { prepare }, postPosition);
 	}
 
 	protected void AddPendingPrepares(long transactionPosition, long[] logPositions)
@@ -72,7 +74,7 @@ public abstract class with_index_committer_service<TLogFormat, TStreamId>
 			prepares.Add(CreatePrepare(transactionPosition, pos));
 		}
 
-		Service.AddPendingPrepare(prepares.ToArray(), logPositions[^1]);
+		Service.AddPendingPrepare(transactionPosition, prepares.ToArray(), logPositions[^1]);
 	}
 
 	private IPrepareLogRecord<TStreamId> CreatePrepare(long transactionPosition, long logPosition)

--- a/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_commit_event.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_commit_event.cs
@@ -40,7 +40,7 @@ public class when_chaser_reads_commit_event<TLogFormat, TStreamId> : with_storag
 		Assert.True(written);
 		await Writer.Flush(token);
 
-		IndexCommitter.AddPendingPrepare(new[] { record }, _logPosition);
+		IndexCommitter.AddPendingPrepare(record.TransactionPosition, new[] { record }, _logPosition);
 		var record2 = new CommitLogRecord(
 			logPosition: _logPosition,
 			correlationId: _transactionId,

--- a/src/EventStore.Core.Tests/Services/Storage/FakeIndexCommitterService.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeIndexCommitterService.cs
@@ -33,7 +33,7 @@ public class FakeIndexCommitterService<TStreamId> : IIndexCommitterService<TStre
 		}
 	}
 
-	public void AddPendingPrepare(IPrepareLogRecord<TStreamId>[] prepares, long postPosition)
+	public void AddPendingPrepare(long transactionPosition, IPrepareLogRecord<TStreamId>[] prepares, long postPosition)
 	{
 		if (prepares == null)
 		{

--- a/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
+++ b/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
@@ -23,7 +23,7 @@ public interface IIndexCommitterService<TStreamId>
 	ValueTask Init(long checkpointPosition, CancellationToken token);
 	void Stop();
 	ValueTask<long> GetCommitLastEventNumber(CommitLogRecord record, CancellationToken token);
-	void AddPendingPrepare(IPrepareLogRecord<TStreamId>[] prepares, long postPosition);
+	void AddPendingPrepare(long transactionPosition, IPrepareLogRecord<TStreamId>[] prepares, long postPosition);
 	void AddPendingCommit(CommitLogRecord commit, long postPosition);
 }
 
@@ -180,6 +180,10 @@ public class IndexCommitterService<TStreamId> : IndexCommitterService, IIndexCom
 			{
 				await _indexCommitter.Commit(transaction.Prepares, isTfEof, true, token);
 			}
+			else if (isTfEof)
+			{
+				_publisher.Publish(new StorageMessage.TfEofAtNonCommitRecord());
+			}
 
 			if (transaction.Commit is not null)
 			{
@@ -203,9 +207,8 @@ public class IndexCommitterService<TStreamId> : IndexCommitterService, IIndexCom
 	public ValueTask<long> GetCommitLastEventNumber(CommitLogRecord commit, CancellationToken token)
 		=> _indexCommitter.GetCommitLastEventNumber(commit, token);
 
-	public void AddPendingPrepare(IPrepareLogRecord<TStreamId>[] prepares, long postPosition)
+	public void AddPendingPrepare(long transactionPosition, IPrepareLogRecord<TStreamId>[] prepares, long postPosition)
 	{
-		var transactionPosition = prepares[0].TransactionPosition;
 		PendingTransaction transaction;
 		if (_pendingTransactions.TryGetValue(transactionPosition, out transaction))
 		{

--- a/src/EventStore.Core/Services/Storage/StorageChaser.cs
+++ b/src/EventStore.Core/Services/Storage/StorageChaser.cs
@@ -54,6 +54,7 @@ public class StorageChaser<TStreamId> : StorageChaser, IMonitoredQueue,
 	private long _lastFlush;
 
 	private readonly List<IPrepareLogRecord<TStreamId>> _transaction = [];
+	private long? _transactionPosition;
 	private bool _commitsAfterEof;
 
 	private readonly TaskCompletionSource<object> _tcs = new();
@@ -232,13 +233,15 @@ public class StorageChaser<TStreamId> : StorageChaser, IMonitoredQueue,
 
 	private void ProcessPrepareRecord(IPrepareLogRecord<TStreamId> record, long postPosition)
 	{
-		if (_transaction.Count > 0 && _transaction[0].TransactionPosition != record.TransactionPosition)
+		if (_transactionPosition is { } transactionPosition && transactionPosition != record.TransactionPosition)
 		{
-			CommitPendingTransaction(_transaction, postPosition);
+			CommitPendingTransaction(postPosition);
 		}
 
 		if (record.Flags.HasAnyOf(PrepareFlags.IsCommitted))
 		{
+			_transactionPosition ??= record.TransactionPosition;
+
 			if (record.Flags.HasAnyOf(PrepareFlags.Data | PrepareFlags.StreamDelete))
 			{
 				_transaction.Add(record);
@@ -249,7 +252,7 @@ public class StorageChaser<TStreamId> : StorageChaser, IMonitoredQueue,
 				return;
 			}
 
-			CommitPendingTransaction(_transaction, postPosition);
+			CommitPendingTransaction(postPosition);
 
 			long firstEventNumber;
 			long lastEventNumber;
@@ -279,7 +282,7 @@ public class StorageChaser<TStreamId> : StorageChaser, IMonitoredQueue,
 
 	private async ValueTask ProcessCommitRecord(CommitLogRecord record, long postPosition, CancellationToken token)
 	{
-		CommitPendingTransaction(_transaction, postPosition);
+		CommitPendingTransaction(postPosition);
 
 		var firstEventNumber = record.FirstEventNumber;
 		var lastEventNumber = await _indexCommitterService.GetCommitLastEventNumber(record, token);
@@ -295,7 +298,7 @@ public class StorageChaser<TStreamId> : StorageChaser, IMonitoredQueue,
 
 	private ValueTask ProcessSystemRecord(ISystemLogRecord record, CancellationToken token)
 	{
-		CommitPendingTransaction(_transaction, record.LogPosition);
+		CommitPendingTransaction(record.LogPosition);
 
 		if (record.SystemRecordType is not SystemRecordType.Epoch)
 		{
@@ -310,15 +313,17 @@ public class StorageChaser<TStreamId> : StorageChaser, IMonitoredQueue,
 		return _epochManager.CacheEpoch(epoch, token);
 	}
 
-	private void CommitPendingTransaction(List<IPrepareLogRecord<TStreamId>> transaction, long postPosition)
+	private void CommitPendingTransaction(long postPosition)
 	{
-		if (transaction.Count <= 0)
+		if (_transactionPosition is not { } transactionPosition)
 		{
+			_transaction.Clear();
 			return;
 		}
 
-		_indexCommitterService.AddPendingPrepare(transaction.ToArray(), postPosition);
+		_indexCommitterService.AddPendingPrepare(transactionPosition, _transaction.ToArray(), postPosition);
 		_transaction.Clear();
+		_transactionPosition = null;
 	}
 
 	public void Handle(SystemMessage.BecomeShuttingDown message)

--- a/src/EventStore.Core/Services/Storage/StorageChaser.cs
+++ b/src/EventStore.Core/Services/Storage/StorageChaser.cs
@@ -214,7 +214,7 @@ public class StorageChaser<TStreamId> : StorageChaser, IMonitoredQueue,
 			case LogRecordType.System:
 				{
 					var record = (ISystemLogRecord)result.LogRecord;
-					await ProcessSystemRecord(record, token);
+					await ProcessSystemRecord(record, result.RecordPostPosition, token);
 					break;
 				}
 			case LogRecordType.Partition:
@@ -296,9 +296,9 @@ public class StorageChaser<TStreamId> : StorageChaser, IMonitoredQueue,
 			record.TransactionPosition, firstEventNumber, lastEventNumber));
 	}
 
-	private ValueTask ProcessSystemRecord(ISystemLogRecord record, CancellationToken token)
+	private ValueTask ProcessSystemRecord(ISystemLogRecord record, long postPosition, CancellationToken token)
 	{
-		CommitPendingTransaction(record.LogPosition);
+		CommitPendingTransaction(postPosition);
 
 		if (record.SystemRecordType is not SystemRecordType.Epoch)
 		{


### PR DESCRIPTION
- Prevent projections from remaining idle after the index catches up at an empty transaction boundary.
- Preserve reader wakeups for append races where no committed event is emitted at the transaction-log end.