### PR TITLE
fix(storage): preserve custom metadata reads

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/PropertyMetadataTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/PropertyMetadataTests.cs
@@ -61,6 +61,7 @@ public class PropertyMetadataTests
 
 		Assert.Equal(propertyMetadata, record.Metadata.ToArray());
 		Assert.Equal(propertyMetadata, record.Properties.ToArray());
+		Assert.Empty(record.CustomMetadata.ToArray());
 	}
 
 	[Fact]
@@ -85,6 +86,7 @@ public class PropertyMetadataTests
 		var record = new EventRecord(0, prepare, "test-stream", "test-event");
 
 		Assert.Equal(customMetadata, record.Metadata.ToArray());
+		Assert.Equal(customMetadata, record.CustomMetadata.ToArray());
 		Assert.Empty(record.Properties.ToArray());
 	}
 }

--- a/src/EventStore.Core/Data/EventRecord.cs
+++ b/src/EventStore.Core/Data/EventRecord.cs
@@ -28,6 +28,9 @@ namespace EventStore.Core.Data
 		public readonly ReadOnlyMemory<byte> Data;
 		public readonly ReadOnlyMemory<byte> Metadata;
 		public readonly ReadOnlyMemory<byte> Properties;
+		public ReadOnlyMemory<byte> CustomMetadata => Flags.HasAllOf(PrepareFlags.IsPropertyMetadata)
+			? ReadOnlyMemory<byte>.Empty
+			: Metadata;
 
 		public EventRecord(long eventNumber, IPrepareLogRecord prepare, string eventStreamId, string eventType)
 		{

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
@@ -172,7 +172,7 @@ internal partial class PersistentSubscriptions
 						: Constants.Metadata.ContentTypes.ApplicationOctetStream
 				},
 				Data = ByteString.CopyFrom(e.Data.Span),
-				CustomMetadata = ByteString.CopyFrom(e.Metadata.Span)
+				CustomMetadata = ByteString.CopyFrom(e.CustomMetadata.Span)
 			};
 		}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -449,7 +449,7 @@ internal partial class Streams<TStreamId>
 					: Constants.Metadata.ContentTypes.ApplicationOctetStream
 			},
 			Data = ByteString.CopyFrom(e.Data.Span),
-			CustomMetadata = ByteString.CopyFrom(e.Metadata.Span)
+			CustomMetadata = ByteString.CopyFrom(e.CustomMetadata.Span)
 		};
 	}
 


### PR DESCRIPTION
- Existing gRPC stream consumers should not observe property metadata as legacy custom metadata.
- Property-aware storage can evolve without changing older read surfaces by accident.