### PR TITLE
chore(tests): tighten filter assertions

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/DataStructures/ProbabilisticFilter/AlignedMemoryTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/DataStructures/ProbabilisticFilter/AlignedMemoryTests.cs
@@ -16,7 +16,7 @@ public unsafe class AlignedMemoryTests
 	{
 		using var sut = new AlignedMemory(size, alignTo);
 
-		Assert.True((long)sut.Pointer % alignTo == 0);
+		Assert.Equal(0, (long)sut.Pointer % alignTo);
 
 		if (size <= int.MaxValue)
 		{

--- a/src/EventStore.Core.XUnit.Tests/DataStructures/ProbabilisticFilter/BloomFilterAccessorTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/DataStructures/ProbabilisticFilter/BloomFilterAccessorTests.cs
@@ -7,7 +7,7 @@ namespace EventStore.Core.XUnit.Tests.DataStructures.ProbabilisticFilter;
 
 public unsafe class BloomFilterAccessorTests
 {
-	BloomFilterAccessor GenSut(long logicalFilterSize, BloomFilterAccessor.OnPageDirty onPageDirty = null)
+	static BloomFilterAccessor GenSut(long logicalFilterSize, BloomFilterAccessor.OnPageDirty onPageDirty = null)
 	{
 		return new BloomFilterAccessor(
 			logicalFilterSize: logicalFilterSize,
@@ -51,7 +51,7 @@ public unsafe class BloomFilterAccessorTests
 	{
 		var sut = GenSut(size);
 		Assert.Equal(expected, sut.FileSize);
-		Assert.True(sut.FileSize % 64 == 0);
+		Assert.Equal(0, sut.FileSize % 64);
 		Assert.Equal(expected / 64, sut.NumCacheLines);
 	}
 


### PR DESCRIPTION
- Keep filter tests aligned with current xUnit analyzer guidance.
- Reduce low-value test diagnostics before broader formatting work.