### PR TITLE
fix(scheduler): complete timer scheduler shutdown

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/TimerService/ThreadBasedSchedulerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/TimerService/ThreadBasedSchedulerTests.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Metrics;
+using EventStore.Core.Services.TimerService;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.TimerService;
+
+public class ThreadBasedSchedulerTests
+{
+	[Fact]
+	public async Task task_completes_when_stopped()
+	{
+		using var scheduler = CreateScheduler();
+
+		scheduler.Stop();
+
+		await scheduler.Task.WaitAsync(TimeSpan.FromSeconds(1));
+	}
+
+	[Fact]
+	public async Task future_work_does_not_keep_shutdown_incomplete()
+	{
+		using var scheduler = CreateScheduler();
+
+		scheduler.Schedule(TimeSpan.FromMinutes(1), static (_, _) => { }, null);
+		scheduler.Stop();
+
+		await scheduler.Task.WaitAsync(TimeSpan.FromSeconds(1));
+	}
+
+	private static ThreadBasedScheduler CreateScheduler() =>
+		new(new QueueStatsManager(), new QueueTrackers());
+}

--- a/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
+++ b/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
@@ -27,11 +27,12 @@ namespace EventStore.Core.Services.TimerService
 
 		private readonly IClock _timeProvider;
 
-		private volatile bool _stop;
+		private int _stopRequested;
 
 		private readonly QueueStatsCollector _queueStats;
 		private readonly QueueTracker _tracker;
-		private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
+		private readonly TaskCompletionSource<object> _tcs =
+			new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		private long _nextWakeupTimeTicks = long.MinValue;
 
@@ -84,7 +85,7 @@ namespace EventStore.Core.Services.TimerService
 			var minTimeout = TimeSpan.FromMilliseconds(1);
 			var maxTimeout = TimeSpan.FromSeconds(5);
 
-			while (!_stop)
+			while (Volatile.Read(ref _stopRequested) == 0)
 			{
 				try
 				{
@@ -163,11 +164,15 @@ namespace EventStore.Core.Services.TimerService
 			_queueStats.Stop();
 			QueueMonitor.Default.Unregister(this);
 			_pendingEvent.Dispose();
+			_tcs.TrySetResult(null);
 		}
 
 		public void Dispose()
 		{
-			_stop = true;
+			if (Interlocked.Exchange(ref _stopRequested, 1) == 0)
+			{
+				_pendingEvent.Set();
+			}
 		}
 
 		public QueueStats GetStatistics()


### PR DESCRIPTION
- Scheduler shutdown needs a reliable completion signal so node lifecycle tracking can distinguish clean exits from stuck background work.
- Future scheduled work should not delay shutdown when the process is already stopping.