### PR TITLE
fix(indexing): fail fast on missing event sources

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/AllStreamsIndexingEventSourceFactoryTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/AllStreamsIndexingEventSourceFactoryTests.cs
@@ -1,0 +1,16 @@
+using System;
+using EventStore.Core.Services.Storage.Indexing;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.Storage.Indexing;
+
+public class AllStreamsIndexingEventSourceFactoryTests
+{
+	[Fact]
+	public void constructor_rejects_missing_publisher()
+	{
+		var exception = Assert.Throws<ArgumentNullException>(() => new AllStreamsIndexingEventSourceFactory(null!));
+
+		Assert.Equal("publisher", exception.ParamName);
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingSubscriptionTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingSubscriptionTests.cs
@@ -80,6 +80,20 @@ public class IndexingSubscriptionTests
 	}
 
 	[Fact]
+	public async Task start_rejects_missing_event_source()
+	{
+		await using var subscription = new IndexingSubscription(
+			new FakeIndexingComponent(),
+			new NullIndexingEventSourceFactory(),
+			IndexingSubscriptionOptions.Default);
+
+		var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+			subscription.Start(CancellationToken.None).AsTask());
+
+		Assert.Equal("Indexing event source factory returned null.", exception.Message);
+	}
+
+	[Fact]
 	public async Task waits_for_in_flight_start_before_disposing_component()
 	{
 		var component = new FakeIndexingComponent(pauseInitializeCompletion: true);
@@ -372,6 +386,11 @@ public class IndexingSubscriptionTests
 		public Task WaitForIndexEntered() => _indexEntered.Task.WaitAsync(Timeout);
 
 		public void ReleaseIndex() => _releaseIndex.TrySetResult();
+	}
+
+	private sealed class NullIndexingEventSourceFactory : IIndexingEventSourceFactory
+	{
+		public IIndexingEventSource Create(IndexCheckpoint? checkpoint, CancellationToken token) => null!;
 	}
 
 	private sealed class FakeIndexingEventSourceFactory(FakeIndexingEventSource source) : IIndexingEventSourceFactory

--- a/src/EventStore.Core/Services/Storage/Indexing/IIndexingEventSource.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IIndexingEventSource.cs
@@ -21,12 +21,17 @@ public interface IIndexingEventSourceFactory
 	IIndexingEventSource Create(IndexCheckpoint? checkpoint, CancellationToken token);
 }
 
-public sealed class AllStreamsIndexingEventSourceFactory(IPublisher publisher) : IIndexingEventSourceFactory
+public sealed class AllStreamsIndexingEventSourceFactory : IIndexingEventSourceFactory
 {
+	private readonly IPublisher _publisher;
+
+	public AllStreamsIndexingEventSourceFactory(IPublisher publisher) =>
+		_publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
+
 	public IIndexingEventSource Create(IndexCheckpoint? checkpoint, CancellationToken token)
 	{
 		var subscription = new Enumerator.AllSubscription(
-			publisher,
+			_publisher,
 			new DefaultExpiryStrategy(),
 			checkpoint?.ToPosition(),
 			resolveLinks: false,

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexingSubscription.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexingSubscription.cs
@@ -89,7 +89,8 @@ public sealed class IndexingSubscription : IAsyncDisposable
 				_component.Processor.Commit,
 				CancellationToken.None);
 
-			eventSource = _eventSourceFactory.Create(checkpoint, _stop.Token);
+			eventSource = _eventSourceFactory.Create(checkpoint, _stop.Token)
+				?? throw new InvalidOperationException("Indexing event source factory returned null.");
 
 			lock (_stateLock)
 			{


### PR DESCRIPTION
- Indexing startup should fail while activation is still observable instead of allowing invalid event-source wiring to fault later in background processing.
- Clear activation failures make lifecycle issues easier to diagnose as indexing components are composed together.