### PR TITLE
fix(archive): avoid unclear s3 storage failures

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/S3StorageCredentialTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Archive/Storage/S3StorageCredentialTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Amazon.Runtime;
 using Amazon.S3;
+using EventStore.Common.Exceptions;
 using EventStore.Core.Services.Archive;
 using EventStore.Core.Services.Archive.Storage;
 using FluentStorage.AWS.Blobs;
@@ -44,6 +45,31 @@ public class S3StorageCredentialTests
 		var credentials = Assert.IsType<BasicAWSCredentials>(GetCredentials(client));
 
 		Assert.True(string.IsNullOrEmpty(credentials.GetCredentials().Token));
+	}
+
+	[Fact]
+	public void native_s3_rejects_missing_bucket_before_creating_client()
+	{
+		var exception = Assert.Throws<InvalidConfigurationException>(() => new InspectableS3Writer(new S3Options
+		{
+			Region = "us-east-1",
+		}));
+
+		Assert.Contains("Bucket", exception.Message);
+	}
+
+	[Fact]
+	public void s3_compatible_storage_rejects_missing_credentials_before_creating_client()
+	{
+		var exception = Assert.Throws<InvalidConfigurationException>(() => new InspectableS3Writer(new S3Options
+		{
+			Bucket = "archive",
+			Region = "us-east-1",
+			ServiceUrl = "https://s3-compatible.example",
+		}));
+
+		Assert.Contains("AccessKeyId", exception.Message);
+		Assert.Contains("SecretAccessKey", exception.Message);
 	}
 
 	private sealed class InspectableS3Writer(S3Options options) : S3Writer(options, "archive.chk")

--- a/src/EventStore.Core/Services/Archive/Storage/S3Reader.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/S3Reader.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Amazon.S3;
 using Amazon.S3.Model;
-using EventStore.Common.Exceptions;
 using EventStore.Core.Services.Archive.Naming;
 using EventStore.Core.Services.Archive.Storage.Exceptions;
 using FluentStorage.AWS.Blobs;
@@ -26,16 +25,6 @@ public class S3Reader : FluentReader, IArchiveStorageReader
 	{
 		AwsTraceLogging.Configure();
 		_options = options;
-
-		if (string.IsNullOrEmpty(options.Bucket))
-		{
-			throw new InvalidConfigurationException("Please specify an Archive S3 Bucket");
-		}
-
-		if (string.IsNullOrEmpty(options.Region))
-		{
-			throw new InvalidConfigurationException("Please specify an Archive S3 Region");
-		}
 
 		_awsBlobStorage = S3Storage.Create(options);
 	}

--- a/src/EventStore.Core/Services/Archive/Storage/S3Storage.cs
+++ b/src/EventStore.Core/Services/Archive/Storage/S3Storage.cs
@@ -8,6 +8,8 @@ internal static class S3Storage
 {
 	public static IAwsS3BlobStorage Create(S3Options options)
 	{
+		options.Validate();
+
 		if (!string.IsNullOrWhiteSpace(options.ServiceUrl))
 		{
 			var sessionToken = string.IsNullOrWhiteSpace(options.SessionToken) ? null : options.SessionToken;


### PR DESCRIPTION
- Direct archive storage construction should fail with the same configuration errors operators see during node startup.
- S3-compatible archive setup should reject incomplete credentials before any AWS client is created.