### PR TITLE
feat(storage): defer archived chunk initialization

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkManagerArchiveSwitchTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkManagerArchiveSwitchTests.cs
@@ -207,6 +207,25 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 	}
 
 	[Fact]
+	public async Task try_get_chunk_for_propagates_archive_initialization_failures()
+	{
+		await AddLocalChunk(0, 0);
+		await StoreArchivedChunk(1);
+		await AddLocalChunk(2, 2);
+		await _sut.SwitchInCompletedChunks([
+			_locatorCodec.EncodeRemote(1),
+		], CancellationToken.None);
+		_archiveStorage.GetChunkLengthException = new IOException("archive chunk is unavailable");
+
+		var ex = Assert.Throws<IOException>(() =>
+		{
+			_sut.TryGetChunkFor(ChunkSize, out _);
+		});
+
+		Assert.Equal("archive chunk is unavailable", ex.Message);
+	}
+
+	[Fact]
 	public async Task rejects_misaligned_archive_ranges_without_mutating_chunks()
 	{
 		var chunk0 = await AddLocalChunk(0, 0);
@@ -358,6 +377,8 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 
 		public int GetChunkRangeCalls { get; private set; }
 
+		public Exception GetChunkLengthException { get; set; }
+
 		public IArchiveChunkNamer ChunkNamer => inner.ChunkNamer;
 
 		public void ResetCounts()
@@ -373,6 +394,11 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 		public ValueTask<long> GetChunkLength(string chunkFile, CancellationToken ct)
 		{
 			GetChunkLengthCalls++;
+			if (GetChunkLengthException is not null)
+			{
+				throw GetChunkLengthException;
+			}
+
 			return inner.GetChunkLength(chunkFile, ct);
 		}
 

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkManagerArchiveSwitchTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkManagerArchiveSwitchTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Services.Archive;
@@ -45,6 +46,11 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 		_archiveChunkNamer = new ArchiveChunkNamer(new VersionedPatternFileNamingStrategy(_archivePath, "chunk-"));
 		_archiveStorage = new(new LocalArchiveStorage(_archivePath, _archiveChunkNamer, ArchiveCheckpointFile));
 
+		_sut = CreateManager(maxChunksCacheSize: 0);
+	}
+
+	private TFChunkManager CreateManager(long maxChunksCacheSize)
+	{
 		var config = new TFChunkDbConfig(
 			path: _dbPath,
 			chunkFileSystem: new FileSystemWithArchive(
@@ -53,7 +59,7 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 				_localFileSystem,
 				_archiveStorage),
 			chunkSize: ChunkSize,
-			maxChunksCacheSize: 0,
+			maxChunksCacheSize: maxChunksCacheSize,
 			writerCheckpoint: new InMemoryCheckpoint(0),
 			chaserCheckpoint: new InMemoryCheckpoint(0),
 			epochCheckpoint: new InMemoryCheckpoint(-1),
@@ -63,7 +69,7 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 			indexCheckpoint: new InMemoryCheckpoint(-1),
 			streamExistenceFilterCheckpoint: new InMemoryCheckpoint(-1));
 
-		_sut = new TFChunkManager(config, new TFChunkTracker.NoOp(), DbTransformManager.Default);
+		return new TFChunkManager(config, new TFChunkTracker.NoOp(), DbTransformManager.Default);
 	}
 
 	public Task InitializeAsync() =>
@@ -153,6 +159,33 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 	}
 
 	[Fact]
+	public async Task reserves_cache_budget_for_uninitialized_archive_chunks()
+	{
+		var manager = CreateManager(maxChunksCacheSize: ChunkSize - 1);
+		try
+		{
+			var olderChunk = await AddLocalChunk(manager, 0, 0);
+			await AddLocalChunk(manager, 1, 1);
+			var latestChunk = await AddLocalChunk(manager, 2, 2);
+			await StoreArchivedChunk(1);
+
+			var switched = await manager.SwitchInCompletedChunks([
+				_locatorCodec.EncodeRemote(1),
+			], CancellationToken.None);
+
+			await RunCachePass(manager);
+
+			Assert.True(switched);
+			Assert.False(olderChunk.IsCached);
+			Assert.True(latestChunk.IsCached);
+		}
+		finally
+		{
+			await manager.TryClose(CancellationToken.None);
+		}
+	}
+
+	[Fact]
 	public async Task initializes_archived_chunk_on_first_access()
 	{
 		await AddLocalChunk(0, 0);
@@ -236,7 +269,19 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 			.Select(chunkNum => _sut.GetChunkInfo(chunkNum).ChunkLocator)
 			.ToArray();
 
-	private async ValueTask<TFChunk> AddLocalChunk(int start, int end)
+	private static async ValueTask RunCachePass(TFChunkManager manager)
+	{
+		var cachePass = typeof(TFChunkManager).GetMethod(
+			"CacheUncacheReadOnlyChunks",
+			BindingFlags.Instance | BindingFlags.NonPublic);
+
+		await (ValueTask)cachePass!.Invoke(manager, [CancellationToken.None])!;
+	}
+
+	private ValueTask<TFChunk> AddLocalChunk(int start, int end) =>
+		AddLocalChunk(_sut, start, end);
+
+	private async ValueTask<TFChunk> AddLocalChunk(TFChunkManager manager, int start, int end)
 	{
 		var fileName = _localFileSystem.NamingStrategy.GetFilenameFor(start, 0);
 		var chunk = await TFChunk.CreateNew(
@@ -254,7 +299,7 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 			transformFactory: new IdentityChunkTransformFactory(),
 			token: CancellationToken.None);
 		await chunk.CompleteScavenge([], CancellationToken.None);
-		await _sut.AddChunk(chunk, CancellationToken.None);
+		await manager.AddChunk(chunk, CancellationToken.None);
 		return chunk;
 	}
 

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkManagerArchiveSwitchTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkManagerArchiveSwitchTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -28,7 +29,7 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 	private readonly string _archivePath;
 	private readonly ChunkLocalFileSystem _localFileSystem;
 	private readonly ILocatorCodec _locatorCodec = new PrefixingLocatorCodec();
-	private readonly IArchiveStorageWriter _archiveWriter;
+	private readonly CountingArchiveStorage _archiveStorage;
 	private readonly ArchiveChunkNamer _archiveChunkNamer;
 	private readonly TFChunkManager _sut;
 
@@ -42,8 +43,7 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 		var dbNamingStrategy = new VersionedPatternFileNamingStrategy(_dbPath, "chunk-");
 		_localFileSystem = new ChunkLocalFileSystem(dbNamingStrategy);
 		_archiveChunkNamer = new ArchiveChunkNamer(new VersionedPatternFileNamingStrategy(_archivePath, "chunk-"));
-		var archiveStorage = new LocalArchiveStorage(_archivePath, _archiveChunkNamer, ArchiveCheckpointFile);
-		_archiveWriter = archiveStorage;
+		_archiveStorage = new(new LocalArchiveStorage(_archivePath, _archiveChunkNamer, ArchiveCheckpointFile));
 
 		var config = new TFChunkDbConfig(
 			path: _dbPath,
@@ -51,7 +51,7 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 				ChunkSize,
 				_locatorCodec,
 				_localFileSystem,
-				archiveStorage),
+				_archiveStorage),
 			chunkSize: ChunkSize,
 			maxChunksCacheSize: 0,
 			writerCheckpoint: new InMemoryCheckpoint(0),
@@ -101,6 +101,51 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 			chunk45.ChunkLocator,
 			chunk45.ChunkLocator,
 		}, ActualChunks);
+	}
+
+	[Fact]
+	public async Task does_not_read_archive_objects_when_switching_in_archived_chunks()
+	{
+		var chunk0 = await AddLocalChunk(0, 0);
+		var chunk2 = await AddLocalChunk(2, 2);
+		await StoreArchivedChunk(1);
+		_archiveStorage.ResetCounts();
+
+		var switched = await _sut.SwitchInCompletedChunks([
+			_locatorCodec.EncodeRemote(1),
+		], CancellationToken.None);
+
+		Assert.True(switched);
+		Assert.Equal(0, _archiveStorage.GetChunkLengthCalls);
+		Assert.Equal(0, _archiveStorage.GetChunkCalls);
+		Assert.Equal(0, _archiveStorage.GetChunkRangeCalls);
+		Assert.Equal(new[]
+		{
+			chunk0.ChunkLocator,
+			_locatorCodec.EncodeRemote(1),
+			chunk2.ChunkLocator,
+		}, ActualChunkInfoLocators);
+	}
+
+	[Fact]
+	public async Task initializes_archived_chunk_on_first_access()
+	{
+		await AddLocalChunk(0, 0);
+		await StoreArchivedChunk(1);
+		await AddLocalChunk(2, 2);
+		_archiveStorage.ResetCounts();
+		await _sut.SwitchInCompletedChunks([
+			_locatorCodec.EncodeRemote(1),
+		], CancellationToken.None);
+		_archiveStorage.ResetCounts();
+
+		var chunk = _sut.GetChunk(1);
+
+		Assert.True(chunk.IsRemote);
+		Assert.Equal(1, chunk.ChunkHeader.ChunkStartNumber);
+		Assert.Equal(1, chunk.ChunkHeader.ChunkEndNumber);
+		Assert.True(_archiveStorage.GetChunkLengthCalls > 0);
+		Assert.True(_archiveStorage.GetChunkRangeCalls > 0);
 	}
 
 	[Fact]
@@ -159,6 +204,11 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 	private string[] ActualChunks =>
 		Enumerable.Range(0, _sut.ChunksCount)
 			.Select(chunkNum => _sut.GetChunk(chunkNum).ChunkLocator)
+			.ToArray();
+
+	private string[] ActualChunkInfoLocators =>
+		Enumerable.Range(0, _sut.ChunksCount)
+			.Select(chunkNum => _sut.GetChunkInfo(chunkNum).ChunkLocator)
 			.ToArray();
 
 	private async ValueTask<TFChunk> AddLocalChunk(int start, int end)
@@ -221,9 +271,57 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 		await sourceChunk.CompleteScavenge([], CancellationToken.None);
 		sourceChunk.Dispose();
 
-		await _archiveWriter.StoreChunk(
+		await _archiveStorage.StoreChunk(
 			sourcePath,
 			_archiveChunkNamer.GetFileNameFor(chunkNumber),
 			CancellationToken.None);
+	}
+
+	private sealed class CountingArchiveStorage(LocalArchiveStorage inner) : IArchiveStorageReader, IArchiveStorageWriter
+	{
+		public int GetChunkLengthCalls { get; private set; }
+
+		public int GetChunkCalls { get; private set; }
+
+		public int GetChunkRangeCalls { get; private set; }
+
+		public IArchiveChunkNamer ChunkNamer => inner.ChunkNamer;
+
+		public void ResetCounts()
+		{
+			GetChunkLengthCalls = 0;
+			GetChunkCalls = 0;
+			GetChunkRangeCalls = 0;
+		}
+
+		public ValueTask<long> GetCheckpoint(CancellationToken ct) =>
+			inner.GetCheckpoint(ct);
+
+		public ValueTask<long> GetChunkLength(string chunkFile, CancellationToken ct)
+		{
+			GetChunkLengthCalls++;
+			return inner.GetChunkLength(chunkFile, ct);
+		}
+
+		public ValueTask<Stream> GetChunk(string chunkFile, CancellationToken ct)
+		{
+			GetChunkCalls++;
+			return inner.GetChunk(chunkFile, ct);
+		}
+
+		public ValueTask<Stream> GetChunk(string chunkFile, long start, long end, CancellationToken ct)
+		{
+			GetChunkRangeCalls++;
+			return inner.GetChunk(chunkFile, start, end, ct);
+		}
+
+		public IAsyncEnumerable<string> ListChunks(CancellationToken ct) =>
+			inner.ListChunks(ct);
+
+		public ValueTask<bool> StoreChunk(string chunkPath, string destinationFile, CancellationToken ct) =>
+			inner.StoreChunk(chunkPath, destinationFile, ct);
+
+		public ValueTask<bool> SetCheckpoint(long checkpoint, CancellationToken ct) =>
+			inner.SetCheckpoint(checkpoint, ct);
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkManagerArchiveSwitchTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkManagerArchiveSwitchTests.cs
@@ -104,7 +104,7 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 	}
 
 	[Fact]
-	public async Task does_not_read_archive_objects_when_switching_in_archived_chunks()
+	public async Task reads_only_archive_header_when_switching_in_archived_chunks()
 	{
 		var chunk0 = await AddLocalChunk(0, 0);
 		var chunk2 = await AddLocalChunk(2, 2);
@@ -118,13 +118,38 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 		Assert.True(switched);
 		Assert.Equal(0, _archiveStorage.GetChunkLengthCalls);
 		Assert.Equal(0, _archiveStorage.GetChunkCalls);
-		Assert.Equal(0, _archiveStorage.GetChunkRangeCalls);
+		Assert.Equal(1, _archiveStorage.GetChunkRangeCalls);
 		Assert.Equal(new[]
 		{
 			chunk0.ChunkLocator,
 			_locatorCodec.EncodeRemote(1),
 			chunk2.ChunkLocator,
 		}, ActualChunkInfoLocators);
+	}
+
+	[Fact]
+	public async Task uses_archived_header_range_when_switching_in_archived_chunks()
+	{
+		var chunk0 = await AddLocalChunk(0, 0);
+		var chunk4 = await AddLocalChunk(4, 4);
+		await AddLocalChunk(1, 3);
+		await StoreArchivedChunk(1, 3, destinationChunkNumber: 1);
+
+		var switched = await _sut.SwitchInCompletedChunks([
+			_locatorCodec.EncodeRemote(1),
+		], CancellationToken.None);
+
+		Assert.True(switched);
+		Assert.Equal(new[]
+		{
+			chunk0.ChunkLocator,
+			_locatorCodec.EncodeRemote(1),
+			_locatorCodec.EncodeRemote(1),
+			_locatorCodec.EncodeRemote(1),
+			chunk4.ChunkLocator,
+		}, ActualChunkInfoLocators);
+		Assert.Equal(1, _sut.GetChunkInfo(1).ChunkStartNumber);
+		Assert.Equal(3, _sut.GetChunkInfo(1).ChunkEndNumber);
 	}
 
 	[Fact]
@@ -218,10 +243,10 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 			fileSystem: _localFileSystem,
 			filename: fileName,
 			chunkDataSize: ChunkSize,
-				chunkStartNumber: start,
-				chunkEndNumber: end,
-				isScavenged: true,
-				unbuffered: false,
+			chunkStartNumber: start,
+			chunkEndNumber: end,
+			isScavenged: true,
+			unbuffered: false,
 			writethrough: false,
 			reduceFileCachePressure: false,
 			asyncIO: false,
@@ -251,17 +276,20 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 		return chunk;
 	}
 
-	private async ValueTask StoreArchivedChunk(int chunkNumber)
+	private ValueTask StoreArchivedChunk(int chunkNumber) =>
+		StoreArchivedChunk(chunkNumber, chunkNumber, destinationChunkNumber: chunkNumber);
+
+	private async ValueTask StoreArchivedChunk(int chunkStartNumber, int chunkEndNumber, int destinationChunkNumber)
 	{
-		var sourcePath = Path.Combine(_dbPath, $"archive-source-{chunkNumber}.tmp");
+		var sourcePath = Path.Combine(_dbPath, $"archive-source-{chunkStartNumber}-{chunkEndNumber}.tmp");
 		var sourceChunk = await TFChunk.CreateNew(
 			fileSystem: _localFileSystem,
 			filename: sourcePath,
 			chunkDataSize: ChunkSize,
-				chunkStartNumber: chunkNumber,
-				chunkEndNumber: chunkNumber,
-				isScavenged: true,
-				unbuffered: false,
+			chunkStartNumber: chunkStartNumber,
+			chunkEndNumber: chunkEndNumber,
+			isScavenged: true,
+			unbuffered: false,
 			writethrough: false,
 			reduceFileCachePressure: false,
 			asyncIO: false,
@@ -273,7 +301,7 @@ public class TFChunkManagerArchiveSwitchTests : IAsyncLifetime
 
 		await _archiveStorage.StoreChunk(
 			sourcePath,
-			_archiveChunkNamer.GetFileNameFor(chunkNumber),
+			_archiveChunkNamer.GetFileNameFor(destinationChunkNumber),
 			CancellationToken.None);
 	}
 

--- a/src/EventStore.Core/Services/RedactionService.cs
+++ b/src/EventStore.Core/Services/RedactionService.cs
@@ -86,7 +86,7 @@ public class RedactionService<TStreamId> :
 		{
 			var eventInfo = result.EventInfos[i];
 			var logPos = eventInfo.LogPosition;
-			var chunk = _db.Manager.GetChunkFor(logPos);
+			var chunk = await _db.Manager.GetChunkForAsync(logPos, token);
 			var localPosition = chunk.ChunkHeader.GetLocalLogPosition(logPos);
 			var chunkEventOffset = await chunk.GetActualRawPosition(localPosition, token);
 
@@ -249,7 +249,7 @@ public class RedactionService<TStreamId> :
 		TFChunk targetChunk;
 		try
 		{
-			targetChunk = _db.Manager.GetChunk(targetChunkNumber);
+			targetChunk = await _db.Manager.GetChunkAsync(targetChunkNumber, token);
 		}
 		catch (ArgumentOutOfRangeException)
 		{

--- a/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
@@ -426,7 +426,7 @@ public class LeaderReplicationService : IMonitoredQueue,
 
 		try
 		{
-			var chunk = _db.Manager.GetChunkFor(logPosition);
+			var chunk = await _db.Manager.GetChunkForAsync(logPosition, token);
 			Debug.Assert(chunk != null, string.Format(
 				"Chunk for LogPosition {0} (0x{0:X}) is null in LeaderReplicationService! Replica: [{1},C:{2},S:{3}]",
 				logPosition, sub.ReplicaEndPoint, sub.ConnectionId, sub.SubscriptionId));

--- a/src/EventStore.Core/Services/Replication/ReplicaService.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicaService.cs
@@ -262,7 +262,8 @@ public class ReplicaService : IHandle<SystemMessage.StateChangeMessage>,
 		var chunkId = Guid.Empty;
 
 		// the chunk may not exist if it's a new database or if we're at a chunk boundary
-		if (_db.Manager.TryGetChunkFor(logPosition, out var chunk))
+		var chunk = await _db.Manager.TryGetChunkForAsync(logPosition, token);
+		if (chunk is not null)
 		{
 			chunkId = chunk.ChunkHeader.ChunkId;
 		}

--- a/src/EventStore.Core/Telemetry/TelemetryService.cs
+++ b/src/EventStore.Core/Telemetry/TelemetryService.cs
@@ -309,7 +309,7 @@ public sealed class TelemetryService :
 	{
 		try
 		{
-			var chunk = _manager.GetChunkFor(0);
+			var chunk = await _manager.GetChunkForAsync(0, token);
 			var result = await chunk.TryReadAt(0, false, token);
 
 			if (!result.Success)

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ArchivedChunkReference.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ArchivedChunkReference.cs
@@ -1,15 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
 
-internal readonly record struct ArchivedChunkReference(int ChunkNumber, int ChunkSize)
+internal readonly record struct ArchivedChunkReference(int ChunkStartNumber, int ChunkEndNumber, int ChunkSize)
 {
-	public int ChunkEndNumber => ChunkNumber;
+	public long ChunkStartPosition => (long)ChunkStartNumber * ChunkSize;
 
-	public long ChunkStartPosition => (long)ChunkNumber * ChunkSize;
-
-	public long ChunkEndPosition => ChunkStartPosition + ChunkSize;
+	public long ChunkEndPosition => (long)(ChunkEndNumber + 1) * ChunkSize;
 }
 
 internal interface IArchivedChunkFileSystem
 {
-	bool TryGetArchivedChunk(string locator, out ArchivedChunkReference archivedChunk);
+	ValueTask<ArchivedChunkReference?> TryGetArchivedChunk(string locator, CancellationToken token);
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ArchivedChunkReference.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ArchivedChunkReference.cs
@@ -1,0 +1,15 @@
+namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
+
+internal readonly record struct ArchivedChunkReference(int ChunkNumber, int ChunkSize)
+{
+	public int ChunkEndNumber => ChunkNumber;
+
+	public long ChunkStartPosition => (long)ChunkNumber * ChunkSize;
+
+	public long ChunkEndPosition => ChunkStartPosition + ChunkSize;
+}
+
+internal interface IArchivedChunkFileSystem
+{
+	bool TryGetArchivedChunk(string locator, out ArchivedChunkReference archivedChunk);
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/FileSystemWithArchive.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/FileSystemWithArchive.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Core.Exceptions;
 using EventStore.Core.Services.Archive.Storage;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
 
@@ -30,16 +31,25 @@ public sealed class FileSystemWithArchive : IChunkFileSystem, IArchivedChunkFile
 
 	public IVersionedFileNamingStrategy NamingStrategy => _localFileSystem.NamingStrategy;
 
-	bool IArchivedChunkFileSystem.TryGetArchivedChunk(string locator, out ArchivedChunkReference archivedChunk)
+	async ValueTask<ArchivedChunkReference?> IArchivedChunkFileSystem.TryGetArchivedChunk(
+		string locator,
+		CancellationToken token)
 	{
-		if (_locatorCodec.Decode(locator, out var logicalChunkNumber, out _))
+		if (!_locatorCodec.Decode(locator, out var logicalChunkNumber, out _))
 		{
-			archivedChunk = new(logicalChunkNumber, _chunkSize);
-			return true;
+			return null;
 		}
 
-		archivedChunk = default;
-		return false;
+		var chunkFile = _archive.ChunkNamer.GetFileNameFor(logicalChunkNumber);
+		await using var stream = await _archive.GetChunk(chunkFile, 0L, ChunkHeader.Size, token);
+		var header = await ChunkHeader.FromStream(stream, token);
+		if (logicalChunkNumber < header.ChunkStartNumber || logicalChunkNumber > header.ChunkEndNumber)
+		{
+			throw new CorruptDatabaseException(new BadChunkInDatabaseException(
+				$"Archived chunk locator '{locator}' does not match chunk header range #{header.ChunkStartNumber}-{header.ChunkEndNumber}."));
+		}
+
+		return new ArchivedChunkReference(header.ChunkStartNumber, header.ChunkEndNumber, header.ChunkSize);
 	}
 
 	public ValueTask<IChunkHandle> OpenForReadAsync(string fileName, ReadOptimizationHint readOptimizationHint,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/FileSystemWithArchive.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/FileSystemWithArchive.cs
@@ -9,7 +9,7 @@ using EventStore.Core.TransactionLog.FileNamingStrategy;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk;
 
-public sealed class FileSystemWithArchive : IChunkFileSystem
+public sealed class FileSystemWithArchive : IChunkFileSystem, IArchivedChunkFileSystem
 {
 	private readonly int _chunkSize;
 	private readonly ILocatorCodec _locatorCodec;
@@ -29,6 +29,18 @@ public sealed class FileSystemWithArchive : IChunkFileSystem
 	}
 
 	public IVersionedFileNamingStrategy NamingStrategy => _localFileSystem.NamingStrategy;
+
+	bool IArchivedChunkFileSystem.TryGetArchivedChunk(string locator, out ArchivedChunkReference archivedChunk)
+	{
+		if (_locatorCodec.Decode(locator, out var logicalChunkNumber, out _))
+		{
+			archivedChunk = new(logicalChunkNumber, _chunkSize);
+			return true;
+		}
+
+		archivedChunk = default;
+		return false;
+	}
 
 	public ValueTask<IChunkHandle> OpenForReadAsync(string fileName, ReadOptimizationHint readOptimizationHint,
 		bool asyncIO, CancellationToken token) =>

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -51,7 +51,9 @@ public partial class TFChunk : IDisposable
 		get { return _cacheStatus is CacheStatus.Cached; }
 	}
 
-	public bool IsRemote => _handle is not null and not ChunkFileHandle;
+	internal bool IsInitialized => _lazyCompletedChunk is null;
+
+	public bool IsRemote => _isRemote;
 
 	// the logical size of (untransformed) data (could be > PhysicalDataSize if scavenged chunk)
 	public long LogicalDataSize
@@ -92,16 +94,34 @@ public partial class TFChunk : IDisposable
 
 	public ChunkInfo ChunkInfo
 	{
-		get => new()
+		get
 		{
-			ChunkLocator = ChunkLocator,
-			ChunkStartNumber = _chunkHeader.ChunkStartNumber,
-			ChunkEndNumber = _chunkHeader.ChunkEndNumber,
-			ChunkStartPosition = _chunkHeader.ChunkStartPosition,
-			ChunkEndPosition = _chunkHeader.ChunkEndPosition,
-			IsCompleted = IsReadOnly,
-			IsRemote = IsRemote
-		};
+			var lazyCompletedChunk = _lazyCompletedChunk;
+			if (lazyCompletedChunk is not null)
+			{
+				return new()
+				{
+					ChunkLocator = ChunkLocator,
+					ChunkStartNumber = lazyCompletedChunk.ArchivedChunk.ChunkNumber,
+					ChunkEndNumber = lazyCompletedChunk.ArchivedChunk.ChunkEndNumber,
+					ChunkStartPosition = lazyCompletedChunk.ArchivedChunk.ChunkStartPosition,
+					ChunkEndPosition = lazyCompletedChunk.ArchivedChunk.ChunkEndPosition,
+					IsCompleted = IsReadOnly,
+					IsRemote = IsRemote
+				};
+			}
+
+			return new()
+			{
+				ChunkLocator = ChunkLocator,
+				ChunkStartNumber = _chunkHeader.ChunkStartNumber,
+				ChunkEndNumber = _chunkHeader.ChunkEndNumber,
+				ChunkStartPosition = _chunkHeader.ChunkStartPosition,
+				ChunkEndPosition = _chunkHeader.ChunkEndPosition,
+				IsCompleted = IsReadOnly,
+				IsRemote = IsRemote
+			};
+		}
 	}
 
 	public ReadOnlyMemory<byte> TransformHeader
@@ -124,6 +144,8 @@ public partial class TFChunk : IDisposable
 	private readonly IChunkFileSystem _fileSystem;
 	private readonly string _filename;
 	private IChunkHandle _handle;
+	private bool _isRemote;
+	private volatile LazyCompletedChunk _lazyCompletedChunk;
 	private int _fileSize;
 
 	// This field establishes happens-before relationship with _fileStreams as follows:
@@ -177,6 +199,18 @@ public partial class TFChunk : IDisposable
 		// UnCacheFromMemory. We are waiting for readers to be returned.
 		// invariants: _cachedData != IntPtr.Zero, _memStreamCount > 0
 		Uncaching,
+	}
+
+	private sealed class LazyCompletedChunk(
+		ArchivedChunkReference archivedChunk,
+		ITransactionFileTracker tracker,
+		Func<TransformType, IChunkTransformFactory> getTransformFactory)
+	{
+		public ArchivedChunkReference ArchivedChunk { get; } = archivedChunk;
+
+		public ITransactionFileTracker Tracker { get; } = tracker;
+
+		public Func<TransformType, IChunkTransformFactory> GetTransformFactory { get; } = getTransformFactory;
 	}
 
 	private readonly ManualResetEventSlim _destroyEvent = new ManualResetEventSlim(false);
@@ -247,6 +281,23 @@ public partial class TFChunk : IDisposable
 			throw;
 		}
 
+		return chunk;
+	}
+
+	internal static TFChunk FromArchivedCompletedFile(IChunkFileSystem fileSystem, string filename,
+		ArchivedChunkReference archivedChunk, bool unbufferedRead,
+		ITransactionFileTracker tracker, Func<TransformType, IChunkTransformFactory> getTransformFactory,
+		bool reduceFileCachePressure = false, bool asyncIO = false)
+	{
+		var chunk = new TFChunk(fileSystem,
+			filename,
+			TFConsts.MidpointsDepth, unbufferedRead, false, reduceFileCachePressure, asyncIO)
+		{
+			_isRemote = true,
+			_lazyCompletedChunk = new(archivedChunk, tracker, getTransformFactory)
+		};
+
+		chunk.IsReadOnly = true;
 		return chunk;
 	}
 
@@ -351,6 +402,7 @@ public partial class TFChunk : IDisposable
 		Func<TransformType, IChunkTransformFactory> getTransformFactory, CancellationToken token)
 	{
 		_handle = await _fileSystem.OpenForReadAsync(ChunkLocator, ReadOnlyReadOptimizationHint, _asyncIO, token);
+		_isRemote = _handle is not ChunkFileHandle;
 		_fileSize = (int)_handle.Length;
 
 		IsReadOnly = true;
@@ -400,6 +452,54 @@ public partial class TFChunk : IDisposable
 		if (verifyHash)
 		{
 			await VerifyFileHash(token);
+		}
+	}
+
+	internal async ValueTask EnsureInitialized(CancellationToken token)
+	{
+		if (_lazyCompletedChunk is null)
+		{
+			return;
+		}
+
+		await _cachedDataLock.AcquireAsync(token);
+		try
+		{
+			var lazyCompletedChunk = _lazyCompletedChunk;
+			if (lazyCompletedChunk is null)
+			{
+				return;
+			}
+
+			try
+			{
+				await InitCompleted(
+					verifyHash: false,
+					lazyCompletedChunk.Tracker,
+					lazyCompletedChunk.GetTransformFactory,
+					token);
+				_lazyCompletedChunk = null;
+			}
+			catch
+			{
+				_handle?.Dispose();
+				_handle = null;
+				_transform = null;
+				_transformHeader = ReadOnlyMemory<byte>.Empty;
+				_chunkFooter = null;
+				_chunkHeader = null;
+				_readSide = null;
+				_fileSize = 0;
+				_logicalDataSize = 0;
+				_physicalDataSize = 0;
+				_isRemote = true;
+				IsReadOnly = true;
+				throw;
+			}
+		}
+		finally
+		{
+			_cachedDataLock.Release();
 		}
 	}
 
@@ -1727,7 +1827,8 @@ public partial class TFChunk : IDisposable
 
 	public override string ToString()
 	{
-		return string.Format("#{0}-{1} ({2})", _chunkHeader.ChunkStartNumber, _chunkHeader.ChunkEndNumber,
+		var chunkInfo = ChunkInfo;
+		return string.Format("#{0}-{1} ({2})", chunkInfo.ChunkStartNumber, chunkInfo.ChunkEndNumber,
 			Path.GetFileName(ChunkLocator));
 	}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -53,7 +53,7 @@ public partial class TFChunk : IDisposable
 
 	internal bool IsInitialized => _lazyCompletedChunk is null;
 
-	public bool IsRemote => _isRemote;
+	public bool IsRemote => _isRemote || _handle is not null and not ChunkFileHandle;
 
 	// the logical size of (untransformed) data (could be > PhysicalDataSize if scavenged chunk)
 	public long LogicalDataSize

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -102,7 +102,7 @@ public partial class TFChunk : IDisposable
 				return new()
 				{
 					ChunkLocator = ChunkLocator,
-					ChunkStartNumber = lazyCompletedChunk.ArchivedChunk.ChunkNumber,
+					ChunkStartNumber = lazyCompletedChunk.ArchivedChunk.ChunkStartNumber,
 					ChunkEndNumber = lazyCompletedChunk.ArchivedChunk.ChunkEndNumber,
 					ChunkStartPosition = lazyCompletedChunk.ArchivedChunk.ChunkStartPosition,
 					ChunkEndPosition = lazyCompletedChunk.ArchivedChunk.ChunkEndPosition,
@@ -482,6 +482,7 @@ public partial class TFChunk : IDisposable
 			}
 			catch
 			{
+				ResetReaderStreamsAfterFailedInitialization();
 				_handle?.Dispose();
 				_handle = null;
 				_transform = null;
@@ -501,6 +502,14 @@ public partial class TFChunk : IDisposable
 		{
 			_cachedDataLock.Release();
 		}
+	}
+
+	private void ResetReaderStreamsAfterFailedInitialization()
+	{
+		_fileStreams.Drain(ref _fileStreamCount);
+		_fileStreams = new();
+		Interlocked.Exchange(ref _fileStreamCount, 0);
+		Interlocked.Exchange(ref _cleanedUpFileStreams, 0);
 	}
 
 	private async ValueTask InitNew(ChunkHeader chunkHeader, int fileSize, ITransactionFileTracker tracker,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -258,12 +258,19 @@ public class TFChunkDb : IAsyncDisposable
 
 		if (verifyHash && lastChunkNum > 0)
 		{
-			var preLastChunk = Manager.GetChunk(lastChunkNum - 1);
-			var lastBgChunkNum = preLastChunk.ChunkHeader.ChunkStartNumber;
+			var preLastChunk = Manager.GetChunkInfo(lastChunkNum - 1);
+			var lastBgChunkNum = preLastChunk.ChunkStartNumber;
 			ThreadPool.UnsafeQueueUserWorkItem(async token =>
 			{
 				for (int chunkNum = lastBgChunkNum; chunkNum >= 0;)
 				{
+					var chunkInfo = Manager.GetChunkInfo(chunkNum);
+					if (chunkInfo.IsRemote)
+					{
+						chunkNum = chunkInfo.ChunkStartNumber - 1;
+						continue;
+					}
+
 					var chunk = Manager.GetChunk(chunkNum);
 					try
 					{
@@ -287,7 +294,7 @@ public class TFChunkDb : IAsyncDisposable
 						return;
 					}
 
-					chunkNum = chunk.ChunkHeader.ChunkStartNumber - 1;
+					chunkNum = chunkInfo.ChunkStartNumber - 1;
 				}
 			}, token, preferLocal: false);
 		}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -265,13 +265,13 @@ public class TFChunkDb : IAsyncDisposable
 				for (int chunkNum = lastBgChunkNum; chunkNum >= 0;)
 				{
 					var chunkInfo = Manager.GetChunkInfo(chunkNum);
-					if (chunkInfo.IsRemote)
+					if (chunkInfo.IsRemote && !Manager.IsChunkInitialized(chunkNum))
 					{
 						chunkNum = chunkInfo.ChunkStartNumber - 1;
 						continue;
 					}
 
-					var chunk = Manager.GetChunk(chunkNum);
+					var chunk = await Manager.GetChunkAsync(chunkNum, token);
 					try
 					{
 						await chunk.VerifyFileHash(token);

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -100,6 +100,13 @@ public class TFChunkManager : IThreadPoolWorkItem
 			for (int chunkNum = _chunksCount - 1; chunkNum >= 0;)
 			{
 				var chunk = _chunks[chunkNum];
+				var chunkInfo = chunk.ChunkInfo;
+				if (chunk.IsRemote && !chunk.IsInitialized)
+				{
+					chunkNum = chunkInfo.ChunkStartNumber - 1;
+					continue;
+				}
+
 				var chunkSize = chunk.IsReadOnly
 					? chunk.ChunkFooter.PhysicalDataSize + chunk.ChunkFooter.MapSize + ChunkHeader.Size +
 					  ChunkFooter.Size
@@ -111,9 +118,9 @@ public class TFChunkManager : IThreadPoolWorkItem
 				}
 
 				totalSize += chunkSize;
-				lastChunkToCache = chunk.ChunkHeader.ChunkStartNumber;
+				lastChunkToCache = chunkInfo.ChunkStartNumber;
 
-				chunkNum = chunk.ChunkHeader.ChunkStartNumber - 1;
+				chunkNum = chunkInfo.ChunkStartNumber - 1;
 			}
 		}
 		finally
@@ -129,18 +136,19 @@ public class TFChunkManager : IThreadPoolWorkItem
 				chunk.UnCacheFromMemory();
 			}
 
-			chunkNum = chunk.ChunkHeader.ChunkStartNumber - 1;
+			chunkNum = chunk.ChunkInfo.ChunkStartNumber - 1;
 		}
 
 		for (int chunkNum = lastChunkToCache; chunkNum < _chunksCount;)
 		{
 			var chunk = _chunks[chunkNum];
-			if (chunk.IsReadOnly)
+			var chunkInfo = chunk.ChunkInfo;
+			if (chunk.IsReadOnly && (!chunk.IsRemote || chunk.IsInitialized))
 			{
 				await chunk.CacheInMemory(token);
 			}
 
-			chunkNum = chunk.ChunkHeader.ChunkEndNumber + 1;
+			chunkNum = chunkInfo.ChunkEndNumber + 1;
 		}
 	}
 
@@ -254,18 +262,19 @@ public class TFChunkManager : IThreadPoolWorkItem
 		Debug.Assert(chunk is not null);
 		Debug.Assert(_chunksLocker.IsLockHeld);
 
-		for (int i = chunk.ChunkHeader.ChunkStartNumber; i <= chunk.ChunkHeader.ChunkEndNumber; ++i)
+		var chunkInfo = chunk.ChunkInfo;
+		for (int i = chunkInfo.ChunkStartNumber; i <= chunkInfo.ChunkEndNumber; ++i)
 		{
 			_chunks[i] = chunk;
 		}
 
-		_chunksCount = Math.Max(chunk.ChunkHeader.ChunkEndNumber + 1, _chunksCount);
+		_chunksCount = Math.Max(chunkInfo.ChunkEndNumber + 1, _chunksCount);
 
 		if (isNew)
 		{
-			if (chunk.ChunkHeader.ChunkStartNumber > 0)
+			if (chunkInfo.ChunkStartNumber > 0)
 			{
-				OnChunkCompleted?.Invoke(_chunks[chunk.ChunkHeader.ChunkStartNumber - 1].ChunkInfo);
+				OnChunkCompleted?.Invoke(_chunks[chunkInfo.ChunkStartNumber - 1].ChunkInfo);
 			}
 		}
 		else
@@ -307,16 +316,27 @@ public class TFChunkManager : IThreadPoolWorkItem
 		{
 			for (var i = 0; i < locators.Count; i++)
 			{
-				newChunks[i] = await TFChunk.TFChunk.FromCompletedFile(
-					fileSystem: FileSystem,
-					filename: locators[i],
-					verifyHash: false,
-					unbufferedRead: _config.Unbuffered,
-					tracker: _tracker,
-					getTransformFactory: getFactoryForExistingChunk,
-					reduceFileCachePressure: _config.ReduceFileCachePressure,
-					asyncIO: _config.AsyncIO,
-					token: token);
+				newChunks[i] = FileSystem is IArchivedChunkFileSystem archivedChunkFileSystem
+							   && archivedChunkFileSystem.TryGetArchivedChunk(locators[i], out var archivedChunk)
+					? TFChunk.TFChunk.FromArchivedCompletedFile(
+						fileSystem: FileSystem,
+						filename: locators[i],
+						archivedChunk: archivedChunk,
+						unbufferedRead: _config.Unbuffered,
+						tracker: _tracker,
+						getTransformFactory: getFactoryForExistingChunk,
+						reduceFileCachePressure: _config.ReduceFileCachePressure,
+						asyncIO: _config.AsyncIO)
+					: await TFChunk.TFChunk.FromCompletedFile(
+						fileSystem: FileSystem,
+						filename: locators[i],
+						verifyHash: false,
+						unbufferedRead: _config.Unbuffered,
+						tracker: _tracker,
+						getTransformFactory: getFactoryForExistingChunk,
+						reduceFileCachePressure: _config.ReduceFileCachePressure,
+						asyncIO: _config.AsyncIO,
+						token: token);
 			}
 
 			return await SwitchInChunks(newChunks, removeChunksAfter: null, token,
@@ -424,7 +444,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 			if (removeChunksAfter.HasValue)
 			{
 				var oldChunksCount = _chunksCount;
-				_chunksCount = newChunks[^1].ChunkHeader.ChunkEndNumber + 1;
+				_chunksCount = newChunks[^1].ChunkInfo.ChunkEndNumber + 1;
 				RemoveChunks(removeChunksAfter.Value + 1, oldChunksCount - 1, "Excessive");
 				if (_chunks[_chunksCount] is not null)
 				{
@@ -465,22 +485,23 @@ public class TFChunkManager : IThreadPoolWorkItem
 			return true;
 		}
 
-		var chunkStartNumber = newChunks[0].ChunkHeader.ChunkStartNumber;
-		var chunkEndNumber = newChunks[^1].ChunkHeader.ChunkEndNumber;
+		var chunkStartNumber = newChunks[0].ChunkInfo.ChunkStartNumber;
+		var chunkEndNumber = newChunks[^1].ChunkInfo.ChunkEndNumber;
 
 		var expectedStart = chunkStartNumber;
 		foreach (var newChunk in newChunks)
 		{
-			if (newChunk.ChunkHeader.ChunkStartNumber != expectedStart)
+			var newChunkInfo = newChunk.ChunkInfo;
+			if (newChunkInfo.ChunkStartNumber != expectedStart)
 			{
 				Log.Error(
 					"Cannot replace chunks because new chunks are not contiguous. ExpectedChunkNumber {Expected}. ActualChunkNumber {Actual}",
 					expectedStart,
-					newChunk.ChunkHeader.ChunkStartNumber);
+					newChunkInfo.ChunkStartNumber);
 				return false;
 			}
 
-			expectedStart = newChunk.ChunkHeader.ChunkEndNumber + 1;
+			expectedStart = newChunkInfo.ChunkEndNumber + 1;
 		}
 
 		for (int i = chunkStartNumber; i <= chunkEndNumber;)
@@ -488,13 +509,13 @@ public class TFChunkManager : IThreadPoolWorkItem
 			var chunk = _chunks[i];
 			if (chunk != null)
 			{
-				var chunkHeader = chunk.ChunkHeader;
-				if (chunkHeader.ChunkStartNumber < chunkStartNumber || chunkHeader.ChunkEndNumber > chunkEndNumber)
+				var chunkInfo = chunk.ChunkInfo;
+				if (chunkInfo.ChunkStartNumber < chunkStartNumber || chunkInfo.ChunkEndNumber > chunkEndNumber)
 				{
 					return false;
 				}
 
-				i = chunkHeader.ChunkEndNumber + 1;
+				i = chunkInfo.ChunkEndNumber + 1;
 			}
 			else
 			{
@@ -539,8 +560,8 @@ public class TFChunkManager : IThreadPoolWorkItem
 		return true;
 
 		static bool Covers(TFChunk.TFChunk chunk, int chunkNumber) =>
-			chunk.ChunkHeader.ChunkStartNumber <= chunkNumber &&
-			chunk.ChunkHeader.ChunkEndNumber >= chunkNumber;
+			chunk.ChunkInfo.ChunkStartNumber <= chunkNumber &&
+			chunk.ChunkInfo.ChunkEndNumber >= chunkNumber;
 	}
 
 	private void RemoveChunks(int chunkStartNumber, int chunkEndNumber, string chunkExplanation)
@@ -601,6 +622,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 				"Requested chunk for LogPosition {0}, which is not present in TFChunkManager.", logPosition));
 		}
 
+		EnsureInitialized(chunk);
 		return chunk;
 	}
 
@@ -618,8 +640,29 @@ public class TFChunkManager : IThreadPoolWorkItem
 				chunkNum));
 		}
 
+		EnsureInitialized(chunk);
 		return chunk;
 	}
+
+	public ChunkInfo GetChunkInfo(int chunkNum)
+	{
+		if (chunkNum < 0 || chunkNum >= _chunksCount)
+		{
+			throw new ArgumentOutOfRangeException(nameof(chunkNum),
+				string.Format("Chunk #{0} is not present in DB.", chunkNum));
+		}
+
+		if (_chunks[chunkNum] is not { } chunk)
+		{
+			throw new Exception(string.Format("Requested chunk #{0}, which is not present in TFChunkManager.",
+				chunkNum));
+		}
+
+		return chunk.ChunkInfo;
+	}
+
+	private static void EnsureInitialized(TFChunk.TFChunk chunk) =>
+		chunk.EnsureInitialized(CancellationToken.None).AsTask().GetAwaiter().GetResult();
 
 	public async ValueTask<bool> TryClose(CancellationToken token)
 	{

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -102,16 +102,7 @@ public class TFChunkManager : IThreadPoolWorkItem
 			{
 				var chunk = _chunks[chunkNum];
 				var chunkInfo = chunk.ChunkInfo;
-				if (chunk.IsRemote && !chunk.IsInitialized)
-				{
-					chunkNum = chunkInfo.ChunkStartNumber - 1;
-					continue;
-				}
-
-				var chunkSize = chunk.IsReadOnly
-					? chunk.ChunkFooter.PhysicalDataSize + chunk.ChunkFooter.MapSize + ChunkHeader.Size +
-					  ChunkFooter.Size
-					: chunk.ChunkHeader.ChunkSize + ChunkHeader.Size + ChunkFooter.Size;
+				var chunkSize = GetCacheBudgetSize(chunk, chunkInfo);
 
 				if (totalSize + chunkSize > _config.MaxChunksCacheSize)
 				{
@@ -151,6 +142,21 @@ public class TFChunkManager : IThreadPoolWorkItem
 
 			chunkNum = chunkInfo.ChunkEndNumber + 1;
 		}
+	}
+
+	private static long GetCacheBudgetSize(TFChunk.TFChunk chunk, ChunkInfo chunkInfo)
+	{
+		if (!chunk.IsReadOnly)
+		{
+			return chunk.ChunkHeader.ChunkSize + ChunkHeader.Size + ChunkFooter.Size;
+		}
+
+		if (!chunk.IsInitialized)
+		{
+			return chunkInfo.ChunkEndPosition - chunkInfo.ChunkStartPosition + ChunkHeader.Size + ChunkFooter.Size;
+		}
+
+		return chunk.ChunkFooter.PhysicalDataSize + chunk.ChunkFooter.MapSize + ChunkHeader.Size + ChunkFooter.Size;
 	}
 
 	public ValueTask<TFChunk.TFChunk> CreateTempChunk(ChunkHeader chunkHeader, int fileSize, CancellationToken token)

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -626,16 +626,21 @@ public class TFChunkManager : IThreadPoolWorkItem
 
 	public bool TryGetChunkFor(long logPosition, out TFChunk.TFChunk chunk)
 	{
-		try
-		{
-			chunk = GetChunkFor(logPosition);
-			return true;
-		}
-		catch
+		var chunkNum = (int)(logPosition / _config.ChunkSize);
+		if (chunkNum < 0 || chunkNum >= _chunksCount)
 		{
 			chunk = null;
 			return false;
 		}
+
+		chunk = _chunks[chunkNum];
+		if (chunk == null)
+		{
+			return false;
+		}
+
+		EnsureInitialized(chunk);
+		return true;
 	}
 
 	public TFChunk.TFChunk GetChunkFor(long logPosition)

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -9,6 +9,7 @@ using EventStore.Common.Utils;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.Transforms;
 using EventStore.Core.Transforms.Identity;
+using EventStore.Plugins.Transforms;
 using ChunkInfo = EventStore.Core.Data.ChunkInfo;
 using ILogger = Serilog.ILogger;
 
@@ -310,33 +311,20 @@ public class TFChunkManager : IThreadPoolWorkItem
 	{
 		Ensure.NotNull(locators, nameof(locators));
 		var getFactoryForExistingChunk = _transformManager.GetFactoryForExistingChunk;
-		var newChunks = new TFChunk.TFChunk[locators.Count];
+		var newChunks = new List<TFChunk.TFChunk>(locators.Count);
 		var ownsNewChunks = true;
 		try
 		{
 			for (var i = 0; i < locators.Count; i++)
 			{
-				newChunks[i] = FileSystem is IArchivedChunkFileSystem archivedChunkFileSystem
-							   && archivedChunkFileSystem.TryGetArchivedChunk(locators[i], out var archivedChunk)
-					? TFChunk.TFChunk.FromArchivedCompletedFile(
-						fileSystem: FileSystem,
-						filename: locators[i],
-						archivedChunk: archivedChunk,
-						unbufferedRead: _config.Unbuffered,
-						tracker: _tracker,
-						getTransformFactory: getFactoryForExistingChunk,
-						reduceFileCachePressure: _config.ReduceFileCachePressure,
-						asyncIO: _config.AsyncIO)
-					: await TFChunk.TFChunk.FromCompletedFile(
-						fileSystem: FileSystem,
-						filename: locators[i],
-						verifyHash: false,
-						unbufferedRead: _config.Unbuffered,
-						tracker: _tracker,
-						getTransformFactory: getFactoryForExistingChunk,
-						reduceFileCachePressure: _config.ReduceFileCachePressure,
-						asyncIO: _config.AsyncIO,
-						token: token);
+				var newChunk = await CreateSwitchInChunk(locators[i], getFactoryForExistingChunk, token);
+				if (newChunks.Count > 0 && SameLogicalRange(newChunks[^1], newChunk))
+				{
+					newChunk.Dispose();
+					continue;
+				}
+
+				newChunks.Add(newChunk);
 			}
 
 			return await SwitchInChunks(newChunks, removeChunksAfter: null, token,
@@ -351,6 +339,44 @@ public class TFChunkManager : IThreadPoolWorkItem
 
 			throw;
 		}
+	}
+
+	private async ValueTask<TFChunk.TFChunk> CreateSwitchInChunk(string locator,
+		Func<TransformType, IChunkTransformFactory> getFactoryForExistingChunk,
+		CancellationToken token)
+	{
+		if (FileSystem is IArchivedChunkFileSystem archivedChunkFileSystem
+			&& await archivedChunkFileSystem.TryGetArchivedChunk(locator, token) is { } archivedChunk)
+		{
+			return TFChunk.TFChunk.FromArchivedCompletedFile(
+				fileSystem: FileSystem,
+				filename: locator,
+				archivedChunk: archivedChunk,
+				unbufferedRead: _config.Unbuffered,
+				tracker: _tracker,
+				getTransformFactory: getFactoryForExistingChunk,
+				reduceFileCachePressure: _config.ReduceFileCachePressure,
+				asyncIO: _config.AsyncIO);
+		}
+
+		return await TFChunk.TFChunk.FromCompletedFile(
+			fileSystem: FileSystem,
+			filename: locator,
+			verifyHash: false,
+			unbufferedRead: _config.Unbuffered,
+			tracker: _tracker,
+			getTransformFactory: getFactoryForExistingChunk,
+			reduceFileCachePressure: _config.ReduceFileCachePressure,
+			asyncIO: _config.AsyncIO,
+			token: token);
+	}
+
+	private static bool SameLogicalRange(TFChunk.TFChunk left, TFChunk.TFChunk right)
+	{
+		var leftInfo = left.ChunkInfo;
+		var rightInfo = right.ChunkInfo;
+		return leftInfo.ChunkStartNumber == rightInfo.ChunkStartNumber
+			   && leftInfo.ChunkEndNumber == rightInfo.ChunkEndNumber;
 	}
 
 	public async ValueTask<TFChunk.TFChunk> SwitchChunk(TFChunk.TFChunk chunk, bool verifyHash,
@@ -626,6 +652,44 @@ public class TFChunkManager : IThreadPoolWorkItem
 		return chunk;
 	}
 
+	public async ValueTask<TFChunk.TFChunk> TryGetChunkForAsync(long logPosition, CancellationToken token)
+	{
+		var chunkNum = (int)(logPosition / _config.ChunkSize);
+		if (chunkNum < 0 || chunkNum >= _chunksCount)
+		{
+			return null;
+		}
+
+		var chunk = _chunks[chunkNum];
+		if (chunk is null)
+		{
+			return null;
+		}
+
+		await EnsureInitialized(chunk, token);
+		return chunk;
+	}
+
+	public async ValueTask<TFChunk.TFChunk> GetChunkForAsync(long logPosition, CancellationToken token)
+	{
+		var chunkNum = (int)(logPosition / _config.ChunkSize);
+		if (chunkNum < 0 || chunkNum >= _chunksCount)
+		{
+			throw new ArgumentOutOfRangeException("logPosition",
+				string.Format("LogPosition {0} does not have corresponding chunk in DB.", logPosition));
+		}
+
+		var chunk = _chunks[chunkNum];
+		if (chunk == null)
+		{
+			throw new Exception(string.Format(
+				"Requested chunk for LogPosition {0}, which is not present in TFChunkManager.", logPosition));
+		}
+
+		await EnsureInitialized(chunk, token);
+		return chunk;
+	}
+
 	public TFChunk.TFChunk GetChunk(int chunkNum)
 	{
 		if (chunkNum < 0 || chunkNum >= _chunksCount)
@@ -641,6 +705,24 @@ public class TFChunkManager : IThreadPoolWorkItem
 		}
 
 		EnsureInitialized(chunk);
+		return chunk;
+	}
+
+	public async ValueTask<TFChunk.TFChunk> GetChunkAsync(int chunkNum, CancellationToken token)
+	{
+		if (chunkNum < 0 || chunkNum >= _chunksCount)
+		{
+			throw new ArgumentOutOfRangeException("chunkNum",
+				string.Format("Chunk #{0} is not present in DB.", chunkNum));
+		}
+
+		if (_chunks[chunkNum] is not { } chunk)
+		{
+			throw new Exception(string.Format("Requested chunk #{0}, which is not present in TFChunkManager.",
+				chunkNum));
+		}
+
+		await EnsureInitialized(chunk, token);
 		return chunk;
 	}
 
@@ -661,8 +743,33 @@ public class TFChunkManager : IThreadPoolWorkItem
 		return chunk.ChunkInfo;
 	}
 
+	public bool IsChunkInitialized(int chunkNum)
+	{
+		if (chunkNum < 0 || chunkNum >= _chunksCount)
+		{
+			throw new ArgumentOutOfRangeException(nameof(chunkNum),
+				string.Format("Chunk #{0} is not present in DB.", chunkNum));
+		}
+
+		if (_chunks[chunkNum] is not { } chunk)
+		{
+			throw new Exception(string.Format("Requested chunk #{0}, which is not present in TFChunkManager.",
+				chunkNum));
+		}
+
+		return chunk.IsInitialized;
+	}
+
 	private static void EnsureInitialized(TFChunk.TFChunk chunk) =>
 		chunk.EnsureInitialized(CancellationToken.None).AsTask().GetAwaiter().GetResult();
+
+	private static async ValueTask EnsureInitialized(TFChunk.TFChunk chunk, CancellationToken token)
+	{
+		if (!chunk.IsInitialized)
+		{
+			await chunk.EnsureInitialized(token);
+		}
+	}
 
 	public async ValueTask<bool> TryClose(CancellationToken token)
 	{

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkReader.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkReader.cs
@@ -55,7 +55,7 @@ public class TFChunkReader : ITransactionFileReader
 				return SeqReadResult.Failure;
 			}
 
-			var chunk = _db.Manager.GetChunkFor(pos);
+			var chunk = await _db.Manager.GetChunkForAsync(pos, token);
 			RecordReadResult result;
 			try
 			{
@@ -115,13 +115,13 @@ public class TFChunkReader : ITransactionFileReader
 			}
 
 			bool readLast = false;
-			if (!_db.Manager.TryGetChunkFor(pos, out var chunk) ||
-				pos == chunk.ChunkHeader.ChunkStartPosition)
+			var chunk = await _db.Manager.TryGetChunkForAsync(pos, token);
+			if (chunk is null || pos == chunk.ChunkHeader.ChunkStartPosition)
 			{
 				// we are exactly at the boundary of physical chunks
 				// so we switch to previous chunk and request TryReadLast
 				readLast = true;
-				chunk = _db.Manager.GetChunkFor(pos - 1);
+				chunk = await _db.Manager.GetChunkForAsync(pos - 1, token);
 			}
 
 			RecordReadResult result;
@@ -176,7 +176,7 @@ public class TFChunkReader : ITransactionFileReader
 			return RecordReadResult.Failure;
 		}
 
-		var chunk = _db.Manager.GetChunkFor(position);
+		var chunk = await _db.Manager.GetChunkForAsync(position, token);
 		try
 		{
 			CountRead(chunk.IsCached);
@@ -205,7 +205,7 @@ public class TFChunkReader : ITransactionFileReader
 			return false;
 		}
 
-		var chunk = _db.Manager.GetChunkFor(position);
+		var chunk = await _db.Manager.GetChunkForAsync(position, token);
 		try
 		{
 			CountRead(chunk.IsCached);

--- a/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkReaderForAccumulator.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkReaderForAccumulator.cs
@@ -51,7 +51,7 @@ public class ChunkReaderForAccumulator<TStreamId> : IChunkReaderForAccumulator<T
 	{
 
 		// the physical chunk might contain several logical chunks, we are only interested in one of them
-		var chunk = _manager.GetChunk(logicalChunkNumber);
+		var chunk = await _manager.GetChunkAsync(logicalChunkNumber, cancellationToken);
 		long chunkStartPos = (long)_chunkSize * logicalChunkNumber;
 		long chunkEndPos = (long)_chunkSize * (logicalChunkNumber + 1);
 		long nextPos = chunkStartPos;


### PR DESCRIPTION
- Remote archive switch-in should not require object storage reads before any archived data is requested.
- S3-compatible archive deployments need cold chunks to remain cheap to discover during startup and range replacement.
- Metadata-only chunk checks avoid background cache and hash maintenance from turning archive discovery into remote object loading.