### PR TITLE
fix(storage): validate virtual stream readers

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/InMemory/VirtualStreamReaderTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/InMemory/VirtualStreamReaderTests.cs
@@ -26,6 +26,23 @@ public class VirtualStreamReaderTests
 		_sut = new VirtualStreamReader([_listener.Stream]);
 	}
 
+	[Fact]
+	public void constructor_rejects_missing_readers()
+	{
+		var exception = Assert.Throws<ArgumentNullException>(() => new VirtualStreamReader(null!));
+
+		Assert.Equal("readers", exception.ParamName);
+	}
+
+	[Fact]
+	public void constructor_rejects_missing_reader()
+	{
+		var exception = Assert.Throws<ArgumentException>(() => new VirtualStreamReader([null!]));
+
+		Assert.Equal("readers", exception.ParamName);
+		Assert.Equal("Virtual stream readers cannot contain null. (Parameter 'readers')", exception.Message);
+	}
+
 	private static ClientMessage.ReadStreamEventsBackward GenReadBackwards(
 		Guid correlation,
 		long fromEventNumber,

--- a/src/EventStore.Core/Services/Storage/InMemory/VirtualStreamReader.cs
+++ b/src/EventStore.Core/Services/Storage/InMemory/VirtualStreamReader.cs
@@ -12,6 +12,12 @@ public class VirtualStreamReader : IVirtualStreamReader
 
 	public VirtualStreamReader(IVirtualStreamReader[] readers)
 	{
+		ArgumentNullException.ThrowIfNull(readers);
+		if (Array.Exists(readers, static reader => reader is null))
+		{
+			throw new ArgumentException("Virtual stream readers cannot contain null.", nameof(readers));
+		}
+
 		_readers = readers;
 	}
 


### PR DESCRIPTION
- Virtual stream reader wiring should fail at construction with clear parameter names.
- Invalid reader collections should not surface later as less actionable read-path failures.