### PR TITLE
fix(config): keep yaml precedence over json defaults

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using EventStore.Common.Exceptions;
 using EventStore.Common.Options;
+using EventStore.Common.Utils;
 using EventStore.Core.Configuration;
 using EventStore.Core.Configuration.Sources;
 using FluentAssertions;
@@ -15,6 +16,7 @@ using Xunit;
 
 namespace EventStore.Core.XUnit.Tests.Configuration;
 
+[Collection("EventStoreConfigurationTests")]
 public class ClusterVNodeOptionsTests
 {
 	static ClusterVNodeOptions GetOptions(string args)
@@ -305,6 +307,42 @@ public class ClusterVNodeOptionsTests
 	}
 
 	[Fact]
+	public void explicit_yaml_config_overrides_default_json_config_files()
+	{
+		var configDirectory = Path.Combine(Locations.ApplicationDirectory, "config");
+		var jsonPath = Path.Combine(configDirectory, $"zzzz-yaml-precedence-{Guid.NewGuid():N}.json");
+		var yamlPath = Path.Combine(Path.GetTempPath(), $"eventstore-yaml-precedence-{Guid.NewGuid():N}.conf");
+
+		Directory.CreateDirectory(configDirectory);
+
+		try
+		{
+			File.WriteAllText(jsonPath, """
+				{
+					"EventStore": {
+						"ClusterSize": 3
+					}
+				}
+				""");
+			File.WriteAllText(yamlPath, """
+				---
+				ClusterSize: 5
+				""");
+
+			var config = EventStoreConfiguration.Build(["--config", yamlPath]);
+
+			var options = ClusterVNodeOptions.FromConfiguration(config);
+
+			options.Cluster.ClusterSize.Should().Be(5);
+		}
+		finally
+		{
+			File.Delete(jsonPath);
+			File.Delete(yamlPath);
+		}
+	}
+
+	[Fact]
 	public void can_set_log_level_from_env_vars()
 	{
 		var config = new ConfigurationBuilder()
@@ -327,3 +365,6 @@ public class ClusterVNodeOptionsTests
 		options.GetDeprecationWarnings().Should().BeNullOrEmpty();
 	}
 }
+
+[CollectionDefinition("EventStoreConfigurationTests", DisableParallelization = true)]
+public class EventStoreConfigurationTestsCollection;

--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -329,7 +330,7 @@ public class ClusterVNodeOptionsTests
 				ClusterSize: 5
 				""");
 
-			var config = EventStoreConfiguration.Build(["--config", yamlPath]);
+			var config = EventStoreConfiguration.Build(["--config", yamlPath], new Hashtable());
 
 			var options = ClusterVNodeOptions.FromConfiguration(config);
 

--- a/src/EventStore.Core/Configuration/EventStoreConfiguration.cs
+++ b/src/EventStore.Core/Configuration/EventStoreConfiguration.cs
@@ -25,7 +25,6 @@ public static class EventStoreConfiguration
 		var builder = new ConfigurationBuilder()
 			// we should be able to stop doing this soon as long as we bind the options automatically
 			.AddEventStoreDefaultValues()
-			.AddEventStoreYamlConfigFile(configFile.Path, configFile.Optional)
 
 			.AddSection("EventStore:Metrics", x => x.AddEsdbConfigFile("metricsconfig.json", true, true))
 
@@ -36,6 +35,7 @@ public static class EventStoreConfiguration
 			// Load all json files in the  `config` subdirectory (if it exists) of each configuration
 			// directory. We use the subdirectory to ensure that we only load configuration files.
 			.AddEsdbConfigFiles("*.json")
+			.AddEventStoreYamlConfigFile(configFile.Path, configFile.Optional)
 
 #if DEBUG
 			// load all json files in the current directory


### PR DESCRIPTION
- User-provided YAML should keep final say over bundled JSON defaults during startup.