### PR TITLE
chore(projections): reuse query test arrays

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_completed_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_completed_projection.cs
@@ -42,7 +42,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query
 					ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 						_reader, new TFPos(100, 50), new TFPos(100, 50), "stream", 1, "stream", 1, false,
 						Guid.NewGuid(), "type",
-						false, new byte[0], new byte[0], 100, 33.3f));
+						false, Array.Empty<byte>(), Array.Empty<byte>(), 100, 33.3f));
 				yield return (new ReaderSubscriptionMessage.EventReaderEof(_reader));
 			}
 		}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_failed_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_failed_projection.cs
@@ -36,7 +36,7 @@ public class a_failed_projection
 			yield return
 				(ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					reader, new TFPos(100, 50), new TFPos(100, 50), "stream", 1, "stream", 1, false, Guid.NewGuid(),
-					"event", false, new byte[0], new byte[0], 100, 33.3f));
+					"event", false, Array.Empty<byte>(), Array.Empty<byte>(), 100, 33.3f));
 		}
 	}
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_new_posted_projection.cs
@@ -122,7 +122,7 @@ public static class a_new_posted_projection
 			yield return
 				(ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					reader, new TFPos(100, 50), new TFPos(100, 50), "stream", 1, "stream", 1, false, Guid.NewGuid(),
-					"fail", false, new byte[0], new byte[0], 100, 33.3f));
+					"fail", false, Array.Empty<byte>(), Array.Empty<byte>(), 100, 33.3f));
 		}
 
 		[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_running_foreach_stream_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_running_foreach_stream_projection.cs
@@ -51,22 +51,22 @@ public class a_running_foreach_stream_projection
 				(ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					_reader, new TFPos(100, 50), new TFPos(100, 50), "stream1", 1, "stream1", 1, false,
 					Guid.NewGuid(),
-					"type", false, Helper.UTF8NoBom.GetBytes("1"), new byte[0], 100, 33.3f));
+					"type", false, Helper.UTF8NoBom.GetBytes("1"), Array.Empty<byte>(), 100, 33.3f));
 			yield return
 				(ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					_reader, new TFPos(200, 150), new TFPos(200, 150), "stream2", 1, "stream2", 1, false,
 					Guid.NewGuid(),
-					"type", false, Helper.UTF8NoBom.GetBytes("1"), new byte[0], 100, 33.3f));
+					"type", false, Helper.UTF8NoBom.GetBytes("1"), Array.Empty<byte>(), 100, 33.3f));
 			yield return
 				(ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					_reader, new TFPos(300, 250), new TFPos(300, 250), "stream3", 1, "stream3", 1, false,
 					Guid.NewGuid(),
-					"type", false, Helper.UTF8NoBom.GetBytes("1"), new byte[0], 100, 33.3f));
+					"type", false, Helper.UTF8NoBom.GetBytes("1"), Array.Empty<byte>(), 100, 33.3f));
 			yield return
 				(ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					_reader, new TFPos(400, 350), new TFPos(400, 350), "stream1", 2, "stream1", 2, false,
 					Guid.NewGuid(),
-					"type", false, Helper.UTF8NoBom.GetBytes("1"), new byte[0], 100, 33.3f));
+					"type", false, Helper.UTF8NoBom.GetBytes("1"), Array.Empty<byte>(), 100, 33.3f));
 		}
 	}
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_running_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_running_projection.cs
@@ -42,7 +42,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query
 					(ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 						_reader, new TFPos(100, 50), new TFPos(100, 50), "stream", 1, "stream", 1, false,
 						Guid.NewGuid(),
-						"type", false, new byte[0], new byte[0], 100, 33.3f));
+						"type", false, Array.Empty<byte>(), Array.Empty<byte>(), 100, 33.3f));
 			}
 		}
 
@@ -132,7 +132,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query
 				yield return
 					(ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 						_reader, new TFPos(200, 150), new TFPos(200, 150), "stream", 2, "stream", 1, false,
-						Guid.NewGuid(), "type", false, new byte[0], new byte[0], 100, 33.3f));
+						Guid.NewGuid(), "type", false, Array.Empty<byte>(), Array.Empty<byte>(), 100, 33.3f));
 			}
 
 			[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/an_expired_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/an_expired_projection.cs
@@ -40,7 +40,7 @@ public class an_expired_projection
 				(ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					_reader, new TFPos(100, 50), new TFPos(100, 50), "stream", 1, "stream", 1, false,
 					Guid.NewGuid(),
-					"type", false, new byte[0], new byte[0], 100, 33.3f));
+					"type", false, Array.Empty<byte>(), Array.Empty<byte>(), 100, 33.3f));
 			_timeProvider.AddToUtcTime(TimeSpan.FromMinutes(6));
 			yield return Yield;
 			foreach (var m in _consumer.HandledMessages.OfType<TimerMessage.Schedule>().ToArray())


### PR DESCRIPTION
- Keep projection query tests quiet under allocation-focused analyzers.\n- Preserve query lifecycle scenarios while avoiding repeated empty-array allocations.