### PR TITLE
fix(storage): make write failures diagnosable

### DIFF
--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_completes_wrong_expected_version.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_completes_wrong_expected_version.cs
@@ -13,7 +13,8 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr;
 [TestFixture]
 public class when_delete_stream_completes_wrong_expected_version : RequestManagerSpecification<DeleteStream>
 {
-	private long commitPosition = 1000;
+	private readonly long _commitPosition = 1000;
+	private readonly long _expectedVersion = 10;
 	private readonly string _streamId = $"DeleteTest-{Guid.NewGuid()}";
 
 	protected override DeleteStream OnManager(FakePublisher publisher)
@@ -25,19 +26,23 @@ public class when_delete_stream_completes_wrong_expected_version : RequestManage
 			InternalCorrId,
 			ClientCorrId,
 			streamId: _streamId,
-			expectedVersion: 10,
+			expectedVersion: _expectedVersion,
 			hardDelete: false,
 			commitSource: CommitSource);
 	}
 
 	protected override IEnumerable<Message> WithInitialMessages()
 	{
-		yield return new StorageMessage.CommitIndexed(InternalCorrId, commitPosition, 2, 3, 3);
+		yield return new StorageMessage.CommitIndexed(InternalCorrId, _commitPosition, 2, 3, 3);
 	}
 
 	protected override Message When()
 	{
-		return new StorageMessage.WrongExpectedVersion(InternalCorrId, 3);
+		return StorageMessage.ConsistencyChecksFailed.ForSingleStream(
+			InternalCorrId,
+			_expectedVersion,
+			currentVersion: 3,
+			isSoftDeleted: false);
 	}
 
 	[Test]
@@ -53,6 +58,9 @@ public class when_delete_stream_completes_wrong_expected_version : RequestManage
 		Assert.That(Envelope.Replies.ContainsSingle<ClientMessage.DeleteStreamCompleted>(
 			x => x.CorrelationId == ClientCorrId &&
 				 x.Result == OperationResult.WrongExpectedVersion &&
-				 x.CurrentVersion == 3));
+				 x.CurrentVersion == 3 &&
+				 x.ConsistencyCheckFailures.Count == 1 &&
+				 x.ConsistencyCheckFailures[0].ExpectedVersion == _expectedVersion &&
+				 x.ConsistencyCheckFailures[0].CurrentVersion == 3));
 	}
 }

--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_stream_deleted.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_stream_deleted.cs
@@ -33,7 +33,11 @@ public class when_delete_stream_gets_stream_deleted : RequestManagerSpecificatio
 
 	protected override Message When()
 	{
-		return new StorageMessage.StreamDeleted(InternalCorrId);
+		return StorageMessage.ConsistencyChecksFailed.ForSingleStream(
+			InternalCorrId,
+			ExpectedVersion.Any,
+			EventNumber.DeletedStream,
+			isSoftDeleted: false);
 	}
 
 	[Test]
@@ -47,6 +51,9 @@ public class when_delete_stream_gets_stream_deleted : RequestManagerSpecificatio
 	public void the_envelope_is_replied_to_with_failure()
 	{
 		Assert.That(Envelope.Replies.ContainsSingle<ClientMessage.DeleteStreamCompleted>(
-			x => x.CorrelationId == ClientCorrId && x.Result == OperationResult.StreamDeleted));
+			x => x.CorrelationId == ClientCorrId &&
+				 x.Result == OperationResult.StreamDeleted &&
+				 x.ConsistencyCheckFailures.Count == 1 &&
+				 x.ConsistencyCheckFailures[0].CurrentVersion == EventNumber.DeletedStream));
 	}
 }

--- a/src/EventStore.Core.Tests/Services/RequestManagement/RequestManagerSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/RequestManagerSpecification.cs
@@ -52,8 +52,7 @@ public abstract class RequestManagerSpecification<TManager>
 		Manager = OnManager(Publisher);
 		Dispatcher.Subscribe<StorageMessage.UncommittedPrepareChased>(Manager);
 		Dispatcher.Subscribe<StorageMessage.InvalidTransaction>(Manager);
-		Dispatcher.Subscribe<StorageMessage.StreamDeleted>(Manager);
-		Dispatcher.Subscribe<StorageMessage.WrongExpectedVersion>(Manager);
+		Dispatcher.Subscribe<StorageMessage.ConsistencyChecksFailed>(Manager);
 		Dispatcher.Subscribe<StorageMessage.AlreadyCommitted>(Manager);
 		Dispatcher.Subscribe<StorageMessage.RequestManagerTimerTick>(Manager);
 		Dispatcher.Subscribe<StorageMessage.CommitIndexed>(Manager);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
@@ -52,8 +52,7 @@ public abstract class RequestManagerServiceSpecification :
 		Dispatcher.Subscribe<ClientMessage.WriteEvents>(Service);
 		Dispatcher.Subscribe<StorageMessage.UncommittedPrepareChased>(Service);
 		Dispatcher.Subscribe<StorageMessage.InvalidTransaction>(Service);
-		Dispatcher.Subscribe<StorageMessage.StreamDeleted>(Service);
-		Dispatcher.Subscribe<StorageMessage.WrongExpectedVersion>(Service);
+		Dispatcher.Subscribe<StorageMessage.ConsistencyChecksFailed>(Service);
 		Dispatcher.Subscribe<StorageMessage.AlreadyCommitted>(Service);
 		Dispatcher.Subscribe<StorageMessage.RequestManagerTimerTick>(Service);
 		Dispatcher.Subscribe<StorageMessage.CommitIndexed>(Service);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_stream_deleted.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_stream_deleted.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.RequestManager.Managers;
@@ -12,7 +13,9 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr;
 public class when_transaction_commit_gets_stream_deleted : RequestManagerSpecification<TransactionCommit>
 {
 
-	private int transactionId = 2341;
+	private readonly int _transactionId = 2341;
+	private readonly long _expectedVersion = ExpectedVersion.StreamExists;
+
 	protected override TransactionCommit OnManager(FakePublisher publisher)
 	{
 		return new TransactionCommit(
@@ -22,7 +25,7 @@ public class when_transaction_commit_gets_stream_deleted : RequestManagerSpecifi
 			Envelope,
 			InternalCorrId,
 			ClientCorrId,
-			transactionId,
+			_transactionId,
 			CommitSource);
 	}
 
@@ -33,7 +36,11 @@ public class when_transaction_commit_gets_stream_deleted : RequestManagerSpecifi
 
 	protected override Message When()
 	{
-		return new StorageMessage.StreamDeleted(InternalCorrId);
+		return StorageMessage.ConsistencyChecksFailed.ForSingleStream(
+			InternalCorrId,
+			_expectedVersion,
+			currentVersion: 0,
+			isSoftDeleted: true);
 	}
 
 	[Test]
@@ -47,6 +54,10 @@ public class when_transaction_commit_gets_stream_deleted : RequestManagerSpecifi
 	public void the_envelope_is_replied_to_with_failure()
 	{
 		Assert.That(Envelope.Replies.ContainsSingle<ClientMessage.TransactionCommitCompleted>(
-			x => x.CorrelationId == ClientCorrId && x.Result == OperationResult.StreamDeleted));
+			x => x.CorrelationId == ClientCorrId &&
+				 x.Result == OperationResult.StreamDeleted &&
+				 x.ConsistencyCheckFailures.Count == 1 &&
+				 x.ConsistencyCheckFailures[0].ExpectedVersion == _expectedVersion &&
+				 x.ConsistencyCheckFailures[0].IsSoftDeleted == true));
 	}
 }

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_stream_deleted.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_stream_deleted.cs
@@ -12,18 +12,20 @@ namespace EventStore.Core.Tests.Services.RequestManagement.WriteStreamMgr;
 [TestFixture]
 public class when_write_stream_gets_stream_deleted : RequestManagerSpecification<WriteEvents>
 {
+	private readonly long _expectedVersion = ExpectedVersion.StreamExists;
+
 	protected override WriteEvents OnManager(FakePublisher publisher)
 	{
 		return new WriteEvents(
-		publisher,
-		CommitTimeout,
-		Envelope,
-		InternalCorrId,
-		ClientCorrId,
-		"test123",
-		ExpectedVersion.Any,
-		new[] { DummyEvent() },
-		CommitSource);
+			publisher,
+			CommitTimeout,
+			Envelope,
+			InternalCorrId,
+			ClientCorrId,
+			"test123",
+			_expectedVersion,
+			new[] { DummyEvent() },
+			CommitSource);
 	}
 
 	protected override IEnumerable<Message> WithInitialMessages()
@@ -33,7 +35,11 @@ public class when_write_stream_gets_stream_deleted : RequestManagerSpecification
 
 	protected override Message When()
 	{
-		return new StorageMessage.StreamDeleted(InternalCorrId);
+		return StorageMessage.ConsistencyChecksFailed.ForSingleStream(
+			InternalCorrId,
+			_expectedVersion,
+			currentVersion: 0,
+			isSoftDeleted: true);
 	}
 
 	[Test]
@@ -47,6 +53,10 @@ public class when_write_stream_gets_stream_deleted : RequestManagerSpecification
 	public void the_envelope_is_replied_to_with_failure()
 	{
 		Assert.That(Envelope.Replies.ContainsSingle<ClientMessage.WriteEventsCompleted>(
-			x => x.CorrelationId == ClientCorrId && x.Result == OperationResult.StreamDeleted));
+			x => x.CorrelationId == ClientCorrId &&
+				 x.Result == OperationResult.StreamDeleted &&
+				 x.ConsistencyCheckFailures.Count == 1 &&
+				 x.ConsistencyCheckFailures[0].ExpectedVersion == _expectedVersion &&
+				 x.ConsistencyCheckFailures[0].IsSoftDeleted == true));
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommit/when_checking_deleted_stream_with_expected_version_no_stream.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommit/when_checking_deleted_stream_with_expected_version_no_stream.cs
@@ -56,6 +56,6 @@ public class when_checking_deleted_stream_with_expected_version_no_stream<TLogFo
 			CancellationToken.None);
 
 		Assert.AreEqual(CommitDecision.Ok, result.Decision);
-		Assert.IsTrue(result.IsSoftDeleted);
+		Assert.That(result.IsSoftDeleted, Is.True);
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommit/when_checking_stream_with_expected_version_soft_deleted.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommit/when_checking_stream_with_expected_version_soft_deleted.cs
@@ -51,7 +51,7 @@ public class when_checking_stream_with_expected_version_soft_deleted<TLogFormat,
 			CancellationToken.None);
 
 		Assert.AreEqual(CommitDecision.Ok, result.Decision);
-		Assert.IsTrue(result.IsSoftDeleted);
+		Assert.That(result.IsSoftDeleted, Is.True);
 	}
 
 	[Test]
@@ -65,7 +65,7 @@ public class when_checking_stream_with_expected_version_soft_deleted<TLogFormat,
 			CancellationToken.None);
 
 		Assert.AreEqual(CommitDecision.Ok, result.Decision);
-		Assert.IsTrue(result.IsSoftDeleted);
+		Assert.That(result.IsSoftDeleted, Is.True);
 	}
 
 	[Test]

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1148,9 +1148,8 @@ public class ClusterVNode<TStreamId> :
 		_mainBus.Subscribe<StorageMessage.RequestCompleted>(requestManagement);
 		_mainBus.Subscribe<StorageMessage.CommitIndexed>(requestManagement);
 
-		_mainBus.Subscribe<StorageMessage.WrongExpectedVersion>(requestManagement);
 		_mainBus.Subscribe<StorageMessage.InvalidTransaction>(requestManagement);
-		_mainBus.Subscribe<StorageMessage.StreamDeleted>(requestManagement);
+		_mainBus.Subscribe<StorageMessage.ConsistencyChecksFailed>(requestManagement);
 
 		_mainBus.Subscribe<StorageMessage.RequestManagerTimerTick>(requestManagement);
 

--- a/src/EventStore.Core/Data/ConsistencyCheckFailure.cs
+++ b/src/EventStore.Core/Data/ConsistencyCheckFailure.cs
@@ -1,0 +1,7 @@
+namespace EventStore.Core.Data;
+
+public readonly record struct ConsistencyCheckFailure(
+	int StreamIndex,
+	long ExpectedVersion,
+	long CurrentVersion,
+	bool? IsSoftDeleted);

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -273,6 +273,7 @@ public static partial class ClientMessage
 		public readonly long PreparePosition;
 		public readonly long CommitPosition;
 		public readonly long CurrentVersion;
+		public readonly IReadOnlyList<ConsistencyCheckFailure> ConsistencyCheckFailures;
 
 		public WriteEventsCompleted(Guid correlationId, long firstEventNumber, long lastEventNumber,
 			long preparePosition, long commitPosition)
@@ -296,10 +297,12 @@ public static partial class ClientMessage
 			LastEventNumber = lastEventNumber;
 			PreparePosition = preparePosition;
 			CommitPosition = commitPosition;
+			ConsistencyCheckFailures = Array.Empty<ConsistencyCheckFailure>();
 		}
 
 		public WriteEventsCompleted(Guid correlationId, OperationResult result, string message,
-			long currentVersion = -1)
+			long currentVersion = -1,
+			IReadOnlyList<ConsistencyCheckFailure> consistencyCheckFailures = null)
 		{
 			if (result == OperationResult.Success)
 			{
@@ -313,11 +316,13 @@ public static partial class ClientMessage
 			LastEventNumber = EventNumber.Invalid;
 			PreparePosition = EventNumber.Invalid;
 			CurrentVersion = currentVersion;
+			ConsistencyCheckFailures = consistencyCheckFailures ?? Array.Empty<ConsistencyCheckFailure>();
 		}
 
 		private WriteEventsCompleted(Guid correlationId, OperationResult result, string message,
 			long firstEventNumber, long lastEventNumber, long preparePosition, long commitPosition,
-			long currentVersion)
+			long currentVersion,
+			IReadOnlyList<ConsistencyCheckFailure> consistencyCheckFailures)
 		{
 			CorrelationId = correlationId;
 			Result = result;
@@ -327,12 +332,13 @@ public static partial class ClientMessage
 			PreparePosition = preparePosition;
 			CommitPosition = commitPosition;
 			CurrentVersion = currentVersion;
+			ConsistencyCheckFailures = consistencyCheckFailures ?? Array.Empty<ConsistencyCheckFailure>();
 		}
 
 		public WriteEventsCompleted WithCorrelationId(Guid newCorrId)
 		{
 			return new WriteEventsCompleted(newCorrId, Result, Message, FirstEventNumber, LastEventNumber,
-				PreparePosition, CommitPosition, CurrentVersion);
+				PreparePosition, CommitPosition, CurrentVersion, ConsistencyCheckFailures);
 		}
 
 		public override string ToString()
@@ -455,6 +461,7 @@ public static partial class ClientMessage
 		public readonly long LastEventNumber;
 		public readonly long PreparePosition;
 		public readonly long CommitPosition;
+		public readonly IReadOnlyList<ConsistencyCheckFailure> ConsistencyCheckFailures;
 
 		public TransactionCommitCompleted(Guid correlationId, long transactionId, long firstEventNumber,
 			long lastEventNumber, long preparePosition, long commitPosition)
@@ -479,10 +486,11 @@ public static partial class ClientMessage
 			LastEventNumber = lastEventNumber;
 			PreparePosition = preparePosition;
 			CommitPosition = commitPosition;
+			ConsistencyCheckFailures = Array.Empty<ConsistencyCheckFailure>();
 		}
 
 		public TransactionCommitCompleted(Guid correlationId, long transactionId, OperationResult result,
-			string message)
+			string message, IReadOnlyList<ConsistencyCheckFailure> consistencyCheckFailures = null)
 		{
 			if (result == OperationResult.Success)
 			{
@@ -495,11 +503,12 @@ public static partial class ClientMessage
 			Message = message;
 			FirstEventNumber = EventNumber.Invalid;
 			LastEventNumber = EventNumber.Invalid;
+			ConsistencyCheckFailures = consistencyCheckFailures ?? Array.Empty<ConsistencyCheckFailure>();
 		}
 
 		private TransactionCommitCompleted(Guid correlationId, long transactionId, OperationResult result,
 			string message,
-			long firstEventNumber, long lastEventNumber)
+			long firstEventNumber, long lastEventNumber, IReadOnlyList<ConsistencyCheckFailure> consistencyCheckFailures)
 		{
 			CorrelationId = correlationId;
 			TransactionId = transactionId;
@@ -507,12 +516,13 @@ public static partial class ClientMessage
 			Message = message;
 			FirstEventNumber = firstEventNumber;
 			LastEventNumber = lastEventNumber;
+			ConsistencyCheckFailures = consistencyCheckFailures ?? Array.Empty<ConsistencyCheckFailure>();
 		}
 
 		public TransactionCommitCompleted WithCorrelationId(Guid newCorrId)
 		{
 			return new TransactionCommitCompleted(newCorrId, TransactionId, Result, Message, FirstEventNumber,
-				LastEventNumber);
+				LastEventNumber, ConsistencyCheckFailures);
 		}
 	}
 
@@ -549,9 +559,11 @@ public static partial class ClientMessage
 		public readonly long PreparePosition;
 		public readonly long CommitPosition;
 		public readonly long CurrentVersion;
+		public readonly IReadOnlyList<ConsistencyCheckFailure> ConsistencyCheckFailures;
 
 		public DeleteStreamCompleted(Guid correlationId, OperationResult result, string message,
-			long currentVersion, long preparePosition, long commitPosition)
+			long currentVersion, long preparePosition, long commitPosition,
+			IReadOnlyList<ConsistencyCheckFailure> consistencyCheckFailures = null)
 		{
 			CorrelationId = correlationId;
 			Result = result;
@@ -559,17 +571,19 @@ public static partial class ClientMessage
 			CurrentVersion = currentVersion;
 			PreparePosition = preparePosition;
 			CommitPosition = commitPosition;
+			ConsistencyCheckFailures = consistencyCheckFailures ?? Array.Empty<ConsistencyCheckFailure>();
 		}
 
 		public DeleteStreamCompleted(Guid correlationId, OperationResult result, string message,
-			long currentVersion = -1L) : this(correlationId, result, message, currentVersion, -1, -1)
+			long currentVersion = -1L, IReadOnlyList<ConsistencyCheckFailure> consistencyCheckFailures = null) :
+			this(correlationId, result, message, currentVersion, -1, -1, consistencyCheckFailures)
 		{
 		}
 
 		public DeleteStreamCompleted WithCorrelationId(Guid newCorrId)
 		{
 			return new DeleteStreamCompleted(newCorrId, Result, Message, CurrentVersion, PreparePosition,
-				CommitPosition);
+				CommitPosition, ConsistencyCheckFailures);
 		}
 	}
 

--- a/src/EventStore.Core/Messages/StorageMessage.cs
+++ b/src/EventStore.Core/Messages/StorageMessage.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -331,28 +332,28 @@ namespace EventStore.Core.Messages
 		}
 
 		[DerivedMessage(CoreMessage.Storage)]
-		public partial class WrongExpectedVersion : Message
+		public partial class ConsistencyChecksFailed : Message
 		{
 			public readonly Guid CorrelationId;
-			public readonly long CurrentVersion;
+			public readonly IReadOnlyList<ConsistencyCheckFailure> Failures;
 
-			public WrongExpectedVersion(Guid correlationId, long currentVersion)
+			public ConsistencyChecksFailed(Guid correlationId, IReadOnlyList<ConsistencyCheckFailure> failures)
 			{
 				Ensure.NotEmptyGuid(correlationId, "correlationId");
+				Ensure.NotNull(failures, nameof(failures));
 				CorrelationId = correlationId;
-				CurrentVersion = currentVersion;
+				Failures = failures;
 			}
-		}
 
-		[DerivedMessage(CoreMessage.Storage)]
-		public partial class StreamDeleted : Message
-		{
-			public readonly Guid CorrelationId;
-
-			public StreamDeleted(Guid correlationId)
+			public static ConsistencyChecksFailed ForSingleStream(Guid correlationId, long expectedVersion,
+				long currentVersion, bool? isSoftDeleted)
 			{
-				Ensure.NotEmptyGuid(correlationId, "correlationId");
-				CorrelationId = correlationId;
+				return new ConsistencyChecksFailed(
+					correlationId,
+					new[]
+					{
+						new ConsistencyCheckFailure(0, expectedVersion, currentVersion, isSoftDeleted)
+					});
 			}
 		}
 

--- a/src/EventStore.Core/Services/RequestManager/Managers/DeleteStream.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/DeleteStream.cs
@@ -58,6 +58,7 @@ namespace EventStore.Core.Services.RequestManager.Managers
 				 CommitPosition);
 
 		protected override Message ClientFailMsg =>
-			new ClientMessage.DeleteStreamCompleted(ClientCorrId, Result, FailureMessage, FailureCurrentVersion);
+			new ClientMessage.DeleteStreamCompleted(ClientCorrId, Result, FailureMessage, FailureCurrentVersion,
+				ConsistencyCheckFailures);
 	}
 }

--- a/src/EventStore.Core/Services/RequestManager/Managers/RequestManagerBase.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/RequestManagerBase.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Threading;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
+using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.TransactionLog.LogRecords;
@@ -15,8 +16,7 @@ namespace EventStore.Core.Services.RequestManager.Managers
 		IHandle<StorageMessage.UncommittedPrepareChased>,
 		IHandle<StorageMessage.CommitIndexed>,
 		IHandle<StorageMessage.InvalidTransaction>,
-		IHandle<StorageMessage.StreamDeleted>,
-		IHandle<StorageMessage.WrongExpectedVersion>,
+		IHandle<StorageMessage.ConsistencyChecksFailed>,
 		IHandle<StorageMessage.AlreadyCommitted>,
 		IHandle<StorageMessage.RequestManagerTimerTick>,
 		IDisposable
@@ -38,6 +38,8 @@ namespace EventStore.Core.Services.RequestManager.Managers
 		protected long LastEventNumber = -1;
 		protected string FailureMessage = string.Empty;
 		protected long FailureCurrentVersion = -1;
+		protected IReadOnlyList<ConsistencyCheckFailure> ConsistencyCheckFailures =
+			Array.Empty<ConsistencyCheckFailure>();
 		protected long TransactionId;
 
 		protected readonly CommitSource CommitSource;
@@ -187,14 +189,29 @@ namespace EventStore.Core.Services.RequestManager.Managers
 		{
 			CompleteFailedRequest(OperationResult.InvalidTransaction, "Invalid transaction.");
 		}
-		public void Handle(StorageMessage.WrongExpectedVersion message)
+		public void Handle(StorageMessage.ConsistencyChecksFailed message)
 		{
-			FailureCurrentVersion = message.CurrentVersion;
-			CompleteFailedRequest(OperationResult.WrongExpectedVersion, "Wrong expected version.", message.CurrentVersion);
-		}
-		public void Handle(StorageMessage.StreamDeleted message)
-		{
-			CompleteFailedRequest(OperationResult.StreamDeleted, "Stream is deleted.");
+			ConsistencyCheckFailures = message.Failures;
+			FailureCurrentVersion = message.Failures.Count == 1
+				? message.Failures[0].CurrentVersion
+				: -1;
+
+			foreach (var failure in message.Failures)
+			{
+				var tombstoned = failure.CurrentVersion == EventNumber.DeletedStream;
+				var softDeleted = failure.ExpectedVersion == EventStore.Core.Data.ExpectedVersion.StreamExists &&
+								  failure.IsSoftDeleted == true;
+
+				if (tombstoned || softDeleted)
+				{
+					CompleteFailedRequest(OperationResult.StreamDeleted, "Stream is deleted.",
+						FailureCurrentVersion);
+					return;
+				}
+			}
+
+			CompleteFailedRequest(OperationResult.WrongExpectedVersion, "Wrong expected version.",
+				FailureCurrentVersion);
 		}
 		public void Handle(StorageMessage.AlreadyCommitted message)
 		{

--- a/src/EventStore.Core/Services/RequestManager/Managers/TransactionCommit.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/TransactionCommit.cs
@@ -66,7 +66,8 @@ namespace EventStore.Core.Services.RequestManager.Managers
 					ClientCorrId,
 					TransactionId,
 					Result,
-					FailureMessage);
+					FailureMessage,
+					ConsistencyCheckFailures);
 
 		public override void Handle(StorageMessage.CommitIndexed message)
 		{

--- a/src/EventStore.Core/Services/RequestManager/Managers/WriteEvents.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/WriteEvents.cs
@@ -61,6 +61,7 @@ namespace EventStore.Core.Services.RequestManager.Managers
 				 ClientCorrId,
 				 Result,
 				 FailureMessage,
-				 FailureCurrentVersion);
+				 FailureCurrentVersion,
+				 ConsistencyCheckFailures);
 	}
 }

--- a/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
+++ b/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
@@ -24,9 +24,8 @@ namespace EventStore.Core.Services.RequestManager
 		IHandle<ReplicationTrackingMessage.ReplicatedTo>,
 		IHandle<ReplicationTrackingMessage.IndexedTo>,
 		IHandle<StorageMessage.CommitIndexed>,
-		IHandle<StorageMessage.WrongExpectedVersion>,
 		IHandle<StorageMessage.InvalidTransaction>,
-		IHandle<StorageMessage.StreamDeleted>,
+		IHandle<StorageMessage.ConsistencyChecksFailed>,
 		IHandle<StorageMessage.RequestManagerTimerTick>,
 		IHandle<SystemMessage.StateChangeMessage>
 	{
@@ -234,9 +233,8 @@ namespace EventStore.Core.Services.RequestManager
 		public void Handle(StorageMessage.AlreadyCommitted message) => DispatchInternal(message.CorrelationId, message, static (manager, m) => manager.Handle(m));
 		public void Handle(StorageMessage.UncommittedPrepareChased message) => DispatchInternal(message.CorrelationId, message, static (manager, m) => manager.Handle(m));
 		public void Handle(StorageMessage.CommitIndexed message) => DispatchInternal(message.CorrelationId, message, static (manager, m) => manager.Handle(m));
-		public void Handle(StorageMessage.WrongExpectedVersion message) => DispatchInternal(message.CorrelationId, message, static (manager, m) => manager.Handle(m));
 		public void Handle(StorageMessage.InvalidTransaction message) => DispatchInternal(message.CorrelationId, message, static (manager, m) => manager.Handle(m));
-		public void Handle(StorageMessage.StreamDeleted message) => DispatchInternal(message.CorrelationId, message, static (manager, m) => manager.Handle(m));
+		public void Handle(StorageMessage.ConsistencyChecksFailed message) => DispatchInternal(message.CorrelationId, message, static (manager, m) => manager.Handle(m));
 
 		private void DispatchInternal<T>(Guid correlationId, T message, Action<RequestManagerBase, T> handle) where T : Message
 		{

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/CommitCheckResult.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/CommitCheckResult.cs
@@ -4,10 +4,11 @@ namespace EventStore.Core.Services.Storage.ReaderIndex
 	{
 		public readonly CommitDecision Decision;
 		public readonly TStreamId EventStreamId;
+		public readonly long ExpectedVersion;
 		public readonly long CurrentVersion;
 		public readonly long StartEventNumber;
 		public readonly long EndEventNumber;
-		public readonly bool IsSoftDeleted;
+		public readonly bool? IsSoftDeleted;
 		public readonly long IdempotentLogPosition;
 
 		public CommitCheckResult(CommitDecision decision,
@@ -17,9 +18,23 @@ namespace EventStore.Core.Services.Storage.ReaderIndex
 			long endEventNumber,
 			bool isSoftDeleted,
 			long idempotentLogPosition = -1)
+			: this(decision, eventStreamId, EventStore.Core.Data.ExpectedVersion.Invalid, currentVersion,
+				startEventNumber, endEventNumber, isSoftDeleted, idempotentLogPosition)
+		{
+		}
+
+		public CommitCheckResult(CommitDecision decision,
+			TStreamId eventStreamId,
+			long expectedVersion,
+			long currentVersion,
+			long startEventNumber,
+			long endEventNumber,
+			bool? isSoftDeleted,
+			long idempotentLogPosition = -1)
 		{
 			Decision = decision;
 			EventStreamId = eventStreamId;
+			ExpectedVersion = expectedVersion;
 			CurrentVersion = currentVersion;
 			StartEventNumber = startEventNumber;
 			EndEventNumber = endEventNumber;

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexWriter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexWriter.cs
@@ -197,7 +197,8 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId>
 			_ => CommitDecision.WrongExpectedVersion
 		};
 
-		return new CommitCheckResult<TStreamId>(commitDecision, streamId, ExpectedVersion.NoStream, -1, -1, false);
+		return new CommitCheckResult<TStreamId>(commitDecision, streamId, expectedVersion,
+			ExpectedVersion.NoStream, -1, -1, false);
 	}
 
 	public async ValueTask<CommitCheckResult<TStreamId>> CheckCommit(TStreamId streamId, long expectedVersion,
@@ -216,22 +217,25 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId>
 			if (!enumerator.MoveNext() &&
 				expectedVersion is ExpectedVersion.Any or ExpectedVersion.NoStream or EventNumber.DeletedStream)
 			{
-				return new CommitCheckResult<TStreamId>(CommitDecision.Ok, streamId, curVersion, -1, -1, false);
+				return new CommitCheckResult<TStreamId>(CommitDecision.Ok, streamId, expectedVersion, curVersion, -1,
+					-1, false);
 			}
 
-			return new CommitCheckResult<TStreamId>(CommitDecision.Deleted, streamId, curVersion, -1, -1, false);
+			return new CommitCheckResult<TStreamId>(CommitDecision.Deleted, streamId, expectedVersion, curVersion,
+				-1, -1, false);
 		}
 		if (curVersion is EventNumber.Invalid)
 		{
-			return new CommitCheckResult<TStreamId>(CommitDecision.WrongExpectedVersion, streamId, curVersion, -1, -1,
-				false);
+			return new CommitCheckResult<TStreamId>(CommitDecision.WrongExpectedVersion, streamId, expectedVersion,
+				curVersion, -1, -1, false);
 		}
 
 		if (expectedVersion is ExpectedVersion.StreamExists)
 		{
 			if (await IsSoftDeleted(streamId, token))
 			{
-				return new CommitCheckResult<TStreamId>(CommitDecision.Deleted, streamId, curVersion, -1, -1, true);
+				return new CommitCheckResult<TStreamId>(CommitDecision.Deleted, streamId, expectedVersion, curVersion,
+					-1, -1, true);
 			}
 
 			if (curVersion < 0)
@@ -239,8 +243,8 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId>
 				var metadataVersion = await GetStreamLastEventNumber(_systemStreams.MetaStreamOf(streamId), token);
 				if (metadataVersion < 0)
 				{
-					return new CommitCheckResult<TStreamId>(CommitDecision.WrongExpectedVersion, streamId, curVersion,
-						-1, -1,
+					return new CommitCheckResult<TStreamId>(CommitDecision.WrongExpectedVersion, streamId,
+						expectedVersion, curVersion, -1, -1,
 						false);
 				}
 			}
@@ -261,12 +265,12 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId>
 					if (expectedVersion is ExpectedVersion.SoftDeleted && !isSoftDeleted)
 					{
 						return new CommitCheckResult<TStreamId>(CommitDecision.WrongExpectedVersion, streamId,
-							curVersion, -1, -1, false);
+							expectedVersion, curVersion, -1, -1, false);
 					}
 
 					return new CommitCheckResult<TStreamId>(
 						first ? CommitDecision.Ok : CommitDecision.CorruptedIdempotency,
-						streamId, curVersion, -1, -1, first && isSoftDeleted);
+						streamId, expectedVersion, curVersion, -1, -1, first && isSoftDeleted);
 				}
 
 				if (first)
@@ -283,11 +287,12 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId>
 				var isSoftDeleted = await IsSoftDeleted(streamId, token);
 				if (expectedVersion is ExpectedVersion.SoftDeleted && !isSoftDeleted)
 				{
-					return new CommitCheckResult<TStreamId>(CommitDecision.WrongExpectedVersion, streamId, curVersion,
-						-1, -1, false);
+					return new CommitCheckResult<TStreamId>(CommitDecision.WrongExpectedVersion, streamId,
+						expectedVersion, curVersion, -1, -1, false);
 				}
 
-				return new CommitCheckResult<TStreamId>(CommitDecision.Ok, streamId, curVersion, -1, -1,
+				return new CommitCheckResult<TStreamId>(CommitDecision.Ok, streamId, expectedVersion, curVersion,
+					-1, -1,
 					isSoftDeleted);
 			}
 			else
@@ -303,12 +308,14 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId>
 					: -1;
 				if (isReplicated)
 				{
-					return new CommitCheckResult<TStreamId>(CommitDecision.Idempotent, streamId, curVersion,
+					return new CommitCheckResult<TStreamId>(CommitDecision.Idempotent, streamId, expectedVersion,
+						curVersion,
 						startEventNumber, endEventNumber, false, logPos);
 				}
 				else
 				{
-					return new CommitCheckResult<TStreamId>(CommitDecision.IdempotentNotReady, streamId, curVersion,
+					return new CommitCheckResult<TStreamId>(CommitDecision.IdempotentNotReady, streamId,
+						expectedVersion, curVersion,
 						startEventNumber, endEventNumber, false, logPos);
 				}
 			}
@@ -336,17 +343,17 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId>
 				var first = eventNumber == expectedVersion + 1;
 				if (!first)
 				{
-					return new(CommitDecision.CorruptedIdempotency, streamId, curVersion,
+					return new(CommitDecision.CorruptedIdempotency, streamId, expectedVersion, curVersion,
 						-1, -1,
 						false);
 				}
 
 				if (expectedVersion is ExpectedVersion.NoStream && await IsSoftDeleted(streamId, token))
 				{
-					return new(CommitDecision.Ok, streamId, curVersion, -1, -1, true);
+					return new(CommitDecision.Ok, streamId, expectedVersion, curVersion, -1, -1, true);
 				}
 
-				return new(CommitDecision.WrongExpectedVersion, streamId, curVersion, -1,
+				return new(CommitDecision.WrongExpectedVersion, streamId, expectedVersion, curVersion, -1,
 					-1,
 					false);
 			}
@@ -355,10 +362,10 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId>
 			{
 				if (expectedVersion is ExpectedVersion.NoStream && await IsSoftDeleted(streamId, token))
 				{
-					return new(CommitDecision.Ok, streamId, curVersion, -1, -1, true);
+					return new(CommitDecision.Ok, streamId, expectedVersion, curVersion, -1, -1, true);
 				}
 
-				return new(CommitDecision.WrongExpectedVersion, streamId, curVersion, -1,
+				return new(CommitDecision.WrongExpectedVersion, streamId, expectedVersion, curVersion, -1,
 					-1, false);
 			}
 
@@ -374,18 +381,19 @@ public class IndexWriter<TStreamId> : IndexWriter, IIndexWriter<TStreamId>
 
 			return new(
 				isReplicated ? CommitDecision.Idempotent : CommitDecision.IdempotentNotReady, streamId,
+				expectedVersion,
 				curVersion,
 				expectedVersion + 1, eventNumber, false, logPos);
 		}
 
 		if (expectedVersion > curVersion)
 		{
-			return new CommitCheckResult<TStreamId>(CommitDecision.WrongExpectedVersion, streamId, curVersion, -1, -1,
-				false);
+			return new CommitCheckResult<TStreamId>(CommitDecision.WrongExpectedVersion, streamId, expectedVersion,
+				curVersion, -1, -1, false);
 		}
 
 		// expectedVersion == currentVersion
-		return new CommitCheckResult<TStreamId>(CommitDecision.Ok, streamId, curVersion, -1, -1,
+		return new CommitCheckResult<TStreamId>(CommitDecision.Ok, streamId, expectedVersion, curVersion, -1, -1,
 			await IsSoftDeleted(streamId, token));
 	}
 

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -447,7 +447,7 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 			// note: the stream & event type records are indexed separately and must not be pre-committed to the main index
 			_indexWriter.PreCommit(CollectionsMarshal.AsSpan(prepares)[^msg.Events.Length..]);
 
-			if (commitCheck.IsSoftDeleted)
+			if (commitCheck.IsSoftDeleted is true)
 			{
 				await SoftUndeleteStream(streamId, commitCheck.CurrentVersion + 1, token);
 			}
@@ -613,7 +613,7 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 				if (await _indexWriter.GetStreamLastEventNumber(streamId, token) < 0 && expectedVersion < 0)
 				{
 					var result = new CommitCheckResult<TStreamId>(CommitDecision.WrongExpectedVersion, streamId,
-						-1, -1, -1, false);
+						message.ExpectedVersion, -1, -1, -1, false);
 					await ActOnCommitCheckFailure(message.Envelope, message.CorrelationId, result, token);
 					return;
 				}
@@ -816,7 +816,7 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 
 			await _indexWriter.PreCommit(commit, token);
 
-			if (commitCheck.IsSoftDeleted)
+			if (commitCheck.IsSoftDeleted is true)
 			{
 				await SoftUndeleteStream(commitCheck.EventStreamId, commitCheck.CurrentVersion + 1, token);
 			}
@@ -843,10 +843,10 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 		switch (result.Decision)
 		{
 			case CommitDecision.WrongExpectedVersion:
-				envelope.ReplyWith(new StorageMessage.WrongExpectedVersion(correlationId, result.CurrentVersion));
+				envelope.ReplyWith(CreateConsistencyChecksFailed(correlationId, result));
 				break;
 			case CommitDecision.Deleted:
-				envelope.ReplyWith(new StorageMessage.StreamDeleted(correlationId));
+				envelope.ReplyWith(CreateConsistencyChecksFailed(correlationId, result));
 				break;
 			case CommitDecision.Idempotent:
 				var eventStreamName = await _indexWriter.GetStreamName(result.EventStreamId, token);
@@ -859,7 +859,7 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 			case CommitDecision.CorruptedIdempotency:
 				// in case of corrupted idempotency (part of transaction is ok, other is different)
 				// then we can say that the transaction is not idempotent, so WrongExpectedVersion is ok answer
-				envelope.ReplyWith(new StorageMessage.WrongExpectedVersion(correlationId, result.CurrentVersion));
+				envelope.ReplyWith(CreateConsistencyChecksFailed(correlationId, result));
 				break;
 			case CommitDecision.InvalidTransaction:
 				envelope.ReplyWith(new StorageMessage.InvalidTransaction(correlationId));
@@ -874,6 +874,17 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 			default:
 				throw new ArgumentOutOfRangeException();
 		}
+	}
+
+	private static StorageMessage.ConsistencyChecksFailed CreateConsistencyChecksFailed(
+		Guid correlationId,
+		CommitCheckResult<TStreamId> result)
+	{
+		return StorageMessage.ConsistencyChecksFailed.ForSingleStream(
+			correlationId,
+			result.ExpectedVersion,
+			result.CurrentVersion,
+			result.IsSoftDeleted);
 	}
 
 	private async ValueTask<bool> TryWritePreparesWithRetry(IList<IPrepareLogRecord<TStreamId>> prepares,


### PR DESCRIPTION
- Write failures should retain the consistency-check context that operators and newer internal callers need to understand the mismatch.
- Existing clients still need stable success/failure status behavior while the core carries richer failure details forward.