### PR TITLE
fix(indexing): keep readiness startup idempotent

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingServiceTests.cs
@@ -38,6 +38,45 @@ public class IndexingServiceTests
 	}
 
 	[Fact]
+	public async Task repeated_system_ready_does_not_restart_subscription()
+	{
+		var subscriber = new RecordingSubscriber();
+		var component = new FakeIndexingComponent();
+		var service = new IndexingService(
+			component,
+			new FakeIndexingEventSourceFactory(new FakeIndexingEventSource()),
+			subscriber,
+			IndexingSubscriptionOptions.Default);
+
+		await service.HandleAsync(new SystemMessage.SystemReady(), CancellationToken.None);
+		await service.HandleAsync(new SystemMessage.SystemReady(), CancellationToken.None);
+
+		Assert.Equal(1, component.InitializeCount);
+
+		await service.DisposeAsync();
+	}
+
+	[Fact]
+	public async Task failed_system_ready_can_be_retried()
+	{
+		var subscriber = new RecordingSubscriber();
+		var component = new FakeIndexingComponent(initializeFailures: 1);
+		var service = new IndexingService(
+			component,
+			new FakeIndexingEventSourceFactory(new FakeIndexingEventSource()),
+			subscriber,
+			IndexingSubscriptionOptions.Default);
+
+		await Assert.ThrowsAsync<InvalidOperationException>(() =>
+			service.HandleAsync(new SystemMessage.SystemReady(), CancellationToken.None).AsTask());
+		await service.HandleAsync(new SystemMessage.SystemReady(), CancellationToken.None);
+
+		Assert.Equal(2, component.InitializeCount);
+
+		await service.DisposeAsync();
+	}
+
+	[Fact]
 	public async Task dispose_unsubscribes_when_subscription_cleanup_fails()
 	{
 		var subscriber = new RecordingSubscriber();
@@ -69,15 +108,28 @@ public class IndexingServiceTests
 		public bool Has<T>() where T : Message => _subscriptions.Contains(typeof(T));
 	}
 
-	private sealed class FakeIndexingComponent(bool throwOnDispose = false) : IIndexingComponent
+	private sealed class FakeIndexingComponent(bool throwOnDispose = false, int initializeFailures = 0) : IIndexingComponent
 	{
+		private int _initializeFailures = initializeFailures;
+
 		public IIndexingProcessor Processor { get; } = new FakeIndexingProcessor();
 
 		public IReadOnlyList<IVirtualStreamReader> VirtualStreamReaders { get; } = [];
 
 		public bool Disposed { get; private set; }
 
-		public ValueTask Initialize(CancellationToken token) => ValueTask.CompletedTask;
+		public int InitializeCount { get; private set; }
+
+		public ValueTask Initialize(CancellationToken token)
+		{
+			InitializeCount++;
+			if (Interlocked.Decrement(ref _initializeFailures) >= 0)
+			{
+				throw new InvalidOperationException("initialize failed");
+			}
+
+			return ValueTask.CompletedTask;
+		}
 
 		public ValueTask<IndexCheckpoint?> ReadCheckpoint(CancellationToken token) => ValueTask.FromResult<IndexCheckpoint?>(null);
 

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexingService.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexingService.cs
@@ -12,6 +12,7 @@ public sealed class IndexingService : IAsyncHandle<SystemMessage.SystemReady>, I
 	private readonly IndexingSubscription _subscription;
 	private readonly object _registrationLock = new();
 	private int _disposed;
+	private int _started;
 	private bool _registered;
 
 	public IndexingService(
@@ -40,8 +41,23 @@ public sealed class IndexingService : IAsyncHandle<SystemMessage.SystemReady>, I
 		}
 	}
 
-	public ValueTask HandleAsync(SystemMessage.SystemReady message, CancellationToken token) =>
-		_subscription.Start(token);
+	public async ValueTask HandleAsync(SystemMessage.SystemReady message, CancellationToken token)
+	{
+		if (Interlocked.CompareExchange(ref _started, 1, 0) is not 0)
+		{
+			return;
+		}
+
+		try
+		{
+			await _subscription.Start(token);
+		}
+		catch
+		{
+			Volatile.Write(ref _started, 0);
+			throw;
+		}
+	}
 
 	public ValueTask HandleAsync(SystemMessage.BecomeShuttingDown message, CancellationToken token) =>
 		DisposeAsync();


### PR DESCRIPTION
- Indexing startup should tolerate repeated readiness signals without turning lifecycle noise into a node fault.
- Transient startup failures should stay retryable so activation does not get permanently wedged.