### PR TITLE
feat(indexing): add index stream identifiers

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexStreamIdTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/IndexStreamIdTests.cs
@@ -1,0 +1,47 @@
+using System;
+using EventStore.Core.Services.Storage.Indexing;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.Storage.Indexing;
+
+public class IndexStreamIdTests
+{
+	[Theory]
+	[InlineData("index-stream")]
+	[InlineData("$index-stream")]
+	public void constructor_accepts_valid_stream_id(string value)
+	{
+		var streamId = new IndexStreamId(value);
+
+		Assert.Equal(value, streamId.Value);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("$$")]
+	public void constructor_rejects_invalid_stream_id(string value)
+	{
+		var exception = Assert.Throws<ArgumentException>(() => new IndexStreamId(value));
+
+		Assert.Equal("value", exception.ParamName);
+		Assert.Equal("Index stream id must be a valid stream id. (Parameter 'value')", exception.Message);
+	}
+
+	[Fact]
+	public void constructor_rejects_metastream_id()
+	{
+		var exception = Assert.Throws<ArgumentException>(() => new IndexStreamId("$$index-stream"));
+
+		Assert.Equal("value", exception.ParamName);
+		Assert.Equal("Index stream id cannot be a metastream id. (Parameter 'value')", exception.Message);
+	}
+
+	[Fact]
+	public void to_string_returns_stream_id()
+	{
+		var streamId = new IndexStreamId("$index-stream");
+
+		Assert.Equal("$index-stream", streamId.ToString());
+	}
+}

--- a/src/EventStore.Core/Services/Storage/Indexing/IndexStreamId.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IndexStreamId.cs
@@ -1,0 +1,26 @@
+using System;
+using EventStore.Core.Services;
+
+namespace EventStore.Core.Services.Storage.Indexing;
+
+public sealed record IndexStreamId
+{
+	public string Value { get; }
+
+	public IndexStreamId(string value)
+	{
+		if (SystemStreams.IsInvalidStream(value))
+		{
+			throw new ArgumentException("Index stream id must be a valid stream id.", nameof(value));
+		}
+
+		if (SystemStreams.IsMetastream(value))
+		{
+			throw new ArgumentException("Index stream id cannot be a metastream id.", nameof(value));
+		}
+
+		Value = value;
+	}
+
+	public override string ToString() => Value;
+}


### PR DESCRIPTION
- Indexing components need a typed boundary for streams they own before richer lifecycle work can safely build on them.
- Keeping validation near the boundary makes invalid stream usage fail early without committing the runtime to a broader definition model yet.