### PR TITLE
feat(projections): expose state size metrics

### DIFF
--- a/docs/diagnostics/metrics.md
+++ b/docs/diagnostics/metrics.md
@@ -394,7 +394,10 @@ Projection metrics track the statistics for projections.
 | `eventstore_projection_events_processed_after_restart_total{projection=<PROJECTION_NAME>}` | [Counter](#common-types) | Projection event processed count after restart                   |
 | `eventstore_projection_progress{projection=<PROJECTION_NAME>}`                             | [Gauge](#common-types)   | Projection progress 0 - 1, where 1 = projection progress at 100% |
 | `eventstore_projection_running{projection=<PROJECTION_NAME>}`                              | [Gauge](#common-types)   | If 1, projection is in 'Running' state                           |
+| `eventstore_projection_state_size{projection=<PROJECTION_NAME>,partition=<PARTITION>}`     | [Gauge](#common-types)   | Projection state size in bytes when close to the configured limit |
 | `eventstore_projection_status{projection=<PROJECTION_NAME>,status=<PROJECTION_STATUS>}`    | [Gauge](#common-types)   | If 1, projection is in specified state                           |
+
+The `partition` label is omitted for the root projection state.
 
 `Status` can have one of the following statuses:
 
@@ -419,6 +422,9 @@ eventstore_projection_progress{projection="$stream_by_category"} 1 1719526306309
 
 # TYPE eventstore_projection_running gauge
 eventstore_projection_running{projection="$by_category"} 1 1719526306309
+
+# TYPE eventstore_projection_state_size gauge
+eventstore_projection_state_size{projection="$by_category"} 1048576 1719526306309
 
 # TYPE eventstore_projection_status gauge
 eventstore_projection_status{projection="$by_category",status="Running"} 1 1719526306309

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_projection_state_is_too_large.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_projection_state_is_too_large.cs
@@ -168,6 +168,6 @@ public class when_projection_state_drops_below_the_metrics_threshold<TLogFormat,
 		var stats = new ProjectionStatistics();
 		_manager.GetStatistics(stats);
 
-		Assert.IsEmpty(stats.StateSizes);
+		Assert.IsNull(stats.StateSizes);
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_projection_state_is_too_large.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_projection_state_is_too_large.cs
@@ -87,3 +87,43 @@ public class when_projection_state_is_too_large<TLogFormat, TStreamId> :
 		Assert.AreEqual(CheckpointTag.FromStreamPosition(0, "stream", 11).ToString(), stats.Position);
 	}
 }
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class when_projection_state_is_near_the_limit<TLogFormat, TStreamId> :
+	TestFixtureWithCoreProjectionCheckpointManager<TLogFormat, TStreamId>
+{
+	protected override void Given()
+	{
+		AllWritesSucceed();
+		base.Given();
+		_maxProjectionStateSize = 100;
+	}
+
+	protected override void When()
+	{
+		base.When();
+
+		_checkpointReader.BeginLoadState();
+		var checkpointLoaded =
+			_consumer.HandledMessages.OfType<CoreProjectionProcessingMessage.CheckpointLoaded>().First();
+		_checkpointWriter.StartFrom(checkpointLoaded.CheckpointTag, checkpointLoaded.CheckpointEventNumber);
+		_manager.BeginLoadPrerecordedEvents(checkpointLoaded.CheckpointTag);
+
+		var initialCheckpointTag = CheckpointTag.FromStreamPosition(0, "stream", 10);
+		_manager.Start(initialCheckpointTag, null);
+		var oldState = new PartitionState("", "", initialCheckpointTag);
+
+		var firstEventCheckpointTag = CheckpointTag.FromStreamPosition(0, "stream", 11);
+		var newState = new PartitionState(new string('x', 80), "", firstEventCheckpointTag);
+		_manager.StateUpdated("", oldState, newState);
+	}
+
+	[Test]
+	public void reports_root_state_size()
+	{
+		var stats = new ProjectionStatistics();
+		_manager.GetStatistics(stats);
+
+		Assert.AreEqual(80, stats.StateSizes[string.Empty]);
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_projection_state_is_too_large.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_projection_state_is_too_large.cs
@@ -127,3 +127,47 @@ public class when_projection_state_is_near_the_limit<TLogFormat, TStreamId> :
 		Assert.AreEqual(80, stats.StateSizes[string.Empty]);
 	}
 }
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class when_projection_state_drops_below_the_metrics_threshold<TLogFormat, TStreamId> :
+	TestFixtureWithCoreProjectionCheckpointManager<TLogFormat, TStreamId>
+{
+	protected override void Given()
+	{
+		AllWritesSucceed();
+		base.Given();
+		_maxProjectionStateSize = 100;
+	}
+
+	protected override void When()
+	{
+		base.When();
+
+		_checkpointReader.BeginLoadState();
+		var checkpointLoaded =
+			_consumer.HandledMessages.OfType<CoreProjectionProcessingMessage.CheckpointLoaded>().First();
+		_checkpointWriter.StartFrom(checkpointLoaded.CheckpointTag, checkpointLoaded.CheckpointEventNumber);
+		_manager.BeginLoadPrerecordedEvents(checkpointLoaded.CheckpointTag);
+
+		var initialCheckpointTag = CheckpointTag.FromStreamPosition(0, "stream", 10);
+		_manager.Start(initialCheckpointTag, null);
+		var oldState = new PartitionState("", "", initialCheckpointTag);
+
+		var firstEventCheckpointTag = CheckpointTag.FromStreamPosition(0, "stream", 11);
+		var nearLimitState = new PartitionState(new string('x', 80), "", firstEventCheckpointTag);
+		_manager.StateUpdated("", oldState, nearLimitState);
+
+		var secondEventCheckpointTag = CheckpointTag.FromStreamPosition(0, "stream", 12);
+		var belowLimitState = new PartitionState(new string('x', 79), "", secondEventCheckpointTag);
+		_manager.StateUpdated("", nearLimitState, belowLimitState);
+	}
+
+	[Test]
+	public void stops_reporting_root_state_size()
+	{
+		var stats = new ProjectionStatistics();
+		_manager.GetStatistics(stats);
+
+		Assert.IsEmpty(stats.StateSizes);
+	}
+}

--- a/src/EventStore.Projections.Core.XUnit.Tests/Metrics/ProjectionMetricsTests.cs
+++ b/src/EventStore.Projections.Core.XUnit.Tests/Metrics/ProjectionMetricsTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using EventStore.Projections.Core.Metrics;
 using EventStore.Projections.Core.Services;
@@ -83,6 +84,32 @@ public class ProjectionMetricsTests
 			AssertMeasurement(running, ("projection", "TestProjection"), ("status", "Running")),
 			AssertMeasurement(faulted, ("projection", "TestProjection"), ("status", "Faulted")),
 			AssertMeasurement(stopped, ("projection", "TestProjection"), ("status", "Stopped")));
+	}
+
+	[Fact]
+	public void ObserveStateSizes()
+	{
+		_sut.OnNewStats([new() {
+			Name = "TestProjection",
+			StateSizes = new Dictionary<string, int> {
+				[string.Empty] = 10,
+				["test-partition"] = 12,
+			},
+		}]);
+
+		var measurements = _sut.ObserveStateSize();
+
+		Assert.Collection(measurements,
+			AssertMeasurement(10, ("projection", "TestProjection")),
+			AssertMeasurement(12, ("projection", "TestProjection"), ("partition", "test-partition")));
+	}
+
+	[Fact]
+	public void ObserveStateSizesWithoutStateSizes()
+	{
+		var measurements = _sut.ObserveStateSize();
+
+		Assert.Empty(measurements);
 	}
 
 	static Action<Measurement<T>> AssertMeasurement<T>(

--- a/src/EventStore.Projections.Core/Metrics/ProjectionTracker.cs
+++ b/src/EventStore.Projections.Core/Metrics/ProjectionTracker.cs
@@ -81,4 +81,29 @@ public class ProjectionTracker : IProjectionTracker
 			]);
 		}
 	}
+
+	public IEnumerable<Measurement<int>> ObserveStateSize()
+	{
+		foreach (var statistics in _currentStats)
+		{
+			if (statistics.StateSizes is null)
+			{
+				continue;
+			}
+
+			foreach (var (partition, stateSize) in statistics.StateSizes)
+			{
+				List<KeyValuePair<string, object>> tags = [
+					new("projection", statistics.Name),
+				];
+
+				if (partition != string.Empty)
+				{
+					tags.Add(new KeyValuePair<string, object>("partition", partition));
+				}
+
+				yield return new Measurement<int>(stateSize, tags);
+			}
+		}
+	}
 }

--- a/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
@@ -201,6 +201,7 @@ public sealed class ProjectionsSubsystem : ISubsystem,
 		projectionMeter.CreateObservableUpDownCounter("eventstore-projection-progress", tracker.ObserveProgress);
 		projectionMeter.CreateObservableUpDownCounter("eventstore-projection-running", tracker.ObserveRunning);
 		projectionMeter.CreateObservableUpDownCounter("eventstore-projection-status", tracker.ObserveStatus);
+		projectionMeter.CreateObservableUpDownCounter("eventstore-projection-state-size", tracker.ObserveStateSize);
 	}
 
 	public void ConfigureServices(IServiceCollection services, IConfiguration configuration) =>

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using EventStore.Core.Bus;
 using EventStore.Projections.Core.Messages;
@@ -17,6 +19,7 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 	protected readonly ProjectionConfig _projectionConfig;
 	protected readonly ILogger _logger;
 	protected readonly int _maxProjectionStateSize;
+	private readonly int _maxProjectionStateSizeThreshold;
 
 	private readonly bool _usePersistentCheckpoints;
 
@@ -40,6 +43,7 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 	protected bool _stopped;
 
 	private PartitionState _currentProjectionState;
+	private readonly ConcurrentDictionary<string, int> _stateSizeByPartition = new();
 
 	protected CoreProjectionCheckpointManager(
 		IPublisher publisher,
@@ -101,6 +105,7 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		_requestedCheckpointState = new PartitionState("", null, _zeroTag);
 		_currentProjectionState = new PartitionState("", null, _zeroTag);
 		_maxProjectionStateSize = maxProjectionStateSize;
+		_maxProjectionStateSizeThreshold = (int)(0.80 * _maxProjectionStateSize);
 	}
 
 	protected abstract ProjectionCheckpoint CreateProjectionCheckpoint(CheckpointTag checkpointPosition);
@@ -147,6 +152,7 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		_stopping = false;
 		_stopped = false;
 		_currentProjectionState = new PartitionState("", null, _zeroTag);
+		_stateSizeByPartition.Clear();
 	}
 
 	public virtual void Start(CheckpointTag checkpointTag, PartitionState rootPartitionState)
@@ -162,6 +168,7 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		if (rootPartitionState != null)
 		{
 			_currentProjectionState = rootPartitionState;
+			UpdateStateSizeMetrics(string.Empty, rootPartitionState.Size);
 		}
 
 		_lastProcessedEventPosition.UpdateByCheckpointTagInitial(checkpointTag);
@@ -225,6 +232,12 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		info.WritesInProgress = (_closingCheckpoint != null ? _closingCheckpoint.GetWritesInProgress() : 0)
 								+ (_currentCheckpoint != null ? _currentCheckpoint.GetWritesInProgress() : 0);
 		info.CheckpointStatus = _inCheckpoint ? "Requested" : "";
+
+		foreach (var (partition, stateSize) in _stateSizeByPartition)
+		{
+			info.StateSizes ??= new Dictionary<string, int>();
+			info.StateSizes[partition] = stateSize;
+		}
 	}
 
 	public void StateUpdated(
@@ -259,6 +272,7 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		if (partition == "")
 		{
 			_currentProjectionState = newState;
+			UpdateStateSizeMetrics(string.Empty, newState.Size);
 		}
 	}
 
@@ -544,6 +558,25 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		_publisher.Publish(
 			new CoreProjectionProcessingMessage.CheckpointCompleted(
 				_projectionCorrelationId, _lastCompletedCheckpointPosition));
+	}
+
+	protected void UpdateStateSizeMetrics(string partition, int newStateSize)
+	{
+		if (newStateSize >= _maxProjectionStateSizeThreshold)
+		{
+			_stateSizeByPartition[partition] = newStateSize;
+		}
+		else if (_stateSizeByPartition.TryGetValue(partition, out var oldStateSize))
+		{
+			if (oldStateSize >= _maxProjectionStateSizeThreshold)
+			{
+				_stateSizeByPartition[partition] = newStateSize;
+			}
+			else
+			{
+				_stateSizeByPartition.TryRemove(partition, out _);
+			}
+		}
 	}
 
 	public virtual void BeginLoadPrerecordedEvents(CheckpointTag checkpointTag)

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
@@ -232,12 +232,9 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		info.WritesInProgress = (_closingCheckpoint != null ? _closingCheckpoint.GetWritesInProgress() : 0)
 								+ (_currentCheckpoint != null ? _currentCheckpoint.GetWritesInProgress() : 0);
 		info.CheckpointStatus = _inCheckpoint ? "Requested" : "";
-		info.StateSizes = new Dictionary<string, int>();
-
-		foreach (var (partition, stateSize) in _stateSizeByPartition)
-		{
-			info.StateSizes[partition] = stateSize;
-		}
+		info.StateSizes = _stateSizeByPartition.IsEmpty
+			? null
+			: new Dictionary<string, int>(_stateSizeByPartition);
 	}
 
 	public void StateUpdated(

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/CoreProjectionCheckpointManager.cs
@@ -232,10 +232,10 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		info.WritesInProgress = (_closingCheckpoint != null ? _closingCheckpoint.GetWritesInProgress() : 0)
 								+ (_currentCheckpoint != null ? _currentCheckpoint.GetWritesInProgress() : 0);
 		info.CheckpointStatus = _inCheckpoint ? "Requested" : "";
+		info.StateSizes = new Dictionary<string, int>();
 
 		foreach (var (partition, stateSize) in _stateSizeByPartition)
 		{
-			info.StateSizes ??= new Dictionary<string, int>();
 			info.StateSizes[partition] = stateSize;
 		}
 	}
@@ -566,16 +566,9 @@ public abstract class CoreProjectionCheckpointManager : IProjectionCheckpointMan
 		{
 			_stateSizeByPartition[partition] = newStateSize;
 		}
-		else if (_stateSizeByPartition.TryGetValue(partition, out var oldStateSize))
+		else
 		{
-			if (oldStateSize >= _maxProjectionStateSizeThreshold)
-			{
-				_stateSizeByPartition[partition] = newStateSize;
-			}
-			else
-			{
-				_stateSizeByPartition.TryRemove(partition, out _);
-			}
+			_stateSizeByPartition.TryRemove(partition, out _);
 		}
 	}
 

--- a/src/EventStore.Projections.Core/Services/Processing/Checkpointing/DefaultCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Checkpointing/DefaultCheckpointManager.cs
@@ -195,6 +195,7 @@ public class DefaultCheckpointManager : CoreProjectionCheckpointManager,
 		}
 
 		_partitionStateUpdateManager.StateUpdated(partition, newState, oldState.CausedBy);
+		UpdateStateSizeMetrics(partition, newState.Size);
 	}
 
 	protected override void EmitPartitionCheckpoints()

--- a/src/EventStore.Projections.Core/Services/ProjectionStatistics.cs
+++ b/src/EventStore.Projections.Core/Services/ProjectionStatistics.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using EventStore.Projections.Core.Services.Management;
 
 namespace EventStore.Projections.Core.Services;
@@ -52,9 +53,13 @@ public class ProjectionStatistics
 
 	public long CoreProcessingTime { get; set; }
 
+	public Dictionary<string, int> StateSizes { get; set; }
+
 	public ProjectionStatistics Clone()
 	{
-		return (ProjectionStatistics)MemberwiseClone();
+		var clone = (ProjectionStatistics)MemberwiseClone();
+		clone.StateSizes = StateSizes is null ? null : new Dictionary<string, int>(StateSizes);
+		return clone;
 	}
 
 	protected bool Equals(ProjectionStatistics other)
@@ -81,7 +86,8 @@ public class ProjectionStatistics
 												   && WritesInProgress == other.WritesInProgress &&
 												   string.Equals(EffectiveName, other.EffectiveName)
 												   && string.Equals(ResultStreamName, other.ResultStreamName) &&
-												   CoreProcessingTime == other.CoreProcessingTime;
+												   CoreProcessingTime == other.CoreProcessingTime &&
+												   StateSizesEqual(StateSizes, other.StateSizes);
 	}
 
 	public override bool Equals(object obj)
@@ -131,6 +137,50 @@ public class ProjectionStatistics
 			hashCode = (hashCode * 397) ^ (EffectiveName != null ? EffectiveName.GetHashCode() : 0);
 			hashCode = (hashCode * 397) ^ (ResultStreamName != null ? ResultStreamName.GetHashCode() : 0);
 			hashCode = (hashCode * 397) ^ CoreProcessingTime.GetHashCode();
+			hashCode = (hashCode * 397) ^ GetStateSizesHashCode(StateSizes);
+			return hashCode;
+		}
+	}
+
+	private static bool StateSizesEqual(Dictionary<string, int> left, Dictionary<string, int> right)
+	{
+		if (ReferenceEquals(left, right))
+		{
+			return true;
+		}
+
+		if (left is null || right is null || left.Count != right.Count)
+		{
+			return false;
+		}
+
+		foreach (var (partition, stateSize) in left)
+		{
+			if (!right.TryGetValue(partition, out var otherStateSize) || stateSize != otherStateSize)
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static int GetStateSizesHashCode(Dictionary<string, int> stateSizes)
+	{
+		if (stateSizes is null)
+		{
+			return 0;
+		}
+
+		unchecked
+		{
+			var hashCode = 0;
+
+			foreach (var (partition, stateSize) in stateSizes)
+			{
+				hashCode ^= ((partition != null ? partition.GetHashCode() : 0) * 397) ^ stateSize;
+			}
+
 			return hashCode;
 		}
 	}


### PR DESCRIPTION
- Operators need visibility into projection state growth before it reaches the configured limit.