### PR TITLE
feat(storage): unblock property-aware indexing

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/PropertyMetadataTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/PropertyMetadataTests.cs
@@ -1,0 +1,90 @@
+using System;
+using EventStore.Core.Data;
+using EventStore.Core.LogV2;
+using EventStore.Core.TransactionLog.LogRecords;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.TransactionLog.LogRecords;
+
+public class PropertyMetadataTests
+{
+	[Fact]
+	public void events_default_to_custom_metadata()
+	{
+		var evnt = new Event(
+			Guid.NewGuid(),
+			"test-event",
+			isJson: true,
+			data: [1, 2, 3],
+			metadata: [4, 5, 6]);
+
+		Assert.False(evnt.IsPropertyMetadata);
+		Assert.Equal([4, 5, 6], evnt.Metadata);
+	}
+
+	[Fact]
+	public void events_can_mark_the_metadata_slot_as_properties()
+	{
+		var evnt = new Event(
+			Guid.NewGuid(),
+			"test-event",
+			isJson: false,
+			data: [1, 2, 3],
+			isPropertyMetadata: true,
+			metadata: [4, 5, 6]);
+
+		Assert.True(evnt.IsPropertyMetadata);
+		Assert.Equal([4, 5, 6], evnt.Metadata);
+	}
+
+	[Fact]
+	public void transaction_write_carries_the_property_metadata_flag()
+	{
+		var propertyMetadata = new byte[] { 4, 5, 6 };
+		var prepare = LogRecord.TransactionWrite(
+			new LogV2RecordFactory(),
+			logPosition: 0,
+			correlationId: Guid.NewGuid(),
+			eventId: Guid.NewGuid(),
+			transactionPos: 0,
+			transactionOffset: 0,
+			eventStreamId: "test-stream",
+			eventType: "test-event",
+			data: [1, 2, 3],
+			metadata: propertyMetadata,
+			isJson: false,
+			isPropertyMetadata: true);
+
+		Assert.True(prepare.Flags.HasAllOf(PrepareFlags.IsPropertyMetadata));
+
+		var record = new EventRecord(0, prepare, "test-stream", "test-event");
+
+		Assert.Equal(propertyMetadata, record.Metadata.ToArray());
+		Assert.Equal(propertyMetadata, record.Properties.ToArray());
+	}
+
+	[Fact]
+	public void custom_metadata_is_not_exposed_as_properties()
+	{
+		var customMetadata = new byte[] { 4, 5, 6 };
+		var prepare = LogRecord.TransactionWrite(
+			new LogV2RecordFactory(),
+			logPosition: 0,
+			correlationId: Guid.NewGuid(),
+			eventId: Guid.NewGuid(),
+			transactionPos: 0,
+			transactionOffset: 0,
+			eventStreamId: "test-stream",
+			eventType: "test-event",
+			data: [1, 2, 3],
+			metadata: customMetadata,
+			isJson: true);
+
+		Assert.False(prepare.Flags.HasAllOf(PrepareFlags.IsPropertyMetadata));
+
+		var record = new EventRecord(0, prepare, "test-stream", "test-event");
+
+		Assert.Equal(customMetadata, record.Metadata.ToArray());
+		Assert.Empty(record.Properties.ToArray());
+	}
+}

--- a/src/EventStore.Core/Data/Event.cs
+++ b/src/EventStore.Core/Data/Event.cs
@@ -10,11 +10,13 @@ namespace EventStore.Core.Data
 		public readonly string EventType;
 		public readonly bool IsJson;
 		public readonly byte[] Data;
+		public readonly bool IsPropertyMetadata;
 		public readonly byte[] Metadata;
 
 		public Event(Guid eventId, string eventType, bool isJson, string data, string metadata)
 			: this(
 				eventId, eventType, isJson, Helper.UTF8NoBom.GetBytes(data),
+				isPropertyMetadata: false,
 				metadata != null ? Helper.UTF8NoBom.GetBytes(metadata) : null)
 		{
 		}
@@ -26,6 +28,11 @@ namespace EventStore.Core.Data
 			SizeOnDisk(eventType, data, metadata) > TFConsts.EffectiveMaxLogRecordSize;
 
 		public Event(Guid eventId, string eventType, bool isJson, byte[] data, byte[] metadata)
+			: this(eventId, eventType, isJson, data, isPropertyMetadata: false, metadata)
+		{
+		}
+
+		public Event(Guid eventId, string eventType, bool isJson, byte[] data, bool isPropertyMetadata, byte[] metadata)
 		{
 			if (eventId == Guid.Empty)
 			{
@@ -46,6 +53,7 @@ namespace EventStore.Core.Data
 			EventType = eventType;
 			IsJson = isJson;
 			Data = data ?? Array.Empty<byte>();
+			IsPropertyMetadata = isPropertyMetadata;
 			Metadata = metadata ?? Array.Empty<byte>();
 		}
 	}

--- a/src/EventStore.Core/Data/EventRecord.cs
+++ b/src/EventStore.Core/Data/EventRecord.cs
@@ -27,6 +27,7 @@ namespace EventStore.Core.Data
 		public readonly string EventType;
 		public readonly ReadOnlyMemory<byte> Data;
 		public readonly ReadOnlyMemory<byte> Metadata;
+		public readonly ReadOnlyMemory<byte> Properties;
 
 		public EventRecord(long eventNumber, IPrepareLogRecord prepare, string eventStreamId, string eventType)
 		{
@@ -47,6 +48,9 @@ namespace EventStore.Core.Data
 			EventType = eventType ?? string.Empty;
 			Data = prepare.Data;
 			Metadata = prepare.Metadata;
+			Properties = prepare.Flags.HasAllOf(PrepareFlags.IsPropertyMetadata)
+				? prepare.Metadata
+				: ReadOnlyMemory<byte>.Empty;
 		}
 
 		// called from tests only
@@ -89,6 +93,9 @@ namespace EventStore.Core.Data
 			EventType = eventType ?? string.Empty;
 			Data = data ?? Empty.ByteArray;
 			Metadata = metadata ?? Empty.ByteArray;
+			Properties = flags.HasAllOf(PrepareFlags.IsPropertyMetadata)
+				? Metadata
+				: ReadOnlyMemory<byte>.Empty;
 		}
 
 		public bool Equals(EventRecord other)
@@ -115,7 +122,8 @@ namespace EventStore.Core.Data
 				   && Flags.Equals(other.Flags)
 				   && string.Equals(EventType, other.EventType)
 				   && Data.Span.SequenceEqual(other.Data.Span)
-				   && Metadata.Span.SequenceEqual(other.Metadata.Span);
+				   && Metadata.Span.SequenceEqual(other.Metadata.Span)
+				   && Properties.Span.SequenceEqual(other.Properties.Span);
 		}
 
 		public override bool Equals(object obj)
@@ -155,6 +163,7 @@ namespace EventStore.Core.Data
 				hashCode = (hashCode * 397) ^ EventType.GetHashCode();
 				hashCode = (hashCode * 397) ^ Data.GetHashCode();
 				hashCode = (hashCode * 397) ^ Metadata.GetHashCode();
+				hashCode = (hashCode * 397) ^ Properties.GetHashCode();
 				return hashCode;
 			}
 		}

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -399,6 +399,11 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 						flags |= PrepareFlags.IsJson;
 					}
 
+					if (evnt.IsPropertyMetadata)
+					{
+						flags |= PrepareFlags.IsPropertyMetadata;
+					}
+
 					// when IsCommitted ExpectedVersion is always explicit
 					var expectedVersion = commitCheck.CurrentVersion + i;
 					var prepare = LogRecord.Prepare(_recordFactory, logPosition, msg.CorrelationId, evnt.EventId,
@@ -710,7 +715,8 @@ public class StorageWriterService<TStreamId> : IHandle<SystemMessage.SystemInit>
 						eventType,
 						evnt.Data,
 						evnt.Metadata,
-						evnt.IsJson);
+						evnt.IsJson,
+						evnt.IsPropertyMetadata);
 					var res = await WritePrepareWithRetry(record, token);
 					logPosition = res.NewPos;
 					lastLogPosition = res.WrittenPos;

--- a/src/EventStore.Core/TransactionLog/LogRecords/LogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/LogRecord.cs
@@ -100,11 +100,13 @@ public abstract class LogRecord : ILogRecord
 	public static IPrepareLogRecord<TStreamId> TransactionWrite<TStreamId>(IRecordFactory<TStreamId> factory,
 		long logPosition, Guid correlationId, Guid eventId,
 		long transactionPos, int transactionOffset, TStreamId eventStreamId, TStreamId eventType, byte[] data,
-		byte[] metadata, bool isJson)
+		byte[] metadata, bool isJson, bool isPropertyMetadata = false)
 	{
 		return factory.CreatePrepare(logPosition, correlationId, eventId, transactionPos, transactionOffset,
 			eventStreamId, ExpectedVersion.Any, DateTime.UtcNow,
-			PrepareFlags.Data | (isJson ? PrepareFlags.IsJson : PrepareFlags.None),
+			PrepareFlags.Data |
+			(isJson ? PrepareFlags.IsJson : PrepareFlags.None) |
+			(isPropertyMetadata ? PrepareFlags.IsPropertyMetadata : PrepareFlags.None),
 			eventType, data, metadata);
 	}
 

--- a/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
@@ -26,6 +26,7 @@ public enum PrepareFlags : ushort
 
 	IsJson = 0x100, // indicates data & metadata are valid json
 	IsRedacted = 0x200,
+	IsPropertyMetadata = 0x400,
 
 	// aggregate flag set
 	// unused and easily confused with StreamDelete:  DeleteTombstone = TransactionBegin | TransactionEnd | StreamDelete,


### PR DESCRIPTION
- Property-aware storage needs an explicit marker before indexing and archive work can depend on it.
- Existing custom metadata writes should remain unambiguous while future writers opt into property metadata.