### PR TITLE
feat(metrics): expose parked subscription request metrics

### DIFF
--- a/docs/diagnostics/metrics.md
+++ b/docs/diagnostics/metrics.md
@@ -256,6 +256,8 @@ Persistent subscription metrics track the statistics for the persistent subscrip
 |:----------------------------------------------------------------------------------------------------------------------|:-------------------------|:---------------------------------------------------------------|
 | `eventstore_persistent_sub_connections{event_stream_id=<STREAM_NAME>,group_name=<GROUP_NAME>}`                        | [Gauge](#common-types)   | Number of connections                                          |
 | `eventstore_persistent_sub_parked_messages{event_stream_id=<STREAM_NAME>,group_name=<GROUP_NAME>}`                    | [Gauge](#common-types)   | Number of parked messages                                      |
+| `eventstore_persistent_sub_park_message_requests{event_stream_id=<STREAM_NAME>,group_name=<GROUP_NAME>,reason=<REASON>}` | [Counter](#common-types) | Number of park message requests by reason                      |
+| `eventstore_persistent_sub_parked_message_replays{event_stream_id=<STREAM_NAME>,group_name=<GROUP_NAME>}`              | [Counter](#common-types) | Number of parked message replay requests                       |
 | `eventstore_persistent_sub_in_flight_messages{event_stream_id=<STREAM_NAME>,group_name=<GROUP_NAME>}`                 | [Gauge](#common-types)   | Number of messages in flight                                   |
 | `eventstore_persistent_sub_oldest_parked_message_seconds{event_stream_id=<STREAM_NAME>,group_name=<GROUP_NAME>}`      | [Gauge](#common-types)   | Oldest parked message age in seconds                           |
 | `eventstore_persistent_sub_items_processed{event_stream_id=<STREAM_NAME>,group_name=<GROUP_NAME>}`                    | [Counter](#common-types) | Total items processed                                          |
@@ -280,6 +282,16 @@ eventstore_persistent_sub_connections{event_stream_id="$all",group_name="group1"
 # TYPE eventstore_persistent_sub_parked_messages gauge
 eventstore_persistent_sub_parked_messages{event_stream_id="test-stream",group_name="group1"} 0 1720172078179
 eventstore_persistent_sub_parked_messages{event_stream_id="$all",group_name="group1"} 0 1720172078179
+
+# TYPE eventstore_persistent_sub_park_message_requests counter
+eventstore_persistent_sub_park_message_requests{event_stream_id="test-stream",group_name="group1",reason="client-nak"} 0 1720172078179
+eventstore_persistent_sub_park_message_requests{event_stream_id="test-stream",group_name="group1",reason="max-retries"} 0 1720172078179
+eventstore_persistent_sub_park_message_requests{event_stream_id="$all",group_name="group1",reason="client-nak"} 0 1720172078179
+eventstore_persistent_sub_park_message_requests{event_stream_id="$all",group_name="group1",reason="max-retries"} 0 1720172078179
+
+# TYPE eventstore_persistent_sub_parked_message_replays counter
+eventstore_persistent_sub_parked_message_replays{event_stream_id="test-stream",group_name="group1"} 0 1720172078179
+eventstore_persistent_sub_parked_message_replays{event_stream_id="$all",group_name="group1"} 0 1720172078179
 
 # TYPE eventstore_persistent_sub_in_flight_messages gauge
 eventstore_persistent_sub_in_flight_messages{event_stream_id="test-stream",group_name="group1"} 0 1720172078179

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionMessageParkerTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionMessageParkerTests.cs
@@ -234,10 +234,42 @@ public class PersistentSubscriptionMessageParkerTests
 		[Test]
 		public async Task should_have_one_parked_message()
 		{
+			_messageParker.RecordParkMessageRequest(ParkReason.ClientNak);
 			_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", (_, __) =>
 			{
 				Assert.AreEqual(1, _messageParker.ParkedMessageCount);
+				Assert.AreEqual(1, _messageParker.ParkedDueToClientNak);
+				Assert.AreEqual(0, _messageParker.ParkedDueToMaxRetries);
 				Assert.AreEqual(EventTimeStamps[0], _messageParker.GetOldestParkedMessage);
+				_done.TrySetResult(true);
+			});
+			await _done.Task.WithTimeout();
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class given_a_message_is_parked_due_to_max_retries<TLogFormat, TStreamId> : TestFixtureWithExistingEvents<TLogFormat, TStreamId>
+	{
+		private PersistentSubscriptionMessageParker _messageParker;
+		private string _streamId = Guid.NewGuid().ToString();
+		private TaskCompletionSource<bool> _done = new TaskCompletionSource<bool>();
+
+		protected override void Given()
+		{
+			base.Given();
+			_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
+			NoOtherStreams();
+			AllWritesSucceed();
+		}
+
+		[Test]
+		public async Task should_count_max_retry_park_requests()
+		{
+			_messageParker.RecordParkMessageRequest(ParkReason.MaxRetries);
+			_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", (_, __) =>
+			{
+				Assert.AreEqual(0, _messageParker.ParkedDueToClientNak);
+				Assert.AreEqual(1, _messageParker.ParkedDueToMaxRetries);
 				_done.TrySetResult(true);
 			});
 			await _done.Task.WithTimeout();
@@ -281,6 +313,7 @@ public class PersistentSubscriptionMessageParkerTests
 			});
 			await _done.Task.WithTimeout();
 		}
+
 	}
 
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -1963,6 +1963,37 @@ public class TimeoutTests
 		Assert.AreEqual(0, envelope1.Replies.Count);
 		Assert.AreEqual(1, parker.ParkedEvents.Count);
 		Assert.AreEqual(Helper.GetEventIdFor(0), parker.ParkedEvents[0].OriginalEvent.EventId);
+		Assert.AreEqual(1, parker.ParkedDueToMaxRetries);
+	}
+
+	[Test]
+	public void retrying_a_failed_park_write_does_not_count_a_new_park_request()
+	{
+		var envelope1 = new FakeEnvelope();
+		var reader = new FakeCheckpointReader();
+		var parker = new FakeMessageParker();
+		var sub = new Core.Services.PersistentSubscription.PersistentSubscription(
+			Helper.CreatePersistentSubscriptionBuilderFor(_eventSource)
+				.WithEventLoader(new FakeStreamReader())
+				.WithCheckpointReader(reader)
+				.WithCheckpointWriter(new FakeCheckpointWriter(i => { }))
+				.WithMessageParker(parker)
+				.PreferDispatchToSingle()
+				.StartFromBeginning()
+				.WithMaxRetriesOf(0)
+				.WithMessageTimeoutOf(TimeSpan.FromSeconds(1)));
+		reader.Load(null);
+		sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
+		sub.HandleReadCompleted(new[] {
+			Helper.GetFakeEventFor(0, _eventSource)
+		}, Helper.GetStreamPositionFor(1, _eventSource), false);
+
+		sub.NotifyClockTick(DateTime.UtcNow.AddSeconds(3));
+		Assert.AreEqual(1, parker.ParkedDueToMaxRetries);
+
+		parker.ParkMessageCompleted(0, OperationResult.PrepareTimeout);
+		Assert.AreEqual(2, parker.ParkedEvents.Count);
+		Assert.AreEqual(1, parker.ParkedDueToMaxRetries);
 	}
 
 	[Test]
@@ -2936,6 +2967,19 @@ class FakeMessageParker : IPersistentSubscriptionMessageParker
 		_parkMessageCompleted?.Invoke(ParkedEvents[idx], result);
 	}
 
+	public void RecordParkMessageRequest(ParkReason parkReason)
+	{
+		switch (parkReason)
+		{
+			case ParkReason.ClientNak:
+				ParkedDueToClientNak++;
+				break;
+			case ParkReason.MaxRetries:
+				ParkedDueToMaxRetries++;
+				break;
+		}
+	}
+
 	public void BeginParkMessage(ResolvedEvent ev, string reason,
 		Action<ResolvedEvent, OperationResult> completed)
 	{
@@ -2947,6 +2991,7 @@ class FakeMessageParker : IPersistentSubscriptionMessageParker
 	public void BeginReadEndSequence(Action<long?> completed)
 	{
 		BeginReadEndSequenceCount++;
+		ParkedMessageReplays++;
 		if (_lastParkedEventNumber == -1)
 		{
 			completed(null); //NoStream
@@ -2983,6 +3028,9 @@ class FakeMessageParker : IPersistentSubscriptionMessageParker
 	}
 
 	public DateTime? GetOldestParkedMessage { get; }
+	public long ParkedDueToClientNak { get; private set; }
+	public long ParkedDueToMaxRetries { get; private set; }
+	public long ParkedMessageReplays { get; private set; }
 }
 
 

--- a/src/EventStore.Core.XUnit.Tests/Metrics/PersistentSubscriptionMetricsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/PersistentSubscriptionMetricsTests.cs
@@ -36,6 +36,9 @@ public class PersistentSubscriptionMetricsTests
 			NamedConsumerStrategy = "Round Robin",
 			OldestParkedMessage = 1007,
 			OutstandingMessagesCount = 2,
+			ParkedDueToClientNak = 1015,
+			ParkedDueToMaxRetries = 1016,
+			ParkedMessageReplays = 1017,
 			ParkedMessageCount = 1003,
 			ReadBatchSize = 20,
 			ReadBufferCount = 0,
@@ -69,6 +72,9 @@ public class PersistentSubscriptionMetricsTests
 			NamedConsumerStrategy = "Round Robin",
 			OldestParkedMessage = 1008,
 			OutstandingMessagesCount = 2,
+			ParkedDueToClientNak = 1018,
+			ParkedDueToMaxRetries = 1019,
+			ParkedMessageReplays = 1020,
 			ParkedMessageCount = 1004,
 			ReadBatchSize = 20,
 			ReadBufferCount = 0,
@@ -102,6 +108,26 @@ public class PersistentSubscriptionMetricsTests
 		Assert.Collection(measurements,
 			AssertMeasurement("test", "testGroup", 1003),
 			AssertMeasurement("$all", "testGroup", 1004));
+	}
+
+	[Fact]
+	public void ObserveParkMessageRequests()
+	{
+		var measurements = _sut.ObserveParkMessageRequests();
+		Assert.Collection(measurements,
+			AssertMeasurement("test", "testGroup", "client-nak", 1015),
+			AssertMeasurement("test", "testGroup", "max-retries", 1016),
+			AssertMeasurement("$all", "testGroup", "client-nak", 1018),
+			AssertMeasurement("$all", "testGroup", "max-retries", 1019));
+	}
+
+	[Fact]
+	public void ObserveParkedMessageReplays()
+	{
+		var measurements = _sut.ObserveParkedMessageReplays();
+		Assert.Collection(measurements,
+			AssertMeasurement("test", "testGroup", 1017),
+			AssertMeasurement("$all", "testGroup", 1020));
 	}
 
 	[Fact]
@@ -182,6 +208,35 @@ public class PersistentSubscriptionMetricsTests
 				{
 					Assert.Equal("group_name", tag.Key);
 					Assert.Equal(groupName, tag.Value);
+				}
+			);
+		};
+
+	static Action<Measurement<long>> AssertMeasurement(
+		string sourceName,
+		string groupName,
+		string reason,
+		long expectedValue) =>
+
+		actualMeasurement =>
+		{
+			Assert.Equal(expectedValue, actualMeasurement.Value);
+			Assert.Collection(
+				actualMeasurement.Tags.ToArray(),
+				tag =>
+				{
+					Assert.Equal("event_stream_id", tag.Key);
+					Assert.Equal(sourceName, tag.Value);
+				},
+				tag =>
+				{
+					Assert.Equal("group_name", tag.Key);
+					Assert.Equal(groupName, tag.Value);
+				},
+				tag =>
+				{
+					Assert.Equal("reason", tag.Key);
+					Assert.Equal(reason, tag.Value);
 				}
 			);
 		};

--- a/src/EventStore.Core/Messages/MonitoringMessage.cs
+++ b/src/EventStore.Core/Messages/MonitoringMessage.cs
@@ -149,6 +149,9 @@ namespace EventStore.Core.Messages
 			public string NamedConsumerStrategy { get; set; }
 			public int MaxSubscriberCount { get; set; }
 			public long ParkedMessageCount { get; set; }
+			public long ParkedDueToClientNak { get; set; }
+			public long ParkedDueToMaxRetries { get; set; }
+			public long ParkedMessageReplays { get; set; }
 			public long OldestParkedMessage { get; set; }
 		}
 

--- a/src/EventStore.Core/Metrics/PersistentSubscriptionTracker.cs
+++ b/src/EventStore.Core/Metrics/PersistentSubscriptionTracker.cs
@@ -29,6 +29,27 @@ public class PersistentSubscriptionTracker : IPersistentSubscriptionTracker
 				new("group_name", x.GroupName)
 			]));
 
+	public IEnumerable<Measurement<long>> ObserveParkMessageRequests() =>
+		_currentStats.SelectMany<MonitoringMessage.PersistentSubscriptionInfo, Measurement<long>>(x => [
+			new(x.ParkedDueToClientNak, [
+				new("event_stream_id", x.EventSource),
+				new("group_name", x.GroupName),
+				new("reason", "client-nak")
+			]),
+			new(x.ParkedDueToMaxRetries, [
+				new("event_stream_id", x.EventSource),
+				new("group_name", x.GroupName),
+				new("reason", "max-retries")
+			])
+		]);
+
+	public IEnumerable<Measurement<long>> ObserveParkedMessageReplays() =>
+		_currentStats.Select(x =>
+			new Measurement<long>(x.ParkedMessageReplays, [
+				new("event_stream_id", x.EventSource),
+				new("group_name", x.GroupName)
+			]));
+
 	public IEnumerable<Measurement<long>> ObserveInFlightMessages() =>
 		_currentStats.Select(x =>
 			new Measurement<long>(x.TotalInFlightMessages, [

--- a/src/EventStore.Core/MetricsBootstrapper.cs
+++ b/src/EventStore.Core/MetricsBootstrapper.cs
@@ -195,6 +195,8 @@ public static class MetricsBootstrapper
 			coreMeter.CreateObservableUpDownCounter("eventstore-persistent-sub-in-flight-messages", tracker.ObserveInFlightMessages);
 			coreMeter.CreateObservableUpDownCounter("eventstore-persistent-sub-oldest-parked-message-seconds", tracker.ObserveOldestParkedMessage);
 
+			coreMeter.CreateObservableCounter("eventstore-persistent-sub-park-message-requests", tracker.ObserveParkMessageRequests);
+			coreMeter.CreateObservableCounter("eventstore-persistent-sub-parked-message-replays", tracker.ObserveParkedMessageReplays);
 			coreMeter.CreateObservableCounter("eventstore-persistent-sub-items-processed", tracker.ObserveItemsProcessed);
 			coreMeter.CreateObservableCounter("eventstore-persistent-sub-last-known-event-number", tracker.ObserveLastKnownEvent);
 			coreMeter.CreateObservableCounter("eventstore-persistent-sub-last-known-event-commit-position", tracker.ObserveLastKnownEventCommitPosition);

--- a/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
@@ -6,6 +6,7 @@ namespace EventStore.Core.Services.PersistentSubscription
 {
 	public interface IPersistentSubscriptionMessageParker
 	{
+		void RecordParkMessageRequest(ParkReason parkReason);
 		void BeginParkMessage(ResolvedEvent ev, string reason, Action<ResolvedEvent, OperationResult> completed);
 		void BeginReadEndSequence(Action<long?> completed);
 		void BeginMarkParkedMessagesReprocessed(long sequence, DateTime? oldestParkedMessageTimestamp, bool updateOldestParkedMessage);
@@ -13,5 +14,15 @@ namespace EventStore.Core.Services.PersistentSubscription
 		long ParkedMessageCount { get; }
 		public void BeginLoadStats(Action completed);
 		DateTime? GetOldestParkedMessage { get; }
+		long ParkedDueToClientNak { get; }
+		long ParkedDueToMaxRetries { get; }
+		long ParkedMessageReplays { get; }
+	}
+
+	public enum ParkReason
+	{
+		Unknown,
+		ClientNak,
+		MaxRetries
 	}
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -671,7 +671,7 @@ namespace EventStore.Core.Services.PersistentSubscription
 				case NakAction.Park:
 					if (_outstandingMessages.GetMessageById(id, out m))
 					{
-						ParkMessage(m.ResolvedEvent, "Client explicitly NAK'ed message.\n" + reason, 0);
+						ParkMessage(m.ResolvedEvent, "Client explicitly NAK'ed message.\n" + reason, ParkReason.ClientNak, 0);
 					}
 
 					break;
@@ -687,8 +687,13 @@ namespace EventStore.Core.Services.PersistentSubscription
 			}
 		}
 
-		private void ParkMessage(ResolvedEvent resolvedEvent, string reason, int count)
+		private void ParkMessage(ResolvedEvent resolvedEvent, string reason, ParkReason parkReason, int count)
 		{
+			if (count == 0)
+			{
+				_settings.MessageParker.RecordParkMessageRequest(parkReason);
+			}
+
 			_settings.MessageParker.BeginParkMessage(resolvedEvent, reason, (e, result) =>
 			{
 				if (result != OperationResult.Success)
@@ -698,7 +703,7 @@ namespace EventStore.Core.Services.PersistentSubscription
 						Log.Information("Unable to park message {stream}/{eventNumber} operation failed {e} retrying",
 							e.OriginalStreamId,
 							e.OriginalEventNumber, result);
-						ParkMessage(e, reason, count + 1);
+						ParkMessage(e, reason, parkReason, count + 1);
 						return;
 					}
 
@@ -921,7 +926,7 @@ namespace EventStore.Core.Services.PersistentSubscription
 				return false;
 			}
 
-			ParkMessage(message.ResolvedEvent, string.Format("Reached retry count of {0}", _settings.MaxRetryCount), 0);
+			ParkMessage(message.ResolvedEvent, string.Format("Reached retry count of {0}", _settings.MaxRetryCount), ParkReason.MaxRetries, 0);
 			return true;
 		}
 

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using EventStore.Common.Utils;
 using EventStore.Core.Data;
 using EventStore.Core.Helpers;
@@ -16,6 +17,9 @@ namespace EventStore.Core.Services.PersistentSubscription
 		public readonly string ParkedStreamId;
 		private long _lastTruncateBefore = -1;
 		private long _lastParkedEventNumber = -1;
+		private long _parkedDueToClientNak;
+		private long _parkedDueToMaxRetries;
+		private long _parkedMessageReplays;
 		private DateTime? _oldestParkedMessage;
 		public long ParkedMessageCount
 		{
@@ -26,6 +30,12 @@ namespace EventStore.Core.Services.PersistentSubscription
 					_lastParkedEventNumber - _lastTruncateBefore + 1;
 			}
 		}
+
+		public long ParkedDueToClientNak => Interlocked.Read(ref _parkedDueToClientNak);
+
+		public long ParkedDueToMaxRetries => Interlocked.Read(ref _parkedDueToMaxRetries);
+
+		public long ParkedMessageReplays => Interlocked.Read(ref _parkedMessageReplays);
 
 		private static readonly ILogger Log = Serilog.Log.ForContext<PersistentSubscriptionMessageParker>();
 
@@ -72,6 +82,21 @@ namespace EventStore.Core.Services.PersistentSubscription
 			}
 
 			completed?.Invoke(ev, msg.Result);
+		}
+
+		public void RecordParkMessageRequest(ParkReason parkReason)
+		{
+			switch (parkReason)
+			{
+				case ParkReason.ClientNak:
+					Interlocked.Increment(ref _parkedDueToClientNak);
+					break;
+				case ParkReason.MaxRetries:
+					Interlocked.Increment(ref _parkedDueToMaxRetries);
+					break;
+				default:
+					throw new ArgumentOutOfRangeException(nameof(parkReason));
+			}
 		}
 
 		public void BeginParkMessage(ResolvedEvent ev, string reason,
@@ -125,6 +150,8 @@ namespace EventStore.Core.Services.PersistentSubscription
 
 		public void BeginReadEndSequence(Action<long?> completed)
 		{
+			Interlocked.Increment(ref _parkedMessageReplays);
+
 			_ioDispatcher.ReadBackward(ParkedStreamId,
 				long.MaxValue,
 				1,

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
@@ -129,6 +129,9 @@ namespace EventStore.Core.Services.PersistentSubscription
 				NamedConsumerStrategy = _settings.ConsumerStrategy.Name,
 				MaxSubscriberCount = _settings.MaxSubscriberCount,
 				ParkedMessageCount = parkedMessageCount,
+				ParkedDueToClientNak = _settings.MessageParker.ParkedDueToClientNak,
+				ParkedDueToMaxRetries = _settings.MessageParker.ParkedDueToMaxRetries,
+				ParkedMessageReplays = _settings.MessageParker.ParkedMessageReplays,
 				OldestParkedMessage = oldestParkedMessage
 			};
 		}


### PR DESCRIPTION
- Operators need visibility into why persistent subscription messages are being parked and when parked-message replay work is requested.
- The existing parked-message totals do not separate client-driven parking from retry-exhaustion parking, which makes operational diagnosis slower.