### PR TITLE
feat(storage): unblock pluggable in-memory streams

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -21,6 +21,7 @@ using EventStore.Core.Hashing;
 using EventStore.Core.LogAbstraction;
 using EventStore.Core.PluginModel;
 using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
+using EventStore.Core.Services.Storage.InMemory;
 using EventStore.PluginHosting;
 using EventStore.Plugins;
 using EventStore.Plugins.Authentication;
@@ -124,7 +125,10 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable
 		Node = ClusterVNode.Create(_options, logFormatFactory, GetAuthenticationProviderFactory(),
 			authProviderFactory,
 			GetPersistentSubscriptionConsumerStrategyFactories(), certificateProvider,
-			configuration);
+			configuration,
+			additionalVirtualStreamReaders: _options.PlugableComponents
+				.OfType<IVirtualStreamReaderProvider>()
+				.GetVirtualStreamReaders());
 
 		EnabledNodeSubsystems = projectionMode >= ProjectionType.System
 			? new[] { NodeSubsystems.Projections }

--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/InMemory/VirtualStreamReaderProviderTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/InMemory/VirtualStreamReaderProviderTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.Storage.InMemory;
+using EventStore.Plugins;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.Storage.InMemory;
+
+public class VirtualStreamReaderProviderTests
+{
+	[Fact]
+	public void returns_no_readers_when_no_provider_components_are_configured()
+	{
+		var readers = new ClusterVNodeOptions()
+			.PlugableComponents
+			.OfType<IVirtualStreamReaderProvider>()
+			.GetVirtualStreamReaders();
+
+		Assert.Empty(readers);
+	}
+
+	[Fact]
+	public void collects_readers_from_provider_components_in_registration_order()
+	{
+		var first = new FakeVirtualStreamReader("$mem-first");
+		var second = new FakeVirtualStreamReader("$mem-second");
+		var third = new FakeVirtualStreamReader("$mem-third");
+
+		var options = new ClusterVNodeOptions()
+			.WithPlugableComponent(new FakeComponent("regular"))
+			.WithPlugableComponent(new FakeProvider("first-provider", first, second))
+			.WithPlugableComponent(new FakeProvider("second-provider", third));
+
+		var readers = options
+			.PlugableComponents
+			.OfType<IVirtualStreamReaderProvider>()
+			.GetVirtualStreamReaders();
+
+		Assert.Equal([first, second, third], readers);
+	}
+
+	private sealed class FakeComponent(string name) : Plugin(name);
+
+	private sealed class FakeProvider(string name, params IVirtualStreamReader[] readers)
+		: Plugin(name), IVirtualStreamReaderProvider
+	{
+		public IReadOnlyList<IVirtualStreamReader> VirtualStreamReaders { get; } = readers;
+	}
+
+	private sealed class FakeVirtualStreamReader(string streamId) : IVirtualStreamReader
+	{
+		public ValueTask<ClientMessage.ReadStreamEventsForwardCompleted> ReadForwards(
+			ClientMessage.ReadStreamEventsForward msg,
+			CancellationToken token) =>
+			throw new NotSupportedException();
+
+		public ValueTask<ClientMessage.ReadStreamEventsBackwardCompleted> ReadBackwards(
+			ClientMessage.ReadStreamEventsBackward msg,
+			CancellationToken token) =>
+			throw new NotSupportedException();
+
+		public long GetLastEventNumber(string streamId) => 0;
+
+		public long GetLastIndexedPosition(string streamId) => 0;
+
+		public bool CanReadStream(string candidateStreamId) => candidateStreamId == streamId;
+	}
+}

--- a/src/EventStore.Core/Services/Storage/InMemory/IVirtualStreamReaderProvider.cs
+++ b/src/EventStore.Core/Services/Storage/InMemory/IVirtualStreamReaderProvider.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EventStore.Core.Services.Storage.InMemory;
+
+public interface IVirtualStreamReaderProvider
+{
+	IReadOnlyList<IVirtualStreamReader> VirtualStreamReaders { get; }
+}
+
+public static class VirtualStreamReaderProviderExtensions
+{
+	public static IReadOnlyList<IVirtualStreamReader> GetVirtualStreamReaders(
+		this IEnumerable<IVirtualStreamReaderProvider> providers) =>
+		providers.SelectMany(provider => provider.VirtualStreamReaders).ToArray();
+}


### PR DESCRIPTION
- Internal node capabilities need the same startup path as built-in in-memory streams.
- Future storage-adjacent features should not require special-case node construction to become readable.
