### PR TITLE
fix(container): use current liveness probe path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,6 @@ VOLUME /var/lib/eventstore /var/log/eventstore
 EXPOSE 1112/tcp 1113/tcp 2113/tcp
 
 HEALTHCHECK --interval=5s --timeout=5s --retries=24 \
-    CMD curl --fail --insecure https://localhost:2113/health/live || curl --fail http://localhost:2113/health/live || exit 1
+    CMD curl --fail --insecure https://localhost:2113/-/liveness || curl --fail http://localhost:2113/-/liveness || exit 1
 
 ENTRYPOINT ["/opt/eventstore/EventStore.ClusterNode"]

--- a/samples/server/docker-compose-cluster.yaml
+++ b/samples/server/docker-compose-cluster.yaml
@@ -30,7 +30,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl --fail --insecure https://node1.eventstore:2113/-/liveness || exit 1",
+          "curl --fail --insecure https://node1.eventstore:2113/-/liveness || curl --fail http://node1.eventstore:2113/-/liveness || exit 1",
         ]
       interval: 5s
       timeout: 5s
@@ -62,7 +62,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl --fail --insecure https://node2.eventstore:2113/-/liveness || exit 1",
+          "curl --fail --insecure https://node2.eventstore:2113/-/liveness || curl --fail http://node2.eventstore:2113/-/liveness || exit 1",
         ]
       interval: 5s
       timeout: 5s
@@ -87,7 +87,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl --fail --insecure https://node3.eventstore:2113/-/liveness || exit 1",
+          "curl --fail --insecure https://node3.eventstore:2113/-/liveness || curl --fail http://node3.eventstore:2113/-/liveness || exit 1",
         ]
       interval: 5s
       timeout: 5s

--- a/samples/server/docker-compose-cluster.yaml
+++ b/samples/server/docker-compose-cluster.yaml
@@ -30,7 +30,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl --fail --insecure https://node1.eventstore:2113/health/live || exit 1",
+          "curl --fail --insecure https://node1.eventstore:2113/-/liveness || exit 1",
         ]
       interval: 5s
       timeout: 5s
@@ -62,7 +62,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl --fail --insecure https://node2.eventstore:2113/health/live || exit 1",
+          "curl --fail --insecure https://node2.eventstore:2113/-/liveness || exit 1",
         ]
       interval: 5s
       timeout: 5s
@@ -87,7 +87,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl --fail --insecure https://node3.eventstore:2113/health/live || exit 1",
+          "curl --fail --insecure https://node3.eventstore:2113/-/liveness || exit 1",
         ]
       interval: 5s
       timeout: 5s


### PR DESCRIPTION
- Container health checks should follow the same liveness endpoint exposed by the node.