### PR TITLE
chore(scavenge): clarify collision assertion

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Scavenge/CollisionMapTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/CollisionMapTests.cs
@@ -95,9 +95,9 @@ public class OriginalStreamCollisionMapTests : SqliteDbPerTest<OriginalStreamCol
 			x => Assert.Equal("(Hash: 101, 5)", $"({x.Item1}, {x.Item2.MaxCount})"),
 			x => Assert.Equal("(Hash: 102, 6)", $"({x.Item1}, {x.Item2.MaxCount})"));
 
-			// hash checkpoint
-			var active = Assert.Single(sut.EnumerateActive(checkpoint: StreamHandle.ForHash<string>(101)));
-			Assert.Equal("(Hash: 102, 6)", $"({active.Item1}, {active.Item2.MaxCount})");
+		// hash checkpoint
+		var active = Assert.Single(sut.EnumerateActive(checkpoint: StreamHandle.ForHash<string>(101)));
+		Assert.Equal("(Hash: 102, 6)", $"({active.Item1}, {active.Item2.MaxCount})");
 
 		// end checkpoint
 		Assert.Empty(sut.EnumerateActive(checkpoint: StreamHandle.ForHash<string>(102)));

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/CollisionMapTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/CollisionMapTests.cs
@@ -95,10 +95,9 @@ public class OriginalStreamCollisionMapTests : SqliteDbPerTest<OriginalStreamCol
 			x => Assert.Equal("(Hash: 101, 5)", $"({x.Item1}, {x.Item2.MaxCount})"),
 			x => Assert.Equal("(Hash: 102, 6)", $"({x.Item1}, {x.Item2.MaxCount})"));
 
-		// hash checkpoint
-		Assert.Collection(
-			sut.EnumerateActive(checkpoint: StreamHandle.ForHash<string>(101)),
-			x => Assert.Equal("(Hash: 102, 6)", $"({x.Item1}, {x.Item2.MaxCount})"));
+			// hash checkpoint
+			var active = Assert.Single(sut.EnumerateActive(checkpoint: StreamHandle.ForHash<string>(101)));
+			Assert.Equal("(Hash: 102, 6)", $"({active.Item1}, {active.Item2.MaxCount})");
 
 		// end checkpoint
 		Assert.Empty(sut.EnumerateActive(checkpoint: StreamHandle.ForHash<string>(102)));


### PR DESCRIPTION
- Keep collision-map tests aligned with current xUnit analyzer guidance.
- Reduce low-value diagnostics around scavenge-map coverage.