### PR TITLE
chore(buffer): clean test analyzer noise

### DIFF
--- a/src/EventStore.BufferManagement.Tests/BufferManagerTests.cs
+++ b/src/EventStore.BufferManagement.Tests/BufferManagerTests.cs
@@ -84,7 +84,7 @@ public class when_checking_out_a_buffer
 	public void should_release_acquired_buffers_if_size_requirement_cant_be_satisfied()
 	{
 		BufferManager manager = new BufferManager(1, 1000, 1, false);
-		Assert.Throws(Is.InstanceOf(typeof(Exception)), () => manager.CheckOut(2));
+		Assert.Throws(Is.InstanceOf<Exception>(), () => manager.CheckOut(2));
 		Assert.AreEqual(1, manager.AvailableBuffers);
 	}
 }

--- a/src/EventStore.BufferManagement.Tests/BufferPoolTests.cs
+++ b/src/EventStore.BufferManagement.Tests/BufferPoolTests.cs
@@ -41,7 +41,7 @@ public class when_instantiating_a_bufferpool : has_buffer_manager_fixture
 	public void the_requested_buffers_should_be_removed_from_the_buffer_manager()
 	{
 		int initialBuffers = BufferManager.AvailableBuffers;
-		new BufferPool(10, BufferManager);
+		_ = new BufferPool(10, BufferManager);
 		Assert.AreEqual(initialBuffers - 10, BufferManager.AvailableBuffers);
 	}
 }


### PR DESCRIPTION
- Keep buffer tests quiet under the current analyzer set so future signal is easier to spot.\n- Preserve the existing side-effect assertions without relying on analyzer-suppressed patterns.