### PR TITLE
chore(storage): clarify chased log messages

### DIFF
--- a/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_commiter_service_receives_replicated_to_prepare_post_position.cs
+++ b/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_commiter_service_receives_replicated_to_prepare_post_position.cs
@@ -23,7 +23,7 @@ public class when_index_committer_service_receives_replicated_to_prepare_post_po
 	{
 
 		AddPendingPrepare(_logPrePosition, _logPostPosition);
-		Service.Handle(new StorageMessage.CommitAck(_correlationId, _logPrePosition, _logPrePosition, 0, 0));
+		Service.Handle(new StorageMessage.CommitChased(_correlationId, _logPrePosition, _logPrePosition, 0, 0));
 		ReplicationCheckpoint.Write(_logPostPosition);
 		ReplicationCheckpoint.Flush();
 		Service.Handle(new ReplicationTrackingMessage.ReplicatedTo(_logPostPosition));

--- a/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_committer_service_commits_empty_transaction_at_end_of_log.cs
+++ b/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_committer_service_commits_empty_transaction_at_end_of_log.cs
@@ -27,7 +27,7 @@ public class when_index_committer_service_commits_empty_transaction_at_end_of_lo
 		WriterCheckpoint.Flush();
 
 		Service.AddPendingPrepare(_logPrePosition, [], _logPostPosition);
-		Service.Handle(new StorageMessage.CommitAck(_correlationId, _logPrePosition, _logPrePosition, 0, 0));
+		Service.Handle(new StorageMessage.CommitChased(_correlationId, _logPrePosition, _logPrePosition, 0, 0));
 
 		ReplicationCheckpoint.Write(_logPostPosition);
 		ReplicationCheckpoint.Flush();

--- a/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_committer_service_receives_duplicate_commits_chased.cs
+++ b/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_committer_service_receives_duplicate_commits_chased.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 namespace EventStore.Core.Tests.Services.IndexCommitter;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
-public class when_index_committer_service_receives_duplicate_commit_acks<TLogFormat, TStreamId> : with_index_committer_service<TLogFormat, TStreamId>
+public class when_index_committer_service_receives_duplicate_commits_chased<TLogFormat, TStreamId> : with_index_committer_service<TLogFormat, TStreamId>
 {
 	private readonly long _logPosition = 4000;
 	private readonly Guid _correlationId = Guid.NewGuid();
@@ -14,8 +14,8 @@ public class when_index_committer_service_receives_duplicate_commit_acks<TLogFor
 	{
 		AddPendingPrepare(_logPosition);
 
-		Service.Handle(new StorageMessage.CommitAck(_correlationId, _logPosition, _logPosition, 0, 0));
-		Service.Handle(new StorageMessage.CommitAck(_correlationId, _logPosition, _logPosition, 0, 0));
+		Service.Handle(new StorageMessage.CommitChased(_correlationId, _logPosition, _logPosition, 0, 0));
+		Service.Handle(new StorageMessage.CommitChased(_correlationId, _logPosition, _logPosition, 0, 0));
 		Service.Handle(new ReplicationTrackingMessage.ReplicatedTo(_logPosition));
 	}
 

--- a/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_committer_service_receives_multiple_commits_chased_for_different_positions.cs
+++ b/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_committer_service_receives_multiple_commits_chased_for_different_positions.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 namespace EventStore.Core.Tests.Services.IndexCommitter;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
-public class when_index_committer_service_receives_multiple_acks_for_different_positions<TLogFormat, TStreamId> : with_index_committer_service<TLogFormat, TStreamId>
+public class when_index_committer_service_receives_multiple_commits_chased_for_different_positions<TLogFormat, TStreamId> : with_index_committer_service<TLogFormat, TStreamId>
 {
 
 	private readonly long _logPositionP1 = 1000;
@@ -22,9 +22,9 @@ public class when_index_committer_service_receives_multiple_acks_for_different_p
 		AddPendingPrepare(_logPositionP2);
 		AddPendingPrepare(_logPositionP3);
 
-		Service.Handle(new StorageMessage.CommitAck(Guid.NewGuid(), _logPositionCommit1, _logPositionP1, 0, 0));
-		Service.Handle(new StorageMessage.CommitAck(Guid.NewGuid(), _logPositionCommit2, _logPositionP2, 0, 0));
-		Service.Handle(new StorageMessage.CommitAck(Guid.NewGuid(), _logPositionCommit3, _logPositionP3, 0, 0));
+		Service.Handle(new StorageMessage.CommitChased(Guid.NewGuid(), _logPositionCommit1, _logPositionP1, 0, 0));
+		Service.Handle(new StorageMessage.CommitChased(Guid.NewGuid(), _logPositionCommit2, _logPositionP2, 0, 0));
+		Service.Handle(new StorageMessage.CommitChased(Guid.NewGuid(), _logPositionCommit3, _logPositionP3, 0, 0));
 	}
 
 	public override void When()

--- a/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_committer_service_receives_multiple_commits_chased_for_different_positions_out_of_order.cs
+++ b/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_committer_service_receives_multiple_commits_chased_for_different_positions_out_of_order.cs
@@ -6,7 +6,7 @@ namespace EventStore.Core.Tests.Services.IndexCommitter;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
 public class
-	when_index_committer_service_receives_multiple_acks_for_different_positions_out_of_order<TLogFormat, TStreamId>
+	when_index_committer_service_receives_multiple_commits_chased_for_different_positions_out_of_order<TLogFormat, TStreamId>
 	: with_index_committer_service<TLogFormat, TStreamId>
 {
 
@@ -26,8 +26,8 @@ public class
 
 		AddPendingPrepare(_logPosition2);
 		AddPendingPrepare(_logPosition1);
-		Service.Handle(new StorageMessage.CommitAck(_correlationId2, _logPosition4, _logPosition2, 0, 0));
-		Service.Handle(new StorageMessage.CommitAck(_correlationId1, _logPosition3, _logPosition1, 0, 0));
+		Service.Handle(new StorageMessage.CommitChased(_correlationId2, _logPosition4, _logPosition2, 0, 0));
+		Service.Handle(new StorageMessage.CommitChased(_correlationId1, _logPosition3, _logPosition1, 0, 0));
 
 
 		ReplicationCheckpoint.Write(_logPosition4 + 1);
@@ -54,7 +54,7 @@ public class
 		Assert.AreEqual(_logPosition4, msg.LogPosition);
 	}
 	[Test]
-	public void prepare_ack_message_should_have_been_published_for_both_events()
+	public void committed_prepares_should_have_been_published_for_both_events()
 	{
 		AssertEx.IsOrBecomesTrue(() => 2 == IndexCommitter.CommittedPrepares.Count);
 		Assert.True(IndexCommitter.CommittedPrepares.TryDequeue(out var msg));

--- a/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_committer_service_receives_replicated_lower_position.cs
+++ b/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_committer_service_receives_replicated_lower_position.cs
@@ -23,7 +23,7 @@ public class
 	public override void Given() { }
 	public override void When()
 	{
-		Service.Handle(new StorageMessage.CommitAck(_correlationId, _logPosition, _logPosition, 0, 0));
+		Service.Handle(new StorageMessage.CommitChased(_correlationId, _logPosition, _logPosition, 0, 0));
 		ReplicationCheckpoint.Write(_logPosition - 1);
 		ReplicationCheckpoint.Flush();
 		Service.Handle(new ReplicationTrackingMessage.ReplicatedTo(_logPosition - 1));

--- a/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_committer_service_receives_replicated_to_prepare_pre_position.cs
+++ b/src/EventStore.Core.Tests/Services/IndexCommitter/when_index_committer_service_receives_replicated_to_prepare_pre_position.cs
@@ -23,7 +23,7 @@ public class when_index_committer_service_receives_replicated_to_prepare_pre_pos
 	{
 
 		AddPendingPrepare(_logPrePosition, _logPostPosition);
-		Service.Handle(new StorageMessage.CommitAck(_correlationId, _logPrePosition, _logPrePosition, 0, 0));
+		Service.Handle(new StorageMessage.CommitChased(_correlationId, _logPrePosition, _logPrePosition, 0, 0));
 		ReplicationCheckpoint.Write(_logPrePosition);
 		ReplicationCheckpoint.Flush();
 		Service.Handle(new ReplicationTrackingMessage.ReplicatedTo(_logPrePosition));

--- a/src/EventStore.Core.Tests/Services/RequestManagement/RequestManagerSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/RequestManagerSpecification.cs
@@ -50,7 +50,7 @@ public abstract class RequestManagerSpecification<TManager>
 		Publisher.Messages.Clear();
 
 		Manager = OnManager(Publisher);
-		Dispatcher.Subscribe<StorageMessage.PrepareAck>(Manager);
+		Dispatcher.Subscribe<StorageMessage.UncommittedPrepareChased>(Manager);
 		Dispatcher.Subscribe<StorageMessage.InvalidTransaction>(Manager);
 		Dispatcher.Subscribe<StorageMessage.StreamDeleted>(Manager);
 		Dispatcher.Subscribe<StorageMessage.WrongExpectedVersion>(Manager);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
@@ -50,7 +50,7 @@ public abstract class RequestManagerServiceSpecification :
 			TimeSpan.FromSeconds(2),
 			explicitTransactionsSupported: true);
 		Dispatcher.Subscribe<ClientMessage.WriteEvents>(Service);
-		Dispatcher.Subscribe<StorageMessage.PrepareAck>(Service);
+		Dispatcher.Subscribe<StorageMessage.UncommittedPrepareChased>(Service);
 		Dispatcher.Subscribe<StorageMessage.InvalidTransaction>(Service);
 		Dispatcher.Subscribe<StorageMessage.StreamDeleted>(Service);
 		Dispatcher.Subscribe<StorageMessage.WrongExpectedVersion>(Service);
@@ -91,7 +91,7 @@ public abstract class RequestManagerServiceSpecification :
 		var transactionPosition = LogPosition;
 		foreach (var _ in message.Events)
 		{
-			Dispatcher.Publish(new StorageMessage.PrepareAck(
+			Dispatcher.Publish(new StorageMessage.UncommittedPrepareChased(
 									message.CorrelationId,
 									LogPosition,
 									PrepareFlags));

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_completes_successfully.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_completes_successfully.cs
@@ -31,8 +31,8 @@ public class when_transaction_commit_completes_successfully : RequestManagerSpec
 
 	protected override IEnumerable<Message> WithInitialMessages()
 	{
-		yield return new StorageMessage.PrepareAck(InternalCorrId, _transactionPosition, PrepareFlags.TransactionEnd);
-		yield return new StorageMessage.CommitAck(InternalCorrId, _commitPosition, _transactionPosition, 1, 3);
+		yield return new StorageMessage.UncommittedPrepareChased(InternalCorrId, _transactionPosition, PrepareFlags.TransactionEnd);
+		yield return new StorageMessage.CommitChased(InternalCorrId, _commitPosition, _transactionPosition, 1, 3);
 		yield return new ReplicationTrackingMessage.ReplicatedTo(_commitPosition);
 	}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_already_committed_after_committed.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_already_committed_after_committed.cs
@@ -31,7 +31,7 @@ public class when_transaction_commit_gets_already_committed_after_committed : Re
 
 	protected override IEnumerable<Message> WithInitialMessages()
 	{
-		yield return new StorageMessage.PrepareAck(InternalCorrId, transactionId, PrepareFlags.TransactionEnd);
+		yield return new StorageMessage.UncommittedPrepareChased(InternalCorrId, transactionId, PrepareFlags.TransactionEnd);
 		yield return new StorageMessage.CommitIndexed(Guid.NewGuid(), commitPosition, transactionId, 0, 10);
 		yield return new ReplicationTrackingMessage.ReplicatedTo(commitPosition);
 		yield return new StorageMessage.CommitIndexed(InternalCorrId, commitPosition, transactionId, 0, 0);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_already_committed_before_committed.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_already_committed_before_committed.cs
@@ -32,7 +32,7 @@ public class when_transaction_commit_gets_already_committed_before_committed : R
 	protected override IEnumerable<Message> WithInitialMessages()
 	{
 
-		yield return new StorageMessage.PrepareAck(InternalCorrId, transactionId, PrepareFlags.TransactionEnd);
+		yield return new StorageMessage.UncommittedPrepareChased(InternalCorrId, transactionId, PrepareFlags.TransactionEnd);
 	}
 
 	protected override Message When()

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_prepare_timeout_after_prepares.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_prepare_timeout_after_prepares.cs
@@ -29,7 +29,7 @@ public class when_transaction_commit_gets_prepare_timeout_after_prepares : Reque
 
 	protected override IEnumerable<Message> WithInitialMessages()
 	{
-		yield return new StorageMessage.PrepareAck(InternalCorrId, transactionId, PrepareFlags.SingleWrite);
+		yield return new StorageMessage.UncommittedPrepareChased(InternalCorrId, transactionId, PrepareFlags.SingleWrite);
 	}
 
 	protected override Message When()

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_timeout_before_cluster_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_timeout_before_cluster_commit.cs
@@ -29,9 +29,9 @@ public class when_transaction_commit_gets_timeout_before_cluster_commit : Reques
 
 	protected override IEnumerable<Message> WithInitialMessages()
 	{
-		yield return new StorageMessage.PrepareAck(InternalCorrId, 100, PrepareFlags.Data);
-		yield return new StorageMessage.PrepareAck(InternalCorrId, 200, PrepareFlags.Data);
-		yield return new StorageMessage.CommitAck(InternalCorrId, 300, 100, 1, 2);
+		yield return new StorageMessage.UncommittedPrepareChased(InternalCorrId, 100, PrepareFlags.Data);
+		yield return new StorageMessage.UncommittedPrepareChased(InternalCorrId, 200, PrepareFlags.Data);
+		yield return new StorageMessage.CommitChased(InternalCorrId, 300, 100, 1, 2);
 	}
 
 	protected override Message When()

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_multiple_write_completes_successfully.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_multiple_write_completes_successfully.cs
@@ -33,9 +33,9 @@ public class when_transaction_multiple_write_completes_successfully : RequestMan
 
 	protected override IEnumerable<Message> WithInitialMessages()
 	{
-		yield return new StorageMessage.PrepareAck(InternalCorrId, _event1Position, PrepareFlags.Data);
-		yield return new StorageMessage.PrepareAck(InternalCorrId, _event2Position, PrepareFlags.Data);
-		yield return new StorageMessage.PrepareAck(InternalCorrId, _event3Position, PrepareFlags.Data);
+		yield return new StorageMessage.UncommittedPrepareChased(InternalCorrId, _event1Position, PrepareFlags.Data);
+		yield return new StorageMessage.UncommittedPrepareChased(InternalCorrId, _event2Position, PrepareFlags.Data);
+		yield return new StorageMessage.UncommittedPrepareChased(InternalCorrId, _event3Position, PrepareFlags.Data);
 	}
 
 	protected override Message When()

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_multiple_write_does_not_get_prepares.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_multiple_write_does_not_get_prepares.cs
@@ -33,8 +33,8 @@ public class when_transaction_multiple_write_does_not_get_prepares : RequestMana
 
 	protected override IEnumerable<Message> WithInitialMessages()
 	{
-		yield return new StorageMessage.PrepareAck(InternalCorrId, _event1Position, PrepareFlags.Data);
-		yield return new StorageMessage.PrepareAck(InternalCorrId, _event2Position, PrepareFlags.Data);
+		yield return new StorageMessage.UncommittedPrepareChased(InternalCorrId, _event1Position, PrepareFlags.Data);
+		yield return new StorageMessage.UncommittedPrepareChased(InternalCorrId, _event2Position, PrepareFlags.Data);
 	}
 
 	protected override Message When()

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_single_write_completes_successfully.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_single_write_completes_successfully.cs
@@ -31,7 +31,7 @@ public class when_transaction_single_write_completes_successfully : RequestManag
 
 	protected override IEnumerable<Message> WithInitialMessages()
 	{
-		yield return new StorageMessage.PrepareAck(InternalCorrId, _event1Position, PrepareFlags.Data);
+		yield return new StorageMessage.UncommittedPrepareChased(InternalCorrId, _event1Position, PrepareFlags.Data);
 	}
 
 	protected override Message When()

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_start_completes_successfully.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_start_completes_successfully.cs
@@ -29,7 +29,7 @@ public class when_transaction_start_completes_successfully : RequestManagerSpeci
 
 	protected override IEnumerable<Message> WithInitialMessages()
 	{
-		yield return new StorageMessage.PrepareAck(InternalCorrId, _transactionPosition, PrepareFlags.TransactionBegin);
+		yield return new StorageMessage.UncommittedPrepareChased(InternalCorrId, _transactionPosition, PrepareFlags.TransactionBegin);
 	}
 
 	protected override Message When()

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_already_committed.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_already_committed.cs
@@ -31,7 +31,7 @@ public class when_write_stream_gets_already_committed : RequestManagerSpecificat
 
 	protected override IEnumerable<Message> WithInitialMessages()
 	{
-		yield return new StorageMessage.PrepareAck(InternalCorrId, _prepareLogPosition, PrepareFlags.SingleWrite | PrepareFlags.Data);
+		yield return new StorageMessage.UncommittedPrepareChased(InternalCorrId, _prepareLogPosition, PrepareFlags.SingleWrite | PrepareFlags.Data);
 	}
 
 	protected override Message When()

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_already_committed_and_log_is_committed.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_already_committed_and_log_is_committed.cs
@@ -31,7 +31,7 @@ public class when_write_stream_gets_already_committed_and_log_is_committed : Req
 
 	protected override IEnumerable<Message> WithInitialMessages()
 	{
-		yield return new StorageMessage.PrepareAck(InternalCorrId, _prepareLogPosition, PrepareFlags.SingleWrite | PrepareFlags.Data);
+		yield return new StorageMessage.UncommittedPrepareChased(InternalCorrId, _prepareLogPosition, PrepareFlags.SingleWrite | PrepareFlags.Data);
 		yield return new ReplicationTrackingMessage.ReplicatedTo(_commitLogPosition);
 	}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_after_cluster_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_after_cluster_commit.cs
@@ -31,7 +31,7 @@ public class when_write_stream_gets_timeout_after_cluster_commit : RequestManage
 
 	protected override IEnumerable<Message> WithInitialMessages()
 	{
-		yield return new StorageMessage.PrepareAck(InternalCorrId, _prepareLogPosition, PrepareFlags.SingleWrite | PrepareFlags.Data);
+		yield return new StorageMessage.UncommittedPrepareChased(InternalCorrId, _prepareLogPosition, PrepareFlags.SingleWrite | PrepareFlags.Data);
 		yield return new StorageMessage.CommitIndexed(InternalCorrId, _commitPosition, 1, 0, 0);
 		yield return new ReplicationTrackingMessage.ReplicatedTo(_commitPosition);
 	}

--- a/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_commit_event.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_commit_event.cs
@@ -53,11 +53,11 @@ public class when_chaser_reads_commit_event<TLogFormat, TStreamId> : with_storag
 		await Writer.Flush(token);
 	}
 	[Test]
-	public void commit_ack_should_be_published()
+	public void commit_chased_should_be_published()
 	{
-		AssertEx.IsOrBecomesTrue(() => CommitAcks.Count == 1, msg: "CommitAck msg not received");
-		Assert.True(CommitAcks.TryDequeue(out var commitAck));
-		Assert.AreEqual(_transactionId, commitAck.CorrelationId);
+		AssertEx.IsOrBecomesTrue(() => CommitsChased.Count == 1, msg: "CommitChased msg not received");
+		Assert.True(CommitsChased.TryDequeue(out var commitChased));
+		Assert.AreEqual(_transactionId, commitChased.CorrelationId);
 	}
 
 }

--- a/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_committed_prepare_event.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_committed_prepare_event.cs
@@ -40,11 +40,11 @@ public class WhenChaserReadsCommittedPrepareEvent<TLogFormat, TStreamId> : with_
 		await Writer.Flush(token);
 	}
 	[Test]
-	public void commit_ack_should_be_published()
+	public void commit_chased_should_be_published()
 	{
-		AssertEx.IsOrBecomesTrue(() => CommitAcks.Count >= 1, msg: "CommitAck msg not received");
-		Assert.True(CommitAcks.TryDequeue(out var commitAck));
-		Assert.AreEqual(_transactionId, commitAck.CorrelationId);
+		AssertEx.IsOrBecomesTrue(() => CommitsChased.Count >= 1, msg: "CommitChased msg not received");
+		Assert.True(CommitsChased.TryDequeue(out var commitChased));
+		Assert.AreEqual(_transactionId, commitChased.CorrelationId);
 
 	}
 

--- a/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_prepare_event.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_prepare_event.cs
@@ -40,11 +40,11 @@ public class WhenChaserReadsPrepareEvent<TLogFormat, TStreamId> : with_storage_c
 		await Writer.Flush(token);
 	}
 	[Test]
-	public void prepare_ack_should_be_published()
+	public void uncommitted_prepare_chased_should_be_published()
 	{
-		AssertEx.IsOrBecomesTrue(() => PrepareAcks.Count == 1, msg: "PrepareAck msg not received");
-		Assert.True(PrepareAcks.TryDequeue(out var prepareAck));
-		Assert.AreEqual(_transactionId, prepareAck.CorrelationId);
+		AssertEx.IsOrBecomesTrue(() => UncommittedPreparesChased.Count == 1, msg: "UncommittedPrepareChased msg not received");
+		Assert.True(UncommittedPreparesChased.TryDequeue(out var uncommittedPrepareChased));
+		Assert.AreEqual(_transactionId, uncommittedPrepareChased.CorrelationId);
 
 	}
 

--- a/src/EventStore.Core.Tests/Services/Storage/Chaser/with_storage_chaser_service.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Chaser/with_storage_chaser_service.cs
@@ -34,8 +34,8 @@ public abstract class with_storage_chaser_service<TLogFormat, TStreamId> : Speci
 	protected TFChunkChaser Chaser;
 	protected TFChunkWriter Writer;
 
-	protected ConcurrentQueue<StorageMessage.PrepareAck> PrepareAcks = new();
-	protected ConcurrentQueue<StorageMessage.CommitAck> CommitAcks = new();
+	protected ConcurrentQueue<StorageMessage.UncommittedPrepareChased> UncommittedPreparesChased = new();
+	protected ConcurrentQueue<StorageMessage.CommitChased> CommitsChased = new();
 
 	[OneTimeSetUp]
 	public override async Task TestFixtureSetUp()
@@ -62,8 +62,8 @@ public abstract class with_storage_chaser_service<TLogFormat, TStreamId> : Speci
 		Service.Handle(new SystemMessage.SystemStart());
 		Service.Handle(new SystemMessage.SystemInit());
 
-		Publisher.Subscribe(new AdHocHandler<StorageMessage.CommitAck>(CommitAcks.Enqueue));
-		Publisher.Subscribe(new AdHocHandler<StorageMessage.PrepareAck>(PrepareAcks.Enqueue));
+		Publisher.Subscribe(new AdHocHandler<StorageMessage.CommitChased>(CommitsChased.Enqueue));
+		Publisher.Subscribe(new AdHocHandler<StorageMessage.UncommittedPrepareChased>(UncommittedPreparesChased.Enqueue));
 
 		await When(CancellationToken.None);
 	}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -856,7 +856,7 @@ public class ClusterVNode<TStreamId> :
 
 		_mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(indexCommitterService);
 		_mainBus.Subscribe<ReplicationTrackingMessage.ReplicatedTo>(indexCommitterService);
-		_mainBus.Subscribe<StorageMessage.CommitAck>(indexCommitterService);
+		_mainBus.Subscribe<StorageMessage.CommitChased>(indexCommitterService);
 		_mainBus.Subscribe<ClientMessage.MergeIndexes>(indexCommitterService);
 
 		var chaser = new TFChunkChaser(
@@ -1137,7 +1137,7 @@ public class ClusterVNode<TStreamId> :
 
 		_mainBus.Subscribe<StorageMessage.AlreadyCommitted>(requestManagement);
 
-		_mainBus.Subscribe<StorageMessage.PrepareAck>(requestManagement);
+		_mainBus.Subscribe<StorageMessage.UncommittedPrepareChased>(requestManagement);
 		_mainBus.Subscribe<ReplicationTrackingMessage.ReplicatedTo>(requestManagement);
 		_mainBus.Subscribe<ReplicationTrackingMessage.IndexedTo>(requestManagement);
 		_mainBus.Subscribe<StorageMessage.RequestCompleted>(requestManagement);

--- a/src/EventStore.Core/Messages/StorageMessage.cs
+++ b/src/EventStore.Core/Messages/StorageMessage.cs
@@ -164,13 +164,13 @@ namespace EventStore.Core.Messages
 		}
 
 		[DerivedMessage(CoreMessage.Storage)]
-		public partial class PrepareAck : Message
+		public partial class UncommittedPrepareChased : Message
 		{
 			public readonly Guid CorrelationId;
 			public readonly long LogPosition;
 			public readonly PrepareFlags Flags;
 
-			public PrepareAck(Guid correlationId, long logPosition, PrepareFlags flags)
+			public UncommittedPrepareChased(Guid correlationId, long logPosition, PrepareFlags flags)
 			{
 				Ensure.NotEmptyGuid(correlationId, "correlationId");
 				Ensure.Nonnegative(logPosition, "logPosition");
@@ -182,7 +182,7 @@ namespace EventStore.Core.Messages
 		}
 
 		[DerivedMessage(CoreMessage.Storage)]
-		public partial class CommitAck : Message
+		public partial class CommitChased : Message
 		{
 			public readonly Guid CorrelationId;
 			public readonly long LogPosition;
@@ -190,7 +190,7 @@ namespace EventStore.Core.Messages
 			public readonly long FirstEventNumber;
 			public readonly long LastEventNumber;
 
-			public CommitAck(Guid correlationId, long logPosition, long transactionPosition, long firstEventNumber,
+			public CommitChased(Guid correlationId, long logPosition, long transactionPosition, long firstEventNumber,
 				long lastEventNumber)
 			{
 				Ensure.NotEmptyGuid(correlationId, "correlationId");

--- a/src/EventStore.Core/Services/RequestManager/Managers/RequestManagerBase.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/RequestManagerBase.cs
@@ -12,7 +12,7 @@ using ILogger = Serilog.ILogger;
 namespace EventStore.Core.Services.RequestManager.Managers
 {
 	public abstract class RequestManagerBase :
-		IHandle<StorageMessage.PrepareAck>,
+		IHandle<StorageMessage.UncommittedPrepareChased>,
 		IHandle<StorageMessage.CommitIndexed>,
 		IHandle<StorageMessage.InvalidTransaction>,
 		IHandle<StorageMessage.StreamDeleted>,
@@ -106,7 +106,7 @@ namespace EventStore.Core.Services.RequestManager.Managers
 			Publisher.Publish(WriteRequestMsg);
 		}
 
-		public void Handle(StorageMessage.PrepareAck message)
+		public void Handle(StorageMessage.UncommittedPrepareChased message)
 		{
 			if (Interlocked.Read(ref _complete) == 1 || _allPreparesWritten)
 			{ return; }

--- a/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
+++ b/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Services.RequestManager
 		IHandle<ClientMessage.TransactionCommit>,
 		IHandle<StorageMessage.RequestCompleted>,
 		IHandle<StorageMessage.AlreadyCommitted>,
-		IHandle<StorageMessage.PrepareAck>,
+		IHandle<StorageMessage.UncommittedPrepareChased>,
 		IHandle<ReplicationTrackingMessage.ReplicatedTo>,
 		IHandle<ReplicationTrackingMessage.IndexedTo>,
 		IHandle<StorageMessage.CommitIndexed>,
@@ -232,7 +232,7 @@ namespace EventStore.Core.Services.RequestManager
 		public void Handle(ReplicationTrackingMessage.IndexedTo message) => _commitSource.Handle(message);
 
 		public void Handle(StorageMessage.AlreadyCommitted message) => DispatchInternal(message.CorrelationId, message, static (manager, m) => manager.Handle(m));
-		public void Handle(StorageMessage.PrepareAck message) => DispatchInternal(message.CorrelationId, message, static (manager, m) => manager.Handle(m));
+		public void Handle(StorageMessage.UncommittedPrepareChased message) => DispatchInternal(message.CorrelationId, message, static (manager, m) => manager.Handle(m));
 		public void Handle(StorageMessage.CommitIndexed message) => DispatchInternal(message.CorrelationId, message, static (manager, m) => manager.Handle(m));
 		public void Handle(StorageMessage.WrongExpectedVersion message) => DispatchInternal(message.CorrelationId, message, static (manager, m) => manager.Handle(m));
 		public void Handle(StorageMessage.InvalidTransaction message) => DispatchInternal(message.CorrelationId, message, static (manager, m) => manager.Handle(m));

--- a/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
+++ b/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
@@ -36,7 +36,7 @@ public class IndexCommitterService<TStreamId> : IndexCommitterService, IIndexCom
 	IMonitoredQueue,
 	IHandle<SystemMessage.BecomeShuttingDown>,
 	IHandle<ReplicationTrackingMessage.ReplicatedTo>,
-	IHandle<StorageMessage.CommitAck>,
+	IHandle<StorageMessage.CommitChased>,
 	IHandle<ClientMessage.MergeIndexes>,
 	IThreadPoolWorkItem
 {
@@ -57,11 +57,11 @@ public class IndexCommitterService<TStreamId> : IndexCommitterService, IIndexCom
 
 	private readonly QueueStatsCollector _queueStats;
 
-	private readonly ConcurrentQueueWrapper<StorageMessage.CommitAck> _replicatedQueue = new();
+	private readonly ConcurrentQueueWrapper<StorageMessage.CommitChased> _commitChasedQueue = new();
 
 	private readonly ConcurrentDictionary<long, PendingTransaction> _pendingTransactions = new();
 
-	private readonly SortedList<long, StorageMessage.CommitAck> _commitAcks = new();
+	private readonly SortedList<long, StorageMessage.CommitChased> _commitsChased = new();
 	private readonly AsyncManualResetEvent _addMsgSignal = new(initialState: false);
 	private TimeSpan _waitTimeoutMs = TimeSpan.FromMilliseconds(100);
 	private readonly TaskCompletionSource<object> _tcs = new();
@@ -121,19 +121,19 @@ public class IndexCommitterService<TStreamId> : IndexCommitterService, IIndexCom
 			_queueStats.Start();
 			QueueMonitor.Default.Register(this);
 
-			StorageMessage.CommitAck replicatedMessage;
-			var msgType = typeof(StorageMessage.CommitAck);
+			StorageMessage.CommitChased commitChased;
+			var msgType = typeof(StorageMessage.CommitChased);
 			while (!_stopToken.IsCancellationRequested)
 			{
 				_addMsgSignal.Reset();
-				if (_replicatedQueue.TryDequeue(out replicatedMessage))
+				if (_commitChasedQueue.TryDequeue(out commitChased))
 				{
 					_queueStats.EnterBusy();
 #if DEBUG
-					_queueStats.Dequeued(replicatedMessage);
+					_queueStats.Dequeued(commitChased);
 #endif
-					_queueStats.ProcessingStarted(msgType, _replicatedQueue.Count);
-					await ProcessCommitReplicated(replicatedMessage, _stopToken);
+					_queueStats.ProcessingStarted(msgType, _commitChasedQueue.Count);
+					await ProcessCommitChased(commitChased, _stopToken);
 					_queueStats.ProcessingEnded(1);
 				}
 				else
@@ -169,7 +169,7 @@ public class IndexCommitterService<TStreamId> : IndexCommitterService, IIndexCom
 		_publisher.Publish(new SystemMessage.ServiceShutdown(Name));
 	}
 
-	private async ValueTask ProcessCommitReplicated(StorageMessage.CommitAck message, CancellationToken token)
+	private async ValueTask ProcessCommitChased(StorageMessage.CommitChased message, CancellationToken token)
 	{
 		PendingTransaction transaction;
 		long lastEventNumber = message.LastEventNumber;
@@ -257,46 +257,46 @@ public class IndexCommitterService<TStreamId> : IndexCommitterService, IIndexCom
 		Stop();
 	}
 
-	public void Handle(StorageMessage.CommitAck message)
+	public void Handle(StorageMessage.CommitChased message)
 	{
-		lock (_commitAcks)
+		lock (_commitsChased)
 		{
-			_commitAcks.TryAdd(message.LogPosition, message);
+			_commitsChased.TryAdd(message.LogPosition, message);
 		}
 
-		EnqueueReplicatedCommits();
+		EnqueueCommitsChased();
 	}
 
 	public void Handle(ReplicationTrackingMessage.ReplicatedTo message)
 	{
-		EnqueueReplicatedCommits();
+		EnqueueCommitsChased();
 	}
 
-	private void EnqueueReplicatedCommits()
+	private void EnqueueCommitsChased()
 	{
-		var replicated = new List<StorageMessage.CommitAck>();
-		lock (_commitAcks)
+		var commitsChased = new List<StorageMessage.CommitChased>();
+		lock (_commitsChased)
 		{
-			if (_commitAcks.Count > 0)
+			if (_commitsChased.Count > 0)
 			{
 				do
 				{
-					var ack = _commitAcks.Values[0];
-					if (ack.LogPosition >= _replicationCheckpoint.Read())
+					var commitChased = _commitsChased.Values[0];
+					if (commitChased.LogPosition >= _replicationCheckpoint.Read())
 					{ break; }
 
-					replicated.Add(ack);
-					_commitAcks.RemoveAt(0);
-				} while (_commitAcks.Count > 0);
+					commitsChased.Add(commitChased);
+					_commitsChased.RemoveAt(0);
+				} while (_commitsChased.Count > 0);
 			}
 		}
 
-		foreach (var ack in replicated)
+		foreach (var commitChased in commitsChased)
 		{
 #if DEBUG
 			_queueStats.Enqueued();
 #endif
-			_replicatedQueue.Enqueue(ack);
+			_commitChasedQueue.Enqueue(commitChased);
 			_addMsgSignal.Set();
 		}
 	}

--- a/src/EventStore.Core/Services/Storage/StorageChaser.cs
+++ b/src/EventStore.Core/Services/Storage/StorageChaser.cs
@@ -267,7 +267,7 @@ public class StorageChaser<TStreamId> : StorageChaser, IMonitoredQueue,
 				lastEventNumber = record.ExpectedVersion;
 			}
 
-			_leaderBus.Publish(new StorageMessage.CommitAck(record.CorrelationId,
+			_leaderBus.Publish(new StorageMessage.CommitChased(record.CorrelationId,
 				record.LogPosition,
 				record.TransactionPosition,
 				firstEventNumber,
@@ -276,7 +276,7 @@ public class StorageChaser<TStreamId> : StorageChaser, IMonitoredQueue,
 		else if (record.Flags.HasAnyOf(PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd | PrepareFlags.Data))
 		{
 			_leaderBus.Publish(
-				new StorageMessage.PrepareAck(record.CorrelationId, record.LogPosition, record.Flags));
+				new StorageMessage.UncommittedPrepareChased(record.CorrelationId, record.LogPosition, record.Flags));
 		}
 	}
 
@@ -292,7 +292,7 @@ public class StorageChaser<TStreamId> : StorageChaser, IMonitoredQueue,
 			lastEventNumber = record.FirstEventNumber - 1;
 		}
 
-		_leaderBus.Publish(new StorageMessage.CommitAck(record.CorrelationId, record.LogPosition,
+		_leaderBus.Publish(new StorageMessage.CommitChased(record.CorrelationId, record.LogPosition,
 			record.TransactionPosition, firstEventNumber, lastEventNumber));
 	}
 


### PR DESCRIPTION
- Make storage-chaser notifications read as log-chase events instead of client acknowledgements.
- Keep request-management and index-committer terminology aligned with the lifecycle these messages represent.
- Reduce ambiguity before the remaining storage/read-side work continues.