### PR TITLE
chore(projections): reuse empty test arrays

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Integration/specification_with_a_v8_query_posted.cs
+++ b/src/EventStore.Projections.Core.Tests/Integration/specification_with_a_v8_query_posted.cs
@@ -129,6 +129,6 @@ public abstract class specification_with_a_v8_query_posted<TLogFormat, TStreamId
 
 	protected virtual IEnumerable<string> GivenOtherProjections()
 	{
-		return new string[0];
+		return Array.Empty<string>();
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/TestFixtureWithProjectionCoreService.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/TestFixtureWithProjectionCoreService.cs
@@ -161,6 +161,6 @@ public class TestFixtureWithProjectionCoreService
 	{
 		return new ResolvedEvent(
 			"test", -1, "test", -1, false, new TFPos(10, 5), new TFPos(10, 5), Guid.NewGuid(), "t", false,
-			new byte[0], new byte[0], null, null, default(DateTime));
+			Array.Empty<byte>(), Array.Empty<byte>(), null, null, default(DateTime));
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_the_state_handler_does_not_process_event_the_projection_should.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_the_state_handler_does_not_process_event_the_projection_should.cs
@@ -29,7 +29,7 @@ public class when_the_state_handler_does_not_process_event_the_projection_should
 				new ResolvedEvent(
 					"/event_category/1", -1, "/event_category/1", -1, false, new TFPos(120, 110),
 					new TFPos(120, 110),
-					Guid.NewGuid(), "skip_this_type", false, new byte[0], new byte[0], null, null,
+					Guid.NewGuid(), "skip_this_type", false, Array.Empty<byte>(), Array.Empty<byte>(), null, null,
 					default(DateTime)),
 				_subscriptionId, 0));
 	}

--- a/src/EventStore.Projections.Core.Tests/Services/core_service/when_a_subscribed_projection_handler_throws.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_service/when_a_subscribed_projection_handler_throws.cs
@@ -25,7 +25,7 @@ public class when_a_subscribed_projection_handler_throws : TestFixtureWithProjec
 		_readerService.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				readerStrategy.EventReaderId, new TFPos(20, 10), "throws", 10, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0]));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 
 	[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/EventByTypeIndexEventReaderTestFixture.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/EventByTypeIndexEventReaderTestFixture.cs
@@ -38,7 +38,7 @@ public abstract class EventByTypeIndexEventReaderTestFixture<TLogFormat, TStream
 		message.Envelope.ReplyWith(
 			new ClientMessage.ReadStreamEventsBackwardCompleted(
 				corrId == Guid.Empty ? message.CorrelationId : corrId, streamId, 0, 100, ReadStreamResult.Success,
-				new ResolvedEvent[] { }, null, false, "", lastEventNumber + 1, lastEventNumber, true, 200));
+				Array.Empty<ResolvedEvent>(), null, false, "", lastEventNumber + 1, lastEventNumber, true, 200));
 		return message.CorrelationId;
 	}
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reordering_projection_subscription/when_receiving_multiple_events_not_passing_event_filter.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reordering_projection_subscription/when_receiving_multiple_events_not_passing_event_filter.cs
@@ -30,15 +30,15 @@ public class when_receiving_multiple_events_not_passing_event_filter :
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_projectionCorrelationId, new TFPos(200, 150), "a", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0], _timestamp));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>(), _timestamp));
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_projectionCorrelationId, new TFPos(2000, 950), "a", 2, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0], _timestamp.AddMilliseconds(1)));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>(), _timestamp.AddMilliseconds(1)));
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_projectionCorrelationId, new TFPos(2100, 2050), "b", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0], _timestamp.AddMilliseconds(1)));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>(), _timestamp.AddMilliseconds(1)));
 		_subscription.Handle(
 			new ReaderSubscriptionMessage.EventReaderIdle(
 				_projectionCorrelationId, _timestamp.AddMilliseconds(1100)));

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_multiple_committed_event_passing_the_filter.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_multiple_committed_event_passing_the_filter.cs
@@ -21,11 +21,11 @@ public class when_handling_multiple_committed_event_passing_the_filter : TestFix
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(200, 150), "test-stream", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(300, 250), "test-stream", 2, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 
 	[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_receiving_multiple_events_not_passing_event_filter.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_receiving_multiple_events_not_passing_event_filter.cs
@@ -22,15 +22,15 @@ public class when_receiving_multiple_events_not_passing_event_filter : TestFixtu
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(200, 150), "test-stream", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(2000, 1950), "test-stream", 2, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(2100, 2050), "test-stream", 2, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 
 	[Test]

--- a/src/EventStore.Projections.Core.Tests/Subsystem/TestFixtureWithProjectionSubsystem.cs
+++ b/src/EventStore.Projections.Core.Tests/Subsystem/TestFixtureWithProjectionSubsystem.cs
@@ -51,7 +51,7 @@ public class TestFixtureWithProjectionSubsystem
 		var timerService = new TimerService(threadBasedScheduler);
 
 		return new StandardComponents(dbConfig, mainQueue, mainBus,
-			timerService, timeProvider: null, httpServices: new IHttpService[] { },
+			timerService, timeProvider: null, httpServices: Array.Empty<IHttpService>(),
 			networkSendService: null, monitoringQueue: mainQueue, queueStatsManager: new QueueStatsManager(),
 			trackers: new(), true);
 	}


### PR DESCRIPTION
- Keep projection test fixtures from allocating throwaway empty arrays on repeated paths.\n- Reduce analyzer noise around projection subscription and reader tests.