### PR TITLE
feat(storage): protect read workers under load

### DIFF
--- a/src/EventStore.Core.Tests/Services/Storage/when_cancelling_storage_reader_worker.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/when_cancelling_storage_reader_worker.cs
@@ -12,6 +12,7 @@ using EventStore.Core.Services.Storage.InMemory;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Tests.Fakes;
 using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.LogRecords;
 using NUnit.Framework;
 using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
 
@@ -20,6 +21,37 @@ namespace EventStore.Core.Tests.Services.Storage;
 [TestFixture]
 public class when_cancelling_storage_reader_worker
 {
+	[Test]
+	public async Task read_event_waits_for_slot_when_concurrency_limit_is_reached()
+	{
+		using var readIndex = new BlockingReadIndex();
+		var worker = CreateWorker(readIndex, maxConcurrentReadRequests: 1);
+		var first = CreateReadEventMessage();
+		var second = CreateReadEventMessage();
+
+		var firstTask = ((IAsyncHandle<ClientMessage.ReadEvent>)worker)
+			.HandleAsync(first, CancellationToken.None)
+			.AsTask();
+
+		Assert.That(readIndex.ReadEventStarted.Wait(TimeSpan.FromSeconds(5)), Is.True);
+		Assert.That(readIndex.ReadEventStartedCount, Is.EqualTo(1));
+
+		var secondTask = ((IAsyncHandle<ClientMessage.ReadEvent>)worker)
+			.HandleAsync(second, CancellationToken.None)
+			.AsTask();
+
+		Assert.That(
+			SpinWait.SpinUntil(() => readIndex.ReadEventStartedCount == 2, TimeSpan.FromMilliseconds(200)),
+			Is.False);
+
+		readIndex.ReleaseReadEvents();
+
+		await firstTask.WaitAsync(TimeSpan.FromSeconds(5));
+		await secondTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+		Assert.That(readIndex.ReadEventStartedCount, Is.EqualTo(2));
+	}
+
 	[Test]
 	public void read_event_cancellation_from_message_token_is_rethrown_without_reply()
 	{
@@ -183,27 +215,45 @@ public class when_cancelling_storage_reader_worker
 		Assert.That(reply, Is.Null);
 	}
 
-	private static StorageReaderWorker<string> CreateWorker(BlockingReadIndex readIndex) =>
+	private static ClientMessage.ReadEvent CreateReadEventMessage() =>
+		new(
+			Guid.NewGuid(),
+			Guid.NewGuid(),
+			new NoopEnvelope(),
+			"stream",
+			0,
+			resolveLinkTos: false,
+			requireLeader: false,
+			user: new ClaimsPrincipal());
+
+	private static StorageReaderWorker<string> CreateWorker(BlockingReadIndex readIndex, int maxConcurrentReadRequests = 0) =>
 		new(
 			new NoopPublisher(),
 			readIndex,
 			new StubSystemStreamLookup(),
 			new StubCheckpoint(),
 			new StubVirtualStreamReader(),
-			queueId: 0);
+			queueId: 0,
+			StorageReaderConcurrencyLimiter.Create(maxConcurrentReadRequests));
 
 	private sealed class BlockingReadIndex : IReadIndex<string>, IDisposable
 	{
 		public ManualResetEventSlim ReadEventStarted { get; } = new(false);
 		public ManualResetEventSlim ReadStreamForwardStarted { get; } = new(false);
 		public ManualResetEventSlim EffectiveAclStarted { get; } = new(false);
+		private readonly TaskCompletionSource _releaseReadEvents = new(TaskCreationOptions.RunContinuationsAsynchronously);
+		private int _readEventStartedCount;
+
+		public int ReadEventStartedCount => Volatile.Read(ref _readEventStartedCount);
 
 		public long LastIndexedPosition => 0;
 		public IIndexWriter<string> IndexWriter => throw new NotSupportedException();
 
 		public ValueTask<IndexReadEventResult> ReadEvent(string streamName, string streamId, long eventNumber,
 			CancellationToken token) =>
-			AwaitCancellation<IndexReadEventResult>(ReadEventStarted, token);
+			CompleteReadEvent(token);
+
+		public void ReleaseReadEvents() => _releaseReadEvents.TrySetResult();
 
 		public ValueTask<StorageMessage.EffectiveAcl> GetEffectiveAcl(string streamId, CancellationToken token) =>
 			AwaitCancellation<StorageMessage.EffectiveAcl>(EffectiveAclStarted, token);
@@ -265,6 +315,32 @@ public class when_cancelling_storage_reader_worker
 			ReadEventStarted.Dispose();
 			ReadStreamForwardStarted.Dispose();
 			EffectiveAclStarted.Dispose();
+		}
+
+		private async ValueTask<IndexReadEventResult> CompleteReadEvent(CancellationToken token)
+		{
+			Interlocked.Increment(ref _readEventStartedCount);
+			ReadEventStarted.Set();
+			await _releaseReadEvents.Task.WaitAsync(token);
+			return new IndexReadEventResult(
+				ReadEventResult.Success,
+				new EventRecord(
+					eventNumber: 0,
+					logPosition: 0,
+					correlationId: Guid.NewGuid(),
+					eventId: Guid.NewGuid(),
+					transactionPosition: 0,
+					transactionOffset: 0,
+					eventStreamId: "stream",
+					expectedVersion: 0,
+					timeStamp: DateTime.UtcNow,
+					flags: PrepareFlags.Data,
+					eventType: "event-type",
+					data: [],
+					metadata: []),
+				StreamMetadata.Empty,
+				lastEventNumber: 0,
+				originalStreamExists: true);
 		}
 
 		private static async ValueTask<T> AwaitCancellation<T>(ManualResetEventSlim started, CancellationToken token)

--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsValidatorTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsValidatorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using EventStore.Common.Exceptions;
 using Xunit;
 
@@ -39,6 +40,23 @@ public class ClusterVNodeOptionsValidatorTests
 		{
 			Assert.Throws<InvalidConfigurationException>(When);
 		}
+	}
+
+	[Fact]
+	public void max_concurrent_read_requests_cannot_be_negative()
+	{
+		var options = new ClusterVNodeOptions
+		{
+			Database = new()
+			{
+				MaxConcurrentReadRequests = -1,
+			}
+		};
+
+		Assert.Throws<ArgumentOutOfRangeException>(() =>
+		{
+			ClusterVNodeOptionsValidator.Validate(options);
+		});
 	}
 
 	[Fact]

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -815,6 +815,7 @@ public class ClusterVNode<TStreamId> :
 			logFormat.SystemStreams,
 			readerThreadsCount, Db.Config.WriterCheckpoint.AsReadOnly(), virtualStreamReader, _queueStatsManager,
 			trackers.QueueTrackers,
+			StorageReaderConcurrencyLimiter.Create(options.Database.MaxConcurrentReadRequests),
 			metricsConfiguration);
 
 		_mainBus.Subscribe<SystemMessage.SystemInit>(storageReader);

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -452,6 +452,9 @@ public partial record ClusterVNodeOptions
 			"The maximum number of read requests that can be processed concurrently. Set to '0' to scale automatically (Default)")]
 		public int ReadConcurrencyLimit { get; init; } = 0;
 
+		[Description("The maximum number of read requests that can execute concurrently. Set to '0' to disable the limit.")]
+		public int MaxConcurrentReadRequests { get; init; } = 0;
+
 		[Description("During large Index Merge operations, writes may be slowed down. Set this to the maximum " +
 					 "index file level for which automatic merges should happen. Merging indexes above this level " +
 					 "should be done manually.")]

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
@@ -51,6 +51,13 @@ public static class ClusterVNodeOptionsValidator
 				$"{nameof(options.Database.InitializationThreads)} must be greater than 0.");
 		}
 
+		if (options.Database.MaxConcurrentReadRequests < 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(options.Database.MaxConcurrentReadRequests),
+				options.Database.MaxConcurrentReadRequests,
+				$"{nameof(options.Database.MaxConcurrentReadRequests)} must be greater than or equal to 0.");
+		}
+
 		if (options.Grpc.KeepAliveTimeout < 0)
 		{
 			throw new ArgumentOutOfRangeException(

--- a/src/EventStore.Core/Services/Storage/StorageReaderConcurrencyLimiter.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderConcurrencyLimiter.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace EventStore.Core.Services.Storage;
+
+public sealed class StorageReaderConcurrencyLimiter
+{
+	private readonly SemaphoreSlim? _semaphore;
+
+	private StorageReaderConcurrencyLimiter(int maxConcurrentReadRequests)
+	{
+		MaxConcurrentReadRequests = maxConcurrentReadRequests;
+		_semaphore = maxConcurrentReadRequests > 0
+			? new SemaphoreSlim(maxConcurrentReadRequests, maxConcurrentReadRequests)
+			: null;
+	}
+
+	public int MaxConcurrentReadRequests { get; }
+
+	public static StorageReaderConcurrencyLimiter Create(int maxConcurrentReadRequests)
+	{
+		if (maxConcurrentReadRequests < 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(maxConcurrentReadRequests),
+				maxConcurrentReadRequests,
+				$"{nameof(maxConcurrentReadRequests)} must be greater than or equal to 0.");
+		}
+
+		return new StorageReaderConcurrencyLimiter(maxConcurrentReadRequests);
+	}
+
+	public ValueTask<Lease> Acquire(CancellationToken token)
+	{
+		if (_semaphore is null)
+		{
+			return new ValueTask<Lease>(default(Lease));
+		}
+
+		return Wait(_semaphore, token);
+	}
+
+	private static async ValueTask<Lease> Wait(SemaphoreSlim semaphore, CancellationToken token)
+	{
+		await semaphore.WaitAsync(token);
+		return new Lease(semaphore);
+	}
+
+	public readonly struct Lease : IDisposable
+	{
+		private readonly SemaphoreSlim? _semaphore;
+
+		internal Lease(SemaphoreSlim semaphore) => _semaphore = semaphore;
+
+		public void Dispose() => _semaphore?.Release();
+	}
+}

--- a/src/EventStore.Core/Services/Storage/StorageReaderService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderService.cs
@@ -41,6 +41,7 @@ namespace EventStore.Core.Services.Storage
 			IVirtualStreamReader virtualStreamReader,
 			QueueStatsManager queueStatsManager,
 			QueueTrackers trackers,
+			StorageReaderConcurrencyLimiter concurrencyLimiter,
 			MetricsConfiguration metricsConfiguration = null)
 		{
 
@@ -50,6 +51,7 @@ namespace EventStore.Core.Services.Storage
 			Ensure.NotNull(systemStreams, nameof(systemStreams));
 			Ensure.Positive(threadCount, "threadCount");
 			Ensure.NotNull(writerCheckpoint, "writerCheckpoint");
+			Ensure.NotNull(concurrencyLimiter, nameof(concurrencyLimiter));
 
 			_bus = bus;
 			_readIndex = readIndex;
@@ -64,7 +66,7 @@ namespace EventStore.Core.Services.Storage
 			for (var i = 0; i < threadCount; i++)
 			{
 				readerWorkers[i] = new StorageReaderWorker<TStreamId>(bus, readIndex, systemStreams, writerCheckpoint,
-					virtualStreamReader, i);
+					virtualStreamReader, i, concurrencyLimiter);
 				storageReaderBuses[i] = new InMemoryBus("StorageReaderBus",
 					slowMsgThreshold: storageReaderBusSlowMessageThreshold);
 				storageReaderBuses[i].Subscribe<ClientMessage.ReadEvent>(readerWorkers[i]);

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.ReadAllStreams.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.ReadAllStreams.cs
@@ -55,6 +55,7 @@ public partial class StorageReaderWorker<TStreamId>
 		using var cts = Multiplex(ref token, msg);
 		try
 		{
+			using var readSlot = await AcquireReadSlot(token);
 			var res = await ReadAllEventsForward(msg, token);
 			switch (res.Result)
 			{
@@ -150,6 +151,7 @@ public partial class StorageReaderWorker<TStreamId>
 		using var cts = Multiplex(ref token, msg);
 		try
 		{
+			using var readSlot = await AcquireReadSlot(token);
 			msg.Envelope.ReplyWith(await ReadAllEventsBackward(msg, token));
 		}
 		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token && cts.IsTimedOut)

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.ReadEvent.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.ReadEvent.cs
@@ -46,6 +46,7 @@ public partial class StorageReaderWorker<TStreamId>
 		using var cts = Multiplex(ref token, msg);
 		try
 		{
+			using var readSlot = await AcquireReadSlot(token);
 			var ev = await ReadEvent(msg, token);
 			msg.Envelope.ReplyWith(ev);
 		}

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.ReadFilteredAllStreams.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.ReadFilteredAllStreams.cs
@@ -51,6 +51,7 @@ public partial class StorageReaderWorker<TStreamId>
 		using var cts = Multiplex(ref token, msg);
 		try
 		{
+			using var readSlot = await AcquireReadSlot(token);
 			var res = await FilteredReadAllEventsForward(msg, token);
 			switch (res.Result)
 			{
@@ -139,6 +140,7 @@ public partial class StorageReaderWorker<TStreamId>
 		using var cts = Multiplex(ref token, msg);
 		try
 		{
+			using var readSlot = await AcquireReadSlot(token);
 			var res = await FilteredReadAllEventsBackward(msg, token);
 			switch (res.Result)
 			{

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.ReadStream.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.ReadStream.cs
@@ -55,6 +55,7 @@ public partial class StorageReaderWorker<TStreamId>
 		using var cts = Multiplex(ref token, msg);
 		try
 		{
+			using var readSlot = await AcquireReadSlot(token);
 			res = _virtualStreamReader.CanReadStream(msg.EventStreamId)
 				? await _virtualStreamReader.ReadForwards(msg, token)
 				: await ReadStreamEventsForward(msg, token);
@@ -142,6 +143,7 @@ public partial class StorageReaderWorker<TStreamId>
 		using var cts = Multiplex(ref token, msg);
 		try
 		{
+			using var readSlot = await AcquireReadSlot(token);
 			var res = _virtualStreamReader.CanReadStream(msg.EventStreamId)
 				? await _virtualStreamReader.ReadBackwards(msg, token)
 				: await ReadStreamEventsBackward(msg, token);

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
@@ -47,6 +47,7 @@ public partial class StorageReaderWorker<TStreamId> :
 	private readonly IReadOnlyCheckpoint _writerCheckpoint;
 	private readonly IVirtualStreamReader _virtualStreamReader;
 	private readonly int _queueId;
+	private readonly StorageReaderConcurrencyLimiter _concurrencyLimiter;
 	private readonly CancellationTokenMultiplexer _tokenMultiplexer = new();
 	private static readonly char[] LinkToSeparator = { '@' };
 	private const int MaxPageSize = 4096;
@@ -60,12 +61,14 @@ public partial class StorageReaderWorker<TStreamId> :
 		ISystemStreamLookup<TStreamId> systemStreams,
 		IReadOnlyCheckpoint writerCheckpoint,
 		IVirtualStreamReader virtualStreamReader,
-		int queueId)
+		int queueId,
+		StorageReaderConcurrencyLimiter concurrencyLimiter)
 	{
 		Ensure.NotNull(publisher, "publisher");
 		Ensure.NotNull(readIndex, "readIndex");
 		Ensure.NotNull(systemStreams, nameof(systemStreams));
 		Ensure.NotNull(writerCheckpoint, "writerCheckpoint");
+		Ensure.NotNull(concurrencyLimiter, nameof(concurrencyLimiter));
 
 		_publisher = publisher;
 		_readIndex = readIndex;
@@ -73,6 +76,7 @@ public partial class StorageReaderWorker<TStreamId> :
 		_writerCheckpoint = writerCheckpoint;
 		_queueId = queueId;
 		_virtualStreamReader = virtualStreamReader;
+		_concurrencyLimiter = concurrencyLimiter;
 	}
 
 
@@ -306,4 +310,7 @@ public partial class StorageReaderWorker<TStreamId> :
 		token = scope.Token;
 		return scope;
 	}
+
+	private ValueTask<StorageReaderConcurrencyLimiter.Lease> AcquireReadSlot(CancellationToken token) =>
+		_concurrencyLimiter.Acquire(token);
 }


### PR DESCRIPTION
- Operators need a bounded way to keep read pressure from exhausting reader capacity during spikes.
- The default remains unchanged so existing deployments do not inherit new throttling behavior.
- The tracker can move forward on the accepted read-side reliability work without pulling in broader scheduler changes.