### PR TITLE
feat(storage): prepare internal index streams

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/InMemory/VirtualStreamReaderTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/InMemory/VirtualStreamReaderTests.cs
@@ -359,4 +359,107 @@ public class VirtualStreamReaderTests
 			Assert.Empty(result.Events);
 		}
 	}
+
+	public class MultipleReaderTests
+	{
+		private const string FirstStream = "$mem-first";
+		private const string SecondStream = "$mem-second";
+
+		[Fact]
+		public async Task read_forwards_uses_the_reader_that_claims_the_stream()
+		{
+			var firstReader = new FakeVirtualStreamReader(FirstStream, lastEventNumber: 10);
+			var secondReader = new FakeVirtualStreamReader(SecondStream, lastEventNumber: 20);
+			var sut = new VirtualStreamReader([firstReader, secondReader]);
+
+			var result = await sut.ReadForwards(
+				GenReadForwards(Guid.NewGuid(), fromEventNumber: 0, maxCount: 1, SecondStream),
+				CancellationToken.None);
+
+			Assert.Equal(ReadStreamResult.Success, result.Result);
+			Assert.Equal(20, result.LastEventNumber);
+			Assert.Equal(0, firstReader.ForwardReadCount);
+			Assert.Equal(1, secondReader.ForwardReadCount);
+		}
+
+		[Fact]
+		public void metadata_uses_the_reader_that_claims_the_stream()
+		{
+			var firstReader = new FakeVirtualStreamReader(FirstStream, lastEventNumber: 10, lastIndexedPosition: 100);
+			var secondReader = new FakeVirtualStreamReader(SecondStream, lastEventNumber: 20, lastIndexedPosition: 200);
+			var sut = new VirtualStreamReader([firstReader, secondReader]);
+
+			Assert.Equal(20, sut.GetLastEventNumber(SecondStream));
+			Assert.Equal(200, sut.GetLastIndexedPosition(SecondStream));
+		}
+
+		[Fact]
+		public async Task earlier_reader_wins_when_more_than_one_reader_claims_the_stream()
+		{
+			var firstReader = new FakeVirtualStreamReader(FirstStream, lastEventNumber: 10);
+			var secondReader = new FakeVirtualStreamReader(FirstStream, lastEventNumber: 20);
+			var sut = new VirtualStreamReader([firstReader, secondReader]);
+
+			var result = await sut.ReadForwards(
+				GenReadForwards(Guid.NewGuid(), fromEventNumber: 0, maxCount: 1, FirstStream),
+				CancellationToken.None);
+
+			Assert.Equal(10, result.LastEventNumber);
+			Assert.Equal(1, firstReader.ForwardReadCount);
+			Assert.Equal(0, secondReader.ForwardReadCount);
+		}
+	}
+
+	private sealed class FakeVirtualStreamReader(
+		string streamId,
+		long lastEventNumber,
+		long lastIndexedPosition = -1) : IVirtualStreamReader
+	{
+		public int ForwardReadCount { get; private set; }
+
+		public ValueTask<ClientMessage.ReadStreamEventsForwardCompleted> ReadForwards(
+			ClientMessage.ReadStreamEventsForward msg,
+			CancellationToken token)
+		{
+			ForwardReadCount++;
+			return ValueTask.FromResult(new ClientMessage.ReadStreamEventsForwardCompleted(
+				msg.CorrelationId,
+				msg.EventStreamId,
+				msg.FromEventNumber,
+				msg.MaxCount,
+				ReadStreamResult.Success,
+				Array.Empty<ResolvedEvent>(),
+				StreamMetadata.Empty,
+				isCachePublic: false,
+				error: string.Empty,
+				nextEventNumber: lastEventNumber + 1,
+				lastEventNumber: lastEventNumber,
+				isEndOfStream: true,
+				tfLastCommitPosition: lastIndexedPosition));
+		}
+
+		public ValueTask<ClientMessage.ReadStreamEventsBackwardCompleted> ReadBackwards(
+			ClientMessage.ReadStreamEventsBackward msg,
+			CancellationToken token) =>
+			ValueTask.FromResult(new ClientMessage.ReadStreamEventsBackwardCompleted(
+				msg.CorrelationId,
+				msg.EventStreamId,
+				msg.FromEventNumber,
+				msg.MaxCount,
+				ReadStreamResult.Success,
+				Array.Empty<ResolvedEvent>(),
+				StreamMetadata.Empty,
+				isCachePublic: false,
+				error: string.Empty,
+				nextEventNumber: -1,
+				lastEventNumber: lastEventNumber,
+				isEndOfStream: true,
+				tfLastCommitPosition: lastIndexedPosition));
+
+		public long GetLastEventNumber(string streamId) => lastEventNumber;
+
+		public long GetLastIndexedPosition(string streamId) => lastIndexedPosition;
+
+		public bool CanReadStream(string candidate) => candidate == streamId;
+	}
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -97,6 +97,7 @@ public abstract class ClusterVNode
 		IReadOnlyList<IPersistentSubscriptionConsumerStrategyFactory> factories = null,
 		CertificateProvider certificateProvider = null,
 		IConfiguration configuration = null,
+		IReadOnlyList<IVirtualStreamReader> additionalVirtualStreamReaders = null,
 		Guid? instanceId = null,
 		int debugIndex = 0)
 	{
@@ -109,6 +110,7 @@ public abstract class ClusterVNode
 			factories,
 			certificateProvider,
 			configuration,
+			additionalVirtualStreamReaders: additionalVirtualStreamReaders,
 			instanceId: instanceId,
 			debugIndex: debugIndex);
 	}
@@ -245,7 +247,8 @@ public class ClusterVNode<TStreamId> :
 		IConfiguration configuration = null,
 		IExpiryStrategy expiryStrategy = null,
 		Guid? instanceId = null, int debugIndex = 0,
-		Action<IServiceCollection> configureAdditionalNodeServices = null)
+		Action<IServiceCollection> configureAdditionalNodeServices = null,
+		IReadOnlyList<IVirtualStreamReader> additionalVirtualStreamReaders = null)
 	{
 
 		configuration ??= new ConfigurationBuilder().Build();
@@ -805,10 +808,18 @@ public class ClusterVNode<TStreamId> :
 		var nodeStatusListener = new NodeStateListenerService(_mainQueue, memLog);
 		_mainBus.Subscribe<SystemMessage.StateChangeMessage>(nodeStatusListener);
 
-		var virtualStreamReader = new VirtualStreamReader([
+		var virtualStreamReaders = new List<IVirtualStreamReader>
+		{
 			gossipListener.Stream,
 			nodeStatusListener.Stream,
-		]);
+		};
+
+		if (additionalVirtualStreamReaders is not null)
+		{
+			virtualStreamReaders.AddRange(additionalVirtualStreamReaders);
+		}
+
+		var virtualStreamReader = new VirtualStreamReader(virtualStreamReaders.ToArray());
 
 		// Storage Reader
 		var storageReader = new StorageReaderService<TStreamId>(_mainQueue, _mainBus, readIndex,


### PR DESCRIPTION
- Internal indexing needs a safe way to expose read-only virtual streams for future storage capabilities.
- Keeping built-in operational virtual streams first protects existing node behavior while allowing future internal streams to plug in behind them.