### PR TITLE
feat(indexing): support grouped components

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingComponentHostTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingComponentHostTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Bus;
@@ -30,6 +31,18 @@ public class IndexingComponentHostTests
 	}
 
 	[Fact]
+	public void exposes_grouped_component_virtual_stream_readers()
+	{
+		var first = new FakeVirtualStreamReader("$idx-first");
+		var second = new FakeVirtualStreamReader("$idx-second");
+		var firstComponent = new FakeIndexingComponent(first);
+		var secondComponent = new FakeIndexingComponent(second);
+		var host = new IndexingComponentHost([firstComponent, secondComponent]);
+
+		Assert.Equal([first, second], host.VirtualStreamReaders);
+	}
+
+	[Fact]
 	public async Task configure_application_activates_registered_indexing_service()
 	{
 		var subscriber = new RecordingSubscriber();
@@ -52,6 +65,29 @@ public class IndexingComponentHostTests
 
 		Assert.True(subscriber.Has<SystemMessage.SystemReady>());
 		Assert.True(subscriber.Has<SystemMessage.BecomeShuttingDown>());
+	}
+
+	[Fact]
+	public async Task configure_application_activates_grouped_indexing_services()
+	{
+		var subscriber = new RecordingSubscriber();
+		var services = new ServiceCollection();
+		var first = new FakeIndexingComponent();
+		var second = new FakeIndexingComponent();
+		var host = new IndexingComponentHost([first, second]);
+		var configuration = new ConfigurationBuilder().Build();
+
+		services.AddSingleton<ISubscriber>(subscriber);
+		services.AddSingleton<IPublisher>(new RecordingPublisher());
+		host.ConfigureServices(services, configuration);
+
+		await using var provider = services.BuildServiceProvider();
+		Assert.Equal(2, provider.GetServices<IndexingService>().Count());
+
+		host.ConfigureApplication(new ApplicationBuilder(provider), configuration);
+
+		Assert.Equal(2, subscriber.SubscriptionCount<SystemMessage.SystemReady>());
+		Assert.Equal(2, subscriber.SubscriptionCount<SystemMessage.BecomeShuttingDown>());
 	}
 
 	[Fact]

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexingComponentHost.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexingComponentHost.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using EventStore.Core.Bus;
 using EventStore.Core.Services.Storage.InMemory;
 using Microsoft.AspNetCore.Builder;
@@ -7,24 +9,60 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace EventStore.Core.Services.Storage.Indexing;
 
-public sealed class IndexingComponentHost(
-	IIndexingComponent component,
-	IndexingSubscriptionOptions options) : IVirtualStreamReaderProvider
+public sealed class IndexingComponentHost : IVirtualStreamReaderProvider
 {
+	private readonly IReadOnlyList<IIndexingComponent> _components;
+	private readonly IReadOnlyList<IVirtualStreamReader> _virtualStreamReaders;
+	private readonly IndexingSubscriptionOptions _options;
+
 	public IndexingComponentHost(IIndexingComponent component)
 		: this(component, IndexingSubscriptionOptions.Default)
 	{
 	}
 
-	public IReadOnlyList<IVirtualStreamReader> VirtualStreamReaders => component.VirtualStreamReaders;
+	public IndexingComponentHost(IIndexingComponent component, IndexingSubscriptionOptions options)
+		: this([component], options)
+	{
+	}
+
+	public IndexingComponentHost(IReadOnlyList<IIndexingComponent> components)
+		: this(components, IndexingSubscriptionOptions.Default)
+	{
+	}
+
+	public IndexingComponentHost(IReadOnlyList<IIndexingComponent> components, IndexingSubscriptionOptions options)
+	{
+		ArgumentNullException.ThrowIfNull(components);
+		ArgumentNullException.ThrowIfNull(options);
+
+		var componentArray = components.ToArray();
+		if (componentArray.Length == 0)
+		{
+			throw new ArgumentException("At least one indexing component is required.", nameof(components));
+		}
+
+		if (componentArray.Any(static component => component is null))
+		{
+			throw new ArgumentException("Indexing components cannot contain null.", nameof(components));
+		}
+
+		_components = componentArray;
+		_options = options;
+		_virtualStreamReaders = componentArray.SelectMany(static component => component.VirtualStreamReaders).ToArray();
+	}
+
+	public IReadOnlyList<IVirtualStreamReader> VirtualStreamReaders => _virtualStreamReaders;
 
 	public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
 	{
-		services.AddSingleton(serviceProvider => new IndexingService(
-			component,
-			new AllStreamsIndexingEventSourceFactory(serviceProvider.GetRequiredService<IPublisher>()),
-			serviceProvider.GetRequiredService<ISubscriber>(),
-			options));
+		foreach (var component in _components)
+		{
+			services.AddSingleton(serviceProvider => new IndexingService(
+				component,
+				new AllStreamsIndexingEventSourceFactory(serviceProvider.GetRequiredService<IPublisher>()),
+				serviceProvider.GetRequiredService<ISubscriber>(),
+				_options));
+		}
 	}
 
 	public void ConfigureApplication(IApplicationBuilder builder, IConfiguration configuration)


### PR DESCRIPTION
- Indexing activation should scale to multiple independently owned components without forcing each caller to duplicate host plumbing.
- Keeping grouped components behind the existing host preserves one lifecycle path as the indexing surface grows.