### PR TITLE
fix(indexing): validate wiring dependencies

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingComponentHostTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingComponentHostTests.cs
@@ -20,6 +20,53 @@ namespace EventStore.Core.XUnit.Tests.Services.Storage.Indexing;
 public class IndexingComponentHostTests
 {
 	[Fact]
+	public void configure_services_rejects_missing_services()
+	{
+		var host = new IndexingComponentHost(new FakeIndexingComponent());
+		var configuration = new ConfigurationBuilder().Build();
+
+		var exception = Assert.Throws<ArgumentNullException>(() =>
+			host.ConfigureServices(null!, configuration));
+
+		Assert.Equal("services", exception.ParamName);
+	}
+
+	[Fact]
+	public void configure_services_rejects_missing_configuration()
+	{
+		var host = new IndexingComponentHost(new FakeIndexingComponent());
+
+		var exception = Assert.Throws<ArgumentNullException>(() =>
+			host.ConfigureServices(new ServiceCollection(), null!));
+
+		Assert.Equal("configuration", exception.ParamName);
+	}
+
+	[Fact]
+	public void configure_application_rejects_missing_builder()
+	{
+		var host = new IndexingComponentHost(new FakeIndexingComponent());
+		var configuration = new ConfigurationBuilder().Build();
+
+		var exception = Assert.Throws<ArgumentNullException>(() =>
+			host.ConfigureApplication(null!, configuration));
+
+		Assert.Equal("builder", exception.ParamName);
+	}
+
+	[Fact]
+	public void configure_application_rejects_missing_configuration()
+	{
+		var host = new IndexingComponentHost(new FakeIndexingComponent());
+		using var provider = new ServiceCollection().BuildServiceProvider();
+
+		var exception = Assert.Throws<ArgumentNullException>(() =>
+			host.ConfigureApplication(new ApplicationBuilder(provider), null!));
+
+		Assert.Equal("configuration", exception.ParamName);
+	}
+
+	[Fact]
 	public void constructor_rejects_component_with_missing_virtual_stream_readers()
 	{
 		var exception = Assert.Throws<ArgumentException>(() =>

--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingServiceTests.cs
@@ -16,6 +16,30 @@ namespace EventStore.Core.XUnit.Tests.Services.Storage.Indexing;
 public class IndexingServiceTests
 {
 	[Fact]
+	public void constructor_rejects_missing_component()
+	{
+		var exception = Assert.Throws<ArgumentNullException>(() => new IndexingService(
+			null!,
+			new FakeIndexingEventSourceFactory(new FakeIndexingEventSource()),
+			new RecordingSubscriber(),
+			IndexingSubscriptionOptions.Default));
+
+		Assert.Equal("component", exception.ParamName);
+	}
+
+	[Fact]
+	public void constructor_rejects_missing_event_source_factory()
+	{
+		var exception = Assert.Throws<ArgumentNullException>(() => new IndexingService(
+			new FakeIndexingComponent(),
+			null!,
+			new RecordingSubscriber(),
+			IndexingSubscriptionOptions.Default));
+
+		Assert.Equal("eventSourceFactory", exception.ParamName);
+	}
+
+	[Fact]
 	public void constructor_rejects_missing_subscriber()
 	{
 		var exception = Assert.Throws<ArgumentNullException>(() => new IndexingService(
@@ -25,6 +49,18 @@ public class IndexingServiceTests
 			IndexingSubscriptionOptions.Default));
 
 		Assert.Equal("subscriber", exception.ParamName);
+	}
+
+	[Fact]
+	public void constructor_rejects_missing_options()
+	{
+		var exception = Assert.Throws<ArgumentNullException>(() => new IndexingService(
+			new FakeIndexingComponent(),
+			new FakeIndexingEventSourceFactory(new FakeIndexingEventSource()),
+			new RecordingSubscriber(),
+			null!));
+
+		Assert.Equal("options", exception.ParamName);
 	}
 
 	[Fact]

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexingComponentHost.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexingComponentHost.cs
@@ -55,6 +55,9 @@ public sealed class IndexingComponentHost : IVirtualStreamReaderProvider
 
 	public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
 	{
+		ArgumentNullException.ThrowIfNull(services);
+		ArgumentNullException.ThrowIfNull(configuration);
+
 		foreach (var component in _components)
 		{
 			services.AddSingleton(serviceProvider => new IndexingService(
@@ -67,6 +70,9 @@ public sealed class IndexingComponentHost : IVirtualStreamReaderProvider
 
 	public void ConfigureApplication(IApplicationBuilder builder, IConfiguration configuration)
 	{
+		ArgumentNullException.ThrowIfNull(builder);
+		ArgumentNullException.ThrowIfNull(configuration);
+
 		foreach (var service in builder.ApplicationServices.GetServices<IndexingService>())
 		{
 			service.Register();

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexingService.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexingService.cs
@@ -21,7 +21,10 @@ public sealed class IndexingService : IAsyncHandle<SystemMessage.SystemReady>, I
 		ISubscriber subscriber,
 		IndexingSubscriptionOptions options)
 	{
+		ArgumentNullException.ThrowIfNull(component);
+		ArgumentNullException.ThrowIfNull(eventSourceFactory);
 		ArgumentNullException.ThrowIfNull(subscriber);
+		ArgumentNullException.ThrowIfNull(options);
 
 		_subscriber = subscriber;
 		_subscription = new IndexingSubscription(component, eventSourceFactory, options);


### PR DESCRIPTION
- Indexing wiring should fail at the activation boundary with clear parameter names.
- Invalid host setup should not leak into later startup paths as less actionable failures.