### PR TITLE
feat(indexing): support checkpoint storage

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/InMemoryIndexCheckpointStoreTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/Indexing/InMemoryIndexCheckpointStoreTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Services.Storage.Indexing;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.Storage.Indexing;
+
+public class InMemoryIndexCheckpointStoreTests
+{
+	[Fact]
+	public async Task read_returns_null_when_empty()
+	{
+		var store = new InMemoryIndexCheckpointStore();
+
+		var checkpoint = await store.Read(CancellationToken.None);
+
+		Assert.Null(checkpoint);
+	}
+
+	[Fact]
+	public async Task write_and_read_round_trip()
+	{
+		var store = new InMemoryIndexCheckpointStore();
+		var expected = new IndexCheckpoint(10, 5);
+
+		await store.Write(expected, CancellationToken.None);
+		var checkpoint = await store.Read(CancellationToken.None);
+
+		Assert.Equal(expected, checkpoint);
+	}
+
+	[Fact]
+	public async Task write_overwrites_stored_checkpoint()
+	{
+		var store = new InMemoryIndexCheckpointStore();
+		var first = new IndexCheckpoint(10, 5);
+		var second = new IndexCheckpoint(20, 15);
+
+		await store.Write(first, CancellationToken.None);
+		await store.Write(second, CancellationToken.None);
+		var checkpoint = await store.Read(CancellationToken.None);
+
+		Assert.Equal(second, checkpoint);
+	}
+
+	[Fact]
+	public async Task read_honors_cancelled_token()
+	{
+		var store = new InMemoryIndexCheckpointStore();
+		using var cancellation = new CancellationTokenSource();
+		await cancellation.CancelAsync();
+
+		await Assert.ThrowsAsync<OperationCanceledException>(() =>
+			store.Read(cancellation.Token).AsTask());
+	}
+
+	[Fact]
+	public async Task write_honors_cancelled_token()
+	{
+		var store = new InMemoryIndexCheckpointStore();
+		using var cancellation = new CancellationTokenSource();
+		await cancellation.CancelAsync();
+
+		await Assert.ThrowsAsync<OperationCanceledException>(() =>
+			store.Write(new IndexCheckpoint(10, 5), cancellation.Token).AsTask());
+	}
+}

--- a/src/EventStore.Core/Services/Storage/Indexing/IIndexCheckpointStore.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/IIndexCheckpointStore.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.Core.Services.Storage.Indexing;
+
+public interface IIndexCheckpointStore
+{
+	ValueTask<IndexCheckpoint?> Read(CancellationToken token);
+
+	ValueTask Write(IndexCheckpoint checkpoint, CancellationToken token);
+}

--- a/src/EventStore.Core/Services/Storage/Indexing/InMemoryIndexCheckpointStore.cs
+++ b/src/EventStore.Core/Services/Storage/Indexing/InMemoryIndexCheckpointStore.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.Core.Services.Storage.Indexing;
+
+public sealed class InMemoryIndexCheckpointStore : IIndexCheckpointStore
+{
+	private readonly object _lock = new();
+	private IndexCheckpoint? _checkpoint;
+
+	public ValueTask<IndexCheckpoint?> Read(CancellationToken token)
+	{
+		token.ThrowIfCancellationRequested();
+
+		lock (_lock)
+		{
+			return ValueTask.FromResult(_checkpoint);
+		}
+	}
+
+	public ValueTask Write(IndexCheckpoint checkpoint, CancellationToken token)
+	{
+		token.ThrowIfCancellationRequested();
+
+		lock (_lock)
+		{
+			_checkpoint = checkpoint;
+		}
+
+		return ValueTask.CompletedTask;
+	}
+}


### PR DESCRIPTION
- Indexing components need a tested checkpoint boundary before lifecycle wiring can safely resume work.
- Keeping checkpoint state isolated reduces risk when future processors begin committing progress.