### PR TITLE
fix(indexing): honor startup cancellation

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingSubscriptionTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingSubscriptionTests.cs
@@ -80,6 +80,41 @@ public class IndexingSubscriptionTests
 	}
 
 	[Fact]
+	public async Task start_honors_cancelled_token_before_activation()
+	{
+		var checkpoint = new IndexCheckpoint(10, 5);
+		var component = new FakeIndexingComponent(checkpoint);
+		var eventSources = new FakeIndexingEventSourceFactory(new FakeIndexingEventSource());
+		using var cancellation = new CancellationTokenSource();
+		await cancellation.CancelAsync();
+		await using var subscription = new IndexingSubscription(
+			component,
+			eventSources,
+			IndexingSubscriptionOptions.Default);
+
+		await Assert.ThrowsAsync<OperationCanceledException>(() =>
+			subscription.Start(cancellation.Token).AsTask());
+
+		Assert.Null(eventSources.Checkpoint);
+	}
+
+	[Fact]
+	public async Task start_disposes_event_source_when_cancelled_during_activation()
+	{
+		var eventSource = new FakeIndexingEventSource();
+		using var cancellation = new CancellationTokenSource();
+		await using var subscription = new IndexingSubscription(
+			new FakeIndexingComponent(),
+			new CancellingIndexingEventSourceFactory(eventSource, cancellation),
+			IndexingSubscriptionOptions.Default);
+
+		await Assert.ThrowsAsync<OperationCanceledException>(() =>
+			subscription.Start(cancellation.Token).AsTask());
+
+		Assert.True(eventSource.Disposed);
+	}
+
+	[Fact]
 	public async Task start_rejects_missing_event_source()
 	{
 		await using var subscription = new IndexingSubscription(
@@ -418,6 +453,18 @@ public class IndexingSubscriptionTests
 	private sealed class NullIndexingEventSourceFactory : IIndexingEventSourceFactory
 	{
 		public IIndexingEventSource Create(IndexCheckpoint? checkpoint, CancellationToken token) => null!;
+	}
+
+	private sealed class CancellingIndexingEventSourceFactory(
+		FakeIndexingEventSource source,
+		CancellationTokenSource startupCancellation) : IIndexingEventSourceFactory
+	{
+		public IIndexingEventSource Create(IndexCheckpoint? checkpoint, CancellationToken token)
+		{
+			source.Bind(token);
+			startupCancellation.Cancel();
+			return source;
+		}
 	}
 
 	private sealed class FakeIndexingEventSourceFactory(FakeIndexingEventSource source) : IIndexingEventSourceFactory

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexingSubscription.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexingSubscription.cs
@@ -81,8 +81,11 @@ public sealed class IndexingSubscription : IAsyncDisposable
 
 		try
 		{
+			token.ThrowIfCancellationRequested();
 			await _component.Initialize(linked.Token);
 			var checkpoint = await _component.ReadCheckpoint(linked.Token);
+			token.ThrowIfCancellationRequested();
+
 			var processor = _component.Processor
 				?? throw new InvalidOperationException("Indexing component returned null processor.");
 
@@ -94,6 +97,7 @@ public sealed class IndexingSubscription : IAsyncDisposable
 
 			eventSource = _eventSourceFactory.Create(checkpoint, _stop.Token)
 				?? throw new InvalidOperationException("Indexing event source factory returned null.");
+			token.ThrowIfCancellationRequested();
 
 			lock (_stateLock)
 			{


### PR DESCRIPTION
- Indexing startup should stop before activation when the caller cancellation token is already canceled.
- Startup cancellation should clean up partially created resources so activation failures remain deterministic.