### PR TITLE
fix(scheduling): isolate timer callback failures

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/TimerService/ThreadBasedSchedulerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/TimerService/ThreadBasedSchedulerTests.cs
@@ -45,6 +45,32 @@ public class ThreadBasedSchedulerTests
 		await scheduler.Task.WaitAsync(TimeSpan.FromSeconds(1));
 	}
 
+	[Fact]
+	public async Task callback_failure_does_not_fault_scheduler_lifetime()
+	{
+		using var scheduler = CreateScheduler();
+		var failedCallbackRan = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var nextCallbackRan = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		scheduler.Schedule(TimeSpan.Zero, static (_, state) =>
+		{
+			((TaskCompletionSource)state).SetResult();
+			throw new InvalidOperationException("boom");
+		}, failedCallbackRan);
+
+		await failedCallbackRan.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+		scheduler.Schedule(TimeSpan.Zero, static (_, state) =>
+		{
+			((TaskCompletionSource)state).SetResult();
+		}, nextCallbackRan);
+
+		await nextCallbackRan.Task.WaitAsync(TimeSpan.FromSeconds(1));
+		scheduler.Stop();
+
+		await scheduler.Task.WaitAsync(TimeSpan.FromSeconds(1));
+	}
+
 	private static async Task AssertEventually(Func<bool> condition)
 	{
 		var deadline = DateTime.UtcNow.AddSeconds(1);

--- a/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
+++ b/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
@@ -157,7 +157,6 @@ namespace EventStore.Core.Services.TimerService
 				catch (Exception ex)
 				{
 					Log.Error(ex, "Error executing scheduled task");
-					_tcs.TrySetException(ex);
 				}
 			}
 


### PR DESCRIPTION
- Timer callback failures should not make the scheduler lifecycle signal look dead while the scheduler keeps running.
- Node shutdown and background-task observation should reflect the scheduler thread lifetime rather than one failed scheduled callback.