### PR TITLE
chore(projections): reuse client api test arrays

### DIFF
--- a/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
@@ -229,7 +229,7 @@ public abstract class specification_with_standard_projections_runnning<TLogForma
 
 	protected static EventData CreateEvent(string type, string data)
 	{
-		return new EventData(Guid.NewGuid(), type, true, Encoding.UTF8.GetBytes(data), new byte[0]);
+		return new EventData(Guid.NewGuid(), type, true, Encoding.UTF8.GetBytes(data), Array.Empty<byte>());
 	}
 
 	protected void WaitIdle()

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
@@ -198,7 +198,7 @@ public abstract class specification_with_standard_projections_runnning<TLogForma
 
 	protected static EventData CreateEvent(string type, string data)
 	{
-		return new EventData(Guid.NewGuid(), type, true, Encoding.UTF8.GetBytes(data), new byte[0]);
+		return new EventData(Guid.NewGuid(), type, true, Encoding.UTF8.GetBytes(data), Array.Empty<byte>());
 	}
 
 	private IEventStoreConnection CreateConnection()


### PR DESCRIPTION
- Keep projection client API tests quiet under allocation-focused analyzers.\n- Preserve standard projection scenarios while avoiding repeated empty-array allocations.