### PR TITLE
chore(testclient): fix readall position spelling

### DIFF
--- a/src/EventStore.TestClient/Commands/ReadAllProcessor.cs
+++ b/src/EventStore.TestClient/Commands/ReadAllProcessor.cs
@@ -24,7 +24,7 @@ internal class ReadAllProcessor : ICmdProcessor
 		bool forward = true;
 		long commitPos = 0;
 		long preparePos = 0;
-		bool posOverriden = false;
+		bool positionOverridden = false;
 		bool resolveLinkTos = false;
 		bool requireLeader = false;
 
@@ -50,7 +50,7 @@ internal class ReadAllProcessor : ICmdProcessor
 
 			if (args.Length >= 3)
 			{
-				posOverriden = true;
+				positionOverridden = true;
 				if (!long.TryParse(args[1], out commitPos) || !long.TryParse(args[2], out preparePos))
 				{
 					return false;
@@ -63,7 +63,7 @@ internal class ReadAllProcessor : ICmdProcessor
 			}
 		}
 
-		if (!posOverriden)
+		if (!positionOverridden)
 		{
 			commitPos = forward ? 0 : -1;
 			preparePos = forward ? 0 : -1;

--- a/src/EventStore.TestClient/GrpcCommands/ReadAllProcessor.cs
+++ b/src/EventStore.TestClient/GrpcCommands/ReadAllProcessor.cs
@@ -25,7 +25,7 @@ internal class ReadAllProcessor : ICmdProcessor
 		Direction direction = Direction.Forwards;
 		Position position = Position.Start;
 		bool forward = true;
-		bool posOverriden = false;
+		bool positionOverridden = false;
 		int clientCount = 1;
 
 		if (args.Length > 0)
@@ -55,7 +55,7 @@ internal class ReadAllProcessor : ICmdProcessor
 
 			if (args.Length == 4)
 			{
-				posOverriden = true;
+				positionOverridden = true;
 				if (!ulong.TryParse(args[2], out var commitPos) || !ulong.TryParse(args[3], out var preparePos))
 				{
 					return false;
@@ -65,7 +65,7 @@ internal class ReadAllProcessor : ICmdProcessor
 			}
 		}
 
-		if (!posOverriden)
+		if (!positionOverridden)
 		{
 			position = forward ? Position.Start : Position.End;
 		}


### PR DESCRIPTION
- Test client command code should be easy to follow while validating read behavior.