### PR TITLE
chore(runtime): preserve gc adaptation behavior

### DIFF
--- a/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
+++ b/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
@@ -5,6 +5,7 @@
 		<ApplicationIcon>app2.ico</ApplicationIcon>
 		<GenerateSupportedRuntime>false</GenerateSupportedRuntime>
 		<ServerGarbageCollection>true</ServerGarbageCollection>
+		<GarbageCollectionAdaptationMode>false</GarbageCollectionAdaptationMode>
 	</PropertyGroup>
 	<ItemGroup>
 		<RuntimeHostConfigurationOption Include="System.GC.HeapHardLimitPercent" Value="60" />

--- a/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
+++ b/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
@@ -5,7 +5,7 @@
 		<ApplicationIcon>app2.ico</ApplicationIcon>
 		<GenerateSupportedRuntime>false</GenerateSupportedRuntime>
 		<ServerGarbageCollection>true</ServerGarbageCollection>
-		<GarbageCollectionAdaptationMode>false</GarbageCollectionAdaptationMode>
+		<GarbageCollectionAdaptationMode>0</GarbageCollectionAdaptationMode>
 	</PropertyGroup>
 	<ItemGroup>
 		<RuntimeHostConfigurationOption Include="System.GC.HeapHardLimitPercent" Value="60" />


### PR DESCRIPTION
- The node should not silently change memory-retention behavior when running on the newer .NET runtime.