### PR TITLE
fix(scheduling): report timer scheduler busy state

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/TimerService/ThreadBasedSchedulerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/TimerService/ThreadBasedSchedulerTests.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Bus;
 using EventStore.Core.Metrics;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Time;
 using Xunit;
+using Conf = EventStore.Common.Configuration.MetricsConfiguration;
 
 namespace EventStore.Core.XUnit.Tests.Services.TimerService;
 
@@ -93,6 +95,25 @@ public class ThreadBasedSchedulerTests
 		await AssertEventually(() => scheduler.GetStatistics().TotalItemsProcessed >= 4);
 	}
 
+	[Fact]
+	public async Task busy_tracker_observes_scheduler_work_and_idle()
+	{
+		var tracker = new RecordingTracker();
+		using var scheduler = CreateScheduler(trackers: CreateTrackers(tracker));
+		var callbackRan = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var busyBefore = tracker.BusyCount;
+		var idleBefore = tracker.IdleCount;
+
+		scheduler.Schedule(TimeSpan.Zero, static (_, state) =>
+		{
+			((TaskCompletionSource)state).SetResult();
+		}, callbackRan);
+
+		await callbackRan.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+		await AssertEventually(() => tracker.BusyCount > busyBefore && tracker.IdleCount > idleBefore);
+	}
+
 	private static async Task AssertEventually(Func<bool> condition)
 	{
 		var deadline = DateTime.UtcNow.AddSeconds(1);
@@ -108,13 +129,60 @@ public class ThreadBasedSchedulerTests
 		}
 	}
 
-	private static ThreadBasedScheduler CreateScheduler(IClock clock = null) =>
-		new(new QueueStatsManager(), new QueueTrackers(), clock);
+	private static ThreadBasedScheduler CreateScheduler(IClock clock = null, QueueTrackers trackers = null) =>
+		new(new QueueStatsManager(), trackers ?? new QueueTrackers(), clock);
+
+	private static QueueTrackers CreateTrackers(RecordingTracker tracker) =>
+		new(
+			new[]
+			{
+				new Conf.LabelMappingCase
+				{
+					Regex = "Timer",
+					Label = "Timer"
+				}
+			},
+			_ => tracker,
+			_ => tracker,
+			_ => tracker,
+			_ => tracker);
 
 	private sealed class FrozenClock : IClock
 	{
 		public Instant Now => Instant.FromSeconds(1);
 
 		public long SecondsSinceEpoch => 1;
+	}
+
+	private sealed class RecordingTracker :
+		IQueueBusyTracker,
+		IQueueLengthTracker,
+		IDurationMaxTracker,
+		IQueueProcessingTracker
+	{
+		private int _busyCount;
+		private int _idleCount;
+
+		public int BusyCount => Volatile.Read(ref _busyCount);
+
+		public int IdleCount => Volatile.Read(ref _idleCount);
+
+		public void EnterBusy()
+		{
+			Interlocked.Increment(ref _busyCount);
+		}
+
+		public void EnterIdle()
+		{
+			Interlocked.Increment(ref _idleCount);
+		}
+
+		public Instant RecordNow(Instant start) => start;
+
+		public Instant RecordNow(Instant start, string messageType) => start;
+
+		public void SetQueueLength(int length)
+		{
+		}
 	}
 }

--- a/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
+++ b/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
@@ -90,6 +90,7 @@ namespace EventStore.Core.Services.TimerService
 				try
 				{
 					_queueStats.EnterBusy();
+					_tracker.EnterBusy();
 					_queueStats.ProcessingStarted<SchedulePendingTasks>(_pending.Count);
 
 					_pendingEvent.Reset();
@@ -133,6 +134,7 @@ namespace EventStore.Core.Services.TimerService
 					if (processed == 0 && !_pendingEvent.IsSet)
 					{
 						_queueStats.EnterIdle();
+						_tracker.EnterIdle();
 
 						// give some processor time to other threads since we're free right now
 						Thread.Yield();
@@ -157,6 +159,7 @@ namespace EventStore.Core.Services.TimerService
 				}
 			}
 
+			_tracker.EnterIdle();
 			_queueStats.Stop();
 			QueueMonitor.Default.Unregister(this);
 			_pendingEvent.Dispose();


### PR DESCRIPTION
- Timer scheduler metrics should expose busy and idle transitions the same way other queue handlers do.
- Operators need the timer queue to participate in queue busy telemetry, not only queue length and processing duration.