### PR TITLE
chore(ui): map razor static assets

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -305,6 +305,7 @@ internal static class Program
 					{
 						app.MapAdminOperationsEndpoints();
 						app.MapQueueDashboardEndpoints();
+						app.MapStaticAssets();
 						app.MapRazorComponents<App>();
 					}
 


### PR DESCRIPTION
- Prevent hosted Razor UI static assets from depending on legacy middleware behavior under the current runtime.