### PR TITLE
chore(ci): extract container test publishing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ COPY ./.git/ .
 WORKDIR /build
 COPY ./scripts/publish-tests.sh ./scripts/publish-tests.sh
 RUN sh ./scripts/publish-tests.sh /build/src /build/published-tests
+WORKDIR /build/src
 
 # "test" image
 FROM mcr.microsoft.com/dotnet/sdk:10.0-${CONTAINER_RUNTIME} AS test

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,9 @@ COPY ./src .
 WORKDIR /build/.git
 COPY ./.git/ .
 
-WORKDIR /build/src
-RUN find /build/src -maxdepth 1 -type d -name "*.Tests" -print0 | xargs -r -I{} -0 -n1 sh -c \
-    'dotnet publish --runtime=${RUNTIME} --no-self-contained --configuration Release --output /build/published-tests/`basename $1` $1' - '{}'
+WORKDIR /build
+COPY ./scripts/publish-tests.sh ./scripts/publish-tests.sh
+RUN sh ./scripts/publish-tests.sh /build/src /build/published-tests
 
 # "test" image
 FROM mcr.microsoft.com/dotnet/sdk:10.0-${CONTAINER_RUNTIME} AS test

--- a/scripts/publish-tests.sh
+++ b/scripts/publish-tests.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+set -eu
+
+source_directory=$1
+output_directory=$2
+
+find "$source_directory" -maxdepth 1 -type d -name "*.Tests" -print | while IFS= read -r test_project; do
+	dotnet publish \
+		--runtime="${RUNTIME}" \
+		--no-self-contained \
+		--configuration Release \
+		--output "$output_directory/$(basename "$test_project")" \
+		"$test_project"
+done

--- a/scripts/publish-tests.sh
+++ b/scripts/publish-tests.sh
@@ -4,12 +4,16 @@ set -eu
 
 source_directory=$1
 output_directory=$2
+test_projects=$(mktemp)
+trap 'rm -f "$test_projects"' EXIT
 
-find "$source_directory" -maxdepth 1 -type d -name "*.Tests" -print | while IFS= read -r test_project; do
+find "$source_directory" -maxdepth 1 -type d -name "*.Tests" -print > "$test_projects"
+
+while IFS= read -r test_project; do
 	dotnet publish \
 		--runtime="${RUNTIME}" \
 		--no-self-contained \
 		--configuration Release \
 		--output "$output_directory/$(basename "$test_project")" \
 		"$test_project"
-done
+done < "$test_projects"

--- a/src/EventStore.Core.Tests/ClientAPI/SpecificationWithMiniNode.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/SpecificationWithMiniNode.cs
@@ -95,7 +95,6 @@ public abstract class SpecificationWithMiniNode<TLogFormat, TStreamId> : Specifi
 		}
 
 		await _node.Shutdown();
-		await Task.Delay(1000);
 		await base.TestFixtureTearDown();
 
 		MiniNodeLogging.Clear();

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -363,6 +363,7 @@ public class MiniNode<TLogFormat, TStreamId> : MiniNode, IAsyncDisposable
 		HttpClient.Dispose();
 		_kestrelTestHost.Dispose();
 		await Node.StopAsync(TimeSpan.FromSeconds(20));
+		await Task.Delay(1000);
 
 		if (!keepDb)
 		{


### PR DESCRIPTION
- Keep container test publishing easier to review as the CI matrix keeps carrying more targeted shards.