### PR TITLE
chore(tests): prefer single item assertions

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Metrics/IncomingGrpcCallsMetricTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/IncomingGrpcCallsMetricTests.cs
@@ -160,13 +160,9 @@ public class IncomingGrpcCallsMetricTests
 		actualMeasurement =>
 		{
 			Assert.Equal(expectedValue, actualMeasurement.Value);
-			Assert.Collection(
-				actualMeasurement.Tags.ToArray(),
-				tag =>
-				{
-					Assert.Equal("kind", tag.Key);
-					Assert.Equal(expectedKind, tag.Value);
-				});
+			var tag = Assert.Single(actualMeasurement.Tags.ToArray());
+			Assert.Equal("kind", tag.Key);
+			Assert.Equal(expectedKind, tag.Value);
 		};
 
 	static void AssertMeasurements(

--- a/src/EventStore.Core.XUnit.Tests/Metrics/PersistentSubscriptionMetricsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/PersistentSubscriptionMetricsTests.cs
@@ -161,32 +161,28 @@ public class PersistentSubscriptionMetricsTests
 	public void ObserveLastKnownEvent()
 	{
 		var measurements = _sut.ObserveLastKnownEvent();
-		Assert.Collection(measurements,
-			AssertMeasurement("test", "testGroup", 1011));
+		AssertMeasurement("test", "testGroup", 1011)(Assert.Single(measurements));
 	}
 
 	[Fact]
 	public void ObserveLastKnownEventCommitPosition()
 	{
 		var measurements = _sut.ObserveLastKnownEventCommitPosition();
-		Assert.Collection(measurements,
-			AssertMeasurement("$all", "testGroup", 1012));
+		AssertMeasurement("$all", "testGroup", 1012)(Assert.Single(measurements));
 	}
 
 	[Fact]
 	public void ObserveLastCheckpointedEvent()
 	{
 		var measurements = _sut.ObserveLastCheckpointedEvent();
-		Assert.Collection(measurements,
-			AssertMeasurement("test", "testGroup", 1013));
+		AssertMeasurement("test", "testGroup", 1013)(Assert.Single(measurements));
 	}
 
 	[Fact]
 	public void ObserveLastCheckpointedEventCommitPosition()
 	{
 		var measurements = _sut.ObserveLastCheckpointedEventCommitPosition();
-		Assert.Collection(measurements,
-			AssertMeasurement("$all", "testGroup", 1014));
+		AssertMeasurement("$all", "testGroup", 1014)(Assert.Single(measurements));
 	}
 
 	static Action<Measurement<long>> AssertMeasurement(

--- a/src/EventStore.Core.XUnit.Tests/Metrics/QueueBusyTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/QueueBusyTrackerTests.cs
@@ -20,18 +20,10 @@ public class QueueBusyTrackerTests
 		sut.EnterIdle();
 		listener.Observe();
 
-		Assert.Collection(
-			listener.RetrieveMeasurements("the-metric-seconds"),
-			m =>
-			{
-				Assert.True(m.Value > 0.0001);
-				Assert.Collection(
-					m.Tags,
-					t =>
-					{
-						Assert.Equal("queue", t.Key);
-						Assert.Equal("the-queue", t.Value);
-					});
-			});
+		var measurement = Assert.Single(listener.RetrieveMeasurements("the-metric-seconds"));
+		Assert.True(measurement.Value > 0.0001);
+		var tag = Assert.Single(measurement.Tags);
+		Assert.Equal("queue", tag.Key);
+		Assert.Equal("the-queue", tag.Value);
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/SubsequentScavengeTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/SubsequentScavengeTests.cs
@@ -37,14 +37,10 @@ public class SubsequentScavengeTests : SqliteDbPerTest<SubsequentScavengeTests>
 			.RunAsync();
 
 		Assert.Equal(ScavengeResult.Stopped, logger.Result);
-		Assert.Collection(
-			newScavengePoint,
-			sp =>
-			{
-				Assert.Equal(EffectiveNow, sp.EffectiveNow);
-				Assert.Equal(0, sp.EventNumber);
-				Assert.Equal(0, sp.Threshold);
-			});
+		var scavengePoint = Assert.Single(newScavengePoint);
+		Assert.Equal(EffectiveNow, scavengePoint.EffectiveNow);
+		Assert.Equal(0, scavengePoint.EventNumber);
+		Assert.Equal(0, scavengePoint.Threshold);
 	}
 
 	[Fact]
@@ -87,14 +83,10 @@ public class SubsequentScavengeTests : SqliteDbPerTest<SubsequentScavengeTests>
 			.RunAsync();
 
 		Assert.Equal(ScavengeResult.Stopped, logger.Result);
-		Assert.Collection(
-			newScavengePoint,
-			sp =>
-			{
-				Assert.Equal(EffectiveNow, sp.EffectiveNow);
-				Assert.Equal(1, sp.EventNumber);
-				Assert.Equal(0, sp.Threshold);
-			});
+		var scavengePoint = Assert.Single(newScavengePoint);
+		Assert.Equal(EffectiveNow, scavengePoint.EffectiveNow);
+		Assert.Equal(1, scavengePoint.EventNumber);
+		Assert.Equal(0, scavengePoint.Threshold);
 	}
 
 	[Fact]

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Checkpoint/CheckpointMetricTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Checkpoint/CheckpointMetricTests.cs
@@ -19,23 +19,19 @@ public class CheckpointMetricTests
 			new InMemoryCheckpoint("checkpoint", 5));
 
 		listener.Observe();
+		var measurement = Assert.Single(listener.RetrieveMeasurements("eventstore-checkpoints"));
+		Assert.Equal(5, measurement.Value);
 		Assert.Collection(
-			listener.RetrieveMeasurements("eventstore-checkpoints"),
-			measurement =>
+			measurement.Tags.ToArray(),
+			tag =>
 			{
-				Assert.Equal(5, measurement.Value);
-				Assert.Collection(
-					measurement.Tags.ToArray(),
-					tag =>
-					{
-						Assert.Equal("name", tag.Key);
-						Assert.Equal("checkpoint", tag.Value);
-					},
-					tag =>
-					{
-						Assert.Equal("read", tag.Key);
-						Assert.Equal("non-flushed", tag.Value);
-					});
+				Assert.Equal("name", tag.Key);
+				Assert.Equal("checkpoint", tag.Value);
+			},
+			tag =>
+			{
+				Assert.Equal("read", tag.Key);
+				Assert.Equal("non-flushed", tag.Value);
 			});
 	}
 }


### PR DESCRIPTION
- Keep single-item assertions aligned with current xUnit analyzer guidance.
- Reduce test-diagnostic noise around metrics and scavenge coverage.