### PR TITLE
feat(storage): support soft-deleted expected version

### DIFF
--- a/src/EventStore.Core.Tests/ClientOperations/when_creating_transaction_start_message.cs
+++ b/src/EventStore.Core.Tests/ClientOperations/when_creating_transaction_start_message.cs
@@ -1,0 +1,37 @@
+using System;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.ClientOperations;
+
+[TestFixture]
+public class when_creating_transaction_start_message
+{
+	[Test]
+	public void accepts_soft_deleted_expected_version()
+	{
+		Assert.DoesNotThrow(() => new ClientMessage.TransactionStart(
+			Guid.NewGuid(),
+			Guid.NewGuid(),
+			new NoopEnvelope(),
+			requireLeader: true,
+			"test-stream",
+			ExpectedVersion.SoftDeleted,
+			user: null));
+	}
+
+	[Test]
+	public void rejects_stream_exists_expected_version()
+	{
+		Assert.Throws<ArgumentOutOfRangeException>(() => new ClientMessage.TransactionStart(
+			Guid.NewGuid(),
+			Guid.NewGuid(),
+			new NoopEnvelope(),
+			requireLeader: true,
+			"test-stream",
+			ExpectedVersion.StreamExists,
+			user: null));
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommit/when_checking_stream_with_expected_version_soft_deleted.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommit/when_checking_stream_with_expected_version_soft_deleted.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Data;
+using EventStore.Core.Services.Storage.ReaderIndex;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Storage.CheckCommit;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class when_checking_stream_with_expected_version_soft_deleted<TLogFormat, TStreamId> :
+	ReadIndexTestScenario<TLogFormat, TStreamId>
+{
+	private const string HardDeletedStream = "hard-deleted-stream";
+	private const string SoftDeletedStream = "soft-deleted-stream";
+	private const string ExistingStream = "existing-stream";
+	private const string NewStream = "new-stream";
+	private TStreamId _hardDeletedStreamId;
+	private TStreamId _softDeletedStreamId;
+	private TStreamId _existingStreamId;
+	private TStreamId _newStreamId;
+
+	protected override async ValueTask WriteTestScenario(CancellationToken token)
+	{
+		(_hardDeletedStreamId, _) = await GetOrReserve(HardDeletedStream, token);
+		await WriteSingleEvent(HardDeletedStream, 0, "event", token: token);
+		await WriteDelete(HardDeletedStream, token);
+
+		(_softDeletedStreamId, _) = await GetOrReserve(SoftDeletedStream, token);
+		await WriteSingleEvent(SoftDeletedStream, 0, "event", token: token);
+		await WriteStreamMetadata(
+			SoftDeletedStream,
+			0,
+			new StreamMetadata(truncateBefore: EventNumber.DeletedStream).ToJsonString(),
+			token: token);
+
+		(_existingStreamId, _) = await GetOrReserve(ExistingStream, token);
+		await WriteSingleEvent(ExistingStream, 0, "event", token: token);
+
+		(_newStreamId, _) = await GetOrReserve(NewStream, token);
+	}
+
+	[Test]
+	public async Task soft_deleted_stream_accepts_new_events()
+	{
+		var result = await ReadIndex.IndexWriter.CheckCommit(
+			_softDeletedStreamId,
+			ExpectedVersion.SoftDeleted,
+			[Guid.NewGuid()],
+			streamMightExist: true,
+			CancellationToken.None);
+
+		Assert.AreEqual(CommitDecision.Ok, result.Decision);
+		Assert.IsTrue(result.IsSoftDeleted);
+	}
+
+	[Test]
+	public async Task soft_deleted_stream_accepts_check_only_write()
+	{
+		var result = await ReadIndex.IndexWriter.CheckCommit(
+			_softDeletedStreamId,
+			ExpectedVersion.SoftDeleted,
+			Array.Empty<Guid>(),
+			streamMightExist: true,
+			CancellationToken.None);
+
+		Assert.AreEqual(CommitDecision.Ok, result.Decision);
+		Assert.IsTrue(result.IsSoftDeleted);
+	}
+
+	[Test]
+	public async Task hard_deleted_stream_is_rejected()
+	{
+		var result = await ReadIndex.IndexWriter.CheckCommit(
+			_hardDeletedStreamId,
+			ExpectedVersion.SoftDeleted,
+			[Guid.NewGuid()],
+			streamMightExist: true,
+			CancellationToken.None);
+
+		Assert.AreEqual(CommitDecision.Deleted, result.Decision);
+	}
+
+	[Test]
+	public async Task existing_stream_is_rejected()
+	{
+		var result = await ReadIndex.IndexWriter.CheckCommit(
+			_existingStreamId,
+			ExpectedVersion.SoftDeleted,
+			[Guid.NewGuid()],
+			streamMightExist: true,
+			CancellationToken.None);
+
+		Assert.AreEqual(CommitDecision.WrongExpectedVersion, result.Decision);
+	}
+
+	[Test]
+	public async Task new_stream_fast_path_is_rejected()
+	{
+		var result = await ReadIndex.IndexWriter.CheckCommit(
+			_newStreamId,
+			ExpectedVersion.SoftDeleted,
+			[Guid.NewGuid()],
+			streamMightExist: false,
+			CancellationToken.None);
+
+		Assert.AreEqual(CommitDecision.WrongExpectedVersion, result.Decision);
+	}
+}

--- a/src/EventStore.Core/Data/ExpectedVersion.cs
+++ b/src/EventStore.Core/Data/ExpectedVersion.cs
@@ -8,5 +8,7 @@ namespace EventStore.Core.Data
 
 		public const long Invalid = -3;
 		public const long StreamExists = -4;
+		public const long SoftDeleted = -5;
+		public const long MinValue = SoftDeleted;
 	}
 }

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -208,7 +208,7 @@ public static partial class ClientMessage
 				throw new ArgumentOutOfRangeException(nameof(eventStreamId));
 			}
 
-			if (expectedVersion < Data.ExpectedVersion.StreamExists ||
+			if (expectedVersion < Data.ExpectedVersion.MinValue ||
 				expectedVersion == Data.ExpectedVersion.Invalid)
 			{
 				throw new ArgumentOutOfRangeException(nameof(expectedVersion));
@@ -329,7 +329,9 @@ public static partial class ClientMessage
 			: base(internalCorrId, correlationId, envelope, requireLeader, user, tokens, CancellationToken.None)
 		{
 			Ensure.NotNullOrEmpty(eventStreamId, "eventStreamId");
-			if (expectedVersion < Data.ExpectedVersion.Any)
+			if (expectedVersion < Data.ExpectedVersion.MinValue ||
+				expectedVersion == Data.ExpectedVersion.Invalid ||
+				expectedVersion == Data.ExpectedVersion.StreamExists)
 			{
 				throw new ArgumentOutOfRangeException(nameof(expectedVersion));
 			}
@@ -506,7 +508,7 @@ public static partial class ClientMessage
 			ExpectedVersion = expectedVersion switch
 			{
 				Data.ExpectedVersion.Invalid => throw new ArgumentOutOfRangeException(nameof(expectedVersion)),
-				< Data.ExpectedVersion.StreamExists => throw new ArgumentOutOfRangeException(nameof(expectedVersion)),
+				< Data.ExpectedVersion.MinValue => throw new ArgumentOutOfRangeException(nameof(expectedVersion)),
 				_ => expectedVersion
 			};
 			HardDelete = hardDelete;

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexWriter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexWriter.cs
@@ -247,7 +247,7 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId>
 		}
 
 		// idempotency checks
-		if (expectedVersion is ExpectedVersion.Any or ExpectedVersion.StreamExists)
+		if (expectedVersion is ExpectedVersion.Any or ExpectedVersion.StreamExists or ExpectedVersion.SoftDeleted)
 		{
 			var first = true;
 			long startEventNumber = -1;
@@ -257,9 +257,16 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId>
 				if (!_committedEvents.TryGetRecord(eventId, out var prepInfo) ||
 					!StreamIdComparer.Equals(prepInfo.StreamId, streamId))
 				{
+					var isSoftDeleted = await IsSoftDeleted(streamId, token);
+					if (expectedVersion is ExpectedVersion.SoftDeleted && !isSoftDeleted)
+					{
+						return new CommitCheckResult<TStreamId>(CommitDecision.WrongExpectedVersion, streamId,
+							curVersion, -1, -1, false);
+					}
+
 					return new CommitCheckResult<TStreamId>(
 						first ? CommitDecision.Ok : CommitDecision.CorruptedIdempotency,
-						streamId, curVersion, -1, -1, first && await IsSoftDeleted(streamId, token));
+						streamId, curVersion, -1, -1, first && isSoftDeleted);
 				}
 
 				if (first)
@@ -273,8 +280,15 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId>
 
 			if (first) /*no data in transaction*/
 			{
+				var isSoftDeleted = await IsSoftDeleted(streamId, token);
+				if (expectedVersion is ExpectedVersion.SoftDeleted && !isSoftDeleted)
+				{
+					return new CommitCheckResult<TStreamId>(CommitDecision.WrongExpectedVersion, streamId, curVersion,
+						-1, -1, false);
+				}
+
 				return new CommitCheckResult<TStreamId>(CommitDecision.Ok, streamId, curVersion, -1, -1,
-					await IsSoftDeleted(streamId, token));
+					isSoftDeleted);
 			}
 			else
 			{


### PR DESCRIPTION
- Writers need a precise optimistic-concurrency check for streams that are soft-deleted rather than only never-created or tombstoned.
- Storage validation should preserve that distinction so callers can avoid ambiguous recreation behavior.