### PR TITLE
fix(config): handle null array sections

### DIFF
--- a/src/EventStore.Common.Tests/Configuration/SectionTests.cs
+++ b/src/EventStore.Common.Tests/Configuration/SectionTests.cs
@@ -57,5 +57,6 @@ public class SectionTests
 		Assert.Equal("v section2:a2", value);
 		Assert.True(sectionProvider.TryGetProviderFor("section2:a", out var provider));
 		Assert.IsType<MemoryConfigurationProvider>(provider);
+		Assert.False(sectionProvider.TryGet("section2:sub", out _));
 	}
 }

--- a/src/EventStore.Common/Configuration/SectionProvider.cs
+++ b/src/EventStore.Common/Configuration/SectionProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
 
@@ -50,6 +51,11 @@ public sealed class SectionProvider : ConfigurationProvider, IDisposable
 		var data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 		foreach (var kvp in _configuration.AsEnumerable())
 		{
+			if (kvp.Value is null && !_configuration.Providers.Any(provider => provider.TryGet(kvp.Key, out _)))
+			{
+				continue;
+			}
+
 			data[_sectionName + ":" + kvp.Key] = kvp.Value;
 		}
 

--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using EventStore.Common.Configuration;
 using EventStore.Common.Exceptions;
 using EventStore.Common.Options;
 using EventStore.Common.Utils;
@@ -196,10 +197,12 @@ public class ClusterVNodeOptionsTests
 	public void can_set_gossip_seed_values_via_array()
 	{
 		var config = new ConfigurationBuilder()
-			.AddInMemoryCollection([
-				new KeyValuePair<string, string?>("EventStore:GossipSeed:0", "127.0.0.1:1113"),
-				new KeyValuePair<string, string?>("EventStore:GossipSeed:1", "some-host:1114"),
-			])
+			.AddEventStoreDefaultValues()
+			.AddSection(EventStoreConfigurationKeys.Prefix, builder => builder
+				.AddInMemoryCollection([
+					new KeyValuePair<string, string?>("GossipSeed:0", "127.0.0.1:1113"),
+					new KeyValuePair<string, string?>("GossipSeed:1", "some-host:1114"),
+				]))
 			.Build();
 
 		var options = ClusterVNodeOptions.FromConfiguration(config);

--- a/src/EventStore.Core.XUnit.Tests/Configuration/Sources/DefaultValuesConfigurationSourceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/Sources/DefaultValuesConfigurationSourceTests.cs
@@ -12,7 +12,10 @@ public class DefaultValuesConfigurationSourceTests
 	public void Adds()
 	{
 		// Arrange
-		var defaults = ClusterVNodeOptions.DefaultValues.OrderBy(x => x.Key).ToList();
+		var defaults = ClusterVNodeOptions.DefaultValues
+			.Where(x => x.Key is not nameof(ClusterVNodeOptions.ClusterOptions.GossipSeed))
+			.OrderBy(x => x.Key)
+			.ToList();
 
 		// Act
 		var configuration = new ConfigurationBuilder()

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.Framework.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.Framework.cs
@@ -96,18 +96,15 @@ namespace EventStore.Core
 
 				foreach (var option in Metadata.SelectMany(x => x.Options))
 				{
+					var sourceDisplayName = GetSourceDisplayName(option.Value.Key, provider);
+
 					if (!provider.TryGet(option.Value.Key, out var value))
 					{
-						continue;
-					}
+						if (option.Value.OptionSchema.Value<string>("type") is not "array")
+						{
+							continue;
+						}
 
-					var title = GetTitle(option);
-					var sourceDisplayName = GetSourceDisplayName(option.Value.Key, provider);
-					var isDefault = provider.GetType() == typeof(EventStoreDefaultValuesConfigurationProvider);
-
-					// Handle array-style options; currently only GossipSeed uses this
-					if (sourceDisplayName is "<UNKNOWN>" && value is null)
-					{
 						var parentPath = option.Value.Key;
 						var childValues = new List<string>();
 
@@ -123,8 +120,16 @@ namespace EventStore.Core
 							sourceDisplayName = GetSourceDisplayName(absoluteChildKey, provider);
 						}
 
+						if (childValues.Count == 0)
+						{
+							continue;
+						}
+
 						value = string.Join(", ", childValues);
 					}
+
+					var title = GetTitle(option);
+					var isDefault = provider.GetType() == typeof(EventStoreDefaultValuesConfigurationProvider);
 
 					loadedOptions[option.Value.Key] = new(
 						metadata: option.Value,

--- a/src/EventStore.Core/Configuration/Sources/EventStoreDefaultValuesConfigurationSource.cs
+++ b/src/EventStore.Core/Configuration/Sources/EventStoreDefaultValuesConfigurationSource.cs
@@ -19,7 +19,9 @@ namespace EventStore.Core.Configuration.Sources
 	public class EventStoreDefaultValuesConfigurationProvider(IEnumerable<KeyValuePair<string, string?>> initialData)
 		: MemoryConfigurationProvider(new()
 		{
-			InitialData = initialData.ToDictionary(
+			InitialData = initialData
+				.Where(kvp => kvp.Key is not nameof(ClusterVNodeOptions.ClusterOptions.GossipSeed))
+				.ToDictionary(
 				kvp => $"{Prefix}:{kvp.Key}",
 				kvp => kvp.Value,
 				OrdinalIgnoreCase)


### PR DESCRIPTION
- Preserve list-valued configuration when newer runtime binding surfaces parent sections as null values.\n- Avoid treating an empty default parent value as stronger than explicitly configured child entries.