### PR TITLE
fix(indexing): validate component contracts

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingComponentHostTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingComponentHostTests.cs
@@ -20,6 +20,26 @@ namespace EventStore.Core.XUnit.Tests.Services.Storage.Indexing;
 public class IndexingComponentHostTests
 {
 	[Fact]
+	public void constructor_rejects_component_with_missing_virtual_stream_readers()
+	{
+		var exception = Assert.Throws<ArgumentException>(() =>
+			new IndexingComponentHost(new MissingVirtualStreamReadersComponent()));
+
+		Assert.Equal("components", exception.ParamName);
+		Assert.Equal("Indexing component virtual stream readers cannot be null. (Parameter 'components')", exception.Message);
+	}
+
+	[Fact]
+	public void constructor_rejects_component_with_missing_virtual_stream_reader()
+	{
+		var exception = Assert.Throws<ArgumentException>(() =>
+			new IndexingComponentHost(new FakeIndexingComponent([null!])));
+
+		Assert.Equal("components", exception.ParamName);
+		Assert.Equal("Indexing component virtual stream readers cannot contain null. (Parameter 'components')", exception.Message);
+	}
+
+	[Fact]
 	public void exposes_component_virtual_stream_readers()
 	{
 		var first = new FakeVirtualStreamReader("$idx-first");
@@ -141,6 +161,19 @@ public class IndexingComponentHostTests
 		public IIndexingProcessor Processor { get; } = new FakeIndexingProcessor();
 
 		public IReadOnlyList<IVirtualStreamReader> VirtualStreamReaders { get; } = virtualStreamReaders;
+
+		public ValueTask Initialize(CancellationToken token) => ValueTask.CompletedTask;
+
+		public ValueTask<IndexCheckpoint?> ReadCheckpoint(CancellationToken token) => ValueTask.FromResult<IndexCheckpoint?>(null);
+
+		public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+	}
+
+	private sealed class MissingVirtualStreamReadersComponent : IIndexingComponent
+	{
+		public IIndexingProcessor Processor { get; } = new FakeIndexingProcessor();
+
+		public IReadOnlyList<IVirtualStreamReader> VirtualStreamReaders => null!;
 
 		public ValueTask Initialize(CancellationToken token) => ValueTask.CompletedTask;
 

--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingSubscriptionTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingSubscriptionTests.cs
@@ -94,6 +94,20 @@ public class IndexingSubscriptionTests
 	}
 
 	[Fact]
+	public async Task start_rejects_missing_processor()
+	{
+		await using var subscription = new IndexingSubscription(
+			new MissingProcessorComponent(),
+			new FakeIndexingEventSourceFactory(new FakeIndexingEventSource()),
+			IndexingSubscriptionOptions.Default);
+
+		var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+			subscription.Start(CancellationToken.None).AsTask());
+
+		Assert.Equal("Indexing component returned null processor.", exception.Message);
+	}
+
+	[Fact]
 	public async Task waits_for_in_flight_start_before_disposing_component()
 	{
 		var component = new FakeIndexingComponent(pauseInitializeCompletion: true);
@@ -316,6 +330,19 @@ public class IndexingSubscriptionTests
 		public Task WaitForDisposed() => _disposed.Task.WaitAsync(Timeout);
 
 		public void ReleaseInitialize() => _releaseInitialize.TrySetResult();
+	}
+
+	private sealed class MissingProcessorComponent : IIndexingComponent
+	{
+		public IIndexingProcessor Processor => null!;
+
+		public IReadOnlyList<IVirtualStreamReader> VirtualStreamReaders { get; } = [];
+
+		public ValueTask Initialize(CancellationToken token) => ValueTask.CompletedTask;
+
+		public ValueTask<IndexCheckpoint?> ReadCheckpoint(CancellationToken token) => ValueTask.FromResult<IndexCheckpoint?>(null);
+
+		public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 	}
 
 	private sealed class FakeIndexingProcessor(bool pauseIndexCompletion = false) : IIndexingProcessor

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexingComponentHost.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexingComponentHost.cs
@@ -48,7 +48,7 @@ public sealed class IndexingComponentHost : IVirtualStreamReaderProvider
 
 		_components = componentArray;
 		_options = options;
-		_virtualStreamReaders = componentArray.SelectMany(static component => component.VirtualStreamReaders).ToArray();
+		_virtualStreamReaders = GetVirtualStreamReaders(componentArray);
 	}
 
 	public IReadOnlyList<IVirtualStreamReader> VirtualStreamReaders => _virtualStreamReaders;
@@ -71,5 +71,20 @@ public sealed class IndexingComponentHost : IVirtualStreamReaderProvider
 		{
 			service.Register();
 		}
+	}
+
+	private static IReadOnlyList<IVirtualStreamReader> GetVirtualStreamReaders(IReadOnlyList<IIndexingComponent> components)
+	{
+		var readers = components.SelectMany(static component =>
+			component.VirtualStreamReaders
+				?? throw new ArgumentException("Indexing component virtual stream readers cannot be null.", nameof(components)))
+			.ToArray();
+
+		if (readers.Any(static reader => reader is null))
+		{
+			throw new ArgumentException("Indexing component virtual stream readers cannot contain null.", nameof(components));
+		}
+
+		return readers;
 	}
 }

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexingSubscription.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexingSubscription.cs
@@ -34,6 +34,7 @@ public sealed class IndexingSubscription : IAsyncDisposable
 	private readonly CancellationTokenSource _stop = new();
 	private readonly object _stateLock = new();
 
+	private IIndexingProcessor _processor;
 	private IIndexingEventSource _eventSource;
 	private IndexCheckpointCommitTracker _commitTracker;
 	private Task _startup;
@@ -82,11 +83,13 @@ public sealed class IndexingSubscription : IAsyncDisposable
 		{
 			await _component.Initialize(linked.Token);
 			var checkpoint = await _component.ReadCheckpoint(linked.Token);
+			var processor = _component.Processor
+				?? throw new InvalidOperationException("Indexing component returned null processor.");
 
 			commitTracker = new IndexCheckpointCommitTracker(
 				_options.CheckpointCommitBatchSize,
 				_options.CheckpointCommitDelay,
-				_component.Processor.Commit,
+				processor.Commit,
 				CancellationToken.None);
 
 			eventSource = _eventSourceFactory.Create(checkpoint, _stop.Token)
@@ -97,6 +100,7 @@ public sealed class IndexingSubscription : IAsyncDisposable
 				ObjectDisposedException.ThrowIf(_disposed, this);
 
 				_commitTracker = commitTracker;
+				_processor = processor;
 				_eventSource = eventSource;
 				_processing = Task.Run(ProcessEvents);
 				ObserveProcessingFault(_processing);
@@ -291,7 +295,7 @@ public sealed class IndexingSubscription : IAsyncDisposable
 
 			try
 			{
-				await _component.Processor.Index(eventReceived.Event, CancellationToken.None);
+				await _processor.Index(eventReceived.Event, CancellationToken.None);
 				_commitTracker.Track();
 			}
 			catch (OperationCanceledException) when (_stop.IsCancellationRequested)


### PR DESCRIPTION
- Indexing component composition should fail at the lifecycle boundary when a component violates the host or processor contract.
- Earlier failures keep activation problems diagnosable as multiple indexing components are composed together.