### PR TITLE
feat(indexing): add checkpoint commit tracker

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexCheckpointCommitTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexCheckpointCommitTrackerTests.cs
@@ -234,6 +234,23 @@ public class IndexCheckpointCommitTrackerTests
 	}
 
 	[Fact]
+	public async Task dispose_surfaces_pending_commit_failure()
+	{
+		var tracker = new IndexCheckpointCommitTracker(
+			batchSize: 100,
+			maxCommitDelay: TimeSpan.FromSeconds(30),
+			commit: _ => throw new InvalidOperationException("commit failed"),
+			cancellationToken: CancellationToken.None);
+
+		tracker.Track();
+
+		var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+			() => tracker.DisposeAsync().AsTask());
+
+		Assert.Equal("commit failed", exception.Message);
+	}
+
+	[Fact]
 	public async Task track_after_dispose_throws()
 	{
 		var tracker = new IndexCheckpointCommitTracker(

--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexCheckpointCommitTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexCheckpointCommitTrackerTests.cs
@@ -189,6 +189,51 @@ public class IndexCheckpointCommitTrackerTests
 	}
 
 	[Fact]
+	public async Task cancellation_commits_pending_changes_before_stopping()
+	{
+		var calls = 0;
+		var committed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		using var cancellation = new CancellationTokenSource();
+		await using var tracker = new IndexCheckpointCommitTracker(
+			batchSize: 100,
+			maxCommitDelay: TimeSpan.FromSeconds(30),
+			commit: _ =>
+			{
+				Interlocked.Increment(ref calls);
+				committed.SetResult();
+				return ValueTask.CompletedTask;
+			},
+			cancellationToken: cancellation.Token);
+
+		tracker.Track();
+		await cancellation.CancelAsync();
+
+		await committed.Task.WaitAsync(CommitTimeout);
+
+		Assert.Equal(1, calls);
+	}
+
+	[Fact]
+	public async Task dispose_commits_pending_changes_before_stopping()
+	{
+		var calls = 0;
+		var tracker = new IndexCheckpointCommitTracker(
+			batchSize: 100,
+			maxCommitDelay: TimeSpan.FromSeconds(30),
+			commit: _ =>
+			{
+				Interlocked.Increment(ref calls);
+				return ValueTask.CompletedTask;
+			},
+			cancellationToken: CancellationToken.None);
+
+		tracker.Track();
+		await tracker.DisposeAsync();
+
+		Assert.Equal(1, calls);
+	}
+
+	[Fact]
 	public async Task track_after_dispose_throws()
 	{
 		var tracker = new IndexCheckpointCommitTracker(

--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexCheckpointCommitTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexCheckpointCommitTrackerTests.cs
@@ -139,6 +139,31 @@ public class IndexCheckpointCommitTrackerTests
 	}
 
 	[Fact]
+	public async Task failed_commit_keeps_pending_changes_for_retry()
+	{
+		var calls = 0;
+		var committed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		await using var tracker = new IndexCheckpointCommitTracker(
+			batchSize: 1,
+			maxCommitDelay: TimeSpan.FromMilliseconds(25),
+			commit: _ =>
+			{
+				if (Interlocked.Increment(ref calls) == 1)
+					throw new InvalidOperationException("transient failure");
+
+				committed.SetResult();
+				return ValueTask.CompletedTask;
+			},
+			cancellationToken: CancellationToken.None);
+
+		tracker.Track();
+
+		await committed.Task.WaitAsync(CommitTimeout);
+
+		Assert.Equal(2, calls);
+	}
+
+	[Fact]
 	public async Task cancellation_stops_future_commits()
 	{
 		var calls = 0;

--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexCheckpointCommitTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexCheckpointCommitTrackerTests.cs
@@ -145,7 +145,7 @@ public class IndexCheckpointCommitTrackerTests
 		var committed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 		await using var tracker = new IndexCheckpointCommitTracker(
 			batchSize: 1,
-			maxCommitDelay: TimeSpan.FromMilliseconds(25),
+			maxCommitDelay: TimeSpan.FromSeconds(30),
 			commit: _ =>
 			{
 				if (Interlocked.Increment(ref calls) == 1)
@@ -206,15 +206,33 @@ public class IndexCheckpointCommitTrackerTests
 	[Fact]
 	public async Task concurrent_dispose_calls_are_safe()
 	{
+		var commitStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var releaseCommit = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 		var tracker = new IndexCheckpointCommitTracker(
-			batchSize: 10,
+			batchSize: 1,
 			maxCommitDelay: TimeSpan.FromSeconds(30),
-			commit: _ => ValueTask.CompletedTask,
+			commit: async _ =>
+			{
+				commitStarted.SetResult();
+				await releaseCommit.Task;
+			},
 			cancellationToken: CancellationToken.None);
 
-		await Task.WhenAll(Enumerable
+		tracker.Track();
+		await commitStarted.Task.WaitAsync(CommitTimeout);
+
+		var disposeTasks = Enumerable
 			.Range(0, 5)
-			.Select(_ => Task.Run(async () => await tracker.DisposeAsync())));
+			.Select(_ => Task.Run(async () => await tracker.DisposeAsync()))
+			.ToArray();
+
+		await Task.Delay(TimeSpan.FromMilliseconds(50));
+
+		foreach (var disposeTask in disposeTasks)
+			Assert.False(disposeTask.IsCompleted);
+
+		releaseCommit.SetResult();
+		await Task.WhenAll(disposeTasks).WaitAsync(CommitTimeout);
 	}
 
 	[Fact]

--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexCheckpointCommitTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexCheckpointCommitTrackerTests.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Services.Storage.Indexing;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.Storage.Indexing;
+
+public class IndexCheckpointCommitTrackerTests
+{
+	[Fact]
+	public async Task commits_when_batch_size_is_reached()
+	{
+		var calls = 0;
+		var committed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		await using var tracker = new IndexCheckpointCommitTracker(
+			batchSize: 5,
+			maxCommitDelay: TimeSpan.FromSeconds(30),
+			commit: _ =>
+			{
+				Interlocked.Increment(ref calls);
+				committed.SetResult();
+				return ValueTask.CompletedTask;
+			},
+			cancellationToken: CancellationToken.None);
+
+		for (var index = 0; index < 5; index++)
+			tracker.Track();
+
+		await committed.Task.WaitAsync(CommitTimeout);
+
+		Assert.Equal(1, calls);
+	}
+
+	[Fact]
+	public async Task commits_pending_changes_when_delay_elapses()
+	{
+		var calls = 0;
+		var committed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		await using var tracker = new IndexCheckpointCommitTracker(
+			batchSize: 100,
+			maxCommitDelay: TimeSpan.FromMilliseconds(25),
+			commit: _ =>
+			{
+				Interlocked.Increment(ref calls);
+				committed.SetResult();
+				return ValueTask.CompletedTask;
+			},
+			cancellationToken: CancellationToken.None);
+
+		tracker.Track();
+
+		await committed.Task.WaitAsync(CommitTimeout);
+
+		Assert.Equal(1, calls);
+	}
+
+	[Fact]
+	public async Task does_not_commit_when_no_changes_were_tracked()
+	{
+		var calls = 0;
+		await using (new IndexCheckpointCommitTracker(
+			batchSize: 100,
+			maxCommitDelay: TimeSpan.FromMilliseconds(25),
+			commit: _ =>
+			{
+				Interlocked.Increment(ref calls);
+				return ValueTask.CompletedTask;
+			},
+			cancellationToken: CancellationToken.None))
+		{
+			await Task.Delay(TimeSpan.FromMilliseconds(75));
+		}
+
+		Assert.Equal(0, calls);
+	}
+
+	[Fact]
+	public async Task does_not_run_commits_reentrantly()
+	{
+		var currentCommits = 0;
+		var maxConcurrentCommits = 0;
+		var firstCommitStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var releaseCommit = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		await using var tracker = new IndexCheckpointCommitTracker(
+			batchSize: 3,
+			maxCommitDelay: TimeSpan.FromSeconds(30),
+			commit: async _ =>
+			{
+				var active = Interlocked.Increment(ref currentCommits);
+				SetMax(ref maxConcurrentCommits, active);
+				firstCommitStarted.TrySetResult();
+
+				await releaseCommit.Task;
+
+				Interlocked.Decrement(ref currentCommits);
+			},
+			cancellationToken: CancellationToken.None);
+
+		for (var index = 0; index < 3; index++)
+			tracker.Track();
+
+		await firstCommitStarted.Task.WaitAsync(CommitTimeout);
+
+		for (var index = 0; index < 3; index++)
+			tracker.Track();
+
+		releaseCommit.SetResult();
+
+		await Task.Delay(TimeSpan.FromMilliseconds(50));
+
+		Assert.Equal(1, maxConcurrentCommits);
+	}
+
+	[Fact]
+	public async Task concurrent_tracks_trigger_one_batch_commit()
+	{
+		var calls = 0;
+		var committed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		await using var tracker = new IndexCheckpointCommitTracker(
+			batchSize: 100,
+			maxCommitDelay: TimeSpan.FromSeconds(30),
+			commit: _ =>
+			{
+				Interlocked.Increment(ref calls);
+				committed.SetResult();
+				return ValueTask.CompletedTask;
+			},
+			cancellationToken: CancellationToken.None);
+
+		await Task.WhenAll(Enumerable
+			.Range(0, 100)
+			.Select(_ => Task.Run(tracker.Track)));
+
+		await committed.Task.WaitAsync(CommitTimeout);
+
+		Assert.Equal(1, calls);
+	}
+
+	[Fact]
+	public async Task cancellation_stops_future_commits()
+	{
+		var calls = 0;
+		using var cancellation = new CancellationTokenSource();
+		await using var tracker = new IndexCheckpointCommitTracker(
+			batchSize: 1,
+			maxCommitDelay: TimeSpan.FromSeconds(30),
+			commit: _ =>
+			{
+				Interlocked.Increment(ref calls);
+				return ValueTask.CompletedTask;
+			},
+			cancellationToken: cancellation.Token);
+
+		await cancellation.CancelAsync();
+		await Task.Delay(TimeSpan.FromMilliseconds(50));
+
+		tracker.Track();
+		await Task.Delay(TimeSpan.FromMilliseconds(50));
+
+		Assert.Equal(0, calls);
+	}
+
+	[Fact]
+	public async Task track_after_dispose_throws()
+	{
+		var tracker = new IndexCheckpointCommitTracker(
+			batchSize: 10,
+			maxCommitDelay: TimeSpan.FromSeconds(30),
+			commit: _ => ValueTask.CompletedTask,
+			cancellationToken: CancellationToken.None);
+
+		await tracker.DisposeAsync();
+
+		var exception = Assert.Throws<ObjectDisposedException>(tracker.Track);
+		Assert.Contains(nameof(IndexCheckpointCommitTracker), exception.Message);
+	}
+
+	[Fact]
+	public async Task concurrent_dispose_calls_are_safe()
+	{
+		var tracker = new IndexCheckpointCommitTracker(
+			batchSize: 10,
+			maxCommitDelay: TimeSpan.FromSeconds(30),
+			commit: _ => ValueTask.CompletedTask,
+			cancellationToken: CancellationToken.None);
+
+		await Task.WhenAll(Enumerable
+			.Range(0, 5)
+			.Select(_ => Task.Run(async () => await tracker.DisposeAsync())));
+	}
+
+	[Fact]
+	public async Task dispose_waits_for_active_commit_to_finish()
+	{
+		var commitFinished = false;
+		var commitStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var releaseCommit = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var tracker = new IndexCheckpointCommitTracker(
+			batchSize: 1,
+			maxCommitDelay: TimeSpan.FromSeconds(30),
+			commit: async _ =>
+			{
+				commitStarted.SetResult();
+				await releaseCommit.Task;
+				commitFinished = true;
+			},
+			cancellationToken: CancellationToken.None);
+
+		tracker.Track();
+		await commitStarted.Task.WaitAsync(CommitTimeout);
+
+		var disposeTask = tracker.DisposeAsync().AsTask();
+
+		Assert.False(disposeTask.IsCompleted);
+
+		releaseCommit.SetResult();
+		await disposeTask.WaitAsync(CommitTimeout);
+
+		Assert.True(commitFinished);
+	}
+
+	private static void SetMax(ref int target, int candidate)
+	{
+		while (true)
+		{
+			var current = Volatile.Read(ref target);
+			if (current >= candidate)
+				return;
+
+			if (Interlocked.CompareExchange(ref target, candidate, current) == current)
+				return;
+		}
+	}
+
+	private static readonly TimeSpan CommitTimeout = TimeSpan.FromSeconds(5);
+}

--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexCheckpointCommitTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexCheckpointCommitTrackerTests.cs
@@ -164,7 +164,7 @@ public class IndexCheckpointCommitTrackerTests
 	}
 
 	[Fact]
-	public async Task cancellation_stops_future_commits()
+	public async Task cancellation_stops_future_tracks()
 	{
 		var calls = 0;
 		using var cancellation = new CancellationTokenSource();
@@ -181,9 +181,10 @@ public class IndexCheckpointCommitTrackerTests
 		await cancellation.CancelAsync();
 		await Task.Delay(TimeSpan.FromMilliseconds(50));
 
-		tracker.Track();
+		var exception = Assert.Throws<ObjectDisposedException>(tracker.Track);
 		await Task.Delay(TimeSpan.FromMilliseconds(50));
 
+		Assert.Contains(nameof(IndexCheckpointCommitTracker), exception.Message);
 		Assert.Equal(0, calls);
 	}
 

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexCheckpointCommitTracker.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexCheckpointCommitTracker.cs
@@ -35,7 +35,7 @@ public sealed class IndexCheckpointCommitTracker : IAsyncDisposable
 
 	public void Track()
 	{
-		ObjectDisposedException.ThrowIf(_disposed is not 0, this);
+		ObjectDisposedException.ThrowIf(_disposed is not 0 || _lifetime.IsCancellationRequested, this);
 
 		if (Interlocked.Increment(ref _pending) == _batchSize)
 			RequestCommit();

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexCheckpointCommitTracker.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexCheckpointCommitTracker.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace EventStore.Core.Services.Storage.Indexing;
+
+public sealed class IndexCheckpointCommitTracker : IAsyncDisposable
+{
+	private readonly int _batchSize;
+	private readonly TimeSpan _maxCommitDelay;
+	private readonly Func<CancellationToken, ValueTask> _commit;
+	private readonly CancellationTokenSource _lifetime;
+	private readonly SemaphoreSlim _commitRequested = new(0, 1);
+	private readonly Task _runTask;
+
+	private int _disposed;
+	private int _pending;
+
+	public IndexCheckpointCommitTracker(
+		int batchSize,
+		TimeSpan maxCommitDelay,
+		Func<CancellationToken, ValueTask> commit,
+		CancellationToken cancellationToken)
+	{
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(batchSize);
+		ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(maxCommitDelay, TimeSpan.Zero);
+
+		_batchSize = batchSize;
+		_maxCommitDelay = maxCommitDelay;
+		_commit = commit ?? throw new ArgumentNullException(nameof(commit));
+		_lifetime = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		_runTask = Task.Run(RunAsync);
+	}
+
+	public void Track()
+	{
+		ObjectDisposedException.ThrowIf(_disposed is not 0, this);
+
+		if (Interlocked.Increment(ref _pending) == _batchSize)
+			RequestCommit();
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		if (Interlocked.Exchange(ref _disposed, 1) is not 0)
+			return;
+
+		await _lifetime.CancelAsync();
+
+		try
+		{
+			await _runTask;
+		}
+		catch (OperationCanceledException)
+		{
+		}
+		finally
+		{
+			_commitRequested.Dispose();
+			_lifetime.Dispose();
+		}
+	}
+
+	private async Task RunAsync()
+	{
+		var token = _lifetime.Token;
+
+		while (!token.IsCancellationRequested)
+		{
+			try
+			{
+				await _commitRequested.WaitAsync(_maxCommitDelay, token);
+			}
+			catch (OperationCanceledException) when (token.IsCancellationRequested)
+			{
+				break;
+			}
+
+			if (Interlocked.Exchange(ref _pending, 0) is 0)
+				continue;
+
+			try
+			{
+				await _commit(token);
+			}
+			catch (OperationCanceledException) when (token.IsCancellationRequested)
+			{
+				break;
+			}
+			catch (Exception ex)
+			{
+				Log.Error(ex, "Error while committing an index checkpoint");
+			}
+		}
+	}
+
+	private void RequestCommit()
+	{
+		try
+		{
+			_commitRequested.Release();
+		}
+		catch (SemaphoreFullException)
+		{
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexCheckpointCommitTracker.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexCheckpointCommitTracker.cs
@@ -115,36 +115,57 @@ public sealed class IndexCheckpointCommitTracker : IAsyncDisposable
 	{
 		var token = _lifetime.Token;
 
-		while (!token.IsCancellationRequested)
+		try
 		{
-			try
+			while (!token.IsCancellationRequested)
 			{
-				await _commitRequested.WaitAsync(_maxCommitDelay, token);
-			}
-			catch (OperationCanceledException) when (token.IsCancellationRequested)
-			{
-				break;
-			}
+				try
+				{
+					await _commitRequested.WaitAsync(_maxCommitDelay, token);
+				}
+				catch (OperationCanceledException) when (token.IsCancellationRequested)
+				{
+					break;
+				}
 
-			var pending = Interlocked.Exchange(ref _pending, 0);
-			if (pending is 0)
-				continue;
+				try
+				{
+					await CommitPending(token, requestRetry: true);
+				}
+				catch (OperationCanceledException) when (token.IsCancellationRequested)
+				{
+					break;
+				}
+			}
+		}
+		finally
+		{
+			StopTracking();
+			await CommitPending(CancellationToken.None, requestRetry: false);
+		}
+	}
 
-			try
-			{
-				await _commit(token);
-			}
-			catch (OperationCanceledException) when (token.IsCancellationRequested)
-			{
-				break;
-			}
-			catch (Exception ex)
-			{
-				if (Interlocked.Add(ref _pending, pending) >= _batchSize)
-					RequestCommit();
+	private async ValueTask CommitPending(CancellationToken token, bool requestRetry)
+	{
+		var pending = Interlocked.Exchange(ref _pending, 0);
+		if (pending is 0)
+			return;
 
-				Log.Error(ex, "Error while committing an index checkpoint");
-			}
+		try
+		{
+			await _commit(token);
+		}
+		catch (OperationCanceledException) when (token.IsCancellationRequested)
+		{
+			Interlocked.Add(ref _pending, pending);
+			throw;
+		}
+		catch (Exception ex)
+		{
+			if (Interlocked.Add(ref _pending, pending) >= _batchSize && requestRetry)
+				RequestCommit();
+
+			Log.Error(ex, "Error while committing an index checkpoint");
 		}
 	}
 

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexCheckpointCommitTracker.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexCheckpointCommitTracker.cs
@@ -53,7 +53,18 @@ public sealed class IndexCheckpointCommitTracker : IAsyncDisposable
 
 	public async ValueTask DisposeAsync()
 	{
-		if (Interlocked.Exchange(ref _disposed, 1) is not 0)
+		var dispose = false;
+		lock (_stateLock)
+		{
+			if (_disposed is 0)
+			{
+				_disposed = 1;
+				_stopped = true;
+				dispose = true;
+			}
+		}
+
+		if (!dispose)
 		{
 			await _disposeCompleted.Task;
 			return;

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexCheckpointCommitTracker.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexCheckpointCommitTracker.cs
@@ -162,7 +162,14 @@ public sealed class IndexCheckpointCommitTracker : IAsyncDisposable
 		}
 		catch (Exception ex)
 		{
-			if (Interlocked.Add(ref _pending, pending) >= _batchSize && requestRetry)
+			var restoredPending = Interlocked.Add(ref _pending, pending);
+			if (!requestRetry)
+			{
+				Log.Error(ex, "Error while committing an index checkpoint");
+				throw;
+			}
+
+			if (restoredPending >= _batchSize)
 				RequestCommit();
 
 			Log.Error(ex, "Error while committing an index checkpoint");

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexCheckpointCommitTracker.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexCheckpointCommitTracker.cs
@@ -77,7 +77,8 @@ public sealed class IndexCheckpointCommitTracker : IAsyncDisposable
 				break;
 			}
 
-			if (Interlocked.Exchange(ref _pending, 0) is 0)
+			var pending = Interlocked.Exchange(ref _pending, 0);
+			if (pending is 0)
 				continue;
 
 			try
@@ -90,6 +91,7 @@ public sealed class IndexCheckpointCommitTracker : IAsyncDisposable
 			}
 			catch (Exception ex)
 			{
+				Interlocked.Add(ref _pending, pending);
 				Log.Error(ex, "Error while committing an index checkpoint");
 			}
 		}

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexCheckpointCommitTracker.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexCheckpointCommitTracker.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Serilog;
@@ -10,12 +11,16 @@ public sealed class IndexCheckpointCommitTracker : IAsyncDisposable
 	private readonly int _batchSize;
 	private readonly TimeSpan _maxCommitDelay;
 	private readonly Func<CancellationToken, ValueTask> _commit;
+	private readonly object _stateLock = new();
 	private readonly CancellationTokenSource _lifetime;
+	private readonly CancellationTokenRegistration _stopTracking;
 	private readonly SemaphoreSlim _commitRequested = new(0, 1);
+	private readonly TaskCompletionSource _disposeCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
 	private readonly Task _runTask;
 
 	private int _disposed;
 	private int _pending;
+	private bool _stopped;
 
 	public IndexCheckpointCommitTracker(
 		int batchSize,
@@ -30,36 +35,69 @@ public sealed class IndexCheckpointCommitTracker : IAsyncDisposable
 		_maxCommitDelay = maxCommitDelay;
 		_commit = commit ?? throw new ArgumentNullException(nameof(commit));
 		_lifetime = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		_stopTracking = _lifetime.Token.Register(static state =>
+			((IndexCheckpointCommitTracker)state!).StopTracking(), this);
 		_runTask = Task.Run(RunAsync);
 	}
 
 	public void Track()
 	{
-		ObjectDisposedException.ThrowIf(_disposed is not 0 || _lifetime.IsCancellationRequested, this);
+		lock (_stateLock)
+		{
+			ObjectDisposedException.ThrowIf(_stopped, this);
 
-		if (Interlocked.Increment(ref _pending) == _batchSize)
-			RequestCommit();
+			if (Interlocked.Increment(ref _pending) >= _batchSize)
+				RequestCommit();
+		}
 	}
 
 	public async ValueTask DisposeAsync()
 	{
 		if (Interlocked.Exchange(ref _disposed, 1) is not 0)
+		{
+			await _disposeCompleted.Task;
 			return;
+		}
 
-		await _lifetime.CancelAsync();
+		Exception failure = null;
 
 		try
 		{
-			await _runTask;
+			StopTracking();
+			await _lifetime.CancelAsync();
+
+			try
+			{
+				await _runTask;
+			}
+			catch (OperationCanceledException)
+			{
+			}
 		}
-		catch (OperationCanceledException)
+		catch (Exception ex)
 		{
+			failure = ex;
 		}
-		finally
+
+		try
 		{
+			_stopTracking.Dispose();
 			_commitRequested.Dispose();
 			_lifetime.Dispose();
 		}
+		catch (Exception ex) when (failure is null)
+		{
+			failure = ex;
+		}
+
+		if (failure is null)
+		{
+			_disposeCompleted.SetResult();
+			return;
+		}
+
+		_disposeCompleted.SetException(failure);
+		ExceptionDispatchInfo.Capture(failure).Throw();
 	}
 
 	private async Task RunAsync()
@@ -91,10 +129,18 @@ public sealed class IndexCheckpointCommitTracker : IAsyncDisposable
 			}
 			catch (Exception ex)
 			{
-				Interlocked.Add(ref _pending, pending);
+				if (Interlocked.Add(ref _pending, pending) >= _batchSize)
+					RequestCommit();
+
 				Log.Error(ex, "Error while committing an index checkpoint");
 			}
 		}
+	}
+
+	private void StopTracking()
+	{
+		lock (_stateLock)
+			_stopped = true;
 	}
 
 	private void RequestCommit()


### PR DESCRIPTION
- Internal indexing checkpoints need a race-safe commit trigger before the wider indexing pipeline can rely on them.
- Delayed and batched commits need deterministic cancellation and disposal behavior so future indexing work does not duplicate checkpoint writes.