### PR TITLE
fix(log): keep prepare timestamps unambiguous

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/PrepareLogRecordViewTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/PrepareLogRecordViewTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Text;
 using DotNext.Buffers;
+using DotNext.IO;
 using EventStore.Core.TransactionLog.LogRecords;
 using Xunit;
 
@@ -17,7 +18,7 @@ public class PrepareLogRecordViewTests
 	private const int TransactionOffset = 321;
 	private const string EventStreamId = "test_stream";
 	private const long ExpectedVersion = 789;
-	private readonly DateTime _timestamp = new(DateTime.UtcNow.Ticks);
+	private readonly DateTime _timestamp = DateTime.UtcNow;
 	private const PrepareFlags Flags = PrepareFlags.SingleWrite;
 	private const string EventType = "test_event_type";
 	private readonly byte[] _data = { 0xDE, 0XAD, 0xC0, 0XDE };
@@ -63,9 +64,41 @@ public class PrepareLogRecordViewTests
 		Assert.True(_prepare.EventStreamId.SequenceEqual(Encoding.UTF8.GetBytes(EventStreamId)));
 		Assert.Equal(ExpectedVersion, _prepare.ExpectedVersion);
 		Assert.Equal(_timestamp, _prepare.TimeStamp);
+		Assert.Equal(DateTimeKind.Utc, _prepare.TimeStamp.Kind);
 		Assert.Equal(Flags, _prepare.Flags);
 		Assert.True(_prepare.Data.SequenceEqual(_data));
 		Assert.True(_prepare.Metadata.SequenceEqual(_metadata));
 		Assert.Equal(Version, _prepare.Version);
+	}
+
+	[Fact]
+	public void parsed_record_should_preserve_utc_timestamp_kind()
+	{
+		var prepare = new PrepareLogRecord(
+			LogPosition,
+			_correlationId,
+			_eventId,
+			TransactionPosition,
+			TransactionOffset,
+			EventStreamId,
+			null,
+			ExpectedVersion,
+			_timestamp,
+			Flags,
+			EventType,
+			null,
+			_data,
+			_metadata,
+			Version);
+
+		var writer = new BufferWriterSlim<byte>();
+		prepare.WriteTo(ref writer);
+
+		using var recordBuffer = writer.DetachOrCopyBuffer();
+		var reader = new SequenceReader(new(recordBuffer.Memory));
+		var parsed = Assert.IsType<PrepareLogRecord>(LogRecord.ReadFrom(ref reader));
+
+		Assert.Equal(_timestamp, parsed.TimeStamp);
+		Assert.Equal(DateTimeKind.Utc, parsed.TimeStamp.Kind);
 	}
 }

--- a/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
@@ -195,7 +195,7 @@ public sealed class PrepareLogRecord : LogRecord, IEquatable<PrepareLogRecord>, 
 		EventStreamId = ReadString(ref reader, in context);
 		EventId = reader.Read<Blittable<Guid>>().Value;
 		CorrelationId = reader.Read<Blittable<Guid>>().Value;
-		TimeStamp = new(reader.ReadLittleEndian<long>());
+		TimeStamp = new DateTime(reader.ReadLittleEndian<long>(), DateTimeKind.Utc);
 		EventType = ReadString(ref reader, in context);
 		_dataOnDisk = reader.ReadLittleEndian<int>() is var dataCount && dataCount > 0
 			? reader.Read(dataCount).ToArray()

--- a/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecordView.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecordView.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.TransactionLog.LogRecords
 		public ReadOnlySpan<byte> EventStreamId => _record.AsSpan(_streamIdOffset, _streamIdSize);
 		public Guid EventId => new Guid(_record.AsSpan(_eventIdOffset, 16).ToArray()); // allocates
 		public Guid CorrelationId => new Guid(_record.AsSpan(_correlationIdOffset, 16).ToArray()); // allocates
-		public DateTime TimeStamp => new DateTime(BitConverter.ToInt64(_record, _timestampOffset));
+		public DateTime TimeStamp => new(BitConverter.ToInt64(_record, _timestampOffset), DateTimeKind.Utc);
 		public ReadOnlySpan<byte> EventType => _record.AsSpan(_eventTypeOffset, _eventTypeSize);
 		public ReadOnlySpan<byte> Data => _record.AsSpan(_dataOffset, _dataSize);
 		public ReadOnlySpan<byte> Metadata => _record.AsSpan(_metadataOffset, _metadataSize);


### PR DESCRIPTION
- Avoid losing UTC timestamp semantics when prepare records are read back for downstream time-based behavior.