### PR TITLE
chore(indexing): cover boundary validation

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexCheckpointTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexCheckpointTests.cs
@@ -1,0 +1,54 @@
+using System;
+using EventStore.Core.Services.Storage.Indexing;
+using EventStore.Core.Services.Transport.Common;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.Storage.Indexing;
+
+public class IndexCheckpointTests
+{
+	[Theory]
+	[InlineData(0, 0)]
+	[InlineData(10, 5)]
+	public void constructor_accepts_valid_positions(long commitPosition, long preparePosition)
+	{
+		var checkpoint = new IndexCheckpoint(commitPosition, preparePosition);
+
+		Assert.Equal(commitPosition, checkpoint.CommitPosition);
+		Assert.Equal(preparePosition, checkpoint.PreparePosition);
+	}
+
+	[Fact]
+	public void constructor_rejects_negative_commit_position()
+	{
+		var exception = Assert.Throws<ArgumentOutOfRangeException>(() => new IndexCheckpoint(-1, 0));
+
+		Assert.Equal("commitPosition", exception.ParamName);
+	}
+
+	[Fact]
+	public void constructor_rejects_negative_prepare_position()
+	{
+		var exception = Assert.Throws<ArgumentOutOfRangeException>(() => new IndexCheckpoint(0, -1));
+
+		Assert.Equal("preparePosition", exception.ParamName);
+	}
+
+	[Fact]
+	public void constructor_rejects_commit_position_before_prepare_position()
+	{
+		var exception = Assert.Throws<ArgumentOutOfRangeException>(() => new IndexCheckpoint(5, 10));
+
+		Assert.Equal("CommitPosition", exception.ParamName);
+	}
+
+	[Fact]
+	public void converts_to_all_stream_position()
+	{
+		var checkpoint = new IndexCheckpoint(10, 5);
+
+		var position = checkpoint.ToPosition();
+
+		Assert.Equal(Position.FromInt64(10, 5), position);
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingComponentHostTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingComponentHostTests.cs
@@ -67,6 +67,35 @@ public class IndexingComponentHostTests
 	}
 
 	[Fact]
+	public void constructor_rejects_missing_components()
+	{
+		var exception = Assert.Throws<ArgumentNullException>(() =>
+			new IndexingComponentHost((IReadOnlyList<IIndexingComponent>)null!));
+
+		Assert.Equal("components", exception.ParamName);
+	}
+
+	[Fact]
+	public void constructor_rejects_empty_components()
+	{
+		var exception = Assert.Throws<ArgumentException>(() =>
+			new IndexingComponentHost([]));
+
+		Assert.Equal("components", exception.ParamName);
+		Assert.Equal("At least one indexing component is required. (Parameter 'components')", exception.Message);
+	}
+
+	[Fact]
+	public void constructor_rejects_missing_component()
+	{
+		var exception = Assert.Throws<ArgumentException>(() =>
+			new IndexingComponentHost([null!]));
+
+		Assert.Equal("components", exception.ParamName);
+		Assert.Equal("Indexing components cannot contain null. (Parameter 'components')", exception.Message);
+	}
+
+	[Fact]
 	public void constructor_rejects_component_with_missing_virtual_stream_readers()
 	{
 		var exception = Assert.Throws<ArgumentException>(() =>

--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingSubscriptionOptionsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexingSubscriptionOptionsTests.cs
@@ -1,0 +1,39 @@
+using System;
+using EventStore.Core.Services.Storage.Indexing;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.Storage.Indexing;
+
+public class IndexingSubscriptionOptionsTests
+{
+	[Fact]
+	public void constructor_accepts_valid_values()
+	{
+		var options = new IndexingSubscriptionOptions(100, TimeSpan.FromSeconds(5));
+
+		Assert.Equal(100, options.CheckpointCommitBatchSize);
+		Assert.Equal(TimeSpan.FromSeconds(5), options.CheckpointCommitDelay);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void constructor_rejects_non_positive_checkpoint_commit_batch_size(int batchSize)
+	{
+		var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+			new IndexingSubscriptionOptions(batchSize, TimeSpan.FromSeconds(5)));
+
+		Assert.Equal("checkpointCommitBatchSize", exception.ParamName);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void constructor_rejects_non_positive_checkpoint_commit_delay(int milliseconds)
+	{
+		var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+			new IndexingSubscriptionOptions(100, TimeSpan.FromMilliseconds(milliseconds)));
+
+		Assert.Equal("checkpointCommitDelay", exception.ParamName);
+	}
+}


### PR DESCRIPTION
- Indexing lifecycle work depends on checkpoint and subscription boundary values staying strict as more components are added.
- Host registration needs explicit coverage for invalid component collections so future wiring failures stay local and easy to diagnose.