### PR TITLE
fix(core): retry expired read enumerator pages

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.ReadAllBackwards.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.ReadAllBackwards.Tests.cs
@@ -23,7 +23,6 @@ public partial class EnumeratorTests
 			resolveLinks: false,
 			user: SystemAccounts.System,
 			requiresLeader: false,
-			deadline: DateTime.Now,
 			cancellationToken: CancellationToken.None));
 	}
 

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.ReadAllBackwardsFiltered.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.ReadAllBackwardsFiltered.Tests.cs
@@ -26,7 +26,6 @@ public partial class EnumeratorTests
 			user: SystemAccounts.System,
 			requiresLeader: false,
 			maxSearchWindow: null,
-			deadline: DateTime.Now,
 			cancellationToken: CancellationToken.None));
 	}
 

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.ReadAllForwards.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.ReadAllForwards.Tests.cs
@@ -23,7 +23,6 @@ public partial class EnumeratorTests
 			resolveLinks: false,
 			user: SystemAccounts.System,
 			requiresLeader: false,
-			deadline: DateTime.Now,
 			cancellationToken: CancellationToken.None));
 	}
 

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.ReadAllForwardsFiltered.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.ReadAllForwardsFiltered.Tests.cs
@@ -26,7 +26,6 @@ public partial class EnumeratorTests
 			user: SystemAccounts.System,
 			requiresLeader: false,
 			maxSearchWindow: null,
-			deadline: DateTime.Now,
 			cancellationToken: CancellationToken.None));
 	}
 

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.ReadExpiryRetry.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.ReadExpiryRetry.Tests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.Transport.Common;
+using EventStore.Core.Services.Transport.Enumerators;
+using EventStore.Core.Services.UserManagement;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Transport.Enumerators;
+
+[TestFixture]
+public partial class EnumeratorTests
+{
+	[Test]
+	public async Task read_all_forwards_retries_expired_pages()
+	{
+		var publishCount = 0;
+		var publisher = new ReplyingPublisher(message =>
+		{
+			var request = (ClientMessage.ReadAllEventsForward)message;
+			var response = publishCount++ == 0
+				? Expired(request)
+				: EndOfStream(request);
+			_ = Task.Run(() => request.Envelope.ReplyWith(response));
+		});
+
+		await using var enumerator = new Enumerator.ReadAllForwards(
+			bus: publisher,
+			position: Position.Start,
+			maxCount: 1,
+			resolveLinks: false,
+			user: SystemAccounts.System,
+			requiresLeader: false,
+			cancellationToken: CancellationToken.None);
+
+		Assert.That(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(1)), Is.False);
+		Assert.That(publishCount, Is.EqualTo(2));
+		Assert.That(((ClientMessage.ReadAllEventsForward)publisher.Published[0]).ReplyOnExpired, Is.True);
+	}
+
+	[Test]
+	public async Task read_all_backwards_retries_expired_pages()
+	{
+		var publishCount = 0;
+		var publisher = new ReplyingPublisher(message =>
+		{
+			var request = (ClientMessage.ReadAllEventsBackward)message;
+			var response = publishCount++ == 0
+				? Expired(request)
+				: EndOfStream(request);
+			_ = Task.Run(() => request.Envelope.ReplyWith(response));
+		});
+
+		await using var enumerator = new Enumerator.ReadAllBackwards(
+			bus: publisher,
+			position: Position.End,
+			maxCount: 1,
+			resolveLinks: false,
+			user: SystemAccounts.System,
+			requiresLeader: false,
+			cancellationToken: CancellationToken.None);
+
+		Assert.That(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(1)), Is.False);
+		Assert.That(publishCount, Is.EqualTo(2));
+		Assert.That(((ClientMessage.ReadAllEventsBackward)publisher.Published[0]).ReplyOnExpired, Is.True);
+	}
+
+	private static ClientMessage.ReadAllEventsForwardCompleted Expired(ClientMessage.ReadAllEventsForward request) =>
+		new(
+			request.CorrelationId,
+			ReadAllResult.Expired,
+			error: default,
+			ResolvedEvent.EmptyArray,
+			streamMetadata: default,
+			isCachePublic: default,
+			request.MaxCount,
+			currentPos: new TFPos(request.CommitPosition, request.PreparePosition),
+			nextPos: TFPos.Invalid,
+			prevPos: TFPos.Invalid,
+			tfLastCommitPosition: default);
+
+	private static ClientMessage.ReadAllEventsForwardCompleted EndOfStream(ClientMessage.ReadAllEventsForward request) =>
+		new(
+			request.CorrelationId,
+			ReadAllResult.Success,
+			error: default,
+			ResolvedEvent.EmptyArray,
+			streamMetadata: default,
+			isCachePublic: default,
+			request.MaxCount,
+			currentPos: new TFPos(request.CommitPosition, request.PreparePosition),
+			nextPos: TFPos.Invalid,
+			prevPos: TFPos.Invalid,
+			tfLastCommitPosition: default);
+
+	private static ClientMessage.ReadAllEventsBackwardCompleted Expired(ClientMessage.ReadAllEventsBackward request) =>
+		new(
+			request.CorrelationId,
+			ReadAllResult.Expired,
+			error: default,
+			ResolvedEvent.EmptyArray,
+			streamMetadata: default,
+			isCachePublic: default,
+			request.MaxCount,
+			currentPos: new TFPos(request.CommitPosition, request.PreparePosition),
+			nextPos: TFPos.Invalid,
+			prevPos: TFPos.Invalid,
+			tfLastCommitPosition: default);
+
+	private static ClientMessage.ReadAllEventsBackwardCompleted EndOfStream(ClientMessage.ReadAllEventsBackward request) =>
+		new(
+			request.CorrelationId,
+			ReadAllResult.Success,
+			error: default,
+			ResolvedEvent.EmptyArray,
+			streamMetadata: default,
+			isCachePublic: default,
+			request.MaxCount,
+			currentPos: new TFPos(request.CommitPosition, request.PreparePosition),
+			nextPos: TFPos.Invalid,
+			prevPos: TFPos.Invalid,
+			tfLastCommitPosition: default);
+
+	private sealed class ReplyingPublisher(Action<Message> onPublish) : IPublisher
+	{
+		public List<Message> Published { get; } = new();
+
+		public void Publish(Message message)
+		{
+			Published.Add(message);
+			onPublish(message);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.ReadStreamBackwards.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.ReadStreamBackwards.Tests.cs
@@ -24,7 +24,6 @@ public partial class EnumeratorTests
 			resolveLinks: false,
 			user: SystemAccounts.System,
 			requiresLeader: false,
-			deadline: DateTime.Now,
 			compatibility: 1,
 			cancellationToken: CancellationToken.None));
 	}

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.ReadStreamForwards.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.ReadStreamForwards.Tests.cs
@@ -24,7 +24,6 @@ public partial class EnumeratorTests
 			resolveLinks: false,
 			user: SystemAccounts.System,
 			requiresLeader: false,
-			deadline: DateTime.Now,
 			compatibility: 1,
 			cancellationToken: CancellationToken.None));
 	}

--- a/src/EventStore.Core/Authorization/AuthorizationPolicies/StreamBasedAuthorizationPolicyRegistry.cs
+++ b/src/EventStore.Core/Authorization/AuthorizationPolicies/StreamBasedAuthorizationPolicyRegistry.cs
@@ -252,7 +252,7 @@ public class StreamBasedAuthorizationPolicyRegistry(
 		try
 		{
 			await using var read = new Enumerator.ReadStreamBackwards(publisher, _stream,
-				StreamRevision.End, ulong.MaxValue, false, SystemAccounts.System, false, DateTime.MaxValue, 1, ct);
+				StreamRevision.End, ulong.MaxValue, false, SystemAccounts.System, false, 1, ct);
 			while (await read.MoveNextAsync())
 			{
 				var readResponse = read.Current;

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -720,11 +720,13 @@ public static partial class ClientMessage
 		public readonly bool RequireLeader;
 
 		public readonly long? ValidationStreamVersion;
+		public readonly bool ReplyOnExpired;
 
 		public ReadStreamEventsBackward(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
 			string eventStreamId, long fromEventNumber, int maxCount, bool resolveLinkTos,
 			bool requireLeader, long? validationStreamVersion, ClaimsPrincipal user, DateTime? expires = null,
-			CancellationToken cancellationToken = default)
+			CancellationToken cancellationToken = default,
+			bool replyOnExpired = false)
 			: base(internalCorrId, correlationId, envelope, user, expires, cancellationToken)
 		{
 			Ensure.NotNullOrEmpty(eventStreamId, "eventStreamId");
@@ -739,6 +741,7 @@ public static partial class ClientMessage
 			ResolveLinkTos = resolveLinkTos;
 			RequireLeader = requireLeader;
 			ValidationStreamVersion = validationStreamVersion;
+			ReplyOnExpired = replyOnExpired;
 		}
 
 		public override string ToString() =>
@@ -748,7 +751,8 @@ public static partial class ClientMessage
 			$"MaxCount: {MaxCount}, " +
 			$"ResolveLinkTos: {ResolveLinkTos}, " +
 			$"RequireLeader: {RequireLeader}, " +
-			$"ValidationStreamVersion: {ValidationStreamVersion}";
+			$"ValidationStreamVersion: {ValidationStreamVersion}, " +
+			$"ReplyOnExpired: {ReplyOnExpired}";
 	}
 
 	[DerivedMessage(CoreMessage.Client)]
@@ -785,7 +789,7 @@ public static partial class ClientMessage
 		{
 			Ensure.NotNull(events, "events");
 
-			if (result != ReadStreamResult.Success)
+			if (result != ReadStreamResult.Success && result != ReadStreamResult.Expired)
 			{
 				Ensure.Equal(nextEventNumber, -1, "nextEventNumber");
 				Ensure.Equal(isEndOfStream, true, "isEndOfStream");
@@ -904,12 +908,14 @@ public static partial class ClientMessage
 		public readonly bool RequireLeader;
 
 		public readonly long? ValidationTfLastCommitPosition;
+		public readonly bool ReplyOnExpired;
 
 		public ReadAllEventsBackward(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
 			long commitPosition, long preparePosition, int maxCount, bool resolveLinkTos,
 			bool requireLeader, long? validationTfLastCommitPosition, ClaimsPrincipal user,
 			DateTime? expires = null,
-			CancellationToken cancellationToken = default)
+			CancellationToken cancellationToken = default,
+			bool replyOnExpired = false)
 			: base(internalCorrId, correlationId, envelope, user, expires, cancellationToken)
 		{
 			CommitPosition = commitPosition;
@@ -918,6 +924,7 @@ public static partial class ClientMessage
 			ResolveLinkTos = resolveLinkTos;
 			RequireLeader = requireLeader;
 			ValidationTfLastCommitPosition = validationTfLastCommitPosition;
+			ReplyOnExpired = replyOnExpired;
 		}
 
 		public override string ToString() =>
@@ -927,7 +934,8 @@ public static partial class ClientMessage
 			$"MaxCount: {MaxCount}, " +
 			$"ResolveLinkTos: {ResolveLinkTos}, " +
 			$"RequireLeader: {RequireLeader}, " +
-			$"ValidationTfLastCommitPosition: {ValidationTfLastCommitPosition}";
+			$"ValidationTfLastCommitPosition: {ValidationTfLastCommitPosition}, " +
+			$"ReplyOnExpired: {ReplyOnExpired}";
 	}
 
 	[DerivedMessage(CoreMessage.Client)]
@@ -1075,6 +1083,7 @@ public static partial class ClientMessage
 		public readonly bool RequireLeader;
 		public readonly int MaxSearchWindow;
 		public readonly IEventFilter EventFilter;
+		public readonly bool ReplyOnExpired;
 
 		public readonly long? ValidationTfLastCommitPosition;
 		public readonly TimeSpan? LongPollTimeout;
@@ -1083,7 +1092,8 @@ public static partial class ClientMessage
 			long commitPosition, long preparePosition, int maxCount, bool resolveLinkTos, bool requireLeader,
 			int maxSearchWindow, long? validationTfLastCommitPosition, IEventFilter eventFilter, ClaimsPrincipal user,
 			TimeSpan? longPollTimeout = null, DateTime? expires = null,
-			CancellationToken cancellationToken = default)
+			CancellationToken cancellationToken = default,
+			bool replyOnExpired = false)
 			: base(internalCorrId, correlationId, envelope, user, expires, cancellationToken)
 		{
 			CommitPosition = commitPosition;
@@ -1095,6 +1105,7 @@ public static partial class ClientMessage
 			LongPollTimeout = longPollTimeout;
 			MaxSearchWindow = maxSearchWindow;
 			EventFilter = eventFilter;
+			ReplyOnExpired = replyOnExpired;
 		}
 
 		public override string ToString() =>
@@ -1107,7 +1118,8 @@ public static partial class ClientMessage
 			$"MaxSearchWindow: {MaxSearchWindow}, " +
 			$"EventFilter: {{ {EventFilter} }}, " +
 			$"LongPollTimeout: {LongPollTimeout}, " +
-			$"ValidationTfLastCommitPosition: {ValidationTfLastCommitPosition}";
+			$"ValidationTfLastCommitPosition: {ValidationTfLastCommitPosition}, " +
+			$"ReplyOnExpired: {ReplyOnExpired}";
 	}
 
 	[DerivedMessage(CoreMessage.Client)]

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
@@ -186,6 +186,14 @@ public class StorageReaderWorker<TStreamId> :
 
 		if (msg.Expires < DateTime.UtcNow)
 		{
+			if (msg.ReplyOnExpired)
+			{
+				msg.Envelope.ReplyWith(new ClientMessage.ReadStreamEventsBackwardCompleted(
+					msg.CorrelationId, msg.EventStreamId, msg.FromEventNumber, msg.MaxCount,
+					ReadStreamResult.Expired,
+					ResolvedEvent.EmptyArray, default, default, default, default, default, default, default));
+			}
+
 			if (LogExpiredMessage(msg.Expires))
 			{
 				Log.Debug(
@@ -290,6 +298,15 @@ public class StorageReaderWorker<TStreamId> :
 
 		if (msg.Expires < DateTime.UtcNow)
 		{
+			if (msg.ReplyOnExpired)
+			{
+				msg.Envelope.ReplyWith(new ClientMessage.ReadAllEventsBackwardCompleted(
+					msg.CorrelationId, ReadAllResult.Expired,
+					default, ResolvedEvent.EmptyArray, default, default, default,
+					currentPos: new TFPos(msg.CommitPosition, msg.PreparePosition),
+					TFPos.Invalid, TFPos.Invalid, default));
+			}
+
 			if (LogExpiredMessage(msg.Expires))
 			{
 				Log.Debug(
@@ -378,6 +395,15 @@ public class StorageReaderWorker<TStreamId> :
 
 		if (msg.Expires < DateTime.UtcNow)
 		{
+			if (msg.ReplyOnExpired)
+			{
+				msg.Envelope.ReplyWith(new ClientMessage.FilteredReadAllEventsBackwardCompleted(
+					msg.CorrelationId, FilteredReadAllResult.Expired,
+					default, ResolvedEvent.EmptyArray, default, default, default,
+					currentPos: new TFPos(msg.CommitPosition, msg.PreparePosition),
+					TFPos.Invalid, TFPos.Invalid, default, default));
+			}
+
 			Log.Debug(
 				"Read All Stream Events Backward Filtered operation has expired for C:{0}/P:{1}. Operation Expired at {2}",
 				msg.CommitPosition, msg.PreparePosition, msg.Expires);

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllBackwards.cs
@@ -22,7 +22,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 			private readonly bool _resolveLinks;
 			private readonly ClaimsPrincipal _user;
 			private readonly bool _requiresLeader;
-			private readonly DateTime _deadline;
 			private readonly CancellationToken _cancellationToken;
 			private readonly SemaphoreSlim _semaphore;
 			private readonly Channel<ReadResponse> _channel;
@@ -37,7 +36,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 				bool resolveLinks,
 				ClaimsPrincipal user,
 				bool requiresLeader,
-				DateTime deadline,
 				CancellationToken cancellationToken)
 			{
 				if (bus == null)
@@ -50,7 +48,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 				_resolveLinks = resolveLinks;
 				_user = user;
 				_requiresLeader = requiresLeader;
-				_deadline = deadline;
 				_cancellationToken = cancellationToken;
 				_semaphore = new SemaphoreSlim(1, 1);
 				_channel = Channel.CreateBounded<ReadResponse>(BoundedChannelOptions);
@@ -85,8 +82,9 @@ namespace EventStore.Core.Services.Transport.Enumerators
 				_bus.Publish(new ClientMessage.ReadAllEventsBackward(
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					commitPosition, preparePosition, (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
-					_requiresLeader, default, _user, _deadline,
-					cancellationToken: _cancellationToken));
+					_requiresLeader, default, _user,
+					cancellationToken: _cancellationToken,
+					replyOnExpired: true));
 
 				async Task OnMessage(Message message, CancellationToken ct)
 				{
@@ -131,6 +129,11 @@ namespace EventStore.Core.Services.Transport.Enumerators
 							ReadPage(Position.FromInt64(
 								completed.NextPos.CommitPosition,
 								completed.NextPos.PreparePosition), readCount);
+							return;
+						case ReadAllResult.Expired:
+							ReadPage(Position.FromInt64(
+								completed.CurrentPos.CommitPosition,
+								completed.CurrentPos.PreparePosition), readCount);
 							return;
 						case ReadAllResult.AccessDenied:
 							_channel.Writer.TryComplete(new ReadResponseException.AccessDenied());

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllBackwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllBackwardsFiltered.cs
@@ -27,7 +27,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 			private readonly IEventFilter _eventFilter;
 			private readonly ClaimsPrincipal _user;
 			private readonly bool _requiresLeader;
-			private readonly DateTime _deadline;
 			private readonly uint _maxSearchWindow;
 			private readonly CancellationToken _cancellationToken;
 			private readonly SemaphoreSlim _semaphore;
@@ -45,7 +44,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 				ClaimsPrincipal user,
 				bool requiresLeader,
 				uint? maxSearchWindow,
-				DateTime deadline,
 				CancellationToken cancellationToken)
 			{
 				if (bus == null)
@@ -65,7 +63,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 				_user = user;
 				_requiresLeader = requiresLeader;
 				_maxSearchWindow = maxSearchWindow ?? ReadBatchSize;
-				_deadline = deadline;
 				_cancellationToken = cancellationToken;
 				_semaphore = new SemaphoreSlim(1, 1);
 				_channel = Channel.CreateBounded<ReadResponse>(BoundedChannelOptions);
@@ -100,8 +97,9 @@ namespace EventStore.Core.Services.Transport.Enumerators
 				_bus.Publish(new ClientMessage.FilteredReadAllEventsBackward(
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					commitPosition, preparePosition, (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
-					_requiresLeader, (int)_maxSearchWindow, null, _eventFilter, _user, expires: _deadline,
-					cancellationToken: _cancellationToken));
+					_requiresLeader, (int)_maxSearchWindow, null, _eventFilter, _user,
+					cancellationToken: _cancellationToken,
+					replyOnExpired: true));
 
 				async Task OnMessage(Message message, CancellationToken ct)
 				{
@@ -142,6 +140,11 @@ namespace EventStore.Core.Services.Transport.Enumerators
 							ReadPage(Position.FromInt64(
 								completed.NextPos.CommitPosition,
 								completed.NextPos.PreparePosition), readCount);
+							return;
+						case FilteredReadAllResult.Expired:
+							ReadPage(Position.FromInt64(
+								completed.CurrentPos.CommitPosition,
+								completed.CurrentPos.PreparePosition), readCount);
 							return;
 						case FilteredReadAllResult.AccessDenied:
 							_channel.Writer.TryComplete(new ReadResponseException.AccessDenied());

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllForwards.cs
@@ -21,7 +21,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 			private readonly bool _resolveLinks;
 			private readonly ClaimsPrincipal _user;
 			private readonly bool _requiresLeader;
-			private readonly DateTime _deadline;
 			private readonly CancellationToken _cancellationToken;
 			private readonly SemaphoreSlim _semaphore;
 			private readonly Channel<ReadResponse> _channel;
@@ -36,7 +35,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 				bool resolveLinks,
 				ClaimsPrincipal user,
 				bool requiresLeader,
-				DateTime deadline,
 				CancellationToken cancellationToken)
 			{
 				if (bus == null)
@@ -49,7 +47,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 				_resolveLinks = resolveLinks;
 				_user = user;
 				_requiresLeader = requiresLeader;
-				_deadline = deadline;
 				_cancellationToken = cancellationToken;
 				_semaphore = new SemaphoreSlim(1, 1);
 				_channel = Channel.CreateBounded<ReadResponse>(BoundedChannelOptions);
@@ -84,7 +81,7 @@ namespace EventStore.Core.Services.Transport.Enumerators
 				_bus.Publish(new ClientMessage.ReadAllEventsForward(
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					commitPosition, preparePosition, (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
-					_requiresLeader, default, _user, replyOnExpired: false, expires: _deadline,
+					_requiresLeader, default, _user, replyOnExpired: true,
 					cancellationToken: _cancellationToken));
 
 				async Task OnMessage(Message message, CancellationToken ct)
@@ -127,6 +124,11 @@ namespace EventStore.Core.Services.Transport.Enumerators
 							ReadPage(Position.FromInt64(
 								completed.NextPos.CommitPosition,
 								completed.NextPos.PreparePosition), readCount);
+							return;
+						case ReadAllResult.Expired:
+							ReadPage(Position.FromInt64(
+								completed.CurrentPos.CommitPosition,
+								completed.CurrentPos.PreparePosition), readCount);
 							return;
 						case ReadAllResult.AccessDenied:
 							_channel.Writer.TryComplete(new ReadResponseException.AccessDenied());

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllForwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllForwardsFiltered.cs
@@ -27,7 +27,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 			private readonly IEventFilter _eventFilter;
 			private readonly ClaimsPrincipal _user;
 			private readonly bool _requiresLeader;
-			private readonly DateTime _deadline;
 			private readonly uint _maxSearchWindow;
 			private readonly CancellationToken _cancellationToken;
 			private readonly SemaphoreSlim _semaphore;
@@ -45,7 +44,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 				ClaimsPrincipal user,
 				bool requiresLeader,
 				uint? maxSearchWindow,
-				DateTime deadline,
 				CancellationToken cancellationToken)
 			{
 				if (bus == null)
@@ -65,7 +63,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 				_user = user;
 				_requiresLeader = requiresLeader;
 				_maxSearchWindow = maxSearchWindow ?? ReadBatchSize;
-				_deadline = deadline;
 				_cancellationToken = cancellationToken;
 				_semaphore = new SemaphoreSlim(1, 1);
 				_channel = Channel.CreateBounded<ReadResponse>(BoundedChannelOptions);
@@ -101,8 +98,7 @@ namespace EventStore.Core.Services.Transport.Enumerators
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					commitPosition, preparePosition, (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
 					_requiresLeader, (int)_maxSearchWindow, null, _eventFilter, _user,
-					replyOnExpired: false,
-					expires: _deadline,
+					replyOnExpired: true,
 					cancellationToken: _cancellationToken));
 
 				async Task OnMessage(Message message, CancellationToken ct)
@@ -145,6 +141,11 @@ namespace EventStore.Core.Services.Transport.Enumerators
 							ReadPage(Position.FromInt64(
 								completed.NextPos.CommitPosition,
 								completed.NextPos.PreparePosition), readCount);
+							return;
+						case FilteredReadAllResult.Expired:
+							ReadPage(Position.FromInt64(
+								completed.CurrentPos.CommitPosition,
+								completed.CurrentPos.PreparePosition), readCount);
 							return;
 						case FilteredReadAllResult.AccessDenied:
 							_channel.Writer.TryComplete(new ReadResponseException.AccessDenied());

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadStreamBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadStreamBackwards.cs
@@ -22,7 +22,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 			private readonly bool _resolveLinks;
 			private readonly ClaimsPrincipal _user;
 			private readonly bool _requiresLeader;
-			private readonly DateTime _deadline;
 			private readonly uint _compatibility;
 			private readonly CancellationToken _cancellationToken;
 			private readonly SemaphoreSlim _semaphore;
@@ -39,7 +38,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 				bool resolveLinks,
 				ClaimsPrincipal user,
 				bool requiresLeader,
-				DateTime deadline,
 				uint compatibility,
 				CancellationToken cancellationToken)
 			{
@@ -49,7 +47,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 				_resolveLinks = resolveLinks;
 				_user = user;
 				_requiresLeader = requiresLeader;
-				_deadline = deadline;
 				_compatibility = compatibility;
 				_cancellationToken = cancellationToken;
 				_semaphore = new SemaphoreSlim(1, 1);
@@ -83,8 +80,9 @@ namespace EventStore.Core.Services.Transport.Enumerators
 				_bus.Publish(new ClientMessage.ReadStreamEventsBackward(
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					_streamName, startRevision.ToInt64(), (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
-					_requiresLeader, null, _user, _deadline,
-					cancellationToken: _cancellationToken));
+					_requiresLeader, null, _user,
+					cancellationToken: _cancellationToken,
+					replyOnExpired: true));
 
 				async Task OnMessage(Message message, CancellationToken ct)
 				{
@@ -130,6 +128,9 @@ namespace EventStore.Core.Services.Transport.Enumerators
 							}
 
 							_channel.Writer.TryComplete();
+							return;
+						case ReadStreamResult.Expired:
+							ReadPage(StreamRevision.FromInt64(completed.FromEventNumber), readCount);
 							return;
 						case ReadStreamResult.NoStream:
 							await _channel.Writer.WriteAsync(new ReadResponse.StreamNotFound(_streamName), ct);

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadStreamForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadStreamForwards.cs
@@ -22,7 +22,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 			private readonly bool _resolveLinks;
 			private readonly ClaimsPrincipal _user;
 			private readonly bool _requiresLeader;
-			private readonly DateTime _deadline;
 			private readonly uint _compatibility;
 			private readonly CancellationToken _cancellationToken;
 			private readonly SemaphoreSlim _semaphore;
@@ -39,7 +38,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 				bool resolveLinks,
 				ClaimsPrincipal user,
 				bool requiresLeader,
-				DateTime deadline,
 				uint compatibility,
 				CancellationToken cancellationToken)
 			{
@@ -49,7 +47,6 @@ namespace EventStore.Core.Services.Transport.Enumerators
 				_resolveLinks = resolveLinks;
 				_user = user;
 				_requiresLeader = requiresLeader;
-				_deadline = deadline;
 				_compatibility = compatibility;
 				_cancellationToken = cancellationToken;
 				_semaphore = new SemaphoreSlim(1, 1);
@@ -83,7 +80,7 @@ namespace EventStore.Core.Services.Transport.Enumerators
 				_bus.Publish(new ClientMessage.ReadStreamEventsForward(
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					_streamName, startRevision.ToInt64(), (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
-					_requiresLeader, null, _user, replyOnExpired: false, expires: _deadline,
+					_requiresLeader, null, _user, replyOnExpired: true,
 					cancellationToken: _cancellationToken));
 
 				async Task OnMessage(Message message, CancellationToken ct)
@@ -145,6 +142,9 @@ namespace EventStore.Core.Services.Transport.Enumerators
 							_channel.Writer.TryComplete();
 							return;
 
+						case ReadStreamResult.Expired:
+							ReadPage(StreamRevision.FromInt64(completed.FromEventNumber), readCount);
+							return;
 						case ReadStreamResult.NoStream:
 							await _channel.Writer.WriteAsync(new ReadResponse.StreamNotFound(_streamName), ct);
 							_channel.Writer.TryComplete();

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -74,7 +74,6 @@ internal partial class Streams<TStreamId>
 					countOptionsCase,
 					readDirection,
 					filterOptionsCase,
-					context.Deadline,
 					context.CancellationToken);
 
 				async void DisposeEnumerator() => await enumerator.DisposeAsync();
@@ -114,7 +113,6 @@ internal partial class Streams<TStreamId>
 		CountOptionOneofCase countOptionsCase,
 		ReadDirection readDirection,
 		FilterOptionOneofCase filterOptionsCase,
-		DateTime deadline,
 		CancellationToken cancellationToken)
 	{
 		return (streamOptionsCase, countOptionsCase, readDirection, filterOptionsCase) switch
@@ -130,7 +128,6 @@ internal partial class Streams<TStreamId>
 					request.Options.ResolveLinks,
 					user,
 					requiresLeader,
-					deadline,
 					compatibility,
 					cancellationToken),
 			(StreamOptionOneofCase.Stream,
@@ -144,7 +141,6 @@ internal partial class Streams<TStreamId>
 					request.Options.ResolveLinks,
 					user,
 					requiresLeader,
-					deadline,
 					compatibility,
 					cancellationToken),
 			(StreamOptionOneofCase.All,
@@ -157,7 +153,6 @@ internal partial class Streams<TStreamId>
 					request.Options.ResolveLinks,
 					user,
 					requiresLeader,
-					deadline,
 					cancellationToken),
 			(StreamOptionOneofCase.All,
 				CountOptionOneofCase.Count,
@@ -177,7 +172,6 @@ internal partial class Streams<TStreamId>
 							.Max,
 						_ => throw RpcExceptions.InvalidArgument(request.Options.Filter.WindowCase)
 					},
-					deadline,
 					cancellationToken),
 			(StreamOptionOneofCase.All,
 				CountOptionOneofCase.Count,
@@ -189,7 +183,6 @@ internal partial class Streams<TStreamId>
 					request.Options.ResolveLinks,
 					user,
 					requiresLeader,
-					deadline,
 					cancellationToken),
 			(StreamOptionOneofCase.All,
 				CountOptionOneofCase.Count,
@@ -209,7 +202,6 @@ internal partial class Streams<TStreamId>
 							.Max,
 						_ => throw RpcExceptions.InvalidArgument(request.Options.Filter.WindowCase)
 					},
-					deadline,
 					cancellationToken),
 			(StreamOptionOneofCase.Stream,
 				CountOptionOneofCase.Subscription,


### PR DESCRIPTION
- Prevent transient storage-reader expiry from ending active gRPC reads as user-visible failures.
- Keep caller cancellation as the boundary for read enumeration under load.