### PR TITLE
chore(auth): make fallback test helpers static

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Authorization/FallbackStreamAccessPolicyVerification.cs
+++ b/src/EventStore.Core.XUnit.Tests/Authorization/FallbackStreamAccessPolicyVerification.cs
@@ -20,12 +20,12 @@ public class FallbackStreamAccessPolicyVerification
 	private readonly ClaimsPrincipal _claimsPrincipal = new(new ClaimsIdentity(
 		new[] { new Claim(ClaimTypes.Name, "test-user") }));
 
-		private static MultiPolicyEvaluator CreateSut()
-		{
-			var fallback = new FallbackStreamAccessPolicySelector();
-			var dummy = DummyStreamAccess.Create(SampleOperations);
-			return new MultiPolicyEvaluator(new StaticAuthorizationPolicyRegistry([fallback, dummy]));
-		}
+	private static MultiPolicyEvaluator CreateSut()
+	{
+		var fallback = new FallbackStreamAccessPolicySelector();
+		var dummy = DummyStreamAccess.Create(SampleOperations);
+		return new MultiPolicyEvaluator(new StaticAuthorizationPolicyRegistry([fallback, dummy]));
+	}
 
 	// This is not an extensive list of all operations
 	// Just a sample of the different resources

--- a/src/EventStore.Core.XUnit.Tests/Authorization/FallbackStreamAccessPolicyVerification.cs
+++ b/src/EventStore.Core.XUnit.Tests/Authorization/FallbackStreamAccessPolicyVerification.cs
@@ -20,12 +20,12 @@ public class FallbackStreamAccessPolicyVerification
 	private readonly ClaimsPrincipal _claimsPrincipal = new(new ClaimsIdentity(
 		new[] { new Claim(ClaimTypes.Name, "test-user") }));
 
-	private MultiPolicyEvaluator CreateSut()
-	{
-		var fallback = new FallbackStreamAccessPolicySelector();
-		var dummy = new DummyStreamAccess().Create(SampleOperations);
-		return new MultiPolicyEvaluator(new StaticAuthorizationPolicyRegistry([fallback, dummy]));
-	}
+		private static MultiPolicyEvaluator CreateSut()
+		{
+			var fallback = new FallbackStreamAccessPolicySelector();
+			var dummy = DummyStreamAccess.Create(SampleOperations);
+			return new MultiPolicyEvaluator(new StaticAuthorizationPolicyRegistry([fallback, dummy]));
+		}
 
 	// This is not an extensive list of all operations
 	// Just a sample of the different resources
@@ -133,7 +133,7 @@ public class FallbackStreamAccessPolicyVerification
 
 	private class DummyStreamAccess
 	{
-		public StaticPolicySelector Create(OperationDefinition[] operations)
+		public static StaticPolicySelector Create(OperationDefinition[] operations)
 		{
 			var policy = new Policy("dummy", 1, DateTimeOffset.MinValue);
 			foreach (var op in operations)


### PR DESCRIPTION
- Keep authorization tests aligned with current analyzer guidance.
- Reduce low-value diagnostics around fallback policy coverage.