### PR TITLE
chore(indexing): avoid hidden activation side effects

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingComponentHostTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingComponentHostTests.cs
@@ -43,23 +43,54 @@ public class IndexingComponentHostTests
 		host.ConfigureServices(services, configuration);
 
 		await using var provider = services.BuildServiceProvider();
+		_ = provider.GetRequiredService<IndexingService>();
+
+		Assert.False(subscriber.Has<SystemMessage.SystemReady>());
+		Assert.False(subscriber.Has<SystemMessage.BecomeShuttingDown>());
+
 		host.ConfigureApplication(new ApplicationBuilder(provider), configuration);
 
 		Assert.True(subscriber.Has<SystemMessage.SystemReady>());
 		Assert.True(subscriber.Has<SystemMessage.BecomeShuttingDown>());
 	}
 
+	[Fact]
+	public async Task configure_application_can_register_indexing_service_more_than_once()
+	{
+		var subscriber = new RecordingSubscriber();
+		var services = new ServiceCollection();
+		var component = new FakeIndexingComponent();
+		var host = new IndexingComponentHost(component);
+		var configuration = new ConfigurationBuilder().Build();
+
+		services.AddSingleton<ISubscriber>(subscriber);
+		services.AddSingleton<IPublisher>(new RecordingPublisher());
+		host.ConfigureServices(services, configuration);
+
+		await using var provider = services.BuildServiceProvider();
+		var application = new ApplicationBuilder(provider);
+
+		host.ConfigureApplication(application, configuration);
+		host.ConfigureApplication(application, configuration);
+
+		Assert.Equal(1, subscriber.SubscriptionCount<SystemMessage.SystemReady>());
+		Assert.Equal(1, subscriber.SubscriptionCount<SystemMessage.BecomeShuttingDown>());
+	}
+
 	private sealed class RecordingSubscriber : ISubscriber
 	{
-		private readonly HashSet<Type> _subscriptions = [];
+		private readonly Dictionary<Type, int> _subscriptions = [];
 
 		public void Subscribe<T>(IAsyncHandle<T> handler) where T : Message =>
-			_subscriptions.Add(typeof(T));
+			_subscriptions[typeof(T)] = SubscriptionCount<T>() + 1;
 
 		public void Unsubscribe<T>(IAsyncHandle<T> handler) where T : Message =>
 			_subscriptions.Remove(typeof(T));
 
-		public bool Has<T>() where T : Message => _subscriptions.Contains(typeof(T));
+		public bool Has<T>() where T : Message => SubscriptionCount<T>() > 0;
+
+		public int SubscriptionCount<T>() where T : Message =>
+			_subscriptions.GetValueOrDefault(typeof(T));
 	}
 
 	private sealed class RecordingPublisher : IPublisher

--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingServiceTests.cs
@@ -27,6 +27,7 @@ public class IndexingServiceTests
 			subscriber,
 			IndexingSubscriptionOptions.Default);
 
+		service.Register();
 		await service.HandleAsync(new SystemMessage.SystemReady(), CancellationToken.None);
 		await service.HandleAsync(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), false, false), CancellationToken.None);
 
@@ -46,6 +47,7 @@ public class IndexingServiceTests
 			subscriber,
 			IndexingSubscriptionOptions.Default);
 
+		service.Register();
 		var exception = await Assert.ThrowsAsync<InvalidOperationException>(
 			() => service.DisposeAsync().AsTask());
 

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexingComponentHost.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexingComponentHost.cs
@@ -29,11 +29,9 @@ public sealed class IndexingComponentHost(
 
 	public void ConfigureApplication(IApplicationBuilder builder, IConfiguration configuration)
 	{
-		// IndexingService subscribes to the bus from its constructor, so force singleton activation
-		// while the application is being configured instead of waiting for the first service lookup.
 		foreach (var service in builder.ApplicationServices.GetServices<IndexingService>())
 		{
-			_ = service;
+			service.Register();
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexingService.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexingService.cs
@@ -10,7 +10,9 @@ public sealed class IndexingService : IAsyncHandle<SystemMessage.SystemReady>, I
 {
 	private readonly ISubscriber _subscriber;
 	private readonly IndexingSubscription _subscription;
+	private readonly object _registrationLock = new();
 	private int _disposed;
+	private bool _registered;
 
 	public IndexingService(
 		IIndexingComponent component,
@@ -20,9 +22,22 @@ public sealed class IndexingService : IAsyncHandle<SystemMessage.SystemReady>, I
 	{
 		_subscriber = subscriber;
 		_subscription = new IndexingSubscription(component, eventSourceFactory, options);
+	}
 
-		subscriber.Subscribe<SystemMessage.SystemReady>(this);
-		subscriber.Subscribe<SystemMessage.BecomeShuttingDown>(this);
+	public void Register()
+	{
+		lock (_registrationLock)
+		{
+			ObjectDisposedException.ThrowIf(_disposed is not 0, this);
+			if (_registered)
+			{
+				return;
+			}
+
+			_subscriber.Subscribe<SystemMessage.SystemReady>(this);
+			_subscriber.Subscribe<SystemMessage.BecomeShuttingDown>(this);
+			_registered = true;
+		}
 	}
 
 	public ValueTask HandleAsync(SystemMessage.SystemReady message, CancellationToken token) =>
@@ -44,8 +59,21 @@ public sealed class IndexingService : IAsyncHandle<SystemMessage.SystemReady>, I
 		}
 		finally
 		{
-			_subscriber.Unsubscribe<SystemMessage.SystemReady>(this);
-			_subscriber.Unsubscribe<SystemMessage.BecomeShuttingDown>(this);
+			var registered = false;
+			lock (_registrationLock)
+			{
+				if (_registered)
+				{
+					_registered = false;
+					registered = true;
+				}
+			}
+
+			if (registered)
+			{
+				_subscriber.Unsubscribe<SystemMessage.SystemReady>(this);
+				_subscriber.Unsubscribe<SystemMessage.BecomeShuttingDown>(this);
+			}
 		}
 	}
 }


### PR DESCRIPTION
- Indexing service registration should be tied to application configuration instead of happening as a constructor side effect.\n- Repeated application configuration should not duplicate lifecycle subscriptions.