### PR TITLE
feat(indexing): expose indexing component lifecycle

### DIFF
--- a/src/EventStore.Core.Tests/Services/Replication/LogReplication/Tests/data_chunk_replication.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LogReplication/Tests/data_chunk_replication.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 namespace EventStore.Core.Tests.Services.Replication.LogReplication.Tests;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
+[NonParallelizable]
 public class data_chunk_replication<TLogFormat, TStreamId> : LogReplicationFixture<TLogFormat, TStreamId>
 {
 	private readonly string _bulkSizedEvent = new(' ', LeaderReplicationService.BulkSize);

--- a/src/EventStore.Core.Tests/Services/Replication/LogReplication/Tests/data_chunk_replication_with_existing_db.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LogReplication/Tests/data_chunk_replication_with_existing_db.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 namespace EventStore.Core.Tests.Services.Replication.LogReplication.Tests;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
+[NonParallelizable]
 public class data_chunk_replication_with_existing_db<TLogFormat, TStreamId> : LogReplicationWithExistingDbFixture<TLogFormat, TStreamId>
 {
 	private const int NumCheckpoints = 5 + /* chunk 0-0 (non-raw): 3 complete transactions, 1 incomplete transaction

--- a/src/EventStore.Core.Tests/Services/Replication/LogReplication/Tests/raw_chunk_replication.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LogReplication/Tests/raw_chunk_replication.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 namespace EventStore.Core.Tests.Services.Replication.LogReplication.Tests;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
+[NonParallelizable]
 public class raw_chunk_replication<TLogFormat, TStreamId> : LogReplicationWithExistingDbFixture<TLogFormat, TStreamId>
 {
 	private const int NumCheckpoints = 1 + /* chunk 0-0 (raw): 1 chunk completion */

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.StreamSubscription.CombinationTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.StreamSubscription.CombinationTests.cs
@@ -16,6 +16,7 @@ namespace EventStore.Core.Tests.Services.Transport.Enumerators;
 public partial class EnumeratorTests
 {
 	[TestFixtureSource(nameof(TestCases))]
+	[NonParallelizable]
 	public class StreamSubscriptionCombinationTests : TestFixtureWithMiniNodeConnection
 	{
 		public record struct StreamProperties(int NumEvents = 0, TruncationInfo TruncationInfo = new(), bool IsHardDeleted = false, bool IsEphemeralStream = false);

--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingComponentHostTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingComponentHostTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.Storage.Indexing;
+using EventStore.Core.Services.Storage.InMemory;
+using EventStore.Core.Services.Transport.Enumerators;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.Storage.Indexing;
+
+public class IndexingComponentHostTests
+{
+	[Fact]
+	public void exposes_component_virtual_stream_readers()
+	{
+		var first = new FakeVirtualStreamReader("$idx-first");
+		var second = new FakeVirtualStreamReader("$idx-second");
+		var component = new FakeIndexingComponent(first, second);
+		var host = new IndexingComponentHost(component);
+
+		Assert.Equal([first, second], host.VirtualStreamReaders);
+	}
+
+	[Fact]
+	public async Task configure_application_activates_registered_indexing_service()
+	{
+		var subscriber = new RecordingSubscriber();
+		var services = new ServiceCollection();
+		var component = new FakeIndexingComponent();
+		var host = new IndexingComponentHost(component);
+		var configuration = new ConfigurationBuilder().Build();
+
+		services.AddSingleton<ISubscriber>(subscriber);
+		services.AddSingleton<IPublisher>(new RecordingPublisher());
+		host.ConfigureServices(services, configuration);
+
+		await using var provider = services.BuildServiceProvider();
+		host.ConfigureApplication(new ApplicationBuilder(provider), configuration);
+
+		Assert.True(subscriber.Has<SystemMessage.SystemReady>());
+		Assert.True(subscriber.Has<SystemMessage.BecomeShuttingDown>());
+	}
+
+	private sealed class RecordingSubscriber : ISubscriber
+	{
+		private readonly HashSet<Type> _subscriptions = [];
+
+		public void Subscribe<T>(IAsyncHandle<T> handler) where T : Message =>
+			_subscriptions.Add(typeof(T));
+
+		public void Unsubscribe<T>(IAsyncHandle<T> handler) where T : Message =>
+			_subscriptions.Remove(typeof(T));
+
+		public bool Has<T>() where T : Message => _subscriptions.Contains(typeof(T));
+	}
+
+	private sealed class RecordingPublisher : IPublisher
+	{
+		public void Publish(Message message)
+		{
+		}
+	}
+
+	private sealed class FakeIndexingComponent(params IVirtualStreamReader[] virtualStreamReaders) : IIndexingComponent
+	{
+		public IIndexingProcessor Processor { get; } = new FakeIndexingProcessor();
+
+		public IReadOnlyList<IVirtualStreamReader> VirtualStreamReaders { get; } = virtualStreamReaders;
+
+		public ValueTask Initialize(CancellationToken token) => ValueTask.CompletedTask;
+
+		public ValueTask<IndexCheckpoint?> ReadCheckpoint(CancellationToken token) => ValueTask.FromResult<IndexCheckpoint?>(null);
+
+		public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+	}
+
+	private sealed class FakeIndexingProcessor : IIndexingProcessor
+	{
+		public ValueTask Index(ResolvedEvent resolvedEvent, CancellationToken token) => ValueTask.CompletedTask;
+
+		public ValueTask Commit(CancellationToken token) => ValueTask.CompletedTask;
+	}
+
+	private sealed class FakeVirtualStreamReader(string streamId) : IVirtualStreamReader
+	{
+		public ValueTask<ClientMessage.ReadStreamEventsForwardCompleted> ReadForwards(
+			ClientMessage.ReadStreamEventsForward msg,
+			CancellationToken token) =>
+			throw new NotSupportedException();
+
+		public ValueTask<ClientMessage.ReadStreamEventsBackwardCompleted> ReadBackwards(
+			ClientMessage.ReadStreamEventsBackward msg,
+			CancellationToken token) =>
+			throw new NotSupportedException();
+
+		public long GetLastEventNumber(string streamId) => 0;
+
+		public long GetLastIndexedPosition(string streamId) => 0;
+
+		public bool CanReadStream(string candidateStreamId) => candidateStreamId == streamId;
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingServiceTests.cs
@@ -7,6 +7,7 @@ using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.Storage.Indexing;
+using EventStore.Core.Services.Storage.InMemory;
 using EventStore.Core.Services.Transport.Enumerators;
 using Xunit;
 
@@ -69,6 +70,8 @@ public class IndexingServiceTests
 	private sealed class FakeIndexingComponent(bool throwOnDispose = false) : IIndexingComponent
 	{
 		public IIndexingProcessor Processor { get; } = new FakeIndexingProcessor();
+
+		public IReadOnlyList<IVirtualStreamReader> VirtualStreamReaders { get; } = [];
 
 		public bool Disposed { get; private set; }
 

--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingSubscriptionTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingSubscriptionTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Data;
 using EventStore.Core.Services.Storage.Indexing;
+using EventStore.Core.Services.Storage.InMemory;
 using EventStore.Core.Services.Transport.Common;
 using EventStore.Core.Services.Transport.Enumerators;
 using EventStore.Core.TransactionLog.LogRecords;
@@ -233,6 +234,8 @@ public class IndexingSubscriptionTests
 		public FakeIndexingProcessor Processor { get; } = new(pauseIndexCompletion);
 
 		IIndexingProcessor IIndexingComponent.Processor => Processor;
+
+		public IReadOnlyList<IVirtualStreamReader> VirtualStreamReaders { get; } = [];
 
 		public bool Disposed { get; private set; }
 		public bool DisposedBeforeInitializeCompleted { get; private set; }

--- a/src/EventStore.Core/Services/Storage/Indexing/IIndexingComponent.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IIndexingComponent.cs
@@ -2,10 +2,11 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Data;
+using EventStore.Core.Services.Storage.InMemory;
 
 namespace EventStore.Core.Services.Storage.Indexing;
 
-public interface IIndexingComponent : IAsyncDisposable
+public interface IIndexingComponent : IAsyncDisposable, IVirtualStreamReaderProvider
 {
 	ValueTask Initialize(CancellationToken token);
 

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexingComponentHost.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexingComponentHost.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Bus;
+using EventStore.Core.Services.Storage.InMemory;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventStore.Core.Services.Storage.Indexing;
+
+public sealed class IndexingComponentHost(
+	IIndexingComponent component,
+	IndexingSubscriptionOptions options) : IVirtualStreamReaderProvider
+{
+	public IndexingComponentHost(IIndexingComponent component)
+		: this(component, IndexingSubscriptionOptions.Default)
+	{
+	}
+
+	public IReadOnlyList<IVirtualStreamReader> VirtualStreamReaders => component.VirtualStreamReaders;
+
+	public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+	{
+		services.AddSingleton(serviceProvider => new IndexingService(
+			component,
+			new AllStreamsIndexingEventSourceFactory(serviceProvider.GetRequiredService<IPublisher>()),
+			serviceProvider.GetRequiredService<ISubscriber>(),
+			options));
+	}
+
+	public void ConfigureApplication(IApplicationBuilder builder, IConfiguration configuration)
+	{
+		_ = builder.ApplicationServices.GetServices<IndexingService>().ToArray();
+	}
+}


### PR DESCRIPTION
- Index-backed streams need a single node lifecycle entry point instead of each implementation wiring bus subscriptions differently.
- Reader-backed indexing components should join the existing virtual stream pipeline without duplicating node startup code.