### PR TITLE
chore(auth): make registry test helper static

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Authorization/StreamBasedAuthPolicyRegistryTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Authorization/StreamBasedAuthPolicyRegistryTests.cs
@@ -424,7 +424,7 @@ public class StreamBasedAuthPolicyRegistryTests
 		return ResolvedEvent.ForUnresolvedEvent(eventRecord, logPosition);
 	}
 
-	private ClientMessage.ReadStreamEventsBackwardCompleted CreateReadCompleted(
+	private static ClientMessage.ReadStreamEventsBackwardCompleted CreateReadCompleted(
 		ClientMessage.ReadStreamEventsBackward msg, ResolvedEvent[] events) =>
 		new(msg.CorrelationId, msg.EventStreamId, msg.FromEventNumber, msg.MaxCount,
 			ReadStreamResult.Success, events, StreamMetadata.Empty, true, "",


### PR DESCRIPTION
- Keep authorization registry tests aligned with current analyzer guidance.
- Reduce low-value diagnostics around policy-registry coverage.