### PR TITLE
chore(scavenge): quiet sqlite test diagnostics

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Sqlite/SqliteChunkTimeStampRangeScavengeMapTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Sqlite/SqliteChunkTimeStampRangeScavengeMapTests.cs
@@ -109,7 +109,7 @@ public class SqliteChunkTimeStampRangeScavengeMapTests : SqliteDbPerTest<SqliteC
 		Assert.False(sut.TryRemove(33, out _));
 	}
 
-		private static ChunkTimeStampRange[] GetChunkTimeStampRangeTestData()
+	private static ChunkTimeStampRange[] GetChunkTimeStampRangeTestData()
 	{
 		return
 		[

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Sqlite/SqliteChunkTimeStampRangeScavengeMapTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Sqlite/SqliteChunkTimeStampRangeScavengeMapTests.cs
@@ -109,7 +109,7 @@ public class SqliteChunkTimeStampRangeScavengeMapTests : SqliteDbPerTest<SqliteC
 		Assert.False(sut.TryRemove(33, out _));
 	}
 
-	private ChunkTimeStampRange[] GetChunkTimeStampRangeTestData()
+		private static ChunkTimeStampRange[] GetChunkTimeStampRangeTestData()
 	{
 		return
 		[

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Sqlite/SqliteMetastreamScavengeMapTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Sqlite/SqliteMetastreamScavengeMapTests.cs
@@ -187,7 +187,7 @@ public class SqliteMetastreamScavengeMapTests : SqliteDbPerTest<SqliteMetastream
 		Assert.Empty(sut.AllRecords());
 	}
 
-		private static MetastreamData[] GetMetastreamTestData()
+	private static MetastreamData[] GetMetastreamTestData()
 	{
 		return new[] {
 			new MetastreamData(isTombstoned: false, DiscardPoint.DiscardIncluding(5)),

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Sqlite/SqliteMetastreamScavengeMapTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Sqlite/SqliteMetastreamScavengeMapTests.cs
@@ -187,7 +187,7 @@ public class SqliteMetastreamScavengeMapTests : SqliteDbPerTest<SqliteMetastream
 		Assert.Empty(sut.AllRecords());
 	}
 
-	private MetastreamData[] GetMetastreamTestData()
+		private static MetastreamData[] GetMetastreamTestData()
 	{
 		return new[] {
 			new MetastreamData(isTombstoned: false, DiscardPoint.DiscardIncluding(5)),

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Sqlite/SqliteOriginalStreamScavengeMapTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Sqlite/SqliteOriginalStreamScavengeMapTests.cs
@@ -504,11 +504,11 @@ public class SqliteOriginalStreamScavengeMapTests : SqliteDbPerTest<SqliteOrigin
 
 		sut.DeleteMany(deleteArchived: true);
 
-		Assert.Collection(sut.AllRecords(),
-			item => { Assert.Equal(CalculationStatus.Active, item.Value.Status); });
-	}
+			var item = Assert.Single(sut.AllRecords());
+			Assert.Equal(CalculationStatus.Active, item.Value.Status);
+		}
 
-	private OriginalStreamData[] GetOriginalStreamTestData()
+		private static OriginalStreamData[] GetOriginalStreamTestData()
 	{
 		return new[] {
 			new OriginalStreamData() {

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Sqlite/SqliteOriginalStreamScavengeMapTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Sqlite/SqliteOriginalStreamScavengeMapTests.cs
@@ -504,11 +504,11 @@ public class SqliteOriginalStreamScavengeMapTests : SqliteDbPerTest<SqliteOrigin
 
 		sut.DeleteMany(deleteArchived: true);
 
-			var item = Assert.Single(sut.AllRecords());
-			Assert.Equal(CalculationStatus.Active, item.Value.Status);
-		}
+		var item = Assert.Single(sut.AllRecords());
+		Assert.Equal(CalculationStatus.Active, item.Value.Status);
+	}
 
-		private static OriginalStreamData[] GetOriginalStreamTestData()
+	private static OriginalStreamData[] GetOriginalStreamTestData()
 	{
 		return new[] {
 			new OriginalStreamData() {


### PR DESCRIPTION
- Keep SQLite scavenge tests aligned with current analyzer guidance.
- Reduce low-value diagnostics around map coverage.