### PR TITLE
chore(projections): reuse reader test arrays

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_heading_event_reader_has_been_created.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_heading_event_reader_has_been_created.cs
@@ -66,7 +66,7 @@ public class when_heading_event_reader_has_been_created : TestFixtureWithReadWri
 			_point.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					Guid.NewGuid(), new TFPos(20, 10), "stream", 10, false, Guid.NewGuid(), "type", false,
-					new byte[0], new byte[0]));
+					Array.Empty<byte>(), Array.Empty<byte>()));
 		});
 	}
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_starting_a_heading_event_reader.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_starting_a_heading_event_reader.cs
@@ -53,7 +53,7 @@ public class when_starting_a_heading_event_reader : TestFixtureWithReadWriteDisp
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(20, 10), "stream", 10, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0]));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 
 	[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_handles_an_event.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_handles_an_event.cs
@@ -41,7 +41,7 @@ public class when_the_heading_event_reader_handles_an_event : TestFixtureWithRea
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(20, 10), "stream", 10, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0]));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 
 	[Test]
@@ -50,7 +50,7 @@ public class when_the_heading_event_reader_handles_an_event : TestFixtureWithRea
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(40, 30), "stream", 12, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0]));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 
 	//TODO: SW1
@@ -72,7 +72,7 @@ public class when_the_heading_event_reader_handles_an_event : TestFixtureWithRea
 			_point.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					_distibutionPointCorrelationId, new TFPos(5, 0), "stream", 8, false, Guid.NewGuid(), "type",
-					false, new byte[0], new byte[0]));
+					false, Array.Empty<byte>(), Array.Empty<byte>()));
 		});
 	}
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_subscribes_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_subscribes_a_projection.cs
@@ -44,11 +44,11 @@ public class when_the_heading_event_reader_subscribes_a_projection : TestFixture
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(20, 10), "stream", 10, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0]));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(40, 30), "stream", 11, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0]));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_subscription = new FakeReaderSubscription();
 		_projectionSubscriptionId = Guid.NewGuid();
 		_point.TrySubscribe(_projectionSubscriptionId, _subscription, 30);

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_unsubscribes_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_unsubscribes_a_projection.cs
@@ -43,11 +43,11 @@ public class when_the_heading_event_reader_unsubscribes_a_projection : TestFixtu
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(20, 10), "stream", 10, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0]));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(40, 30), "stream", 11, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0]));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_subscription = new FakeReaderSubscription();
 		_projectionSubscriptionId = Guid.NewGuid();
 		var subscribed = _point.TrySubscribe(_projectionSubscriptionId, _subscription, 30);
@@ -63,7 +63,7 @@ public class when_the_heading_event_reader_unsubscribes_a_projection : TestFixtu
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(60, 50), "stream", 12, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0]));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		Assert.AreEqual(count, _subscription.ReceivedEvents.Count);
 	}
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_with_a_subscribed_projection_handles_a_cached_event_and_throws.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_with_a_subscribed_projection_handles_a_cached_event_and_throws.cs
@@ -32,11 +32,11 @@ public class when_the_heading_event_reader_with_a_subscribed_projection_handles_
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(20, 10), "throws", 10, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0]));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(40, 30), "throws", 11, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0]));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_projectionSubscriptionId = Guid.NewGuid();
 		_point.TrySubscribe(_projectionSubscriptionId, new FakeReaderSubscription(), 30);
 	}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_with_a_subscribed_projection_handles_a_live_event_and_throws.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_with_a_subscribed_projection_handles_a_live_event_and_throws.cs
@@ -32,17 +32,17 @@ public class when_the_heading_event_reader_with_a_subscribed_projection_handles_
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(20, 10), "stream", 10, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0]));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(40, 30), "stream", 11, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0]));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_projectionSubscriptionId = Guid.NewGuid();
 		_point.TrySubscribe(_projectionSubscriptionId, new FakeReaderSubscription(), 30);
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(60, 50), "throws", 12, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0]));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 
 	[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_with_a_subscribed_projection_handles_an_event.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_with_a_subscribed_projection_handles_an_event.cs
@@ -45,18 +45,18 @@ public class when_the_heading_event_reader_with_a_subscribed_projection_handles_
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(20, 10), "stream", 10, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0]));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(40, 30), "stream", 11, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0]));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 		_subscription = new FakeReaderSubscription();
 		_projectionSubscriptionId = Guid.NewGuid();
 		_point.TrySubscribe(_projectionSubscriptionId, _subscription, 30);
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(60, 50), "stream", 12, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0]));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>()));
 	}
 
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_with_a_subscribed_projection_handles_an_idle_notification.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_with_a_subscribed_projection_handles_an_idle_notification.cs
@@ -45,11 +45,11 @@ public class when_the_heading_event_reader_with_a_subscribed_projection_handles_
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(20, 10), "stream", 10, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0], timestamp));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>(), timestamp));
 		_point.Handle(
 			ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 				_distibutionPointCorrelationId, new TFPos(40, 30), "stream", 11, false, Guid.NewGuid(),
-				"type", false, new byte[0], new byte[0], timestamp.AddMilliseconds(1)));
+				"type", false, Array.Empty<byte>(), Array.Empty<byte>(), timestamp.AddMilliseconds(1)));
 		_subscription = new FakeReaderSubscription();
 		_projectionSubscriptionId = Guid.NewGuid();
 		_point.TrySubscribe(_projectionSubscriptionId, _subscription, 30);

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_creating.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_creating.cs
@@ -77,7 +77,7 @@ public class when_creating<TLogFormat, TStreamId> : TestFixtureWithExistingEvent
 		Assert.Throws<ArgumentException>(() =>
 		{
 			new MultiStreamEventReader(
-				_ioDispatcher, _bus, Guid.NewGuid(), null, 0, new string[0], _ab12Tag, false, _timeProvider);
+				_ioDispatcher, _bus, Guid.NewGuid(), null, 0, Array.Empty<string>(), _ab12Tag, false, _timeProvider);
 		});
 	}
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed.cs
@@ -113,7 +113,7 @@ public class when_handling_read_completed<TLogFormat, TStreamId> : TestFixtureWi
 								DateTime.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin |
 								PrepareFlags.TransactionEnd,
-								"event_type", new byte[0], new byte[0]))
+								"event_type", Array.Empty<byte>(), Array.Empty<byte>()))
 					}, null, false, "", 3, 4, false, 100));
 		});
 	}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_and_no_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_and_no_stream.cs
@@ -67,7 +67,7 @@ public class when_handling_read_completed_and_no_stream<TLogFormat, TStreamId> :
 			.Last(x => x.EventStreamId == "b").CorrelationId;
 		_edp.Handle(
 			new ClientMessage.ReadStreamEventsForwardCompleted(
-				correlationId, "b", 100, 100, ReadStreamResult.Success, new ResolvedEvent[0], null, false, "",
+				correlationId, "b", 100, 100, ReadStreamResult.Success, Array.Empty<ResolvedEvent>(), null, false, "",
 				-1, ExpectedVersion.NoStream, true, 200));
 	}
 
@@ -149,7 +149,7 @@ public class when_handling_read_completed_and_no_stream<TLogFormat, TStreamId> :
 							3, 250, Guid.NewGuid(), Guid.NewGuid(), 250, 0, "a", ExpectedVersion.Any,
 							DateTime.UtcNow,
 							PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-							"event_type", new byte[0], new byte[0]))
+							"event_type", Array.Empty<byte>(), Array.Empty<byte>()))
 				}, null, false, "", 4, 3, true, 300));
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams.cs
@@ -167,7 +167,7 @@ public class when_handling_read_completed_for_all_streams<TLogFormat, TStreamId>
 								DateTime.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin |
 								PrepareFlags.TransactionEnd,
-								"event_type", new byte[0], new byte[0]))
+								"event_type", Array.Empty<byte>(), Array.Empty<byte>()))
 					}, null, false, "", 11, 10, true, 100));
 		});
 	}
@@ -186,7 +186,7 @@ public class when_handling_read_completed_for_all_streams<TLogFormat, TStreamId>
 							3, 250, Guid.NewGuid(), Guid.NewGuid(), 250, 0, "a", ExpectedVersion.Any,
 							DateTime.UtcNow,
 							PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-							"event_type", new byte[0], new byte[0]))
+							"event_type", Array.Empty<byte>(), Array.Empty<byte>()))
 				}, null, false, "", 4, 4, false, 300));
 	}
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams_after_pause_requested.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams_after_pause_requested.cs
@@ -123,7 +123,7 @@ public class when_handling_read_completed_for_all_streams_after_pause_requested<
 								DateTime.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin |
 								PrepareFlags.TransactionEnd,
-								"event_type", new byte[0], new byte[0]))
+								"event_type", Array.Empty<byte>(), Array.Empty<byte>()))
 					}, null, false, "", 4, 4, false, 300));
 		});
 	}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams_and_eofs.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams_and_eofs.cs
@@ -90,13 +90,13 @@ public class when_handling_read_completed_for_all_streams_and_eofs<TLogFormat, T
 			.Last(x => x.EventStreamId == "a").CorrelationId;
 		_edp.Handle(
 			new ClientMessage.ReadStreamEventsForwardCompleted(
-				correlationId, "a", 100, 100, ReadStreamResult.Success, new ResolvedEvent[0], null, false, "", 3,
+				correlationId, "a", 100, 100, ReadStreamResult.Success, Array.Empty<ResolvedEvent>(), null, false, "", 3,
 				2, true, 400));
 		correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>()
 			.Last(x => x.EventStreamId == "b").CorrelationId;
 		_edp.Handle(
 			new ClientMessage.ReadStreamEventsForwardCompleted(
-				correlationId, "b", 100, 100, ReadStreamResult.Success, new ResolvedEvent[0], null, false, "", 4,
+				correlationId, "b", 100, 100, ReadStreamResult.Success, Array.Empty<ResolvedEvent>(), null, false, "", 4,
 				3, true, 400));
 	}
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_has_been_created.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_has_been_created.cs
@@ -53,7 +53,7 @@ public class when_has_been_created<TLogFormat, TStreamId> : TestFixtureWithExist
 		{
 			_edp.Handle(
 				new ClientMessage.ReadStreamEventsForwardCompleted(
-					_distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, new ResolvedEvent[0],
+					_distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, Array.Empty<ResolvedEvent>(),
 					null, false, "", -1, 4, true, 100));
 		});
 	}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_resuming.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_resuming.cs
@@ -85,7 +85,7 @@ public class when_resuming<TLogFormat, TStreamId> : TestFixtureWithExistingEvent
 							1, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "a", ExpectedVersion.Any,
 							DateTime.UtcNow,
 							PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-							"event_type", new byte[0], new byte[0]), 0)
+							"event_type", Array.Empty<byte>(), Array.Empty<byte>()), 0)
 				}, null, false, "", 2, 4, false, 100));
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_no_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_no_stream.cs
@@ -40,7 +40,7 @@ public class when_handling_no_stream<TLogFormat, TStreamId> : TestFixtureWithExi
 		_edp.Handle(
 			new ClientMessage.ReadStreamEventsForwardCompleted(
 				correlationId, "stream", 100, 100,
-				ReadStreamResult.NoStream, new ResolvedEvent[0], null, false, "", -1, ExpectedVersion.NoStream,
+				ReadStreamResult.NoStream, Array.Empty<ResolvedEvent>(), null, false, "", -1, ExpectedVersion.NoStream,
 				true, 200));
 	}
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_and_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_and_eof.cs
@@ -61,7 +61,7 @@ public class when_handling_read_completed_and_eof<TLogFormat, TStreamId> : TestF
 			.CorrelationId;
 		_edp.Handle(
 			new ClientMessage.ReadStreamEventsForwardCompleted(
-				correlationId, "stream", 100, 100, ReadStreamResult.Success, new ResolvedEvent[0]
+				correlationId, "stream", 100, 100, ReadStreamResult.Success, Array.Empty<ResolvedEvent>()
 				, null, false, "", 12, 11, true, 400));
 	}
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_stream_event_reader.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_stream_event_reader.cs
@@ -132,7 +132,7 @@ public class when_handling_read_completed_stream_event_reader<TLogFormat, TStrea
 							10, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "stream", ExpectedVersion.Any,
 							DateTime.UtcNow,
 							PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-							"event_type", new byte[0], new byte[0]))
+							"event_type", Array.Empty<byte>(), Array.Empty<byte>()))
 				}, null, false, "", 11, 10, true, 100));
 		Assert.AreEqual(1, HandledMessages.OfType<ReaderSubscriptionMessage.Faulted>().Count());
 	}
@@ -151,7 +151,7 @@ public class when_handling_read_completed_stream_event_reader<TLogFormat, TStrea
 							12, 250, Guid.NewGuid(), Guid.NewGuid(), 250, 0, "stream", ExpectedVersion.Any,
 							DateTime.UtcNow,
 							PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-							"event_type", new byte[0], new byte[0]))
+							"event_type", Array.Empty<byte>(), Array.Empty<byte>()))
 				}, null, false, "", 13, 11, true, 300));
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_then_pause_then_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_then_pause_then_eof.cs
@@ -61,7 +61,7 @@ public class when_handling_read_completed_then_pause_then_eof<TLogFormat, TStrea
 			.CorrelationId;
 		_edp.Handle(
 			new ClientMessage.ReadStreamEventsForwardCompleted(
-				correlationId, "stream", 100, 100, ReadStreamResult.Success, new ResolvedEvent[0]
+				correlationId, "stream", 100, 100, ReadStreamResult.Success, Array.Empty<ResolvedEvent>()
 				, null, false, "", 12, 11, true, 400));
 	}
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_paused_then_handling_no_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_paused_then_handling_no_stream.cs
@@ -39,7 +39,7 @@ public class when_paused_then_handling_no_stream<TLogFormat, TStreamId> : TestFi
 			.CorrelationId;
 		_edp.Handle(
 			new ClientMessage.ReadStreamEventsForwardCompleted(
-				correlationId, "stream", 100, 100, ReadStreamResult.NoStream, new ResolvedEvent[0]
+				correlationId, "stream", 100, 100, ReadStreamResult.NoStream, Array.Empty<ResolvedEvent>()
 				, null, false, "", -1, ExpectedVersion.NoStream, true, 200));
 	}
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_resuming_stream_event_reader.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_resuming_stream_event_reader.cs
@@ -65,7 +65,7 @@ public class when_resuming_stream_event_reader<TLogFormat, TStreamId> : TestFixt
 						10, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "stream", ExpectedVersion.Any,
 						DateTime.UtcNow,
 						PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-						"event_type", new byte[0], new byte[0]), 0)
+						"event_type", Array.Empty<byte>(), Array.Empty<byte>()), 0)
 				}, null, false, "", 11, 10, true, 100));
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_stream_event_reader_has_been_created.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_stream_event_reader_has_been_created.cs
@@ -49,7 +49,7 @@ public class when_stream_event_reader_has_been_created<TLogFormat, TStreamId> : 
 			_edp.Handle(
 				new ClientMessage.ReadStreamEventsForwardCompleted(
 					_distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success,
-					new ResolvedEvent[0], null, false, "", -1, 4, true, 100));
+					Array.Empty<ResolvedEvent>(), null, false, "", -1, 4, true, 100));
 		});
 	}
 }


### PR DESCRIPTION
- Keep projection reader tests from creating throwaway empty arrays in repeated paths.\n- Reduce allocation analyzer noise around reader fixture coverage.