### PR TITLE
feat(streams): include checkpoints in subscription status

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -6148,10 +6148,44 @@
             ],
             "messages": [
               {
-                "name": "CaughtUp"
+                "name": "CaughtUp",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "stream_position",
+                    "type": "uint64"
+                  },
+                  {
+                    "id": 2,
+                    "name": "all_stream_position",
+                    "type": "event_store.client.AllStreamPosition"
+                  },
+                  {
+                    "id": 3,
+                    "name": "no_position",
+                    "type": "event_store.client.Empty"
+                  }
+                ]
               },
               {
-                "name": "FellBehind"
+                "name": "FellBehind",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "stream_position",
+                    "type": "uint64"
+                  },
+                  {
+                    "id": 2,
+                    "name": "all_stream_position",
+                    "type": "event_store.client.AllStreamPosition"
+                  },
+                  {
+                    "id": 3,
+                    "name": "no_position",
+                    "type": "event_store.client.Empty"
+                  }
+                ]
               },
               {
                 "name": "ReadEvent",

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscription.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscription.Tests.cs
@@ -54,8 +54,13 @@ public partial class EnumeratorTests
 			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
 			Assert.AreEqual(_eventIds[0], ((Event)await sub.GetNext()).Id);
 			Assert.AreEqual(_eventIds[1], ((Event)await sub.GetNext()).Id);
-			Assert.AreEqual(_eventIds[2], ((Event)await sub.GetNext()).Id);
-			Assert.True(await sub.GetNext() is CaughtUp);
+			var lastEvent = (Event)await sub.GetNext();
+			Assert.AreEqual(_eventIds[2], lastEvent.Id);
+
+			var caughtUp = (CaughtUp)await sub.GetNext();
+			Assert.AreEqual((ulong)lastEvent.EventPosition!.Value.CommitPosition, caughtUp.AllStreamPosition!.Value.CommitPosition);
+			Assert.AreEqual((ulong)lastEvent.EventPosition.Value.PreparePosition, caughtUp.AllStreamPosition.Value.PreparePosition);
+			Assert.Null(caughtUp.StreamPosition);
 		}
 	}
 

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.StreamSubscription.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.StreamSubscription.Tests.cs
@@ -55,7 +55,10 @@ public partial class EnumeratorTests
 
 			Assert.True(await sub.GetNext() is SubscriptionConfirmation);
 			Assert.AreEqual(_eventIds[0], ((Event)await sub.GetNext()).Id);
-			Assert.True(await sub.GetNext() is CaughtUp);
+
+			var caughtUp = (CaughtUp)await sub.GetNext();
+			Assert.Null(caughtUp.AllStreamPosition);
+			Assert.AreEqual(0, caughtUp.StreamPosition);
 		}
 	}
 

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.Tests.cs
@@ -14,8 +14,8 @@ public partial class EnumeratorTests
 	public record SubscriptionResponse { }
 	public record Event(Guid Id, long EventNumber, TFPos? EventPosition) : SubscriptionResponse { }
 	public record SubscriptionConfirmation() : SubscriptionResponse { }
-	public record CaughtUp : SubscriptionResponse { }
-	public record FellBehind : SubscriptionResponse { }
+	public record CaughtUp(Position? AllStreamPosition, long? StreamPosition) : SubscriptionResponse { }
+	public record FellBehind(Position? AllStreamPosition, long? StreamPosition) : SubscriptionResponse { }
 	public record Checkpoint(Position CheckpointPosition) : SubscriptionResponse { }
 
 	public class EnumeratorWrapper : IAsyncDisposable
@@ -42,11 +42,21 @@ public partial class EnumeratorTests
 			{
 				ReadResponse.EventReceived eventReceived => new Event(eventReceived.Event.Event.EventId, eventReceived.Event.OriginalEventNumber, eventReceived.Event.OriginalPosition),
 				ReadResponse.SubscriptionConfirmed => new SubscriptionConfirmation(),
-				ReadResponse.SubscriptionCaughtUp => new CaughtUp(),
-				ReadResponse.SubscriptionFellBehind => new FellBehind(),
+				ReadResponse.SubscriptionCaughtUp caughtUp => new CaughtUp(ToPosition(caughtUp.AllStreamPosition), caughtUp.StreamPosition),
+				ReadResponse.SubscriptionFellBehind fellBehind => new FellBehind(ToPosition(fellBehind.AllStreamPosition), fellBehind.StreamPosition),
 				ReadResponse.CheckpointReceived checkpointReceived => new Checkpoint(new Position(checkpointReceived.CommitPosition, checkpointReceived.PreparePosition)),
 				_ => throw new ArgumentOutOfRangeException(nameof(resp), resp, null),
 			};
+		}
+
+		private static Position? ToPosition(TFPos? position)
+		{
+			if (position is not { CommitPosition: >= 0, PreparePosition: >= 0 } allPosition)
+			{
+				return null;
+			}
+
+			return new Position((ulong)allPosition.CommitPosition, (ulong)allPosition.PreparePosition);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/SubscribeToAllTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/SubscribeToAllTests.cs
@@ -62,9 +62,14 @@ public class SubscribeToAllTests
 				}
 			}, GetCallOptions(AdminCredentials));
 
-			_responses.AddRange(await call.ResponseStream.ReadAllAsync()
-				.TakeWhile(response => response.ContentCase != ReadResp.ContentOneofCase.CaughtUp)
-				.ToArrayAsync());
+			await foreach (var response in call.ResponseStream.ReadAllAsync())
+			{
+				_responses.Add(response);
+				if (response.ContentCase == ReadResp.ContentOneofCase.CaughtUp)
+				{
+					break;
+				}
+			}
 		}
 
 		[Test]
@@ -72,6 +77,14 @@ public class SubscribeToAllTests
 		{
 			Assert.AreEqual(ReadResp.ContentOneofCase.Confirmation, _responses[0].ContentCase);
 			Assert.NotNull(_responses[0].Confirmation.SubscriptionId);
+		}
+
+		[Test]
+		public void caught_up_includes_the_all_stream_position()
+		{
+			var caughtUp = _responses.Single(x => x.ContentCase == ReadResp.ContentOneofCase.CaughtUp).CaughtUp;
+			Assert.AreEqual(_positionOfLastWrite.CommitPosition, caughtUp.AllStreamPosition.CommitPosition);
+			Assert.AreEqual(_positionOfLastWrite.PreparePosition, caughtUp.AllStreamPosition.PreparePosition);
 		}
 	}
 

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscription.cs
@@ -187,7 +187,7 @@ ReadLoop:
 					"Subscription {subscriptionId} to $all caught up at checkpoint {position}.",
 					_subscriptionId, checkpoint);
 
-				await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionCaughtUp(), ct);
+				await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionCaughtUp(checkpoint), ct);
 			}
 
 			private async Task NotifyFellBehind(TFPos checkpoint, CancellationToken ct)
@@ -196,7 +196,7 @@ ReadLoop:
 					"Subscription {subscriptionId} to $all fell behind at checkpoint {position}.",
 					_subscriptionId, checkpoint);
 
-				await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionFellBehind(), ct);
+				await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionFellBehind(checkpoint), ct);
 			}
 
 			private async ValueTask<(TFPos, ulong)> GoLive(TFPos checkpoint, ulong sequenceNumber, CancellationToken ct)

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
@@ -220,7 +220,7 @@ ReadLoop:
 					"Subscription {subscriptionId} to $all:{eventFilter} caught up at checkpoint {position}.",
 					_subscriptionId, _eventFilter, checkpoint);
 
-				await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionCaughtUp(), ct);
+				await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionCaughtUp(checkpoint), ct);
 			}
 
 			private async Task NotifyFellBehind(TFPos checkpoint, CancellationToken ct)
@@ -229,7 +229,7 @@ ReadLoop:
 					"Subscription {subscriptionId} to $all:{eventFilter} fell behind at checkpoint {position}.",
 					_subscriptionId, _eventFilter, checkpoint);
 
-				await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionFellBehind(), ct);
+				await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionFellBehind(checkpoint), ct);
 			}
 
 			private async ValueTask<(TFPos, ulong)> GoLive(TFPos checkpoint, ulong sequenceNumber, CancellationToken ct)

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.StreamSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.StreamSubscription.cs
@@ -203,7 +203,7 @@ ReadLoop:
 					"Subscription {subscriptionId} to {streamName} caught up at checkpoint {streamRevision:N0}.",
 					_subscriptionId, _streamName, checkpoint);
 
-				await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionCaughtUp(), ct);
+				await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionCaughtUp(checkpoint), ct);
 			}
 
 			private async Task NotifyFellBehind(long checkpoint, CancellationToken ct)
@@ -212,7 +212,7 @@ ReadLoop:
 					"Subscription {subscriptionId} to {streamName} fell behind at checkpoint {streamRevision:N0}.",
 					_subscriptionId, _streamName, checkpoint);
 
-				await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionFellBehind(), ct);
+				await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionFellBehind(checkpoint), ct);
 			}
 
 			private async ValueTask<(long, ulong)> GoLive(long checkpoint, ulong sequenceNumber, CancellationToken ct)

--- a/src/EventStore.Core/Services/Transport/Enumerators/ReadResponse.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/ReadResponse.cs
@@ -15,9 +15,37 @@ public abstract class ReadResponse
 		}
 	}
 
-	public class SubscriptionCaughtUp : ReadResponse { }
+	public class SubscriptionCaughtUp : ReadResponse
+	{
+		public readonly TFPos? AllStreamPosition;
+		public readonly long? StreamPosition;
 
-	public class SubscriptionFellBehind : ReadResponse { }
+		public SubscriptionCaughtUp(TFPos allStreamPosition)
+		{
+			AllStreamPosition = allStreamPosition;
+		}
+
+		public SubscriptionCaughtUp(long streamPosition)
+		{
+			StreamPosition = streamPosition;
+		}
+	}
+
+	public class SubscriptionFellBehind : ReadResponse
+	{
+		public readonly TFPos? AllStreamPosition;
+		public readonly long? StreamPosition;
+
+		public SubscriptionFellBehind(TFPos allStreamPosition)
+		{
+			AllStreamPosition = allStreamPosition;
+		}
+
+		public SubscriptionFellBehind(long streamPosition)
+		{
+			StreamPosition = streamPosition;
+		}
+	}
 
 	public class CheckpointReceived : ReadResponse
 	{

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -303,11 +303,14 @@ internal partial class Streams<TStreamId>
 					StreamIdentifier = streamNotFound.StreamName
 				}
 			},
-			ReadResponse.SubscriptionCaughtUp => new ReadResp
+			ReadResponse.SubscriptionCaughtUp caughtUp => new ReadResp
 			{
-				CaughtUp = new ReadResp.Types.CaughtUp()
+				CaughtUp = ToCaughtUp(caughtUp)
 			},
-			ReadResponse.SubscriptionFellBehind => null, // currently not sent to clients
+			ReadResponse.SubscriptionFellBehind fellBehind => new ReadResp
+			{
+				FellBehind = ToFellBehind(fellBehind)
+			},
 			ReadResponse.LastStreamPositionReceived lastStreamPositionReceived => new ReadResp
 			{
 				LastStreamPosition = lastStreamPositionReceived.LastStreamPosition
@@ -320,6 +323,77 @@ internal partial class Streams<TStreamId>
 		};
 
 		return readResp != null;
+	}
+
+	private static ReadResp.Types.CaughtUp ToCaughtUp(ReadResponse.SubscriptionCaughtUp caughtUp)
+	{
+		var response = new ReadResp.Types.CaughtUp();
+		SetPosition(response, caughtUp.AllStreamPosition, caughtUp.StreamPosition);
+		return response;
+	}
+
+	private static ReadResp.Types.FellBehind ToFellBehind(ReadResponse.SubscriptionFellBehind fellBehind)
+	{
+		var response = new ReadResp.Types.FellBehind();
+		SetPosition(response, fellBehind.AllStreamPosition, fellBehind.StreamPosition);
+		return response;
+	}
+
+	private static void SetPosition(ReadResp.Types.CaughtUp response, TFPos? allStreamPosition, long? streamPosition)
+	{
+		if (TrySetAllStreamPosition(allStreamPosition, position => response.AllStreamPosition = position))
+		{
+			return;
+		}
+
+		if (TrySetStreamPosition(streamPosition, position => response.StreamPosition = position))
+		{
+			return;
+		}
+
+		response.NoPosition = new Empty();
+	}
+
+	private static void SetPosition(ReadResp.Types.FellBehind response, TFPos? allStreamPosition, long? streamPosition)
+	{
+		if (TrySetAllStreamPosition(allStreamPosition, position => response.AllStreamPosition = position))
+		{
+			return;
+		}
+
+		if (TrySetStreamPosition(streamPosition, position => response.StreamPosition = position))
+		{
+			return;
+		}
+
+		response.NoPosition = new Empty();
+	}
+
+	private static bool TrySetAllStreamPosition(TFPos? position, Action<AllStreamPosition> setPosition)
+	{
+		if (position is not { CommitPosition: >= 0, PreparePosition: >= 0 } allPosition)
+		{
+			return false;
+		}
+
+		setPosition(new AllStreamPosition
+		{
+			CommitPosition = (ulong)allPosition.CommitPosition,
+			PreparePosition = (ulong)allPosition.PreparePosition
+		});
+
+		return true;
+	}
+
+	private static bool TrySetStreamPosition(long? streamPosition, Action<ulong> setPosition)
+	{
+		if (streamPosition is not >= 0)
+		{
+			return false;
+		}
+
+		setPosition((ulong)streamPosition);
+		return true;
 	}
 
 	private static void ConvertReadResponseException(ReadResponseException readResponseEx)

--- a/src/Protos/Grpc/streams.proto
+++ b/src/Protos/Grpc/streams.proto
@@ -103,9 +103,21 @@ message ReadResp {
 		FellBehind fell_behind = 9;
 	}
 	
-	message CaughtUp {}
+	message CaughtUp {
+		oneof position {
+			uint64 stream_position = 1;
+			event_store.client.AllStreamPosition all_stream_position = 2;
+			event_store.client.Empty no_position = 3;
+		}
+	}
 
-	message FellBehind {}
+	message FellBehind {
+		oneof position {
+			uint64 stream_position = 1;
+			event_store.client.AllStreamPosition all_stream_position = 2;
+			event_store.client.Empty no_position = 3;
+		}
+	}
 
 	message ReadEvent {
 		RecordedEvent event = 1;
@@ -314,4 +326,3 @@ message TombstoneResp {
 		uint64 prepare_position = 2;
 	}
 }
-


### PR DESCRIPTION
- Subscription status notifications need position context so clients can resume or diagnose live catch-up transitions without guessing.
- Fell-behind notifications should remain observable through gRPC instead of being dropped after the enumerator detects a gap.