### PR TITLE
chore(projections): remove debug log markers

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/when_invalid_data_is_sent_over_tcp.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/when_invalid_data_is_sent_over_tcp.cs
@@ -21,6 +21,8 @@ public class when_invalid_data_is_sent_over_tcp<TLogFormat, TStreamId> : specifi
 	public async Task connection_should_be_closed_by_remote_party(string endpointProperty, bool secure)
 	{
 		IPEndPoint endpoint = (IPEndPoint)_nodes[0].GetType().GetProperty(endpointProperty).GetValue(_nodes[0], null);
+		await WaitForEndpoint(endpoint);
+
 		var closedEvent = new ManualResetEventSlim();
 		TaskCompletionSource<SocketError> connectionResult = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -63,5 +65,27 @@ public class when_invalid_data_is_sent_over_tcp<TLogFormat, TStreamId> : specifi
 		connection.EnqueueSend(data);
 		Assert.True(closedEvent.Wait(10000));
 		connection.Close("intentional close");
+	}
+
+	private static async Task WaitForEndpoint(IPEndPoint endpoint)
+	{
+		using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+		while (!timeout.IsCancellationRequested)
+		{
+			using var client = new TcpClient();
+
+			try
+			{
+				await client.ConnectAsync(endpoint.Address, endpoint.Port, timeout.Token);
+				return;
+			}
+			catch (Exception ex) when (ex is SocketException or OperationCanceledException)
+			{
+				await Task.Delay(100, CancellationToken.None);
+			}
+		}
+
+		throw new TimeoutException($"TCP endpoint {endpoint} did not accept connections before the test timeout.");
 	}
 }

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -554,7 +554,7 @@ public class ProjectionManager
 		var projection = GetProjection(message.Name);
 		if (projection == null)
 		{
-			_logger.Error("DBG: PROJECTION *{projection}* NOT FOUND.", message.Name);
+			_logger.Error("Projection '{projection}' not found.", message.Name);
 			message.Envelope.ReplyWith(new ProjectionManagementMessage.NotFound());
 		}
 		else
@@ -602,12 +602,12 @@ public class ProjectionManager
 			return;
 		}
 
-		_logger.Information("Setting RunAs1 account for '{projection}' projection", message.Name);
+		_logger.Information("Setting RunAs account for '{projection}' projection", message.Name);
 
 		var projection = GetProjection(message.Name);
 		if (projection == null)
 		{
-			_logger.Error("DBG: PROJECTION *{projection}* NOT FOUND.", message.Name);
+			_logger.Error("Projection '{projection}' not found.", message.Name);
 			message.Envelope.ReplyWith(new ProjectionManagementMessage.NotFound());
 		}
 		else
@@ -636,7 +636,7 @@ public class ProjectionManager
 		var projection = GetProjection(message.Name);
 		if (projection == null)
 		{
-			_logger.Error("DBG: PROJECTION *{projection}* NOT FOUND.", message.Name);
+			_logger.Error("Projection '{projection}' not found.", message.Name);
 			message.Envelope.ReplyWith(new ProjectionManagementMessage.NotFound());
 		}
 		else


### PR DESCRIPTION
- Keeps production projection logs operator-facing rather than carrying debug-era prefixes.
- Reduces noise when projection commands fail because the target projection is missing.