### PR TITLE
fix(storage): preserve reader queue pressure under throttling

### DIFF
--- a/src/EventStore.Core.Tests/Services/Storage/when_cancelling_storage_reader_worker.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/when_cancelling_storage_reader_worker.cs
@@ -22,37 +22,6 @@ namespace EventStore.Core.Tests.Services.Storage;
 public class when_cancelling_storage_reader_worker
 {
 	[Test]
-	public async Task read_event_waits_for_slot_when_concurrency_limit_is_reached()
-	{
-		using var readIndex = new BlockingReadIndex();
-		var worker = CreateWorker(readIndex, maxConcurrentReadRequests: 1);
-		var first = CreateReadEventMessage();
-		var second = CreateReadEventMessage();
-
-		var firstTask = ((IAsyncHandle<ClientMessage.ReadEvent>)worker)
-			.HandleAsync(first, CancellationToken.None)
-			.AsTask();
-
-		Assert.That(readIndex.ReadEventStarted.Wait(TimeSpan.FromSeconds(5)), Is.True);
-		Assert.That(readIndex.ReadEventStartedCount, Is.EqualTo(1));
-
-		var secondTask = ((IAsyncHandle<ClientMessage.ReadEvent>)worker)
-			.HandleAsync(second, CancellationToken.None)
-			.AsTask();
-
-		Assert.That(
-			SpinWait.SpinUntil(() => readIndex.ReadEventStartedCount == 2, TimeSpan.FromMilliseconds(200)),
-			Is.False);
-
-		readIndex.ReleaseReadEvents();
-
-		await firstTask.WaitAsync(TimeSpan.FromSeconds(5));
-		await secondTask.WaitAsync(TimeSpan.FromSeconds(5));
-
-		Assert.That(readIndex.ReadEventStartedCount, Is.EqualTo(2));
-	}
-
-	[Test]
 	public void read_event_cancellation_from_message_token_is_rethrown_without_reply()
 	{
 		using var readIndex = new BlockingReadIndex();
@@ -226,15 +195,14 @@ public class when_cancelling_storage_reader_worker
 			requireLeader: false,
 			user: new ClaimsPrincipal());
 
-	private static StorageReaderWorker<string> CreateWorker(BlockingReadIndex readIndex, int maxConcurrentReadRequests = 0) =>
+	private static StorageReaderWorker<string> CreateWorker(BlockingReadIndex readIndex) =>
 		new(
 			new NoopPublisher(),
 			readIndex,
 			new StubSystemStreamLookup(),
 			new StubCheckpoint(),
 			new StubVirtualStreamReader(),
-			queueId: 0,
-			StorageReaderConcurrencyLimiter.Create(maxConcurrentReadRequests));
+			queueId: 0);
 
 	private sealed class BlockingReadIndex : IReadIndex<string>, IDisposable
 	{

--- a/src/EventStore.Core.XUnit.Tests/Bus/QueuedHandlerThreadPoolTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Bus/QueuedHandlerThreadPoolTests.cs
@@ -42,6 +42,105 @@ public class QueuedHandlerThreadPoolTests
 		}
 	}
 
+	[Fact]
+	public async Task keeps_message_queued_until_processing_limiter_allows_it()
+	{
+		var limiter = new ControlledProcessingLimiter();
+		var consumer = new RecordingConsumer(1, TimeSpan.Zero);
+		var queue = CreateQueue(consumer, limiter);
+
+		_ = queue.Start();
+		try
+		{
+			queue.Publish(new TestMessage());
+
+			await limiter.WaitForAcquireAttempt(TimeSpan.FromSeconds(5));
+
+			Assert.Equal(1, queue.MessageCount);
+			Assert.Equal(0, consumer.HandledCount);
+
+			limiter.ReleaseOne();
+
+			await consumer.WaitUntilComplete(TimeSpan.FromSeconds(5));
+
+			Assert.Equal(0, queue.MessageCount);
+			Assert.Equal(1, consumer.HandledCount);
+		}
+		finally
+		{
+			await queue.Stop();
+		}
+	}
+
+	[Fact]
+	public async Task cancelled_message_does_not_block_later_message_while_waiting_for_limiter()
+	{
+		var limiter = new ControlledProcessingLimiter();
+		var consumer = new RecordingConsumer(1, TimeSpan.Zero);
+		var queue = CreateQueue(consumer, limiter);
+		using var cancellationSource = new CancellationTokenSource();
+
+		_ = queue.Start();
+		try
+		{
+			queue.Publish(new CancelledMessage(cancellationSource.Token));
+			await limiter.WaitForAcquireAttempt(TimeSpan.FromSeconds(5));
+
+			cancellationSource.Cancel();
+			Assert.True(SpinWait.SpinUntil(() => queue.MessageCount == 0, TimeSpan.FromSeconds(5)));
+
+			queue.Publish(new TestMessage());
+			Assert.True(SpinWait.SpinUntil(() => limiter.AcquireAttempts >= 2, TimeSpan.FromSeconds(5)));
+
+			Assert.Equal(1, queue.MessageCount);
+
+			limiter.ReleaseOne();
+			await consumer.WaitUntilComplete(TimeSpan.FromSeconds(5));
+
+			Assert.Equal(0, queue.MessageCount);
+			Assert.Equal(1, consumer.HandledCount);
+		}
+		finally
+		{
+			await queue.Stop();
+		}
+	}
+
+	[Fact]
+	public async Task messages_excluded_by_limiter_are_processed_without_waiting()
+	{
+		var limiter = new ControlledProcessingLimiter(message => message is not UnthrottledMessage);
+		var consumer = new RecordingConsumer(1, TimeSpan.Zero);
+		var queue = CreateQueue(consumer, limiter);
+
+		_ = queue.Start();
+		try
+		{
+			queue.Publish(new UnthrottledMessage());
+
+			await consumer.WaitUntilComplete(TimeSpan.FromSeconds(5));
+
+			Assert.Equal(0, limiter.AcquireAttempts);
+			Assert.Equal(0, queue.MessageCount);
+		}
+		finally
+		{
+			await queue.Stop();
+		}
+	}
+
+	private static QueuedHandlerThreadPool CreateQueue(
+		IAsyncHandle<Message> consumer,
+		IQueueProcessingLimiter processingLimiter) =>
+		new(
+			consumer,
+			"limited-queue-test",
+			new QueueStatsManager(),
+			new QueueTrackers(),
+			watchSlowMsg: false,
+			threadStopWaitTimeout: TimeSpan.FromSeconds(5),
+			processingLimiter: processingLimiter);
+
 	private sealed class RecordingConsumer(int expectedCount, TimeSpan delay) : IAsyncHandle<Message>
 	{
 		private readonly TaskCompletionSource _complete =
@@ -57,6 +156,11 @@ public class QueuedHandlerThreadPoolTests
 
 		public async ValueTask HandleAsync(Message message, CancellationToken token)
 		{
+			if (message is CancelledMessage { CancellationToken.IsCancellationRequested: true })
+			{
+				return;
+			}
+
 			var current = Interlocked.Increment(ref _inFlight);
 			RecordMaxConcurrency(current);
 			try
@@ -96,4 +200,47 @@ public class QueuedHandlerThreadPoolTests
 	}
 
 	private sealed class TestMessage : Message;
+
+	private sealed class CancelledMessage(CancellationToken cancellationToken) : Message(cancellationToken);
+
+	private sealed class UnthrottledMessage : Message;
+
+	private sealed class ControlledProcessingLimiter : IQueueProcessingLimiter
+	{
+		private readonly SemaphoreSlim _semaphore = new(0);
+		private readonly TaskCompletionSource _acquireAttempted =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+		private readonly Func<Message, bool> _shouldLimit;
+		private int _acquireAttempts;
+
+		public ControlledProcessingLimiter(Func<Message, bool> shouldLimit = null)
+		{
+			_shouldLimit = shouldLimit ?? (_ => true);
+		}
+
+		public int AcquireAttempts => Volatile.Read(ref _acquireAttempts);
+
+		public bool ShouldLimit(Message message) =>
+			_shouldLimit(message);
+
+		public async ValueTask<IDisposable> Acquire(CancellationToken token)
+		{
+			Interlocked.Increment(ref _acquireAttempts);
+			_acquireAttempted.TrySetResult();
+			await _semaphore.WaitAsync(token);
+			return new Lease(_semaphore);
+		}
+
+		public Task WaitForAcquireAttempt(TimeSpan timeout) =>
+			_acquireAttempted.Task.WaitAsync(timeout);
+
+		public void ReleaseOne() =>
+			_semaphore.Release();
+
+		private sealed class Lease(SemaphoreSlim semaphore) : IDisposable
+		{
+			public void Dispose() =>
+				semaphore.Release();
+		}
+	}
 }

--- a/src/EventStore.Core/Bus/IQueueProcessingLimiter.cs
+++ b/src/EventStore.Core/Bus/IQueueProcessingLimiter.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Messaging;
+
+namespace EventStore.Core.Bus;
+
+public interface IQueueProcessingLimiter
+{
+	bool ShouldLimit(Message message);
+
+	ValueTask<IDisposable> Acquire(CancellationToken token);
+}

--- a/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
@@ -46,6 +46,7 @@ public class QueuedHandlerThreadPool : IQueuedHandler, IMonitoredQueue, IThreadP
 	private readonly QueueMonitor _queueMonitor;
 	private readonly QueueStatsCollector _queueStats;
 	private readonly QueueTracker _tracker;
+	private readonly IQueueProcessingLimiter _processingLimiter;
 
 	private int _isRunning;
 	private int _queueStatsState; //0 - never started, 1 - started, 2 - stopped
@@ -59,7 +60,8 @@ public class QueuedHandlerThreadPool : IQueuedHandler, IMonitoredQueue, IThreadP
 		bool watchSlowMsg = true,
 		TimeSpan? slowMsgThreshold = null,
 		TimeSpan? threadStopWaitTimeout = null,
-		string groupName = null)
+		string groupName = null,
+		IQueueProcessingLimiter processingLimiter = null)
 	{
 		Ensure.NotNull(consumer, "consumer");
 		Ensure.NotNull(name, "name");
@@ -77,6 +79,7 @@ public class QueuedHandlerThreadPool : IQueuedHandler, IMonitoredQueue, IThreadP
 		_queueMonitor = QueueMonitor.Default;
 		_queueStats = queueStatsManager.CreateQueueStatsCollector(name, groupName);
 		_tracker = trackers.GetTrackerForQueue(name);
+		_processingLimiter = processingLimiter;
 	}
 
 	public Task Start()
@@ -154,8 +157,14 @@ public class QueuedHandlerThreadPool : IQueuedHandler, IMonitoredQueue, IThreadP
 				_queueStats.EnterBusy();
 				_tracker.EnterBusy();
 
-				while (!_lifetimeToken.IsCancellationRequested && _queue.TryDequeue(out var item))
+				while (!_lifetimeToken.IsCancellationRequested && _queue.TryPeek(out var item))
 				{
+					using var processingLease = await AcquireProcessingLease(item.Message);
+					if (!_queue.TryDequeue(out item))
+					{
+						continue;
+					}
+
 					_tracker.RecordQueueLength(_queue.Count);
 					var start = _tracker.RecordMessageDequeued(item.EnqueuedAt);
 					var msg = item.Message;
@@ -245,6 +254,44 @@ public class QueuedHandlerThreadPool : IQueuedHandler, IMonitoredQueue, IThreadP
 		}
 	}
 
+	private async ValueTask<IDisposable> AcquireProcessingLease(Message message)
+	{
+		if (_processingLimiter is null || !_processingLimiter.ShouldLimit(message))
+		{
+			return NoopProcessingLease.Instance;
+		}
+
+		using var source = CreateProcessingWaitCancellationSource(message);
+		try
+		{
+			return await _processingLimiter.Acquire(source?.Token ?? _lifetimeToken);
+		}
+		catch (OperationCanceledException ex) when (_lifetimeToken.IsCancellationRequested)
+		{
+			throw new OperationCanceledException(null, ex, _lifetimeToken);
+		}
+		catch (OperationCanceledException)
+		{
+			return NoopProcessingLease.Instance;
+		}
+	}
+
+	private CancellationTokenSource CreateProcessingWaitCancellationSource(Message message)
+	{
+		if (message is ClientMessage.ReadRequestMessage { CanExpire: true } readRequest)
+		{
+			var source = message.CancellationToken.CanBeCanceled
+				? CancellationTokenSource.CreateLinkedTokenSource(_lifetimeToken, message.CancellationToken)
+				: CancellationTokenSource.CreateLinkedTokenSource(_lifetimeToken);
+			source.CancelAfter(readRequest.Lifetime);
+			return source;
+		}
+
+		return message.CancellationToken.CanBeCanceled
+			? CancellationTokenSource.CreateLinkedTokenSource(_lifetimeToken, message.CancellationToken)
+			: null;
+	}
+
 	private static bool IsExpectedCancellation(
 		OperationCanceledException exception,
 		Message message,
@@ -270,5 +317,18 @@ public class QueuedHandlerThreadPool : IQueuedHandler, IMonitoredQueue, IThreadP
 	public QueueStats GetStatistics()
 	{
 		return _queueStats.GetStatistics(_queue.Count);
+	}
+
+	private sealed class NoopProcessingLease : IDisposable
+	{
+		public static readonly NoopProcessingLease Instance = new();
+
+		private NoopProcessingLease()
+		{
+		}
+
+		public void Dispose()
+		{
+		}
 	}
 }

--- a/src/EventStore.Core/Services/Storage/StorageReaderConcurrencyLimiter.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderConcurrencyLimiter.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
 
 #nullable enable
 
 namespace EventStore.Core.Services.Storage;
 
-public sealed class StorageReaderConcurrencyLimiter
+public sealed class StorageReaderConcurrencyLimiter : IQueueProcessingLimiter
 {
 	private readonly SemaphoreSlim? _semaphore;
 
@@ -19,6 +22,9 @@ public sealed class StorageReaderConcurrencyLimiter
 	}
 
 	public int MaxConcurrentReadRequests { get; }
+
+	public bool ShouldLimit(Message message) =>
+		message is ClientMessage.ReadRequestMessage;
 
 	public static StorageReaderConcurrencyLimiter Create(int maxConcurrentReadRequests)
 	{
@@ -47,6 +53,9 @@ public sealed class StorageReaderConcurrencyLimiter
 		await semaphore.WaitAsync(token);
 		return new Lease(semaphore);
 	}
+
+	async ValueTask<IDisposable> IQueueProcessingLimiter.Acquire(CancellationToken token) =>
+		await Acquire(token);
 
 	public readonly struct Lease : IDisposable
 	{

--- a/src/EventStore.Core/Services/Storage/StorageReaderService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderService.cs
@@ -66,7 +66,7 @@ namespace EventStore.Core.Services.Storage
 			for (var i = 0; i < threadCount; i++)
 			{
 				readerWorkers[i] = new StorageReaderWorker<TStreamId>(bus, readIndex, systemStreams, writerCheckpoint,
-					virtualStreamReader, i, concurrencyLimiter);
+					virtualStreamReader, i);
 				storageReaderBuses[i] = new InMemoryBus("StorageReaderBus",
 					slowMsgThreshold: storageReaderBusSlowMessageThreshold);
 				storageReaderBuses[i].Subscribe<ClientMessage.ReadEvent>(readerWorkers[i]);
@@ -89,7 +89,8 @@ namespace EventStore.Core.Services.Storage
 					trackers,
 					groupName: "StorageReaderQueue",
 					watchSlowMsg: storageReaderQueueSlowMessageThreshold > TimeSpan.Zero,
-					slowMsgThreshold: storageReaderQueueSlowMessageThreshold));
+					slowMsgThreshold: storageReaderQueueSlowMessageThreshold,
+					processingLimiter: concurrencyLimiter));
 			_workersMultiHandler.Start();
 
 			subscriber.Subscribe<ClientMessage.ReadEvent>(_workersMultiHandler);

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.ReadAllStreams.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.ReadAllStreams.cs
@@ -55,7 +55,6 @@ public partial class StorageReaderWorker<TStreamId>
 		using var cts = Multiplex(ref token, msg);
 		try
 		{
-			using var readSlot = await AcquireReadSlot(token);
 			var res = await ReadAllEventsForward(msg, token);
 			switch (res.Result)
 			{
@@ -151,7 +150,6 @@ public partial class StorageReaderWorker<TStreamId>
 		using var cts = Multiplex(ref token, msg);
 		try
 		{
-			using var readSlot = await AcquireReadSlot(token);
 			msg.Envelope.ReplyWith(await ReadAllEventsBackward(msg, token));
 		}
 		catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token && cts.IsTimedOut)

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.ReadEvent.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.ReadEvent.cs
@@ -46,7 +46,6 @@ public partial class StorageReaderWorker<TStreamId>
 		using var cts = Multiplex(ref token, msg);
 		try
 		{
-			using var readSlot = await AcquireReadSlot(token);
 			var ev = await ReadEvent(msg, token);
 			msg.Envelope.ReplyWith(ev);
 		}

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.ReadFilteredAllStreams.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.ReadFilteredAllStreams.cs
@@ -51,7 +51,6 @@ public partial class StorageReaderWorker<TStreamId>
 		using var cts = Multiplex(ref token, msg);
 		try
 		{
-			using var readSlot = await AcquireReadSlot(token);
 			var res = await FilteredReadAllEventsForward(msg, token);
 			switch (res.Result)
 			{
@@ -140,7 +139,6 @@ public partial class StorageReaderWorker<TStreamId>
 		using var cts = Multiplex(ref token, msg);
 		try
 		{
-			using var readSlot = await AcquireReadSlot(token);
 			var res = await FilteredReadAllEventsBackward(msg, token);
 			switch (res.Result)
 			{

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.ReadStream.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.ReadStream.cs
@@ -55,7 +55,6 @@ public partial class StorageReaderWorker<TStreamId>
 		using var cts = Multiplex(ref token, msg);
 		try
 		{
-			using var readSlot = await AcquireReadSlot(token);
 			res = _virtualStreamReader.CanReadStream(msg.EventStreamId)
 				? await _virtualStreamReader.ReadForwards(msg, token)
 				: await ReadStreamEventsForward(msg, token);
@@ -143,7 +142,6 @@ public partial class StorageReaderWorker<TStreamId>
 		using var cts = Multiplex(ref token, msg);
 		try
 		{
-			using var readSlot = await AcquireReadSlot(token);
 			var res = _virtualStreamReader.CanReadStream(msg.EventStreamId)
 				? await _virtualStreamReader.ReadBackwards(msg, token)
 				: await ReadStreamEventsBackward(msg, token);

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
@@ -47,7 +47,6 @@ public partial class StorageReaderWorker<TStreamId> :
 	private readonly IReadOnlyCheckpoint _writerCheckpoint;
 	private readonly IVirtualStreamReader _virtualStreamReader;
 	private readonly int _queueId;
-	private readonly StorageReaderConcurrencyLimiter _concurrencyLimiter;
 	private readonly CancellationTokenMultiplexer _tokenMultiplexer = new();
 	private static readonly char[] LinkToSeparator = { '@' };
 	private const int MaxPageSize = 4096;
@@ -61,14 +60,12 @@ public partial class StorageReaderWorker<TStreamId> :
 		ISystemStreamLookup<TStreamId> systemStreams,
 		IReadOnlyCheckpoint writerCheckpoint,
 		IVirtualStreamReader virtualStreamReader,
-		int queueId,
-		StorageReaderConcurrencyLimiter concurrencyLimiter)
+		int queueId)
 	{
 		Ensure.NotNull(publisher, "publisher");
 		Ensure.NotNull(readIndex, "readIndex");
 		Ensure.NotNull(systemStreams, nameof(systemStreams));
 		Ensure.NotNull(writerCheckpoint, "writerCheckpoint");
-		Ensure.NotNull(concurrencyLimiter, nameof(concurrencyLimiter));
 
 		_publisher = publisher;
 		_readIndex = readIndex;
@@ -76,7 +73,6 @@ public partial class StorageReaderWorker<TStreamId> :
 		_writerCheckpoint = writerCheckpoint;
 		_queueId = queueId;
 		_virtualStreamReader = virtualStreamReader;
-		_concurrencyLimiter = concurrencyLimiter;
 	}
 
 
@@ -310,7 +306,4 @@ public partial class StorageReaderWorker<TStreamId> :
 		token = scope.Token;
 		return scope;
 	}
-
-	private ValueTask<StorageReaderConcurrencyLimiter.Lease> AcquireReadSlot(CancellationToken token) =>
-		_concurrencyLimiter.Acquire(token);
 }


### PR DESCRIPTION
- Reader throttling should preserve visible backlog instead of hiding waiting reads inside worker execution.
- Cancelled or expired reads should not pin throttled reader queues ahead of later work.