### PR TITLE
feat(config): prefer read concurrency limit

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -306,7 +306,7 @@ only: _Error while parsing options: The option UnknownConfig is not a known opti
 Some options are configured at startup to make better use of the available resources on larger instances or
 machines.
 
-These options are `StreamInfoCacheCapacity`, `ReaderThreadsCount`, and `WorkerThreads`.
+These options are `StreamInfoCacheCapacity`, `ReadConcurrencyLimit`, and `WorkerThreads`.
 
 Autoconfiguration does not apply in containerized environments.
 
@@ -335,9 +335,9 @@ The total number of streams can be obtained by checking the event count in the `
 It should be noted that the total number of streams does not necessarily give you the anticipated working set. The working set of streams is the set of streams that you intend on actively reading, writing, and/or subscribing to. This can be much lower than the total number of streams in certain cases, especially in systems that have many short-lived streams.
 :::
 
-### ReaderThreadsCount
+### ReadConcurrencyLimit
 
-This option configures the number of reader threads available to EventStoreDb. Having more reader threads
+This option configures the number of read requests EventStoreDb can process concurrently. Having more reader threads
 allows more concurrent reads to be processed.
 
 The reader threads count will be set at startup to twice the number of available processors, with a minimum of
@@ -345,9 +345,9 @@ The reader threads count will be set at startup to twice the number of available
 
 | Format               | Syntax                            |
 |:---------------------|:----------------------------------|
-| Command line         | `--reader-threads-count`          |
-| YAML                 | `ReaderThreadsCount`              |
-| Environment variable | `EVENTSTORE_READER_THREADS_COUNT` |
+| Command line         | `--read-concurrency-limit`        |
+| YAML                 | `ReadConcurrencyLimit`            |
+| Environment variable | `EVENTSTORE_READ_CONCURRENCY_LIMIT` |
 
 The option is set to 0 by default, which enables autoconfiguration. The default on previous versions of
 EventStoreDb was 4 threads.

--- a/docs/db-config.md
+++ b/docs/db-config.md
@@ -132,7 +132,7 @@ Increasing the number of threads beyond that necessary to satisfy the workload g
 
 **Default**: `5`
 
-### Reader threads count
+### Read concurrency limit
 
 Reader threads are used for all read operations on data files - whether the requests originate from the client or internal requests to the database. There are a number of things that cause operations to be dispatched to reader threads, including:
 
@@ -143,11 +143,11 @@ Reader threads are used for all read operations on data files - whether the requ
 
 | Format               | Syntax                            |
 |:---------------------|:----------------------------------|
-| Command line         | `--reader-threads-count`          |
-| YAML                 | `ReaderThreadsCount`              |
-| Environment variable | `EVENTSTORE_READER_THREADS_COUNT` |
+| Command line         | `--read-concurrency-limit`        |
+| YAML                 | `ReadConcurrencyLimit`            |
+| Environment variable | `EVENTSTORE_READ_CONCURRENCY_LIMIT` |
 
-**Default**: `4`
+**Default**: `0`
 
 Reads are queued until a reader thread becomes available to service them. If an operation doesn't complete within an internal deadline window, a disk operation is not dispatched by the worker thread which processes the operation.
 

--- a/docs/server-settings.md
+++ b/docs/server-settings.md
@@ -178,7 +178,7 @@ Increasing the number of threads beyond that necessary to satisfy the workload g
 
 **Default**: `5`
 
-### Reader threads count
+### Read concurrency limit
 
 Reader threads are used for all read operations on data files - whether the requests originate from the client or internal requests to the database. There are a number of things that cause operations to be dispatched to reader threads, including:
 
@@ -189,11 +189,11 @@ Reader threads are used for all read operations on data files - whether the requ
 
 | Format               | Syntax                            |
 | :------------------- | :-------------------------------- |
-| Command line         | `--reader-threads-count`          |
-| YAML                 | `ReaderThreadsCount`              |
-| Environment variable | `EVENTSTORE_READER_THREADS_COUNT` |
+| Command line         | `--read-concurrency-limit`        |
+| YAML                 | `ReadConcurrencyLimit`            |
+| Environment variable | `EVENTSTORE_READ_CONCURRENCY_LIMIT` |
 
-**Default**: `4`
+**Default**: `0`
 
 Reads are queued until a reader thread becomes available to service them. If an operation doesn't complete within an internal deadline window, a disk operation is not dispatched by the worker thread which processes the operation.
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -430,7 +430,7 @@ public class ClusterVNode<TStreamId> :
 			var processorCount = Environment.ProcessorCount;
 
 			readerThreadsCount =
-				ThreadCountCalculator.CalculateReaderThreadCount(options.Database.ReaderThreadsCount,
+				ThreadCountCalculator.CalculateReaderThreadCount(options.Database.ReadConcurrencyLimit,
 					processorCount, isRunningInContainer);
 
 			workerThreadsCount =

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -449,8 +449,8 @@ public partial record ClusterVNodeOptions
 		public int InitializationThreads { get; init; } = 1;
 
 		[Description(
-			"The number of reader threads to use for processing reads. Set to '0' to scale automatically (Default)")]
-		public int ReaderThreadsCount { get; init; } = 0;
+			"The maximum number of read requests that can be processed concurrently. Set to '0' to scale automatically (Default)")]
+		public int ReadConcurrencyLimit { get; init; } = 0;
 
 		[Description("During large Index Merge operations, writes may be slowed down. Set this to the maximum " +
 					 "index file level for which automatic merges should happen. Merging indexes above this level " +

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
@@ -121,6 +121,7 @@ public static class ClusterVNodeOptionsValidator
 			throw new InvalidConfigurationException(
 				"The Archiving feature is not compatible with UnsafeIgnoreHardDelete.");
 		}
+
 	}
 
 	public static bool ValidateForStartup(ClusterVNodeOptions options)
@@ -158,4 +159,5 @@ public static class ClusterVNodeOptionsValidator
 
 		return true;
 	}
+
 }

--- a/src/EventStore.Core/Settings/ThreadCountCalculator.cs
+++ b/src/EventStore.Core/Settings/ThreadCountCalculator.cs
@@ -15,8 +15,8 @@ namespace EventStore.Core.Settings
 			if (configuredCount > 0)
 			{
 				Log.Information(
-					"ReaderThreadsCount set to {readerThreadsCount:N0}. " +
-					"Calculated based on processor count of {processorCount:N0} and configured value of {configuredCount:N0}",
+					"Reader thread count set to {readerThreadsCount:N0}. " +
+					"Calculated based on processor count of {processorCount:N0} and configured ReadConcurrencyLimit of {configuredCount:N0}",
 					configuredCount,
 					processorCount, configuredCount);
 				return configuredCount;
@@ -25,8 +25,8 @@ namespace EventStore.Core.Settings
 			if (isRunningInContainer)
 			{
 				Log.Information(
-					"ReaderThreadsCount set to {readerThreadsCount:N0}. " +
-					"Calculated based on containerized environment and configured value of {configuredCount:N0}",
+					"Reader thread count set to {readerThreadsCount:N0}. " +
+					"Calculated based on containerized environment and configured ReadConcurrencyLimit of {configuredCount:N0}",
 					ContainerizedEnvironment.ReaderThreadCount,
 					configuredCount);
 				return ContainerizedEnvironment.ReaderThreadCount;
@@ -34,8 +34,8 @@ namespace EventStore.Core.Settings
 
 			var readerCount = Math.Clamp(processorCount * 2, ReaderThreadCountFloor, 16);
 			Log.Information(
-				"ReaderThreadsCount set to {readerThreadsCount:N0}. " +
-				"Calculated based on processor count of {processorCount:N0} and configured value of {configuredCount:N0}",
+				"Reader thread count set to {readerThreadsCount:N0}. " +
+				"Calculated based on processor count of {processorCount:N0} and configured ReadConcurrencyLimit of {configuredCount:N0}",
 				readerCount,
 				processorCount, configuredCount);
 			return readerCount;


### PR DESCRIPTION
- Operators need one clear read concurrency knob that describes the runtime pressure being controlled.
- Conflicting old and new read concurrency settings should fail early instead of producing ambiguous startup behavior.