### PR TITLE
chore(docs): fix spelling in operator docs

### DIFF
--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -129,7 +129,7 @@ Normally, the cluster gossip port is the same as the HTTP port, so you don't nee
 
 ### Gossip interval
 
-Cluster nodes try to ensure that the communication with their neighbour nodes is not broken. They use the gossip protocol and call each other after a specified period of time. This period is called the gossip interval. You can change the `GossipInvervalMs` setting so cluster nodes check in with each other more or less frequently.
+Cluster nodes try to ensure that the communication with their neighbour nodes is not broken. They use the gossip protocol and call each other after a specified period of time. This period is called the gossip interval. You can change the `GossipIntervalMs` setting so cluster nodes check in with each other more or less frequently.
 
 The default value is two seconds (2000 ms).
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -53,7 +53,7 @@ When running with protocol security disabled, everything is sent unencrypted ove
 
 ### Set initial passwords
 
-We are adding an ability to set default admin and ops passwords on the first run of the database. It will not impact the existing credentials, the user can log into their accounts with exising passwords.
+We are adding an ability to set default admin and ops passwords on the first run of the database. It will not impact the existing credentials, the user can log into their accounts with existing passwords.
 
 For this to work, you can use the `DefaultAdminPassword` option:
 


### PR DESCRIPTION
- Operator-facing docs should not make configuration names or recovery guidance harder to scan.