### PR TITLE
fix(storage): attach read timeouts to cancellation

### DIFF
--- a/src/EventStore.Core.Tests/Services/Storage/when_cancelling_storage_reader_worker.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/when_cancelling_storage_reader_worker.cs
@@ -13,6 +13,7 @@ using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Tests.Fakes;
 using EventStore.Core.TransactionLog.Checkpoint;
 using NUnit.Framework;
+using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
 
 namespace EventStore.Core.Tests.Services.Storage;
 
@@ -48,6 +49,87 @@ public class when_cancelling_storage_reader_worker
 		var ex = Assert.CatchAsync<OperationCanceledException>(async () => await task);
 		Assert.That(ex?.CancellationToken, Is.EqualTo(messageCancellation.Token));
 		Assert.That(reply, Is.Null);
+	}
+
+	[Test]
+	public async Task read_event_timeout_completes_without_reply()
+	{
+		using var readIndex = new BlockingReadIndex();
+		var worker = CreateWorker(readIndex);
+		var reply = default(Message);
+		var message = new ClientMessage.ReadEvent(
+			Guid.NewGuid(),
+			Guid.NewGuid(),
+			new CallbackEnvelope(m => reply = m),
+			"stream",
+			0,
+			resolveLinkTos: false,
+			requireLeader: false,
+			user: new ClaimsPrincipal(),
+			expires: DateTime.UtcNow.AddMilliseconds(100));
+
+		var task = ((IAsyncHandle<ClientMessage.ReadEvent>)worker)
+			.HandleAsync(message, CancellationToken.None)
+			.AsTask();
+
+		Assert.That(readIndex.ReadEventStarted.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+		await task.WaitAsync(TimeSpan.FromSeconds(5));
+
+		Assert.That(reply, Is.Null);
+	}
+
+	[Test]
+	public async Task read_request_lifetime_counts_down_to_expiry()
+	{
+		var message = new ClientMessage.ReadEvent(
+			Guid.NewGuid(),
+			Guid.NewGuid(),
+			new NoopEnvelope(),
+			"stream",
+			0,
+			resolveLinkTos: false,
+			requireLeader: false,
+			user: new ClaimsPrincipal(),
+			expires: DateTime.UtcNow.AddSeconds(5));
+
+		var initialLifetime = message.Lifetime;
+
+		await Task.Delay(50);
+
+		Assert.That(message.Lifetime, Is.LessThan(initialLifetime));
+	}
+
+	[Test]
+	public async Task read_stream_forward_timeout_replies_expired()
+	{
+		using var readIndex = new BlockingReadIndex();
+		var worker = CreateWorker(readIndex);
+		var reply = default(Message);
+		var message = new ClientMessage.ReadStreamEventsForward(
+			Guid.NewGuid(),
+			Guid.NewGuid(),
+			new CallbackEnvelope(m => reply = m),
+			"stream",
+			0,
+			1,
+			resolveLinkTos: false,
+			requireLeader: false,
+			validationStreamVersion: null,
+			user: new ClaimsPrincipal(),
+			replyOnExpired: true,
+			expires: DateTime.UtcNow.AddMilliseconds(100));
+
+		var task = ((IAsyncHandle<ClientMessage.ReadStreamEventsForward>)worker)
+			.HandleAsync(message, CancellationToken.None)
+			.AsTask();
+
+		Assert.That(readIndex.ReadStreamForwardStarted.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+		await task.WaitAsync(TimeSpan.FromSeconds(5));
+
+		Assert.That(reply, Is.TypeOf<ClientMessage.ReadStreamEventsForwardCompleted>());
+		Assert.That(((ClientMessage.ReadStreamEventsForwardCompleted)reply!).Result, Is.EqualTo(ReadStreamResult.Expired));
 	}
 
 	[Test]
@@ -113,6 +195,7 @@ public class when_cancelling_storage_reader_worker
 	private sealed class BlockingReadIndex : IReadIndex<string>, IDisposable
 	{
 		public ManualResetEventSlim ReadEventStarted { get; } = new(false);
+		public ManualResetEventSlim ReadStreamForwardStarted { get; } = new(false);
 		public ManualResetEventSlim EffectiveAclStarted { get; } = new(false);
 
 		public long LastIndexedPosition => 0;
@@ -133,7 +216,7 @@ public class when_cancelling_storage_reader_worker
 			throw new NotSupportedException();
 		public ValueTask<IndexReadStreamResult> ReadStreamEventsForward(string streamName, string streamId,
 			long fromEventNumber, int maxCount, CancellationToken token) =>
-			throw new NotSupportedException();
+			AwaitCancellation<IndexReadStreamResult>(ReadStreamForwardStarted, token);
 		public ValueTask<IndexReadEventInfoResult> ReadEventInfo_KeepDuplicates(string streamId, long eventNumber,
 			CancellationToken token) =>
 			throw new NotSupportedException();
@@ -180,6 +263,7 @@ public class when_cancelling_storage_reader_worker
 		public void Dispose()
 		{
 			ReadEventStarted.Dispose();
+			ReadStreamForwardStarted.Dispose();
 			EffectiveAclStarted.Dispose();
 		}
 

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -85,6 +85,10 @@ public static partial class ClientMessage
 	[DerivedMessage]
 	public abstract partial class ReadRequestMessage : Message
 	{
+		private static readonly TimeSpan MaxLifetime = TimeSpan.FromMilliseconds(int.MaxValue - 1);
+
+		public static DateTime NeverExpires => DateTime.MaxValue;
+
 		public readonly Guid InternalCorrId;
 		public readonly Guid CorrelationId;
 		public readonly IEnvelope Envelope;
@@ -92,6 +96,27 @@ public static partial class ClientMessage
 		public readonly ClaimsPrincipal User;
 
 		public readonly DateTime Expires;
+
+		public bool CanExpire => Expires != NeverExpires;
+
+		public TimeSpan Lifetime
+		{
+			get
+			{
+				if (!CanExpire)
+				{
+					return Timeout.InfiniteTimeSpan;
+				}
+
+				var lifetime = Expires - DateTime.UtcNow;
+				if (lifetime <= TimeSpan.Zero)
+				{
+					return TimeSpan.Zero;
+				}
+
+				return lifetime > MaxLifetime ? MaxLifetime : lifetime;
+			}
+		}
 
 		protected ReadRequestMessage(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
 			ClaimsPrincipal user, DateTime? expires,

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -1425,7 +1425,7 @@ public class PersistentSubscriptionService<TStreamId> :
 			1,
 			false,
 			SystemAccounts.System, x =>
-				HandleLoadCompleted(continueWith, x), expires: DateTime.MaxValue);
+				HandleLoadCompleted(continueWith, x), expires: ClientMessage.ReadRequestMessage.NeverExpires);
 
 	private void HandleLoadCompleted(Action continueWith,
 		ClientMessage.ReadStreamEventsBackwardCompleted readStreamEventsBackwardCompleted)

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
@@ -95,11 +95,20 @@ public class StorageReaderWorker<TStreamId> :
 			return;
 		}
 
-		using var cts = Multiplex(ref token, msg.CancellationToken);
+		using var cts = Multiplex(ref token, msg);
 		try
 		{
 			var ev = await ReadEvent(msg, token);
 			msg.Envelope.ReplyWith(ev);
+		}
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token && cts.IsTimedOut)
+		{
+			if (LogExpiredMessage(msg.Expires))
+			{
+				Log.Debug(
+					"Read Event operation has expired for Stream: {stream}, Event Number: {eventNumber}. Operation Expired at {expiryDateTime}",
+					msg.EventStreamId, msg.EventNumber, msg.Expires);
+			}
 		}
 		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token)
 		{
@@ -136,12 +145,31 @@ public class StorageReaderWorker<TStreamId> :
 		}
 
 		ClientMessage.ReadStreamEventsForwardCompleted res;
-		using var cts = Multiplex(ref token, msg.CancellationToken);
+		using var cts = Multiplex(ref token, msg);
 		try
 		{
 			res = SystemStreams.IsInMemoryStream(msg.EventStreamId)
 				? _memoryStreamReader.ReadForwards(msg)
 				: await ReadStreamEventsForward(msg, token);
+		}
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token && cts.IsTimedOut)
+		{
+			if (msg.ReplyOnExpired)
+			{
+				msg.Envelope.ReplyWith(new ClientMessage.ReadStreamEventsForwardCompleted(
+					msg.CorrelationId, msg.EventStreamId, msg.FromEventNumber, msg.MaxCount,
+					ReadStreamResult.Expired,
+					ResolvedEvent.EmptyArray, default, default, default, default, default, default, default));
+			}
+
+			if (LogExpiredMessage(msg.Expires))
+			{
+				Log.Debug(
+					"Read Stream Events Forward operation has expired for Stream: {stream}, From Event Number: {fromEventNumber}, Max Count: {maxCount}. Operation Expired at {expiryDateTime}",
+					msg.EventStreamId, msg.FromEventNumber, msg.MaxCount, msg.Expires);
+			}
+
+			return;
 		}
 		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token)
 		{
@@ -204,7 +232,7 @@ public class StorageReaderWorker<TStreamId> :
 			return;
 		}
 
-		using var cts = Multiplex(ref token, msg.CancellationToken);
+		using var cts = Multiplex(ref token, msg);
 		try
 		{
 			var res = SystemStreams.IsInMemoryStream(msg.EventStreamId)
@@ -212,6 +240,23 @@ public class StorageReaderWorker<TStreamId> :
 				: await ReadStreamEventsBackward(msg, token);
 
 			msg.Envelope.ReplyWith(res);
+		}
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token && cts.IsTimedOut)
+		{
+			if (msg.ReplyOnExpired)
+			{
+				msg.Envelope.ReplyWith(new ClientMessage.ReadStreamEventsBackwardCompleted(
+					msg.CorrelationId, msg.EventStreamId, msg.FromEventNumber, msg.MaxCount,
+					ReadStreamResult.Expired,
+					ResolvedEvent.EmptyArray, default, default, default, default, default, default, default));
+			}
+
+			if (LogExpiredMessage(msg.Expires))
+			{
+				Log.Debug(
+					"Read Stream Events Backward operation has expired for Stream: {stream}, From Event Number: {fromEventNumber}, Max Count: {maxCount}. Operation Expired at {expiryDateTime}",
+					msg.EventStreamId, msg.FromEventNumber, msg.MaxCount, msg.Expires);
+			}
 		}
 		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token)
 		{
@@ -248,43 +293,69 @@ public class StorageReaderWorker<TStreamId> :
 			return;
 		}
 
-		var res = await ReadAllEventsForward(msg, token);
-		switch (res.Result)
+		using var cts = Multiplex(ref token, msg);
+		try
 		{
-			case ReadAllResult.Success:
-				if (msg.LongPollTimeout.HasValue && res.IsEndOfStream && res.Events.Count is 0)
-				{
-					_publisher.Publish(new SubscriptionMessage.PollStream(
-						SubscriptionsService.AllStreamsSubscriptionId, res.TfLastCommitPosition, null,
-						DateTime.UtcNow + msg.LongPollTimeout.Value, msg));
-				}
-				else
-				{
-					msg.Envelope.ReplyWith(res);
-				}
+			var res = await ReadAllEventsForward(msg, token);
+			switch (res.Result)
+			{
+				case ReadAllResult.Success:
+					if (msg.LongPollTimeout.HasValue && res.IsEndOfStream && res.Events.Count is 0)
+					{
+						_publisher.Publish(new SubscriptionMessage.PollStream(
+							SubscriptionsService.AllStreamsSubscriptionId, res.TfLastCommitPosition, null,
+							DateTime.UtcNow + msg.LongPollTimeout.Value, msg));
+					}
+					else
+					{
+						msg.Envelope.ReplyWith(res);
+					}
 
-				break;
-			case ReadAllResult.NotModified:
-				if (msg.LongPollTimeout.HasValue && res.IsEndOfStream &&
-					res.CurrentPos.CommitPosition > res.TfLastCommitPosition)
-				{
-					_publisher.Publish(new SubscriptionMessage.PollStream(
-						SubscriptionsService.AllStreamsSubscriptionId, res.TfLastCommitPosition, null,
-						DateTime.UtcNow + msg.LongPollTimeout.Value, msg));
-				}
-				else
-				{
-					msg.Envelope.ReplyWith(res);
-				}
+					break;
+				case ReadAllResult.NotModified:
+					if (msg.LongPollTimeout.HasValue && res.IsEndOfStream &&
+						res.CurrentPos.CommitPosition > res.TfLastCommitPosition)
+					{
+						_publisher.Publish(new SubscriptionMessage.PollStream(
+							SubscriptionsService.AllStreamsSubscriptionId, res.TfLastCommitPosition, null,
+							DateTime.UtcNow + msg.LongPollTimeout.Value, msg));
+					}
+					else
+					{
+						msg.Envelope.ReplyWith(res);
+					}
 
-				break;
-			case ReadAllResult.Error:
-			case ReadAllResult.AccessDenied:
-			case ReadAllResult.InvalidPosition:
-				msg.Envelope.ReplyWith(res);
-				break;
-			default:
-				throw new ArgumentOutOfRangeException($"Unknown ReadAllResult: {res.Result}");
+					break;
+				case ReadAllResult.Error:
+				case ReadAllResult.AccessDenied:
+				case ReadAllResult.InvalidPosition:
+					msg.Envelope.ReplyWith(res);
+					break;
+				default:
+					throw new ArgumentOutOfRangeException($"Unknown ReadAllResult: {res.Result}");
+			}
+		}
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token && cts.IsTimedOut)
+		{
+			if (msg.ReplyOnExpired)
+			{
+				msg.Envelope.ReplyWith(new ClientMessage.ReadAllEventsForwardCompleted(
+					msg.CorrelationId, ReadAllResult.Expired,
+					default, ResolvedEvent.EmptyArray, default, default, default,
+					currentPos: new TFPos(msg.CommitPosition, msg.PreparePosition),
+					TFPos.Invalid, TFPos.Invalid, default));
+			}
+
+			if (LogExpiredMessage(msg.Expires))
+			{
+				Log.Debug(
+					"Read All Stream Events Forward operation has expired for C:{commitPosition}/P:{preparePosition}. Operation Expired at {expiryDateTime}",
+					msg.CommitPosition, msg.PreparePosition, msg.Expires);
+			}
+		}
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token)
+		{
+			throw new OperationCanceledException(null, ex, cts.CancellationOrigin);
 		}
 	}
 
@@ -317,7 +388,33 @@ public class StorageReaderWorker<TStreamId> :
 			return;
 		}
 
-		msg.Envelope.ReplyWith(await ReadAllEventsBackward(msg, token));
+		using var cts = Multiplex(ref token, msg);
+		try
+		{
+			msg.Envelope.ReplyWith(await ReadAllEventsBackward(msg, token));
+		}
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token && cts.IsTimedOut)
+		{
+			if (msg.ReplyOnExpired)
+			{
+				msg.Envelope.ReplyWith(new ClientMessage.ReadAllEventsBackwardCompleted(
+					msg.CorrelationId, ReadAllResult.Expired,
+					default, ResolvedEvent.EmptyArray, default, default, default,
+					currentPos: new TFPos(msg.CommitPosition, msg.PreparePosition),
+					TFPos.Invalid, TFPos.Invalid, default));
+			}
+
+			if (LogExpiredMessage(msg.Expires))
+			{
+				Log.Debug(
+					"Read All Stream Events Backward operation has expired for C:{commitPosition}/P:{preparePosition}. Operation Expired at {expiryDateTime}",
+					msg.CommitPosition, msg.PreparePosition, msg.Expires);
+			}
+		}
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token)
+		{
+			throw new OperationCanceledException(null, ex, cts.CancellationOrigin);
+		}
 	}
 
 	async ValueTask IAsyncHandle<ClientMessage.FilteredReadAllEventsForward>.HandleAsync(
@@ -345,43 +442,66 @@ public class StorageReaderWorker<TStreamId> :
 			return;
 		}
 
-		var res = await FilteredReadAllEventsForward(msg, token);
-		switch (res.Result)
+		using var cts = Multiplex(ref token, msg);
+		try
 		{
-			case FilteredReadAllResult.Success:
-				if (msg.LongPollTimeout.HasValue && res.IsEndOfStream && res.Events.Count is 0)
-				{
-					_publisher.Publish(new SubscriptionMessage.PollStream(
-						SubscriptionsService.AllStreamsSubscriptionId, res.TfLastCommitPosition, null,
-						DateTime.UtcNow + msg.LongPollTimeout.Value, msg));
-				}
-				else
-				{
-					msg.Envelope.ReplyWith(res);
-				}
+			var res = await FilteredReadAllEventsForward(msg, token);
+			switch (res.Result)
+			{
+				case FilteredReadAllResult.Success:
+					if (msg.LongPollTimeout.HasValue && res.IsEndOfStream && res.Events.Count is 0)
+					{
+						_publisher.Publish(new SubscriptionMessage.PollStream(
+							SubscriptionsService.AllStreamsSubscriptionId, res.TfLastCommitPosition, null,
+							DateTime.UtcNow + msg.LongPollTimeout.Value, msg));
+					}
+					else
+					{
+						msg.Envelope.ReplyWith(res);
+					}
 
-				break;
-			case FilteredReadAllResult.NotModified:
-				if (msg.LongPollTimeout.HasValue && res.IsEndOfStream &&
-					res.CurrentPos.CommitPosition > res.TfLastCommitPosition)
-				{
-					_publisher.Publish(new SubscriptionMessage.PollStream(
-						SubscriptionsService.AllStreamsSubscriptionId, res.TfLastCommitPosition, null,
-						DateTime.UtcNow + msg.LongPollTimeout.Value, msg));
-				}
-				else
-				{
-					msg.Envelope.ReplyWith(res);
-				}
+					break;
+				case FilteredReadAllResult.NotModified:
+					if (msg.LongPollTimeout.HasValue && res.IsEndOfStream &&
+						res.CurrentPos.CommitPosition > res.TfLastCommitPosition)
+					{
+						_publisher.Publish(new SubscriptionMessage.PollStream(
+							SubscriptionsService.AllStreamsSubscriptionId, res.TfLastCommitPosition, null,
+							DateTime.UtcNow + msg.LongPollTimeout.Value, msg));
+					}
+					else
+					{
+						msg.Envelope.ReplyWith(res);
+					}
 
-				break;
-			case FilteredReadAllResult.Error:
-			case FilteredReadAllResult.AccessDenied:
-			case FilteredReadAllResult.InvalidPosition:
-				msg.Envelope.ReplyWith(res);
-				break;
-			default:
-				throw new ArgumentOutOfRangeException($"Unknown ReadAllResult: {res.Result}");
+					break;
+				case FilteredReadAllResult.Error:
+				case FilteredReadAllResult.AccessDenied:
+				case FilteredReadAllResult.InvalidPosition:
+					msg.Envelope.ReplyWith(res);
+					break;
+				default:
+					throw new ArgumentOutOfRangeException($"Unknown ReadAllResult: {res.Result}");
+			}
+		}
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token && cts.IsTimedOut)
+		{
+			if (msg.ReplyOnExpired)
+			{
+				msg.Envelope.ReplyWith(new ClientMessage.FilteredReadAllEventsForwardCompleted(
+					msg.CorrelationId, FilteredReadAllResult.Expired,
+					default, ResolvedEvent.EmptyArray, default, default, default,
+					currentPos: new TFPos(msg.CommitPosition, msg.PreparePosition),
+					TFPos.Invalid, TFPos.Invalid, default, default, default));
+			}
+
+			Log.Debug(
+				"Read All Stream Events Forward Filtered operation has expired for C:{0}/P:{1}. Operation Expired at {2}",
+				msg.CommitPosition, msg.PreparePosition, msg.Expires);
+		}
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token)
+		{
+			throw new OperationCanceledException(null, ex, cts.CancellationOrigin);
 		}
 	}
 
@@ -410,43 +530,66 @@ public class StorageReaderWorker<TStreamId> :
 			return;
 		}
 
-		var res = await FilteredReadAllEventsBackward(msg, token);
-		switch (res.Result)
+		using var cts = Multiplex(ref token, msg);
+		try
 		{
-			case FilteredReadAllResult.Success:
-				if (msg.LongPollTimeout.HasValue && res.IsEndOfStream && res.Events.Count is 0)
-				{
-					_publisher.Publish(new SubscriptionMessage.PollStream(
-						SubscriptionsService.AllStreamsSubscriptionId, res.TfLastCommitPosition, null,
-						DateTime.UtcNow + msg.LongPollTimeout.Value, msg));
-				}
-				else
-				{
-					msg.Envelope.ReplyWith(res);
-				}
+			var res = await FilteredReadAllEventsBackward(msg, token);
+			switch (res.Result)
+			{
+				case FilteredReadAllResult.Success:
+					if (msg.LongPollTimeout.HasValue && res.IsEndOfStream && res.Events.Count is 0)
+					{
+						_publisher.Publish(new SubscriptionMessage.PollStream(
+							SubscriptionsService.AllStreamsSubscriptionId, res.TfLastCommitPosition, null,
+							DateTime.UtcNow + msg.LongPollTimeout.Value, msg));
+					}
+					else
+					{
+						msg.Envelope.ReplyWith(res);
+					}
 
-				break;
-			case FilteredReadAllResult.NotModified:
-				if (msg.LongPollTimeout.HasValue && res.IsEndOfStream &&
-					res.CurrentPos.CommitPosition > res.TfLastCommitPosition)
-				{
-					_publisher.Publish(new SubscriptionMessage.PollStream(
-						SubscriptionsService.AllStreamsSubscriptionId, res.TfLastCommitPosition, null,
-						DateTime.UtcNow + msg.LongPollTimeout.Value, msg));
-				}
-				else
-				{
-					msg.Envelope.ReplyWith(res);
-				}
+					break;
+				case FilteredReadAllResult.NotModified:
+					if (msg.LongPollTimeout.HasValue && res.IsEndOfStream &&
+						res.CurrentPos.CommitPosition > res.TfLastCommitPosition)
+					{
+						_publisher.Publish(new SubscriptionMessage.PollStream(
+							SubscriptionsService.AllStreamsSubscriptionId, res.TfLastCommitPosition, null,
+							DateTime.UtcNow + msg.LongPollTimeout.Value, msg));
+					}
+					else
+					{
+						msg.Envelope.ReplyWith(res);
+					}
 
-				break;
-			case FilteredReadAllResult.Error:
-			case FilteredReadAllResult.AccessDenied:
-			case FilteredReadAllResult.InvalidPosition:
-				msg.Envelope.ReplyWith(res);
-				break;
-			default:
-				throw new ArgumentOutOfRangeException($"Unknown ReadAllResult: {res.Result}");
+					break;
+				case FilteredReadAllResult.Error:
+				case FilteredReadAllResult.AccessDenied:
+				case FilteredReadAllResult.InvalidPosition:
+					msg.Envelope.ReplyWith(res);
+					break;
+				default:
+					throw new ArgumentOutOfRangeException($"Unknown ReadAllResult: {res.Result}");
+			}
+		}
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token && cts.IsTimedOut)
+		{
+			if (msg.ReplyOnExpired)
+			{
+				msg.Envelope.ReplyWith(new ClientMessage.FilteredReadAllEventsBackwardCompleted(
+					msg.CorrelationId, FilteredReadAllResult.Expired,
+					default, ResolvedEvent.EmptyArray, default, default, default,
+					currentPos: new TFPos(msg.CommitPosition, msg.PreparePosition),
+					TFPos.Invalid, TFPos.Invalid, default, default));
+			}
+
+			Log.Debug(
+				"Read All Stream Events Backward Filtered operation has expired for C:{0}/P:{1}. Operation Expired at {2}",
+				msg.CommitPosition, msg.PreparePosition, msg.Expires);
+		}
+		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token)
+		{
+			throw new OperationCanceledException(null, ex, cts.CancellationOrigin);
 		}
 	}
 
@@ -1093,6 +1236,18 @@ public class StorageReaderWorker<TStreamId> :
 		CancellationToken cancellationToken)
 	{
 		var scope = _tokenMultiplexer.Combine([token, cancellationToken]);
+		token = scope.Token;
+		return scope;
+	}
+
+	private CancellationTokenMultiplexer.Scope Multiplex(
+		ref CancellationToken token,
+		ClientMessage.ReadRequestMessage message)
+	{
+		var scope = message.CanExpire
+			? _tokenMultiplexer.Combine(message.Lifetime, [token, message.CancellationToken])
+			: _tokenMultiplexer.Combine([token, message.CancellationToken]);
+
 		token = scope.Token;
 		return scope;
 	}

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscription.cs
@@ -416,7 +416,7 @@ ReadLoop:
 					correlationId, correlationId, envelope,
 					startPos.CommitPosition, startPos.PreparePosition, ReadBatchSize, _resolveLinks, _requiresLeader, null, _user,
 					replyOnExpired: true,
-					expires: _expiryStrategy.GetExpiry(),
+					expires: _expiryStrategy.GetExpiry() ?? ClientMessage.ReadRequestMessage.NeverExpires,
 					cancellationToken: ct));
 			}
 

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
@@ -530,7 +530,7 @@ ReadLoop:
 					startPos.CommitPosition, startPos.PreparePosition, ReadBatchSize, _resolveLinks, _requiresLeader,
 					(int)_maxSearchWindow, null, _eventFilter, _user,
 					replyOnExpired: true,
-					expires: _expiryStrategy.GetExpiry(),
+					expires: _expiryStrategy.GetExpiry() ?? ClientMessage.ReadRequestMessage.NeverExpires,
 					cancellationToken: ct));
 			}
 

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllBackwards.cs
@@ -83,6 +83,7 @@ namespace EventStore.Core.Services.Transport.Enumerators
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					commitPosition, preparePosition, (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
 					_requiresLeader, default, _user,
+					expires: ClientMessage.ReadRequestMessage.NeverExpires,
 					cancellationToken: _cancellationToken,
 					replyOnExpired: true));
 

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllBackwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllBackwardsFiltered.cs
@@ -98,6 +98,7 @@ namespace EventStore.Core.Services.Transport.Enumerators
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					commitPosition, preparePosition, (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
 					_requiresLeader, (int)_maxSearchWindow, null, _eventFilter, _user,
+					expires: ClientMessage.ReadRequestMessage.NeverExpires,
 					cancellationToken: _cancellationToken,
 					replyOnExpired: true));
 

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllForwards.cs
@@ -82,6 +82,7 @@ namespace EventStore.Core.Services.Transport.Enumerators
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					commitPosition, preparePosition, (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
 					_requiresLeader, default, _user, replyOnExpired: true,
+					expires: ClientMessage.ReadRequestMessage.NeverExpires,
 					cancellationToken: _cancellationToken));
 
 				async Task OnMessage(Message message, CancellationToken ct)

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllForwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllForwardsFiltered.cs
@@ -99,6 +99,7 @@ namespace EventStore.Core.Services.Transport.Enumerators
 					commitPosition, preparePosition, (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
 					_requiresLeader, (int)_maxSearchWindow, null, _eventFilter, _user,
 					replyOnExpired: true,
+					expires: ClientMessage.ReadRequestMessage.NeverExpires,
 					cancellationToken: _cancellationToken));
 
 				async Task OnMessage(Message message, CancellationToken ct)

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadStreamBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadStreamBackwards.cs
@@ -81,6 +81,7 @@ namespace EventStore.Core.Services.Transport.Enumerators
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					_streamName, startRevision.ToInt64(), (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
 					_requiresLeader, null, _user,
+					expires: ClientMessage.ReadRequestMessage.NeverExpires,
 					cancellationToken: _cancellationToken,
 					replyOnExpired: true));
 

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadStreamForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadStreamForwards.cs
@@ -81,6 +81,7 @@ namespace EventStore.Core.Services.Transport.Enumerators
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					_streamName, startRevision.ToInt64(), (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
 					_requiresLeader, null, _user, replyOnExpired: true,
+					expires: ClientMessage.ReadRequestMessage.NeverExpires,
 					cancellationToken: _cancellationToken));
 
 				async Task OnMessage(Message message, CancellationToken ct)

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.StreamSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.StreamSubscription.cs
@@ -436,7 +436,7 @@ ReadLoop:
 					_streamName, startEventNumber, ReadBatchSize, _resolveLinks, _requiresLeader, null,
 					_user,
 					replyOnExpired: true,
-					expires: _expiryStrategy.GetExpiry(),
+					expires: _expiryStrategy.GetExpiry() ?? ClientMessage.ReadRequestMessage.NeverExpires,
 					cancellationToken: ct));
 			}
 

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -742,7 +742,7 @@ public class ManagedProjection : IDisposable
 				1,
 				resolveLinkTos: false, requireLeader: false, validationStreamVersion: null,
 				user: SystemAccounts.System,
-				expires: DateTime.MaxValue),
+				expires: ClientMessage.ReadRequestMessage.NeverExpires),
 			new ReadStreamEventsBackwardHandlers.Optimistic(PersistedStateReadCompleted));
 	}
 

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -979,7 +979,7 @@ public class ProjectionManager
 				validationStreamVersion: null,
 				user: SystemAccounts.System,
 				replyOnExpired: false,
-				expires: DateTime.MaxValue),
+				expires: ClientMessage.ReadRequestMessage.NeverExpires),
 			m => OnProjectionsListReadCompleted(m, registeredProjections, from, completedAction));
 	}
 
@@ -1383,7 +1383,7 @@ public class ProjectionManager
 				requireLeader: false,
 				validationStreamVersion: null,
 				user: SystemAccounts.System,
-				expires: DateTime.MaxValue),
+				expires: ClientMessage.ReadRequestMessage.NeverExpires),
 			new ReadStreamEventsBackwardHandlers.Optimistic(onComplete));
 	}
 

--- a/src/EventStore.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
@@ -1,4 +1,3 @@
-using System;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Projections.Core.Messages;
@@ -22,7 +21,8 @@ public class RequestResponseQueueForwarder(IPublisher inputQueue, IPublisher ext
 			new ClientMessage.ReadEvent(
 				msg.InternalCorrId, msg.CorrelationId,
 				new PublishToWrapEnvelop(inputQueue, msg.Envelope, nameof(ClientMessage.ReadEvent)),
-				msg.EventStreamId, msg.EventNumber, msg.ResolveLinkTos, msg.RequireLeader, msg.User));
+				msg.EventStreamId, msg.EventNumber, msg.ResolveLinkTos, msg.RequireLeader, msg.User,
+				expires: msg.CanExpire ? null : msg.Expires));
 
 	public void Handle(ClientMessage.WriteEvents msg) =>
 		externalRequestQueue.Publish(
@@ -38,13 +38,6 @@ public class RequestResponseQueueForwarder(IPublisher inputQueue, IPublisher ext
 				new PublishToWrapEnvelop(inputQueue, msg.Envelope, nameof(ClientMessage.DeleteStream)), true,
 				msg.EventStreamId, msg.ExpectedVersion, msg.HardDelete, msg.User));
 
-	// Historically, message forwarding here has discarded the original Expiration value,
-	// resetting it to the default (10 seconds from now). Ideally, we should propagate the
-	// original Expiration from the source message.
-	//
-	// For now, this fix takes a minimal-impact approach: we only preserve the Expiration
-	// when explicitly needed (i.e., DateTime.MaxValue), and only for the relevant messages.
-
 	public void Handle(ClientMessage.ReadStreamEventsBackward msg) =>
 		externalRequestQueue.Publish(
 			new ClientMessage.ReadStreamEventsBackward(
@@ -52,7 +45,7 @@ public class RequestResponseQueueForwarder(IPublisher inputQueue, IPublisher ext
 				new PublishToWrapEnvelop(inputQueue, msg.Envelope, nameof(ClientMessage.ReadStreamEventsBackward)),
 				msg.EventStreamId, msg.FromEventNumber, msg.MaxCount, msg.ResolveLinkTos, msg.RequireLeader,
 				msg.ValidationStreamVersion, msg.User,
-				expires: msg.Expires == DateTime.MaxValue ? msg.Expires : null));
+				expires: msg.CanExpire ? null : msg.Expires));
 
 	public void Handle(ClientMessage.ReadStreamEventsForward msg) =>
 		externalRequestQueue.Publish(
@@ -61,7 +54,7 @@ public class RequestResponseQueueForwarder(IPublisher inputQueue, IPublisher ext
 				new PublishToWrapEnvelop(inputQueue, msg.Envelope, nameof(ClientMessage.ReadStreamEventsForward)),
 				msg.EventStreamId, msg.FromEventNumber, msg.MaxCount, msg.ResolveLinkTos, msg.RequireLeader,
 				msg.ValidationStreamVersion, msg.User, replyOnExpired: false,
-				expires: msg.Expires == DateTime.MaxValue ? msg.Expires : null));
+				expires: msg.CanExpire ? null : msg.Expires));
 
 	public void Handle(ClientMessage.ReadAllEventsForward msg) =>
 		externalRequestQueue.Publish(
@@ -69,7 +62,8 @@ public class RequestResponseQueueForwarder(IPublisher inputQueue, IPublisher ext
 				msg.InternalCorrId, msg.CorrelationId,
 				new PublishToWrapEnvelop(inputQueue, msg.Envelope, nameof(ClientMessage.ReadAllEventsForward)),
 				msg.CommitPosition, msg.PreparePosition, msg.MaxCount, msg.ResolveLinkTos, msg.RequireLeader,
-				msg.ValidationTfLastCommitPosition, msg.User, replyOnExpired: false));
+				msg.ValidationTfLastCommitPosition, msg.User, replyOnExpired: false,
+				expires: msg.CanExpire ? null : msg.Expires));
 
 	public void Handle(SystemMessage.SubSystemInitialized msg) =>
 		externalRequestQueue.Publish(


### PR DESCRIPTION
- Keep read-request expiry enforced while storage I/O is already in flight.
- Preserve caller cancellation as the source of cancellation instead of letting timeout and request shutdown paths blur together.
- Avoid applying the default read-message timeout to transport requests whose deadline is already owned by the caller.