### PR TITLE
chore(config): use generic enum names

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsPrinterTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsPrinterTests.cs
@@ -93,7 +93,7 @@ DEFAULT OPTIONS:
 
 		var option = loadedOptions["EventStore:DbLogFormat"];
 
-		option.Metadata.AllowedValues.Should().BeEquivalentTo(Enum.GetNames(typeof(DbLogFormat)));
+		option.Metadata.AllowedValues.Should().BeEquivalentTo(Enum.GetNames<DbLogFormat>());
 	}
 
 	[Fact]


### PR DESCRIPTION
- Keep configuration tests aligned with current analyzer guidance.
- Reduce low-value diagnostics around option metadata coverage.