### PR TITLE
fix(ci): keep arm64 lane off pull requests

### DIFF
--- a/.github/workflows/build-ubuntu-lts-arm64.yml
+++ b/.github/workflows/build-ubuntu-lts-arm64.yml
@@ -12,6 +12,10 @@ on:
       - "samples/**"
       - "**.md"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/build-ubuntu-lts-arm64.yml
+++ b/.github/workflows/build-ubuntu-lts-arm64.yml
@@ -1,11 +1,6 @@
 name: Ubuntu LTS ARM64
 
 on:
-  pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "samples/**"
-      - "**.md"
   push:
     branches:
       - master
@@ -16,10 +11,6 @@ on:
       - "docs/**"
       - "samples/**"
       - "**.md"
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
- Avoid spending ARM64 runner time on every pull request when the lane is intended for protected branch and release confidence.
- Keep PR feedback focused on faster validation while preserving ARM64 coverage for master and release publishing.