### PR TITLE
fix(indexing): reject disposed startup

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingServiceTests.cs
@@ -89,6 +89,41 @@ public class IndexingServiceTests
 	}
 
 	[Fact]
+	public async Task system_ready_after_dispose_is_rejected()
+	{
+		var service = new IndexingService(
+			new FakeIndexingComponent(),
+			new FakeIndexingEventSourceFactory(new FakeIndexingEventSource()),
+			new RecordingSubscriber(),
+			IndexingSubscriptionOptions.Default);
+
+		await service.DisposeAsync();
+
+		var exception = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+			service.HandleAsync(new SystemMessage.SystemReady(), CancellationToken.None).AsTask());
+
+		Assert.Contains(nameof(IndexingService), exception.Message);
+	}
+
+	[Fact]
+	public async Task system_ready_after_started_service_is_disposed_is_rejected()
+	{
+		var service = new IndexingService(
+			new FakeIndexingComponent(),
+			new FakeIndexingEventSourceFactory(new FakeIndexingEventSource()),
+			new RecordingSubscriber(),
+			IndexingSubscriptionOptions.Default);
+
+		await service.HandleAsync(new SystemMessage.SystemReady(), CancellationToken.None);
+		await service.DisposeAsync();
+
+		var exception = await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+			service.HandleAsync(new SystemMessage.SystemReady(), CancellationToken.None).AsTask());
+
+		Assert.Contains(nameof(IndexingService), exception.Message);
+	}
+
+	[Fact]
 	public async Task dispose_unsubscribes_when_subscription_cleanup_fails()
 	{
 		var subscriber = new RecordingSubscriber();

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexingService.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexingService.cs
@@ -45,6 +45,8 @@ public sealed class IndexingService : IAsyncHandle<SystemMessage.SystemReady>, I
 
 	public async ValueTask HandleAsync(SystemMessage.SystemReady message, CancellationToken token)
 	{
+		ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) is not 0, this);
+
 		if (Interlocked.CompareExchange(ref _started, 1, 0) is not 0)
 		{
 			return;


### PR DESCRIPTION
- Disposed indexing services should fail fast instead of hiding invalid lifecycle calls.
- Startup handling should keep the same service contract before and after activation.