### PR TITLE
chore(common): add low allocation memory helper

### DIFF
--- a/src/EventStore.Common.Tests/Utils/LowAllocReadOnlyMemoryTests.cs
+++ b/src/EventStore.Common.Tests/Utils/LowAllocReadOnlyMemoryTests.cs
@@ -1,0 +1,83 @@
+using EventStore.Common.Utils;
+
+namespace EventStore.Common.Tests.Utils;
+
+public class LowAllocReadOnlyMemoryTests
+{
+	[Fact]
+	public void Empty_has_no_items()
+	{
+		var sut = LowAllocReadOnlyMemory<int>.Empty;
+
+		Assert.Equal(0, sut.Length);
+		Assert.Throws<InvalidOperationException>(() => sut.Single);
+		Assert.True(sut.Span.IsEmpty);
+		Assert.Empty(sut.ToArray());
+
+		foreach (var item in sut)
+		{
+			Assert.Fail($"Unexpected item: {item}");
+		}
+	}
+
+	[Fact]
+	public void Single_item_is_available_without_backing_memory()
+	{
+		var sut = new LowAllocReadOnlyMemory<int>(5);
+
+		Assert.Equal(1, sut.Length);
+		Assert.Equal(5, sut.Single);
+		Assert.True(new[] { 5 }.AsSpan().SequenceEqual(sut.Span));
+		Assert.Equal(new[] { 5 }, sut.ToArray());
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(1)]
+	[InlineData(2)]
+	[InlineData(3)]
+	public void Read_only_memory_constructor_preserves_items(int length)
+	{
+		var expected = Enumerable.Range(0, length).ToArray();
+		var sut = new LowAllocReadOnlyMemory<int>(expected);
+
+		Assert.Equal(expected.Length, sut.Length);
+		Assert.True(expected.AsSpan().SequenceEqual(sut.Span));
+		Assert.Equal(expected, sut.ToArray());
+
+		if (length == 1)
+		{
+			Assert.Equal(expected[0], sut.Single);
+		}
+		else
+		{
+			Assert.Throws<InvalidOperationException>(() => sut.Single);
+		}
+	}
+
+	[Fact]
+	public void Collection_expressions_build_the_value()
+	{
+		LowAllocReadOnlyMemory<int> empty = [];
+		LowAllocReadOnlyMemory<int> single = [2];
+		LowAllocReadOnlyMemory<int> many = [3, 4, 5];
+
+		Assert.Equal(0, empty.Length);
+		Assert.Equal(2, single.Single);
+		Assert.True(new[] { 3, 4, 5 }.AsSpan().SequenceEqual(many.Span));
+	}
+
+	[Fact]
+	public void Foreach_reads_items_in_order()
+	{
+		LowAllocReadOnlyMemory<int> sut = [1, 2, 3];
+		var actual = new List<int>();
+
+		foreach (var item in sut)
+		{
+			actual.Add(item);
+		}
+
+		Assert.Equal(new[] { 1, 2, 3 }, actual);
+	}
+}

--- a/src/EventStore.Common/Utils/LowAllocReadOnlyMemory.cs
+++ b/src/EventStore.Common/Utils/LowAllocReadOnlyMemory.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace EventStore.Common.Utils;
+
+[CollectionBuilder(typeof(LowAllocReadOnlyMemory), nameof(LowAllocReadOnlyMemory.Create))]
+public readonly struct LowAllocReadOnlyMemory<T>
+{
+	private readonly ReadOnlyMemory<T> _many;
+	private readonly T _single;
+	private readonly bool _hasSingle;
+
+	public LowAllocReadOnlyMemory(T item)
+	{
+		_single = item;
+		_hasSingle = true;
+	}
+
+	public LowAllocReadOnlyMemory(ReadOnlyMemory<T> items)
+	{
+		if (items.Span is [var item])
+		{
+			_single = item;
+			_hasSingle = true;
+			return;
+		}
+
+		_many = items;
+	}
+
+	public static LowAllocReadOnlyMemory<T> Empty => default;
+
+	public static implicit operator LowAllocReadOnlyMemory<T>(T[] items) => new(items);
+
+	public int Length => _hasSingle ? 1 : _many.Length;
+
+	public T Single => _hasSingle
+		? _single
+		: throw new InvalidOperationException($"Cannot read a single item from a collection of length {Length}.");
+
+	public ReadOnlySpan<T> Span => _hasSingle
+		? MemoryMarshal.CreateReadOnlySpan(in _single, 1)
+		: _many.Span;
+
+	public ReadOnlySpan<T>.Enumerator GetEnumerator() => Span.GetEnumerator();
+
+	public T[] ToArray() => Span.ToArray();
+}
+
+public static class LowAllocReadOnlyMemory
+{
+	public static LowAllocReadOnlyMemory<T> Create<T>(ReadOnlySpan<T> items) =>
+		items is [var item]
+			? new LowAllocReadOnlyMemory<T>(item)
+			: new LowAllocReadOnlyMemory<T>(items.ToArray());
+}


### PR DESCRIPTION
- Reduces allocation pressure in common 0-or-1 item paths without forcing callers to materialize arrays.
- Keeps the helper covered in the common test project before it is used by storage or runtime paths.