### PR TITLE
chore(buffer): modernize argument guards

### DIFF
--- a/src/EventStore.BufferManagement/BufferManager.cs
+++ b/src/EventStore.BufferManagement/BufferManager.cs
@@ -65,10 +65,7 @@ public class BufferManager
 	/// <param name="manager">The new default buffer manager.</param>
 	public static void SetDefaultBufferManager(BufferManager manager)
 	{
-		if (manager == null)
-		{
-			throw new ArgumentNullException("manager");
-		}
+		ArgumentNullException.ThrowIfNull(manager);
 
 		_defaultBufferManager = manager;
 	}
@@ -136,17 +133,17 @@ public class BufferManager
 	{
 		if (segmentChunks <= 0)
 		{
-			throw new ArgumentException("segmentChunks");
+			throw new ArgumentException($"{nameof(segmentChunks)} must be greater than 0.", nameof(segmentChunks));
 		}
 
 		if (chunkSize <= 0)
 		{
-			throw new ArgumentException("chunkSize");
+			throw new ArgumentException($"{nameof(chunkSize)} must be greater than 0.", nameof(chunkSize));
 		}
 
 		if (initialSegments < 0)
 		{
-			throw new ArgumentException("initialSegments");
+			throw new ArgumentException($"{nameof(initialSegments)} must be greater than or equal to 0.", nameof(initialSegments));
 		}
 
 		_segmentChunks = segmentChunks;
@@ -298,10 +295,7 @@ public class BufferManager
 	/// <param name="buffersToReturn">The <see cref="ArraySegment{T}"></see> to return to the cache</param>
 	public void CheckIn(IEnumerable<ArraySegment<byte>> buffersToReturn)
 	{
-		if (buffersToReturn == null)
-		{
-			throw new ArgumentNullException("buffersToReturn");
-		}
+		ArgumentNullException.ThrowIfNull(buffersToReturn);
 
 		foreach (var buf in buffersToReturn)
 		{
@@ -320,7 +314,7 @@ public class BufferManager
 
 		if (buffer.Count != _chunkSize)
 		{
-			throw new ArgumentException("Buffer was not of the same chunk size as the buffer manager", "buffer");
+			throw new ArgumentException("Buffer was not of the same chunk size as the buffer manager", nameof(buffer));
 		}
 	}
 }

--- a/src/EventStore.BufferManagement/BufferPool.cs
+++ b/src/EventStore.BufferManagement/BufferPool.cs
@@ -83,7 +83,7 @@ public class BufferPool : IDisposable
 			CheckDisposed();
 			if (index < 0 || index > _length)
 			{
-				throw new ArgumentOutOfRangeException("index");
+				throw new ArgumentOutOfRangeException(nameof(index));
 			}
 
 			Position l = GetPositionFor(index);
@@ -133,13 +133,10 @@ public class BufferPool : IDisposable
 	{
 		if (initialBufferCount <= 0)
 		{
-			throw new ArgumentException("initialBufferCount");
+			throw new ArgumentException($"{nameof(initialBufferCount)} must be greater than 0.", nameof(initialBufferCount));
 		}
 
-		if (bufferManager == null)
-		{
-			throw new ArgumentNullException("bufferManager");
-		}
+		ArgumentNullException.ThrowIfNull(bufferManager);
 
 		_length = 0;
 		_buffers = new List<ArraySegment<byte>>(bufferManager.CheckOut(initialBufferCount));
@@ -155,10 +152,7 @@ public class BufferPool : IDisposable
 	/// <param name="data">The data to write.</param>
 	public void Append(byte[] data)
 	{
-		if (data == null)
-		{
-			throw new ArgumentNullException("data");
-		}
+		ArgumentNullException.ThrowIfNull(data);
 
 		Write(_length, data, 0, data.Length);
 	}
@@ -183,19 +177,16 @@ public class BufferPool : IDisposable
 	/// <param name="count">The count.</param>
 	public void Write(int position, byte[] data, int offset, int count)
 	{
-		if (data == null)
-		{
-			throw new ArgumentNullException("data");
-		}
+		ArgumentNullException.ThrowIfNull(data);
 
 		if (offset < 0 || offset > data.Length)
 		{
-			throw new ArgumentOutOfRangeException("offset");
+			throw new ArgumentOutOfRangeException(nameof(offset));
 		}
 
 		if (count < 0 || count + offset > data.Length)
 		{
-			throw new ArgumentOutOfRangeException("count");
+			throw new ArgumentOutOfRangeException(nameof(count));
 		}
 
 		Write(position, new ArraySegment<byte>(data, offset, count));
@@ -242,19 +233,16 @@ public class BufferPool : IDisposable
 	/// <returns></returns>
 	public int ReadFrom(int position, byte[] data, int offset, int count)
 	{
-		if (data == null)
-		{
-			throw new ArgumentNullException("data");
-		}
+		ArgumentNullException.ThrowIfNull(data);
 
 		if (offset < 0 || offset > data.Length)
 		{
-			throw new ArgumentOutOfRangeException("offset");
+			throw new ArgumentOutOfRangeException(nameof(offset));
 		}
 
 		if (count < 0 || count + offset > data.Length)
 		{
-			throw new ArgumentOutOfRangeException("count");
+			throw new ArgumentOutOfRangeException(nameof(count));
 		}
 
 		return ReadFrom(position, new ArraySegment<byte>(data, offset, count));
@@ -415,9 +403,6 @@ public class BufferPool : IDisposable
 
 	private void CheckDisposed()
 	{
-		if (_disposed)
-		{
-			throw new ObjectDisposedException("Object has been disposed.");
-		}
+		ObjectDisposedException.ThrowIf(_disposed, this);
 	}
 }

--- a/src/EventStore.BufferManagement/BufferPoolStream.cs
+++ b/src/EventStore.BufferManagement/BufferPoolStream.cs
@@ -45,7 +45,7 @@ public class BufferPoolStream : Stream
 		{
 			if (value < 0 || value > _bufferPool.Length)
 			{
-				throw new ArgumentOutOfRangeException("value");
+				throw new ArgumentOutOfRangeException(nameof(value));
 			}
 
 			_position = value;
@@ -58,10 +58,7 @@ public class BufferPoolStream : Stream
 	/// <param name="bufferPool">The buffer pool used as underlying storage.</param>
 	public BufferPoolStream(BufferPool bufferPool)
 	{
-		if (bufferPool == null)
-		{
-			throw new ArgumentNullException("bufferPool");
-		}
+		ArgumentNullException.ThrowIfNull(bufferPool);
 
 		_bufferPool = bufferPool;
 	}


### PR DESCRIPTION
- Keep low-level buffer guard paths aligned with the current runtime analyzer expectations.\n- Reduce noisy diagnostics in a hot shared package without changing buffer ownership semantics.