### PR TITLE
chore(metrics): make slow message thresholds configurable

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Common.Configuration;
 using EventStore.Common.Exceptions;
 using EventStore.Common.Options;
 using EventStore.Common.Utils;
@@ -89,7 +90,8 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable
 					options.Projection.FaultOutOfOrderProjections,
 					options.Projection.ProjectionCompilationTimeout,
 					options.Projection.ProjectionExecutionTimeout,
-					options.Projection.MaxProjectionStateSize)))
+					options.Projection.MaxProjectionStateSize,
+					MetricsConfiguration.Get(configuration))))
 			: options;
 
 		var absolutePath = Path.GetFullPath(_options.Database.Db);

--- a/src/EventStore.ClusterNode/metricsconfig.json
+++ b/src/EventStore.ClusterNode/metricsconfig.json
@@ -124,6 +124,34 @@
 		"Processing": false
 	},
 
+	"SlowMessageThresholdMilliseconds": {
+		"MainBus": 48,
+		"MainQueue": 48,
+		"MonitoringInnerBus": 800,
+		"MonitoringRequestBus": -1,
+		"MonitoringQueue": 800,
+		"PersistentSubscriptionsBus": 50,
+		"PersistentSubscriptions": -1,
+		"ProjectionManagerInputBus": 48,
+		"ProjectionManagerOutputBus": 48,
+		"ProjectionManagerInputQueue": 48,
+		"ProjectionManagerOutputQueue": 48,
+		"ProjectionWorkerInputBus": 48,
+		"ProjectionWorkerOutputBus": 48,
+		"ProjectionWorkerInputQueue": 48,
+		"ProjectionWorkerOutputQueue": 48,
+		"RedactionBus": 2000,
+		"Redaction": -1,
+		"StorageReaderBus": 200,
+		"StorageReaderQueue": 200,
+		"StorageWriterBus": 500,
+		"StorageWriterQueue": 500,
+		"SubscriptionsBus": 50,
+		"Subscriptions": -1,
+		"WorkerBus": 200,
+		"WorkerQueue": 200
+	},
+
 	// this specifies what name to track each queue under, according to regular expressions to
 	// match the queue names against
 	"QueueLabels": [

--- a/src/EventStore.Common/Configuration/MetricsConfiguration.cs
+++ b/src/EventStore.Common/Configuration/MetricsConfiguration.cs
@@ -6,10 +6,22 @@ namespace EventStore.Common.Configuration;
 
 public class MetricsConfiguration
 {
+	public static readonly TimeSpan DefaultSlowMessageThreshold = TimeSpan.FromMilliseconds(48);
+
 	public static MetricsConfiguration Get(IConfiguration configuration) =>
 		configuration
 			.GetSection("EventStore:Metrics")
 			.Get<MetricsConfiguration>() ?? new();
+
+	public TimeSpan GetSlowMessageThreshold(string name) =>
+		GetSlowMessageThreshold(name, DefaultSlowMessageThreshold);
+
+	public TimeSpan GetSlowMessageThreshold(string name, TimeSpan fallback) =>
+		SlowMessageThresholdMilliseconds.TryGetValue(name, out var thresholdMilliseconds)
+			? thresholdMilliseconds > 0
+				? TimeSpan.FromMilliseconds(thresholdMilliseconds)
+				: TimeSpan.Zero
+			: fallback;
 
 	public enum StatusTracker
 	{
@@ -175,6 +187,8 @@ public class MetricsConfiguration
 	public int ExpectedScrapeIntervalSeconds { get; set; }
 
 	public OtlpExporterConfiguration Otlp { get; set; } = new();
+
+	public Dictionary<string, int> SlowMessageThresholdMilliseconds { get; set; } = new();
 
 	public Dictionary<QueueTracker, bool> Queues { get; set; } = new();
 

--- a/src/EventStore.Core.XUnit.Tests/Metrics/MetricsConfigurationTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/MetricsConfigurationTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using EventStore.Common.Configuration;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Metrics;
+
+public class MetricsConfigurationTests
+{
+	[Fact]
+	public void UsesDefaultSlowMessageThresholdWhenNameIsNotConfigured()
+	{
+		var configuration = new ConfigurationBuilder().Build();
+
+		var metrics = MetricsConfiguration.Get(configuration);
+
+		metrics.GetSlowMessageThreshold("MainBus").Should().Be(MetricsConfiguration.DefaultSlowMessageThreshold);
+	}
+
+	[Fact]
+	public void UsesFallbackSlowMessageThresholdWhenNameIsNotConfigured()
+	{
+		var configuration = new ConfigurationBuilder().Build();
+		var fallback = TimeSpan.FromMilliseconds(500);
+
+		var metrics = MetricsConfiguration.Get(configuration);
+
+		metrics.GetSlowMessageThreshold("StorageWriterQueue", fallback).Should().Be(fallback);
+	}
+
+	[Fact]
+	public void BindsNamedSlowMessageThreshold()
+	{
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string>
+			{
+				["EventStore:Metrics:SlowMessageThresholdMilliseconds:StorageReaderBus"] = "200",
+			})
+			.Build();
+
+		var metrics = MetricsConfiguration.Get(configuration);
+
+		metrics.GetSlowMessageThreshold("StorageReaderBus").Should().Be(TimeSpan.FromMilliseconds(200));
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void DisablesSlowMessageThresholdWhenConfiguredAsNonPositive(int thresholdMilliseconds)
+	{
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string>
+			{
+				["EventStore:Metrics:SlowMessageThresholdMilliseconds:MonitoringRequestBus"] =
+					thresholdMilliseconds.ToString(),
+			})
+			.Build();
+
+		var metrics = MetricsConfiguration.Get(configuration);
+
+		metrics.GetSlowMessageThreshold("MonitoringRequestBus").Should().Be(TimeSpan.Zero);
+	}
+}

--- a/src/EventStore.Core/Bus/InMemoryBus.cs
+++ b/src/EventStore.Core/Bus/InMemoryBus.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DotNext;
 using DotNext.Diagnostics;
+using EventStore.Common.Configuration;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using ILogger = Serilog.ILogger;
@@ -21,7 +22,7 @@ public partial class InMemoryBus : ISubscriber, IAsyncHandle<Message>
 	public static InMemoryBus CreateTest(bool watchSlowMsg = true) =>
 		new("Test", watchSlowMsg);
 
-	public static readonly TimeSpan DefaultSlowMessageThreshold = TimeSpan.FromMilliseconds(48);
+	public static readonly TimeSpan DefaultSlowMessageThreshold = MetricsConfiguration.DefaultSlowMessageThreshold;
 	private static readonly ILogger Log = Serilog.Log.ForContext<InMemoryBus>();
 
 	private readonly FrozenDictionary<Type, MessageTypeHandler> _handlers;

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -333,6 +333,7 @@ public class ClusterVNode<TStreamId> :
 		var trackers = new Trackers();
 		var metricsConfiguration = MetricsConfiguration.Get(configuration);
 		MetricsBootstrapper.Bootstrap(metricsConfiguration, dbConfig, trackers);
+		static bool WatchSlowMessages(TimeSpan threshold) => threshold > TimeSpan.Zero;
 
 		Db = new TFChunkDb(
 			dbConfig,
@@ -516,10 +517,13 @@ public class ClusterVNode<TStreamId> :
 		var forwardingProxy = new MessageForwardingProxy();
 
 		// MISC WORKERS
+		var workerBusSlowMessageThreshold = metricsConfiguration.GetSlowMessageThreshold("WorkerBus",
+			TimeSpan.FromMilliseconds(200));
+		var workerQueueSlowMessageThreshold = metricsConfiguration.GetSlowMessageThreshold("WorkerQueue",
+			TimeSpan.FromMilliseconds(200));
 		_workerBuses = Enumerable.Range(0, workerThreadsCount).Select(queueNum =>
 			new InMemoryBus($"Worker #{queueNum + 1} Bus",
-				watchSlowMsg: true,
-				slowMsgThreshold: TimeSpan.FromMilliseconds(200))).ToArray();
+				slowMsgThreshold: workerBusSlowMessageThreshold)).ToArray();
 		_workersHandler = new MultiQueuedHandler(
 			workerThreadsCount,
 			queueNum => new QueuedHandlerThreadPool(_workerBuses[queueNum],
@@ -527,8 +531,8 @@ public class ClusterVNode<TStreamId> :
 				_queueStatsManager,
 				trackers.QueueTrackers,
 				groupName: "Workers",
-				watchSlowMsg: true,
-				slowMsgThreshold: TimeSpan.FromMilliseconds(200)));
+				watchSlowMsg: WatchSlowMessages(workerQueueSlowMessageThreshold),
+				slowMsgThreshold: workerQueueSlowMessageThreshold));
 
 		void StartSubsystems()
 		{
@@ -554,6 +558,7 @@ public class ClusterVNode<TStreamId> :
 				_queueStatsManager, trackers, NodeInfo, Db,
 				trackers.NodeStatusTracker,
 				options, this, forwardingProxy,
+				metricsConfiguration,
 				startSubsystems: StartSubsystems);
 
 		_mainQueue = _controller.MainQueue;
@@ -591,12 +596,20 @@ public class ClusterVNode<TStreamId> :
 		_mainBus.Subscribe<ClientMessage.ReloadConfig>(this);
 
 		// MONITORING
-		var monitoringInnerBus = new InMemoryBus("MonitoringInnerBus", watchSlowMsg: false);
-		var monitoringRequestBus = new InMemoryBus("MonitoringRequestBus", watchSlowMsg: false);
+		var monitoringInnerBusSlowMessageThreshold = metricsConfiguration.GetSlowMessageThreshold("MonitoringInnerBus",
+			TimeSpan.Zero);
+		var monitoringRequestBusSlowMessageThreshold = metricsConfiguration.GetSlowMessageThreshold("MonitoringRequestBus",
+			TimeSpan.Zero);
+		var monitoringQueueSlowMessageThreshold = metricsConfiguration.GetSlowMessageThreshold("MonitoringQueue",
+			TimeSpan.FromMilliseconds(800));
+		var monitoringInnerBus = new InMemoryBus("MonitoringInnerBus",
+			slowMsgThreshold: monitoringInnerBusSlowMessageThreshold);
+		var monitoringRequestBus = new InMemoryBus("MonitoringRequestBus",
+			slowMsgThreshold: monitoringRequestBusSlowMessageThreshold);
 		var monitoringQueue = new QueuedHandlerThreadPool(monitoringInnerBus, "MonitoringQueue", _queueStatsManager,
 			trackers.QueueTrackers,
-			true,
-			TimeSpan.FromMilliseconds(800));
+			WatchSlowMessages(monitoringQueueSlowMessageThreshold),
+			monitoringQueueSlowMessageThreshold);
 
 		var monitoring = new MonitoringService(monitoringQueue,
 			monitoringRequestBus,
@@ -771,7 +784,8 @@ public class ClusterVNode<TStreamId> :
 			trackers.QueueTrackers,
 			trackers.WriterFlushSizeTracker,
 			trackers.WriterFlushDurationTracker,
-			() => readIndex.LastIndexedPosition);
+			() => readIndex.LastIndexedPosition,
+			metricsConfiguration);
 
 		monitoringRequestBus.Subscribe<MonitoringMessage.InternalStatsRequest>(storageWriter);
 
@@ -796,7 +810,8 @@ public class ClusterVNode<TStreamId> :
 		var storageReader = new StorageReaderService<TStreamId>(_mainQueue, _mainBus, readIndex,
 			logFormat.SystemStreams,
 			readerThreadsCount, Db.Config.WriterCheckpoint.AsReadOnly(), inMemReader, _queueStatsManager,
-			trackers.QueueTrackers);
+			trackers.QueueTrackers,
+			metricsConfiguration);
 
 		_mainBus.Subscribe<SystemMessage.SystemInit>(storageReader);
 		_mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(storageReader);
@@ -1135,9 +1150,14 @@ public class ClusterVNode<TStreamId> :
 		_mainBus.Subscribe<StorageMessage.RequestManagerTimerTick>(requestManagement);
 
 		// SUBSCRIPTIONS
-		var subscrBus = new InMemoryBus("SubscriptionsBus", true, TimeSpan.FromMilliseconds(50));
+		var subscriptionBusSlowMessageThreshold = metricsConfiguration.GetSlowMessageThreshold("SubscriptionsBus",
+			TimeSpan.FromMilliseconds(50));
+		var subscriptionQueueSlowMessageThreshold = metricsConfiguration.GetSlowMessageThreshold("Subscriptions",
+			TimeSpan.Zero);
+		var subscrBus = new InMemoryBus("SubscriptionsBus", slowMsgThreshold: subscriptionBusSlowMessageThreshold);
 		var subscrQueue = new QueuedHandlerThreadPool(subscrBus, "Subscriptions", _queueStatsManager,
-			trackers.QueueTrackers, false);
+			trackers.QueueTrackers, WatchSlowMessages(subscriptionQueueSlowMessageThreshold),
+			subscriptionQueueSlowMessageThreshold);
 		_mainBus.Subscribe<SystemMessage.SystemStart>(subscrQueue);
 		_mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(subscrQueue);
 		_mainBus.Subscribe<TcpMessage.ConnectionClosed>(subscrQueue);
@@ -1167,9 +1187,17 @@ public class ClusterVNode<TStreamId> :
 
 		// PERSISTENT SUBSCRIPTIONS
 		// IO DISPATCHER
-		var perSubscrBus = new InMemoryBus("PersistentSubscriptionsBus", true, TimeSpan.FromMilliseconds(50));
+		var persistentSubscriptionBusSlowMessageThreshold = metricsConfiguration.GetSlowMessageThreshold(
+			"PersistentSubscriptionsBus",
+			TimeSpan.FromMilliseconds(50));
+		var persistentSubscriptionQueueSlowMessageThreshold = metricsConfiguration.GetSlowMessageThreshold(
+			"PersistentSubscriptions",
+			TimeSpan.Zero);
+		var perSubscrBus = new InMemoryBus("PersistentSubscriptionsBus",
+			slowMsgThreshold: persistentSubscriptionBusSlowMessageThreshold);
 		var perSubscrQueue = new QueuedHandlerThreadPool(perSubscrBus, "PersistentSubscriptions", _queueStatsManager,
-			trackers.QueueTrackers, false);
+			trackers.QueueTrackers, WatchSlowMessages(persistentSubscriptionQueueSlowMessageThreshold),
+			persistentSubscriptionQueueSlowMessageThreshold);
 		var psubDispatcher = new IODispatcher(_mainQueue, perSubscrQueue);
 		perSubscrBus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(psubDispatcher.BackwardReader);
 		perSubscrBus.Subscribe<ClientMessage.NotHandled>(psubDispatcher.BackwardReader);
@@ -1430,9 +1458,13 @@ public class ClusterVNode<TStreamId> :
 		// ReSharper restore RedundantTypeArgumentsOfMethod
 
 		// REDACTION
-		var redactionBus = new InMemoryBus("RedactionBus", true, TimeSpan.FromSeconds(2));
+		var redactionBusSlowMessageThreshold = metricsConfiguration.GetSlowMessageThreshold("RedactionBus",
+			TimeSpan.FromSeconds(2));
+		var redactionQueueSlowMessageThreshold = metricsConfiguration.GetSlowMessageThreshold("Redaction", TimeSpan.Zero);
+		var redactionBus = new InMemoryBus("RedactionBus", slowMsgThreshold: redactionBusSlowMessageThreshold);
 		var redactionQueue = new QueuedHandlerThreadPool(redactionBus, "Redaction", _queueStatsManager,
-			trackers.QueueTrackers, false);
+			trackers.QueueTrackers, WatchSlowMessages(redactionQueueSlowMessageThreshold),
+			redactionQueueSlowMessageThreshold);
 
 		_mainBus.Subscribe<RedactionMessage.GetEventPosition>(redactionQueue);
 		_mainBus.Subscribe<RedactionMessage.AcquireChunksLock>(redactionQueue);
@@ -1605,7 +1637,7 @@ public class ClusterVNode<TStreamId> :
 
 		var standardComponents = new StandardComponents(Db.Config, _mainQueue, _mainBus, _timerService, _timeProvider,
 			new IHttpService[] { _httpService }, _workersHandler, monitoringQueue, _queueStatsManager,
-			trackers.QueueTrackers, metricsConfiguration.ProjectionStats);
+			trackers.QueueTrackers, metricsConfiguration.ProjectionStats, metricsConfiguration);
 
 		IServiceCollection ConfigureNodeServices(IServiceCollection services)
 		{

--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Common.Configuration;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
@@ -57,10 +58,11 @@ public class ClusterStorageWriterService<TStreamId> : StorageWriterService<TStre
 		QueueTrackers trackers,
 		IMaxTracker<long> flushSizeTracker,
 		IDurationMaxTracker flushDurationTracker,
-		Func<long> getLastIndexedPosition)
+		Func<long> getLastIndexedPosition,
+		MetricsConfiguration metricsConfiguration = null)
 		: base(bus, subscribeToBus, minFlushDelay, db, writer, indexWriter, recordFactory, streamNameIndex,
 			eventTypeIndex, emptyEventTypeId, systemStreams, epochManager, queueStatsManager, trackers,
-			flushSizeTracker, flushDurationTracker)
+			flushSizeTracker, flushDurationTracker, metricsConfiguration)
 	{
 		Ensure.NotNull(getLastIndexedPosition, "getLastCommitPosition");
 

--- a/src/EventStore.Core/Services/Storage/StorageReaderService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Common.Configuration;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.LogAbstraction;
@@ -39,7 +40,8 @@ namespace EventStore.Core.Services.Storage
 			IReadOnlyCheckpoint writerCheckpoint,
 			IInMemoryStreamReader inMemReader,
 			QueueStatsManager queueStatsManager,
-			QueueTrackers trackers)
+			QueueTrackers trackers,
+			MetricsConfiguration metricsConfiguration = null)
 		{
 
 			Ensure.NotNull(bus, "bus");
@@ -52,12 +54,18 @@ namespace EventStore.Core.Services.Storage
 			_bus = bus;
 			_readIndex = readIndex;
 			_threadCount = threadCount;
+			metricsConfiguration ??= new();
+			var storageReaderBusSlowMessageThreshold =
+				metricsConfiguration.GetSlowMessageThreshold("StorageReaderBus", TimeSpan.Zero);
+			var storageReaderQueueSlowMessageThreshold = metricsConfiguration.GetSlowMessageThreshold("StorageReaderQueue",
+				TimeSpan.FromMilliseconds(200));
 			StorageReaderWorker<TStreamId>[] readerWorkers = new StorageReaderWorker<TStreamId>[threadCount];
 			InMemoryBus[] storageReaderBuses = new InMemoryBus[threadCount];
 			for (var i = 0; i < threadCount; i++)
 			{
 				readerWorkers[i] = new StorageReaderWorker<TStreamId>(bus, readIndex, systemStreams, writerCheckpoint, inMemReader, i);
-				storageReaderBuses[i] = new InMemoryBus("StorageReaderBus", watchSlowMsg: false);
+				storageReaderBuses[i] = new InMemoryBus("StorageReaderBus",
+					slowMsgThreshold: storageReaderBusSlowMessageThreshold);
 				storageReaderBuses[i].Subscribe<ClientMessage.ReadEvent>(readerWorkers[i]);
 				storageReaderBuses[i].Subscribe<ClientMessage.ReadStreamEventsBackward>(readerWorkers[i]);
 				storageReaderBuses[i].Subscribe<ClientMessage.ReadStreamEventsForward>(readerWorkers[i]);
@@ -77,8 +85,8 @@ namespace EventStore.Core.Services.Storage
 					queueStatsManager,
 					trackers,
 					groupName: "StorageReaderQueue",
-					watchSlowMsg: true,
-					slowMsgThreshold: TimeSpan.FromMilliseconds(200)));
+					watchSlowMsg: storageReaderQueueSlowMessageThreshold > TimeSpan.Zero,
+					slowMsgThreshold: storageReaderQueueSlowMessageThreshold));
 			_workersMultiHandler.Start();
 
 			subscriber.Subscribe<ClientMessage.ReadEvent>(_workersMultiHandler);

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Common.Configuration;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
@@ -108,7 +109,8 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 		QueueStatsManager queueStatsManager,
 		QueueTrackers queueTrackers,
 		IMaxTracker<long> flushSizeTracker,
-		IDurationMaxTracker flushDurationTracker)
+		IDurationMaxTracker flushDurationTracker,
+		MetricsConfiguration metricsConfiguration = null)
 	{
 
 		Ensure.NotNull(bus, "bus");
@@ -143,13 +145,18 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 
 		Writer = writer;
 
-		_writerBus = new InMemoryBus("StorageWriterBus", watchSlowMsg: false);
+		metricsConfiguration ??= new();
+		var writerBusSlowMessageThreshold = metricsConfiguration.GetSlowMessageThreshold("StorageWriterBus", TimeSpan.Zero);
+		var writerQueueSlowMessageThreshold = metricsConfiguration.GetSlowMessageThreshold("StorageWriterQueue",
+			TimeSpan.FromMilliseconds(500));
+
+		_writerBus = new InMemoryBus("StorageWriterBus", slowMsgThreshold: writerBusSlowMessageThreshold);
 		_writerQueue = new QueuedHandlerThreadPool(new AdHocHandler<Message>(CommonHandle),
 			"StorageWriterQueue",
 			queueStatsManager,
 			queueTrackers,
-			true,
-			TimeSpan.FromMilliseconds(500));
+			writerQueueSlowMessageThreshold > TimeSpan.Zero,
+			writerQueueSlowMessageThreshold);
 
 		SubscribeToMessage<SystemMessage.SystemInit>();
 		SubscribeToMessage<SystemMessage.StateChangeMessage>();

--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Common.Configuration;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Cluster;
@@ -84,6 +85,7 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 		TFChunkDb db,
 		INodeStatusTracker statusTracker,
 		ClusterVNodeOptions options, ClusterVNode<TStreamId> node, MessageForwardingProxy forwardingProxy,
+		MetricsConfiguration metricsConfiguration,
 		Action startSubsystems)
 	{
 		Ensure.NotNull(nodeInfo, "nodeInfo");
@@ -105,9 +107,14 @@ public sealed class ClusterVNodeController<TStreamId> : ClusterVNodeController
 		_forwardingTimeout = TimeSpan.FromMilliseconds(options.Database.PrepareTimeoutMs +
 													   options.Database.CommitTimeoutMs + 300);
 
-		_outputBus = new InMemoryBus("MainBus");
+		metricsConfiguration ??= new();
+		var mainBusSlowMessageThreshold = metricsConfiguration.GetSlowMessageThreshold("MainBus");
+		var mainQueueSlowMessageThreshold = metricsConfiguration.GetSlowMessageThreshold("MainQueue");
+
+		_outputBus = new InMemoryBus("MainBus", slowMsgThreshold: mainBusSlowMessageThreshold);
 		_fsm = CreateFSM();
-		_mainQueue = new QueuedHandlerThreadPool(_fsm, "MainQueue", statsManager, trackers.QueueTrackers);
+		_mainQueue = new QueuedHandlerThreadPool(_fsm, "MainQueue", statsManager, trackers.QueueTrackers,
+			mainQueueSlowMessageThreshold > TimeSpan.Zero, mainQueueSlowMessageThreshold);
 		_publishEnvelope = _mainQueue;
 	}
 

--- a/src/EventStore.Core/StandardComponents.cs
+++ b/src/EventStore.Core/StandardComponents.cs
@@ -30,7 +30,8 @@ namespace EventStore.Core
 			IPublisher monitoringQueue,
 			QueueStatsManager queueStatsManager,
 			QueueTrackers trackers,
-			bool projectionStats)
+			bool projectionStats,
+			MetricsConfiguration metricsConfiguration = null)
 		{
 			_dbConfig = dbConfig;
 			_mainQueue = mainQueue;
@@ -43,6 +44,7 @@ namespace EventStore.Core
 			_queueStatsManager = queueStatsManager;
 			QueueTrackers = trackers;
 			ProjectionStats = projectionStats;
+			MetricsConfiguration = metricsConfiguration ?? new();
 		}
 
 		public TFChunkDbConfig DbConfig
@@ -91,6 +93,8 @@ namespace EventStore.Core
 		}
 
 		public bool ProjectionStats { get; }
+
+		public MetricsConfiguration MetricsConfiguration { get; }
 
 		public QueueTrackers QueueTrackers { get; private set; }
 	}

--- a/src/EventStore.Projections.Core/ProjectionCoreWorkersNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionCoreWorkersNode.cs
@@ -27,17 +27,31 @@ public static class ProjectionCoreWorkersNode
 		var coreWorkers = new Dictionary<Guid, CoreWorker>();
 		while (coreWorkers.Count < projectionsStandardComponents.ProjectionWorkerThreadCount)
 		{
-			var coreInputBus = new InMemoryBus("bus");
+			var coreInputBusSlowMessageThreshold =
+				standardComponents.MetricsConfiguration.GetSlowMessageThreshold("ProjectionWorkerInputBus");
+			var coreOutputBusSlowMessageThreshold =
+				standardComponents.MetricsConfiguration.GetSlowMessageThreshold("ProjectionWorkerOutputBus");
+			var coreInputQueueSlowMessageThreshold =
+				standardComponents.MetricsConfiguration.GetSlowMessageThreshold("ProjectionWorkerInputQueue");
+			var coreOutputQueueSlowMessageThreshold =
+				standardComponents.MetricsConfiguration.GetSlowMessageThreshold("ProjectionWorkerOutputQueue");
+			var coreInputBus = new InMemoryBus("ProjectionWorkerInputBus",
+				slowMsgThreshold: coreInputBusSlowMessageThreshold);
 			var coreInputQueue = new QueuedHandlerThreadPool(coreInputBus,
 				"Projection Core #" + coreWorkers.Count,
 				standardComponents.QueueStatsManager,
 				standardComponents.QueueTrackers,
+				coreInputQueueSlowMessageThreshold > TimeSpan.Zero,
+				coreInputQueueSlowMessageThreshold,
 				groupName: "Projection Core");
-			var coreOutputBus = new InMemoryBus("output bus");
+			var coreOutputBus = new InMemoryBus("ProjectionWorkerOutputBus",
+				slowMsgThreshold: coreOutputBusSlowMessageThreshold);
 			var coreOutputQueue = new QueuedHandlerThreadPool(coreOutputBus,
 				"Projection Core #" + coreWorkers.Count + " output",
 				standardComponents.QueueStatsManager,
 				standardComponents.QueueTrackers,
+				coreOutputQueueSlowMessageThreshold > TimeSpan.Zero,
+				coreOutputQueueSlowMessageThreshold,
 				groupName: "Projection Core");
 			var workerId = Guid.NewGuid();
 			var projectionNode = new ProjectionWorkerNode(

--- a/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Threading.Tasks;
 using DotNext;
+using EventStore.Common.Configuration;
 using EventStore.Common.Options;
 using EventStore.Core;
 using EventStore.Core.Bus;
@@ -31,7 +32,8 @@ public record ProjectionSubsystemOptions(
 	bool FaultOutOfOrderProjections,
 	int CompilationTimeout,
 	int ExecutionTimeout,
-	int MaxProjectionStateSize = int.MaxValue);
+	int MaxProjectionStateSize = int.MaxValue,
+	MetricsConfiguration MetricsConfiguration = null);
 
 public sealed class ProjectionsSubsystem : ISubsystem,
 	IHandle<SystemMessage.SystemCoreReady>,
@@ -70,6 +72,7 @@ public sealed class ProjectionsSubsystem : ISubsystem,
 	private readonly int _compilationTimeout;
 	private readonly int _executionTimeout;
 	private readonly int _maxProjectionStateSize;
+	private readonly MetricsConfiguration _metricsConfiguration;
 
 	private readonly int _componentCount;
 	private readonly int _dispatcherCount;
@@ -113,9 +116,12 @@ public sealed class ProjectionsSubsystem : ISubsystem,
 		_startStandardProjections = projectionSubsystemOptions.StartStandardProjections;
 		_projectionsQueryExpiry = projectionSubsystemOptions.ProjectionQueryExpiry;
 		_faultOutOfOrderProjections = projectionSubsystemOptions.FaultOutOfOrderProjections;
+		_metricsConfiguration = projectionSubsystemOptions.MetricsConfiguration ?? new();
 
-		_leaderInputBus = new InMemoryBus("manager input bus");
-		_leaderOutputBus = new InMemoryBus("ProjectionManagerAndCoreCoordinatorOutput");
+		_leaderInputBus = new InMemoryBus("ProjectionManagerInputBus",
+			slowMsgThreshold: _metricsConfiguration.GetSlowMessageThreshold("ProjectionManagerInputBus"));
+		_leaderOutputBus = new InMemoryBus("ProjectionManagerOutputBus",
+			slowMsgThreshold: _metricsConfiguration.GetSlowMessageThreshold("ProjectionManagerOutputBus"));
 
 		_subsystemInitialized = new();
 		_executionTimeout = projectionSubsystemOptions.ExecutionTimeout;
@@ -138,18 +144,26 @@ public sealed class ProjectionsSubsystem : ISubsystem,
 	public void ConfigureApplication(IApplicationBuilder builder, IConfiguration configuration)
 	{
 		var standardComponents = builder.ApplicationServices.GetRequiredService<StandardComponents>();
+		var leaderInputQueueSlowMessageThreshold =
+			_metricsConfiguration.GetSlowMessageThreshold("ProjectionManagerInputQueue");
+		var leaderOutputQueueSlowMessageThreshold =
+			_metricsConfiguration.GetSlowMessageThreshold("ProjectionManagerOutputQueue");
 
 		_leaderInputQueue = new QueuedHandlerThreadPool(
 			_leaderInputBus,
 			"Projections Leader",
 			standardComponents.QueueStatsManager,
-			standardComponents.QueueTrackers
+			standardComponents.QueueTrackers,
+			leaderInputQueueSlowMessageThreshold > TimeSpan.Zero,
+			leaderInputQueueSlowMessageThreshold
 		);
 		_leaderOutputQueue = new QueuedHandlerThreadPool(
 			_leaderOutputBus,
 			"Projections Leader",
 			standardComponents.QueueStatsManager,
-			standardComponents.QueueTrackers
+			standardComponents.QueueTrackers,
+			leaderOutputQueueSlowMessageThreshold > TimeSpan.Zero,
+			leaderOutputQueueSlowMessageThreshold
 		);
 
 		LeaderInputBus.Subscribe<ProjectionSubsystemMessage.RestartSubsystem>(this);


### PR DESCRIPTION
- Operators need runtime-specific control over slow-message diagnostics without code changes.
- Busy deployments need a supported way to reduce noisy diagnostics while preserving useful defaults for storage, subscriptions, projections, and worker paths.