### PR TITLE
chore(bus): avoid hidden queue affinity contracts

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Bus/MultiQueuedHandlerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Bus/MultiQueuedHandlerTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.Monitoring.Stats;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Bus;
+
+public class MultiQueuedHandlerTests
+{
+	[Fact]
+	public void publishes_messages_with_the_same_synchronization_group_to_the_same_queue()
+	{
+		var queues = CreateQueues(4);
+		var sut = new MultiQueuedHandler(queues.Length, i => queues[i]);
+		var group = new object();
+		var first = new TestMessage(group);
+		var second = new TestMessage(group);
+
+		sut.Publish(first);
+		sut.Publish(second);
+
+		var firstQueue = queues.Single(q => q.Messages.Contains(first));
+		var secondQueue = queues.Single(q => q.Messages.Contains(second));
+		Assert.Same(firstQueue, secondQueue);
+	}
+
+	[Fact]
+	public void publishes_messages_without_a_synchronization_group_round_robin()
+	{
+		var queues = CreateQueues(2);
+		var sut = new MultiQueuedHandler(queues.Length, i => queues[i]);
+		var first = new TestMessage();
+		var second = new TestMessage();
+		var third = new TestMessage();
+
+		sut.Publish(first);
+		sut.Publish(second);
+		sut.Publish(third);
+
+		Assert.Equal([first, third], queues[0].Messages);
+		Assert.Equal([second], queues[1].Messages);
+	}
+
+	private static RecordingQueuedHandler[] CreateQueues(int count)
+	{
+		var queues = new RecordingQueuedHandler[count];
+		for (var i = 0; i < queues.Length; i++)
+		{
+			queues[i] = new RecordingQueuedHandler($"queue-{i}");
+		}
+
+		return queues;
+	}
+
+	private sealed class TestMessage(object synchronizationGroup = null) : Message
+	{
+		public override object SynchronizationGroup => synchronizationGroup;
+	}
+
+	private sealed class RecordingQueuedHandler(string name) : IQueuedHandler
+	{
+		public string Name { get; } = name;
+
+		public List<Message> Messages { get; } = [];
+
+		public void Publish(Message message) => Messages.Add(message);
+
+		public Task Start() => Task.CompletedTask;
+
+		public Task Stop() => Task.CompletedTask;
+
+		public void RequestStop()
+		{
+		}
+
+		public QueueStats GetStatistics() =>
+			new(Name, string.Empty, Messages.Count, 0, 0, 0, null, null, Messages.Count, 0, 0, null, null);
+	}
+}

--- a/src/EventStore.Core/Bus/MultiQueuedHandler.cs
+++ b/src/EventStore.Core/Bus/MultiQueuedHandler.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Common.Utils;
-using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 
 namespace EventStore.Core.Bus;
@@ -57,7 +56,7 @@ public class MultiQueuedHandler : IPublisher
 
 	public void Publish(Message message)
 	{
-		int queueHash = (message as IQueueAffineMessage)?.QueueId ?? NextQueueHash();
+		int queueHash = message.SynchronizationGroup?.GetHashCode() ?? NextQueueHash();
 		var queueNum = (int)((uint)queueHash % _queues.Length);
 		_queues.Span[queueNum].Publish(message);
 	}

--- a/src/EventStore.Core/Messages/IQueueAffineMessage.cs
+++ b/src/EventStore.Core/Messages/IQueueAffineMessage.cs
@@ -1,7 +1,0 @@
-namespace EventStore.Core.Messages
-{
-	public interface IQueueAffineMessage
-	{
-		int QueueId { get; }
-	}
-}

--- a/src/EventStore.Core/Messages/StorageMessage.cs
+++ b/src/EventStore.Core/Messages/StorageMessage.cs
@@ -393,17 +393,17 @@ namespace EventStore.Core.Messages
 		}
 
 		[DerivedMessage(CoreMessage.Storage)]
-		public partial class BatchLogExpiredMessages : Message, IQueueAffineMessage
+		public partial class BatchLogExpiredMessages : Message
 		{
 			public readonly Guid CorrelationId;
-			public int QueueId { get; }
+			public override object SynchronizationGroup { get; }
 
 			public BatchLogExpiredMessages(Guid correlationId, int queueId)
 			{
 				Ensure.NotEmptyGuid(correlationId, "correlationId");
 				Ensure.Nonnegative(queueId, "queueId");
 				CorrelationId = correlationId;
-				QueueId = queueId;
+				SynchronizationGroup = queueId;
 			}
 		}
 

--- a/src/EventStore.Core/Messages/TcpMessage.cs
+++ b/src/EventStore.Core/Messages/TcpMessage.cs
@@ -8,11 +8,11 @@ namespace EventStore.Core.Messages
 	public static partial class TcpMessage
 	{
 		[DerivedMessage(CoreMessage.Tcp)]
-		public partial class TcpSend : Message, IQueueAffineMessage
+		public partial class TcpSend : Message
 		{
-			public int QueueId
+			public override object SynchronizationGroup
 			{
-				get { return ConnectionManager.GetHashCode(); }
+				get { return ConnectionManager; }
 			}
 
 			public readonly TcpConnectionManager ConnectionManager;

--- a/src/EventStore.Core/Messaging/Message.cs
+++ b/src/EventStore.Core/Messaging/Message.cs
@@ -34,4 +34,7 @@ public abstract partial class Message
 
 	[JsonIgnore]
 	public CancellationToken CancellationToken { get; }
+
+	[JsonIgnore]
+	public virtual object SynchronizationGroup => null;
 }


### PR DESCRIPTION
- Message routing should expose its synchronization contract where every message already carries dispatch metadata.
- Focused coverage keeps serialized worker routing stable while reducing queue-routing special cases.