### PR TITLE
fix(scheduling): account failed timer callbacks

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/TimerService/ThreadBasedSchedulerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/TimerService/ThreadBasedSchedulerTests.cs
@@ -71,6 +71,28 @@ public class ThreadBasedSchedulerTests
 		await scheduler.Task.WaitAsync(TimeSpan.FromSeconds(1));
 	}
 
+	[Fact]
+	public async Task callback_failure_is_counted_as_processed_work()
+	{
+		using var scheduler = CreateScheduler();
+		var failedCallbackRan = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var nextCallbackRan = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		scheduler.Schedule(TimeSpan.Zero, static (_, state) =>
+		{
+			((TaskCompletionSource)state).SetResult();
+			throw new InvalidOperationException("boom");
+		}, failedCallbackRan);
+		scheduler.Schedule(TimeSpan.Zero, static (_, state) =>
+		{
+			((TaskCompletionSource)state).SetResult();
+		}, nextCallbackRan);
+
+		await Task.WhenAll(failedCallbackRan.Task, nextCallbackRan.Task).WaitAsync(TimeSpan.FromSeconds(1));
+
+		await AssertEventually(() => scheduler.GetStatistics().TotalItemsProcessed >= 4);
+	}
+
 	private static async Task AssertEventually(Func<bool> condition)
 	{
 		var deadline = DateTime.UtcNow.AddSeconds(1);

--- a/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
+++ b/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
@@ -124,10 +124,7 @@ namespace EventStore.Core.Services.TimerService
 
 						processed += 1;
 						var scheduledTask = _tasks.DeleteMin();
-						var now = _tracker.RecordMessageDequeued(enqueuedAt: scheduledTask.DueTime);
-						scheduledTask.Action(this, scheduledTask.State);
-						var label = (scheduledTask.State as TimerMessage.Schedule)?.ReplyMessage.Label;
-						_tracker.RecordMessageProcessed(now, label ?? "");
+						ExecuteScheduledTask(scheduledTask);
 					}
 
 					_queueStats.ProcessingEnded(processed);
@@ -156,7 +153,7 @@ namespace EventStore.Core.Services.TimerService
 				}
 				catch (Exception ex)
 				{
-					Log.Error(ex, "Error executing scheduled task");
+					Log.Error(ex, "Error running timer scheduler");
 				}
 			}
 
@@ -164,6 +161,24 @@ namespace EventStore.Core.Services.TimerService
 			QueueMonitor.Default.Unregister(this);
 			_pendingEvent.Dispose();
 			_tcs.TrySetResult(null);
+		}
+
+		private void ExecuteScheduledTask(ScheduledTask scheduledTask)
+		{
+			var now = _tracker.RecordMessageDequeued(enqueuedAt: scheduledTask.DueTime);
+			var label = (scheduledTask.State as TimerMessage.Schedule)?.ReplyMessage.Label;
+			try
+			{
+				scheduledTask.Action(this, scheduledTask.State);
+			}
+			catch (Exception ex)
+			{
+				Log.Error(ex, "Error executing scheduled task");
+			}
+			finally
+			{
+				_tracker.RecordMessageProcessed(now, label ?? "");
+			}
 		}
 
 		public void Dispose()


### PR DESCRIPTION
- Scheduler metrics should account for work that was dequeued even when the callback fails.
- Later due callbacks should not wait for another scheduler pass because an earlier callback threw.