### PR TITLE
chore(projections): reuse subscription test arrays

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/failing_test_github_issue_2785.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/failing_test_github_issue_2785.cs
@@ -33,6 +33,6 @@ public class
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), position, stream, 1, resolvedLinkToEvent, Guid.NewGuid(),
-				eventType, false, new byte[0], new byte[0]));
+				eventType, false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_committed_event_passing_the_filter.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_committed_event_passing_the_filter.cs
@@ -13,7 +13,7 @@ public class when_handling_committed_event_passing_the_filter : TestFixtureWithP
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(200, 150), "test-stream", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 
 	[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_duplicate_events.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_duplicate_events.cs
@@ -13,15 +13,15 @@ public class when_handling_duplicate_events : TestFixtureWithProjectionSubscript
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(200, 150), "test-stream", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(100, 50), "test-stream", 0, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(200, 150), "test-stream", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 
 	[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_enough_events_for_a_checkpoint_after_specified_time_elapses.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_enough_events_for_a_checkpoint_after_specified_time_elapses.cs
@@ -23,13 +23,13 @@ public class
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_checkpointHandler.HandledMessages.Clear();
 		((FakeTimeProvider)_timeProvider).AddToUtcTime(TimeSpan.FromMilliseconds(_checkpointAfterMs + 1));
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(300, 300), "test-stream", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 
 	[Test]
@@ -62,17 +62,17 @@ public class
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(300, 300), "test-stream", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_checkpointHandler.HandledMessages.Clear();
 		((FakeTimeProvider)_timeProvider).AddToUtcTime(TimeSpan.FromMilliseconds(_checkpointAfterMs + 1));
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(400, 400), "test-stream", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 
 	[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_enough_events_for_a_checkpoint_before_specified_time_elapses.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_enough_events_for_a_checkpoint_before_specified_time_elapses.cs
@@ -23,13 +23,13 @@ public class
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_checkpointHandler.HandledMessages.Clear();
 		((FakeTimeProvider)_timeProvider).AddToUtcTime(TimeSpan.FromMilliseconds(_checkpointAfterMs));
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(300, 300), "test-stream", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 
 	[Test]
@@ -62,17 +62,17 @@ public class
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(300, 300), "test-stream", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_checkpointHandler.HandledMessages.Clear();
 		((FakeTimeProvider)_timeProvider).AddToUtcTime(TimeSpan.FromMilliseconds(_checkpointAfterMs));
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(400, 400), "test-stream", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 
 	[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_events_with_content_type_validation.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_events_with_content_type_validation.cs
@@ -23,11 +23,11 @@ public class when_handling_events_with_content_type_validation
 			_subscription.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
-					"invalid-json", true, Encoding.UTF8.GetBytes("{foo:bar}"), new byte[0]));
+					"invalid-json", true, Encoding.UTF8.GetBytes("{foo:bar}"), Array.Empty<byte>()));
 			_subscription.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					Guid.NewGuid(), new TFPos(300, 300), "test-stream", 2, false, Guid.NewGuid(),
-					"valid-json", true, Encoding.UTF8.GetBytes("{\"foo\":\"bar\"}"), new byte[0]));
+					"valid-json", true, Encoding.UTF8.GetBytes("{\"foo\":\"bar\"}"), Array.Empty<byte>()));
 			_subscription.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					Guid.NewGuid(), new TFPos(400, 400), "test-stream", 3, false, Guid.NewGuid(),
@@ -38,7 +38,7 @@ public class when_handling_events_with_content_type_validation
 							"foo": "bar",
 						}
 						"""),
-					new byte[0]));
+					Array.Empty<byte>()));
 		}
 
 		protected override IReaderSubscription CreateProjectionSubscription()
@@ -79,11 +79,11 @@ public class when_handling_events_with_content_type_validation
 			_subscription.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
-					"plain-text", false, Encoding.UTF8.GetBytes("foo bar"), new byte[0]));
+					"plain-text", false, Encoding.UTF8.GetBytes("foo bar"), Array.Empty<byte>()));
 			_subscription.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					Guid.NewGuid(), new TFPos(300, 300), "test-stream", 2, false, Guid.NewGuid(),
-					"valid-json", false, Encoding.UTF8.GetBytes("{\"foo\":\"bar\"}"), new byte[0]));
+					"valid-json", false, Encoding.UTF8.GetBytes("{\"foo\":\"bar\"}"), Array.Empty<byte>()));
 		}
 
 		protected override IReaderSubscription CreateProjectionSubscription()
@@ -122,11 +122,11 @@ public class when_handling_events_with_content_type_validation
 			_subscription.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
-					"invalid-json", true, Encoding.UTF8.GetBytes("{foo:bar}"), new byte[0]));
+					"invalid-json", true, Encoding.UTF8.GetBytes("{foo:bar}"), Array.Empty<byte>()));
 			_subscription.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					Guid.NewGuid(), new TFPos(300, 300), "test-stream", 2, false, Guid.NewGuid(),
-					"valid-json", true, Encoding.UTF8.GetBytes("{\"foo\":\"bar\"}"), new byte[0]));
+					"valid-json", true, Encoding.UTF8.GetBytes("{\"foo\":\"bar\"}"), Array.Empty<byte>()));
 			_subscription.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					Guid.NewGuid(), new TFPos(400, 400), "test-stream", 3, false, Guid.NewGuid(),
@@ -134,11 +134,11 @@ public class when_handling_events_with_content_type_validation
 			_subscription.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					Guid.NewGuid(), new TFPos(500, 500), "test-stream", 4, false, Guid.NewGuid(),
-					"plain-text", false, Encoding.UTF8.GetBytes("foo bar"), new byte[0]));
+					"plain-text", false, Encoding.UTF8.GetBytes("foo bar"), Array.Empty<byte>()));
 			_subscription.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					Guid.NewGuid(), new TFPos(600, 600), "test-stream", 5, false, Guid.NewGuid(),
-					"valid-json", false, Encoding.UTF8.GetBytes("{\"foo\":\"bar\"}"), new byte[0]));
+					"valid-json", false, Encoding.UTF8.GetBytes("{\"foo\":\"bar\"}"), Array.Empty<byte>()));
 		}
 
 		protected override IReaderSubscription CreateProjectionSubscription()

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_events_with_different_event_filters.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_events_with_different_event_filters.cs
@@ -83,7 +83,7 @@ public class
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), firstPosition, "a-random-stream-name", 1, false, Guid.NewGuid(),
-				"a-random-event-type", false, new byte[0], new byte[0]));
+				"a-random-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 
 		_checkpointHandler.HandledMessages.Clear();
 
@@ -92,7 +92,7 @@ public class
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), secondPosition, _stream, 1, false, Guid.NewGuid(),
-				_eventType, false, new byte[0], new byte[0]));
+				_eventType, false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 
 	[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_multiple_committed_event_passing_the_filter.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_multiple_committed_event_passing_the_filter.cs
@@ -21,11 +21,11 @@ public class when_handling_multiple_committed_event_passing_the_filter : TestFix
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(200, 150), "test-stream", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(300, 250), "test-stream", 2, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 
 	[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_receiving_multiple_events_not_passing_event_filter.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_receiving_multiple_events_not_passing_event_filter.cs
@@ -22,15 +22,15 @@ public class when_receiving_multiple_events_not_passing_event_filter : TestFixtu
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(200, 150), "test-stream", 1, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(2000, 1950), "test-stream", 2, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_subscription.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				Guid.NewGuid(), new TFPos(2100, 2050), "test-stream", 2, false, Guid.NewGuid(),
-				"bad-event-type", false, new byte[0], new byte[0]));
+				"bad-event-type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 
 	[Test]


### PR DESCRIPTION
- Keep projection subscription tests quiet under allocation-focused analyzers.\n- Preserve the same subscription scenarios while avoiding repeated empty-array allocations.