### PR TITLE
fix(indexing): keep service lifecycle bounded

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingServiceTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.Storage.Indexing;
+using EventStore.Core.Services.Transport.Enumerators;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.Storage.Indexing;
+
+public class IndexingServiceTests
+{
+	[Fact]
+	public async Task shutdown_disposes_subscription_and_unsubscribes()
+	{
+		var subscriber = new RecordingSubscriber();
+		var component = new FakeIndexingComponent();
+		var eventSource = new FakeIndexingEventSource();
+		var service = new IndexingService(
+			component,
+			new FakeIndexingEventSourceFactory(eventSource),
+			subscriber,
+			IndexingSubscriptionOptions.Default);
+
+		await service.HandleAsync(new SystemMessage.SystemReady(), CancellationToken.None);
+		await service.HandleAsync(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), false, false), CancellationToken.None);
+
+		Assert.True(component.Disposed);
+		Assert.True(eventSource.Disposed);
+		Assert.False(subscriber.Has<SystemMessage.SystemReady>());
+		Assert.False(subscriber.Has<SystemMessage.BecomeShuttingDown>());
+	}
+
+	[Fact]
+	public async Task dispose_unsubscribes_when_subscription_cleanup_fails()
+	{
+		var subscriber = new RecordingSubscriber();
+		var service = new IndexingService(
+			new FakeIndexingComponent(throwOnDispose: true),
+			new FakeIndexingEventSourceFactory(new FakeIndexingEventSource()),
+			subscriber,
+			IndexingSubscriptionOptions.Default);
+
+		var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+			() => service.DisposeAsync().AsTask());
+
+		Assert.Equal("dispose failed", exception.Message);
+		Assert.False(subscriber.Has<SystemMessage.SystemReady>());
+		Assert.False(subscriber.Has<SystemMessage.BecomeShuttingDown>());
+	}
+
+	private sealed class RecordingSubscriber : ISubscriber
+	{
+		private readonly HashSet<Type> _subscriptions = [];
+
+		public void Subscribe<T>(IAsyncHandle<T> handler) where T : Message =>
+			_subscriptions.Add(typeof(T));
+
+		public void Unsubscribe<T>(IAsyncHandle<T> handler) where T : Message =>
+			_subscriptions.Remove(typeof(T));
+
+		public bool Has<T>() where T : Message => _subscriptions.Contains(typeof(T));
+	}
+
+	private sealed class FakeIndexingComponent(bool throwOnDispose = false) : IIndexingComponent
+	{
+		public IIndexingProcessor Processor { get; } = new FakeIndexingProcessor();
+
+		public bool Disposed { get; private set; }
+
+		public ValueTask Initialize(CancellationToken token) => ValueTask.CompletedTask;
+
+		public ValueTask<IndexCheckpoint?> ReadCheckpoint(CancellationToken token) => ValueTask.FromResult<IndexCheckpoint?>(null);
+
+		public ValueTask DisposeAsync()
+		{
+			Disposed = true;
+			return throwOnDispose
+				? ValueTask.FromException(new InvalidOperationException("dispose failed"))
+				: ValueTask.CompletedTask;
+		}
+	}
+
+	private sealed class FakeIndexingProcessor : IIndexingProcessor
+	{
+		public ValueTask Index(ResolvedEvent resolvedEvent, CancellationToken token) => ValueTask.CompletedTask;
+
+		public ValueTask Commit(CancellationToken token) => ValueTask.CompletedTask;
+	}
+
+	private sealed class FakeIndexingEventSourceFactory(FakeIndexingEventSource source) : IIndexingEventSourceFactory
+	{
+		public IIndexingEventSource Create(IndexCheckpoint? checkpoint, CancellationToken token)
+		{
+			source.Bind(token);
+			return source;
+		}
+	}
+
+	private sealed class FakeIndexingEventSource : IIndexingEventSource
+	{
+		private CancellationToken _token;
+
+		public ReadResponse Current => null;
+
+		public bool Disposed { get; private set; }
+
+		public void Bind(CancellationToken token) => _token = token;
+
+		public async ValueTask<bool> MoveNextAsync()
+		{
+			await Task.Delay(Timeout.InfiniteTimeSpan, _token);
+			return false;
+		}
+
+		public ValueTask DisposeAsync()
+		{
+			Disposed = true;
+			return ValueTask.CompletedTask;
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexingService.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexingService.cs
@@ -8,7 +8,9 @@ namespace EventStore.Core.Services.Storage.Indexing;
 
 public sealed class IndexingService : IAsyncHandle<SystemMessage.SystemReady>, IAsyncHandle<SystemMessage.BecomeShuttingDown>, IAsyncDisposable
 {
+	private readonly ISubscriber _subscriber;
 	private readonly IndexingSubscription _subscription;
+	private int _disposed;
 
 	public IndexingService(
 		IIndexingComponent component,
@@ -16,6 +18,7 @@ public sealed class IndexingService : IAsyncHandle<SystemMessage.SystemReady>, I
 		ISubscriber subscriber,
 		IndexingSubscriptionOptions options)
 	{
+		_subscriber = subscriber;
 		_subscription = new IndexingSubscription(component, eventSourceFactory, options);
 
 		subscriber.Subscribe<SystemMessage.SystemReady>(this);
@@ -26,7 +29,23 @@ public sealed class IndexingService : IAsyncHandle<SystemMessage.SystemReady>, I
 		_subscription.Start(token);
 
 	public ValueTask HandleAsync(SystemMessage.BecomeShuttingDown message, CancellationToken token) =>
-		_subscription.DisposeAsync();
+		DisposeAsync();
 
-	public ValueTask DisposeAsync() => _subscription.DisposeAsync();
+	public async ValueTask DisposeAsync()
+	{
+		if (Interlocked.Exchange(ref _disposed, 1) is not 0)
+		{
+			return;
+		}
+
+		try
+		{
+			await _subscription.DisposeAsync();
+		}
+		finally
+		{
+			_subscriber.Unsubscribe<SystemMessage.SystemReady>(this);
+			_subscriber.Unsubscribe<SystemMessage.BecomeShuttingDown>(this);
+		}
+	}
 }


### PR DESCRIPTION
- Internal indexing services should not leave stale bus handlers behind after shutdown.
- Failed cleanup should not make later system messages route back into disposed indexing state.