### PR TITLE
chore(plugins): remove license members

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -84,7 +84,7 @@
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.7" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageVersion Include="System.ServiceModel.Http" Version="10.0.652802" />
-    <PackageVersion Include="TrogonEventStore.Plugins" Version="24.10.9" />
+    <PackageVersion Include="TrogonEventStore.Plugins" Version="24.10.10" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/EventStore.Core.Tests/Services/VNode/ShutdownServiceWithMiniNodeTests.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/ShutdownServiceWithMiniNodeTests.cs
@@ -88,7 +88,6 @@ public class ShutdownServiceWithMiniNodeTests<TLogFormat, TStreamId> : Specifica
 		public KeyValuePair<string, object>[] DiagnosticsTags { get; }
 		public string Version => "version";
 		public bool Enabled => true;
-		public string LicensePublicKey { get; }
 		public Task Start() => Task.CompletedTask;
 
 		public Task Stop() => Task.CompletedTask;

--- a/src/EventStore.Core/Authentication/DelegatedAuthentication/DelegatedAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/DelegatedAuthentication/DelegatedAuthenticationProvider.cs
@@ -14,7 +14,6 @@ public class DelegatedAuthenticationProvider(IAuthenticationProvider inner) : Au
 {
 	Name = inner.Name,
 	Version = inner.Version,
-	LicensePublicKey = inner.LicensePublicKey,
 	DiagnosticsName = inner.DiagnosticsName,
 	DiagnosticsTags = inner.DiagnosticsTags
 })

--- a/src/EventStore.Core/Services/Archive/ArchivePlugableComponent.cs
+++ b/src/EventStore.Core/Services/Archive/ArchivePlugableComponent.cs
@@ -6,7 +6,6 @@ using EventStore.Core.Services.Archive.Naming;
 using EventStore.Core.Services.Archive.Storage;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Plugins;
-using EventStore.Plugins.Licensing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,8 +24,6 @@ public class ArchivePlugableComponent(bool isArchiver) : IPlugableComponent
 	public string Version => "0.0.1";
 
 	public bool Enabled { get; private set; }
-
-	public string LicensePublicKey => LicenseConstants.LicensePublicKey;
 
 	public void ConfigureApplication(IApplicationBuilder builder, IConfiguration configuration)
 	{

--- a/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
@@ -139,7 +139,6 @@ public sealed class ProjectionsSubsystem : ISubsystem,
 	public KeyValuePair<string, object>[] DiagnosticsTags => [];
 	public string Version => VERSION.ToString();
 	public bool Enabled => true;
-	public string LicensePublicKey => string.Empty;
 
 	public void ConfigureApplication(IApplicationBuilder builder, IConfiguration configuration)
 	{


### PR DESCRIPTION
- Keep the server aligned with a FOSS-only plugin contract.
- Avoid carrying license-shaped placeholders now that the shared plugin package no longer requires them.