### PR TITLE
chore(tests): clarify archive credential assertion

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/S3StorageCredentialTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/S3StorageCredentialTests.cs
@@ -52,8 +52,9 @@ public class S3StorageCredentialTests
 	}
 
 	private static AWSCredentials GetCredentials(AmazonS3Client client) =>
-		Assert.IsAssignableFrom<AWSCredentials>(
+		Assert.IsType<AWSCredentials>(
 			typeof(AmazonServiceClient)
 				.GetProperty("ExplicitAWSCredentials", BindingFlags.Instance | BindingFlags.NonPublic)!
-				.GetValue(client));
+				.GetValue(client),
+			exactMatch: false);
 }


### PR DESCRIPTION
- Keep archive credential tests aligned with current xUnit analyzer guidance.
- Reduce assertion-shape noise around S3-compatible archive coverage.