### PR TITLE
chore(metrics): tighten test assertions

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Metrics/AverageMetricTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/AverageMetricTests.cs
@@ -19,27 +19,19 @@ public class AverageMetricTests
 
 		Assert.Collection(
 			listener.RetrieveMeasurements("the-metric-seconds"),
-			m =>
-			{
-				Assert.Equal(1.5, m.Value);
-				Assert.Collection(
-					m.Tags,
-					t =>
-					{
-						Assert.Equal("queue", t.Key);
-						Assert.Equal("readers", t.Value);
-					});
-			},
-			m =>
-			{
-				Assert.Equal(3, m.Value);
-				Assert.Collection(
-					m.Tags,
-					t =>
-					{
-						Assert.Equal("queue", t.Key);
-						Assert.Equal("writer", t.Value);
-					});
-			});
+				m =>
+				{
+					Assert.Equal(1.5, m.Value);
+					var tag = Assert.Single(m.Tags);
+					Assert.Equal("queue", tag.Key);
+					Assert.Equal("readers", tag.Value);
+				},
+				m =>
+				{
+					Assert.Equal(3, m.Value);
+					var tag = Assert.Single(m.Tags);
+					Assert.Equal("queue", tag.Key);
+					Assert.Equal("writer", tag.Value);
+				});
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/Metrics/MaxTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/MaxTrackerTests.cs
@@ -27,6 +27,7 @@ public class MaxTrackerTests : IDisposable
 	public void Dispose()
 	{
 		_listener.Dispose();
+		GC.SuppressFinalize(this);
 	}
 
 	[Fact]
@@ -70,23 +71,19 @@ public class MaxTrackerTests : IDisposable
 	{
 		_listener.Observe();
 
+		var measurement = Assert.Single(_listener.RetrieveMeasurements("the-metric"));
+		Assert.Equal(expectedValue, measurement.Value);
 		Assert.Collection(
-			_listener.RetrieveMeasurements("the-metric"),
-			m =>
+			measurement.Tags.ToArray(),
+			t =>
 			{
-				Assert.Equal(expectedValue, m.Value);
-				Assert.Collection(
-					m.Tags.ToArray(),
-					t =>
-					{
-						Assert.Equal("name", t.Key);
-						Assert.Equal("the-tracker", t.Value);
-					},
-					t =>
-					{
-						Assert.Equal("range", t.Key);
-						Assert.Equal("16-20 seconds", t.Value);
-					});
+				Assert.Equal("name", t.Key);
+				Assert.Equal("the-tracker", t.Value);
+			},
+			t =>
+			{
+				Assert.Equal("range", t.Key);
+				Assert.Equal("16-20 seconds", t.Value);
 			});
 	}
 
@@ -102,18 +99,10 @@ public class MaxTrackerTests : IDisposable
 
 		listener.Observe();
 
-		Assert.Collection(
-			listener.RetrieveMeasurements("the-metric"),
-			m =>
-			{
-				Assert.Equal(0, m.Value);
-				Assert.Collection(
-					m.Tags.ToArray(),
-					t =>
-					{
-						Assert.Equal("range", t.Key);
-						Assert.Equal("16-20 seconds", t.Value);
-					});
-			});
+		var measurement = Assert.Single(listener.RetrieveMeasurements("the-metric"));
+		Assert.Equal(0, measurement.Value);
+		var tag = Assert.Single(measurement.Tags.ToArray());
+		Assert.Equal("range", tag.Key);
+		Assert.Equal("16-20 seconds", tag.Value);
 	}
 }


### PR DESCRIPTION
- Keep metrics tests aligned with current xUnit analyzer guidance.
- Reduce low-value diagnostics before broader formatting work.