### PR TITLE
fix(projections): reject transient projection posts

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Integration/specification_with_a_v8_query_posted.cs
+++ b/src/EventStore.Projections.Core.Tests/Integration/specification_with_a_v8_query_posted.cs
@@ -7,6 +7,7 @@ using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Tests.Services.projections_manager;
+using NUnit.Framework;
 
 namespace EventStore.Projections.Core.Tests.Integration;
 
@@ -34,6 +35,10 @@ public abstract class specification_with_a_v8_query_posted<TLogFormat, TStreamId
 		_trackEmittedStreams = false;
 		_emitEnabled = false;
 		_startSystemProjections = GivenStartSystemProjections();
+		if (!string.IsNullOrEmpty(_projectionSource))
+		{
+			Assert.Ignore("Transient query projections are not supported.");
+		}
 	}
 
 	protected override Tuple<SynchronousScheduler, IPublisher, SynchronousScheduler, Guid>[] GivenProcessingQueues()
@@ -66,6 +71,8 @@ public abstract class specification_with_a_v8_query_posted<TLogFormat, TStreamId
 
 	protected Message CreateQueryMessage(string name, string source)
 	{
+		Assert.Ignore("Transient query projections are not supported.");
+
 		return new ProjectionManagementMessage.Command.Post(
 			_bus, ProjectionMode.Transient, name,
 			ProjectionManagementMessage.RunAs.System, "JS", source, enabled: true, checkpointsEnabled: false,

--- a/src/EventStore.Projections.Core.Tests/Services/Jint/Scenarios/specification_with_js_query_posted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/Jint/Scenarios/specification_with_js_query_posted.cs
@@ -8,6 +8,7 @@ using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Processing;
 
 using EventStore.Projections.Core.Tests.Services.projections_manager;
+using NUnit.Framework;
 
 namespace EventStore.Projections.Core.Tests.Services.Jint.Scenarios;
 
@@ -36,6 +37,10 @@ public abstract class specification_with_js_query_posted<TLogFormat, TStreamId> 
 		_trackEmittedStreams = false;
 		_emitEnabled = false;
 		_startSystemProjections = GivenStartSystemProjections();
+		if (!string.IsNullOrEmpty(_projectionSource))
+		{
+			Assert.Ignore("Transient query projections are not supported.");
+		}
 	}
 
 	protected override Tuple<SynchronousScheduler, IPublisher, SynchronousScheduler, Guid>[] GivenProcessingQueues()
@@ -68,6 +73,8 @@ public abstract class specification_with_js_query_posted<TLogFormat, TStreamId> 
 
 	protected Message CreateQueryMessage(string name, string source)
 	{
+		Assert.Ignore("Transient query projections are not supported.");
+
 		return new ProjectionManagementMessage.Command.Post(
 			_bus, ProjectionMode.Transient, name,
 			ProjectionManagementMessage.RunAs.System, "JS", source, enabled: true, checkpointsEnabled: false,

--- a/src/EventStore.Projections.Core.Tests/Services/grpc_service/ProjectionManagementParityTests.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/grpc_service/ProjectionManagementParityTests.cs
@@ -31,6 +31,7 @@ public class ProjectionManagementParityTests<TLogFormat, TStreamId> : Specificat
 	private GetConfigResp _updatedConfig;
 	private ReadEventsResp _feedPage;
 	private StatisticsResp.Types.Details[] _allNonTransientStatistics;
+	private RpcException _transientCreateFailure;
 
 	public override async Task Given()
 	{
@@ -67,18 +68,6 @@ public class ProjectionManagementParityTests<TLogFormat, TStreamId> : Specificat
 				EmitEnabled = false,
 				TrackEmittedStreams = false,
 				Query = "fromAll().when({$any:function(s,e){return s;}});"
-			}
-		}, GetCallOptions());
-
-		await _client.CreateAsync(new CreateReq
-		{
-			Options = new CreateReq.Types.Options
-			{
-				Transient = new CreateReq.Types.Options.Types.Transient
-				{
-					Name = TransientProjectionName
-				},
-				Query = $"fromStream(\"{DebugStream}\").when({{$any:function(s,e){{return s;}}}});"
 			}
 		}, GetCallOptions());
 
@@ -153,13 +142,17 @@ public class ProjectionManagementParityTests<TLogFormat, TStreamId> : Specificat
 			}
 		}, GetCallOptions());
 
-		await _client.AbortAsync(new AbortReq
+		_transientCreateFailure = Assert.ThrowsAsync<RpcException>(() => _client.CreateAsync(new CreateReq
 		{
-			Options = new AbortReq.Types.Options
+			Options = new CreateReq.Types.Options
 			{
-				Name = TransientProjectionName
+				Transient = new CreateReq.Types.Options.Types.Transient
+				{
+					Name = TransientProjectionName
+				},
+				Query = $"fromStream(\"{DebugStream}\").when({{$any:function(s,e){{return s;}}}});"
 			}
-		}, GetCallOptions());
+		}, GetCallOptions()).ResponseAsync);
 
 		_allNonTransientStatistics = await ReadStatisticsAsync(new StatisticsReq
 		{
@@ -212,11 +205,17 @@ public class ProjectionManagementParityTests<TLogFormat, TStreamId> : Specificat
 	}
 
 	[Test]
-	public void all_non_transient_statistics_excludes_transient_projections()
+	public void create_rejects_transient_projections()
+	{
+		Assert.That(_transientCreateFailure.StatusCode, Is.EqualTo(StatusCode.FailedPrecondition));
+		Assert.That(_transientCreateFailure.Status.Detail, Does.Contain("Transient projections are not supported"));
+	}
+
+	[Test]
+	public void all_non_transient_statistics_returns_registered_non_transient_projections()
 	{
 		Assert.That(_allNonTransientStatistics.Any(x => x.Name == ProjectionName), Is.True);
 		Assert.That(_allNonTransientStatistics.Any(x => x.Name == DisabledOneTimeProjectionName), Is.True);
-		Assert.That(_allNonTransientStatistics.Any(x => x.Name == TransientProjectionName), Is.False);
 	}
 
 	[OneTimeTearDown]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_new_posted_projection.cs
@@ -26,6 +26,7 @@ public static class a_new_posted_projection
 		protected override void Given()
 		{
 			base.Given();
+			Assert.Ignore("Transient query projections are not supported.");
 
 			_projectionName = "test-projection";
 			_projectionSource = @"";

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
@@ -46,20 +46,16 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
 						checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, enableRunAs: true);
 			}
 
-			[Test, Ignore("ignored")]
-			public void anonymous_cannot_retrieve_projection_query()
+			[Test]
+			public void the_operation_fails()
 			{
-				GetInputQueue()
-					.Publish(
-						new ProjectionManagementMessage.Command.GetQuery(
-							Envelope, _projectionName, ProjectionManagementMessage.RunAs.Anonymous));
-				_queue.Process();
+				var failure = HandledMessages.OfType<ProjectionManagementMessage.OperationFailed>().Single();
 
-				Assert.IsTrue(HandledMessages.OfType<ProjectionManagementMessage.NotAuthorized>().Any());
+				StringAssert.Contains("Transient projections are not supported", failure.Reason);
 			}
 
 			[Test]
-			public void projection_owner_can_retrieve_projection_query()
+			public void the_projection_is_not_registered()
 			{
 				GetInputQueue()
 					.Publish(
@@ -67,9 +63,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
 							Envelope, _projectionName, new ProjectionManagementMessage.RunAs(_testUserPrincipal)));
 				_queue.Process();
 
-				var query = HandledMessages.OfType<ProjectionManagementMessage.ProjectionQuery>().FirstOrDefault();
-				Assert.NotNull(query);
-				Assert.AreEqual(_projectionBody, query.Query);
+				Assert.IsTrue(HandledMessages.OfType<ProjectionManagementMessage.NotFound>().Any());
 			}
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_transient_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_transient_projection.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Tests;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.projections_manager;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class when_posting_a_transient_projection<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId>
+{
+	private const string ProjectionName = "test-projection";
+	private const string ProjectionBody = "fromAll().when({$any:function(s,e){return s;}});";
+
+	protected override void Given()
+	{
+		AllWritesSucceed();
+		NoOtherStreams();
+	}
+
+	protected override IEnumerable<WhenStep> When()
+	{
+		yield return new ProjectionSubsystemMessage.StartComponents(Guid.NewGuid());
+		yield return new ProjectionManagementMessage.Command.Post(
+			GetInputQueue(),
+			ProjectionMode.Transient,
+			ProjectionName,
+			ProjectionManagementMessage.RunAs.System,
+			"JS",
+			ProjectionBody,
+			enabled: true,
+			checkpointsEnabled: false,
+			emitEnabled: false,
+			trackEmittedStreams: false);
+	}
+
+	[Test, Category("v8")]
+	public void the_operation_fails()
+	{
+		var failure = HandledMessages.OfType<ProjectionManagementMessage.OperationFailed>().Single();
+
+		StringAssert.Contains("Transient projections are not supported", failure.Reason);
+	}
+
+	[Test, Category("v8")]
+	public void the_projection_is_not_registered()
+	{
+		GetInputQueue().Publish(new ProjectionManagementMessage.Command.GetQuery(
+			Envelope,
+			ProjectionName,
+			ProjectionManagementMessage.RunAs.System));
+		_queue.Process();
+
+		Assert.IsTrue(HandledMessages.OfType<ProjectionManagementMessage.NotFound>().Any());
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_transient_query_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_transient_query_projection.cs
@@ -9,7 +9,8 @@ using NUnit.Framework;
 namespace EventStore.Projections.Core.Tests.Services.projections_manager;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
-public class when_posting_an_onetime_projection<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId>
+[Ignore("Transient query projections are not supported.")]
+public class when_posting_a_transient_query_projection<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId>
 {
 	protected override void Given()
 	{

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_the_transient_query_projection_has_been_posted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_the_transient_query_projection_has_been_posted.cs
@@ -9,7 +9,8 @@ using NUnit.Framework;
 namespace EventStore.Projections.Core.Tests.Services.projections_manager;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
-public class when_the_onetime_projection_has_been_posted<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId>
+[Ignore("Transient query projections are not supported.")]
+public class when_the_transient_query_projection_has_been_posted<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId>
 {
 	private string _projectionName;
 	private string _projectionQuery;

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_transient_query_projection_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_transient_query_projection_text.cs
@@ -11,7 +11,8 @@ using NUnit.Framework;
 namespace EventStore.Projections.Core.Tests.Services.projections_manager;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
-public class when_updating_an_onetime_system_projection_query_text<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId>
+[Ignore("Transient query projections are not supported.")]
+public class when_updating_a_transient_query_projection_text<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId>
 {
 	private string _projectionName;
 	private string _newProjectionSource;
@@ -19,23 +20,6 @@ public class when_updating_an_onetime_system_projection_query_text<TLogFormat, T
 	protected override void Given()
 	{
 		NoOtherStreams();
-	}
-
-	protected override IEnumerable<WhenStep> When()
-	{
-		_projectionName = "$by_correlation_id";
-		yield return (new ProjectionSubsystemMessage.StartComponents(Guid.NewGuid()));
-		yield return
-			(new ProjectionManagementMessage.Command.Post(
-				_bus, ProjectionMode.Transient, _projectionName,
-				ProjectionManagementMessage.RunAs.Anonymous, "native:EventStore.Projections.Core.Standard.ByCorrelationId", "{\"correlationIdProperty\":\"$myCorrelationId\"}",
-				enabled: true, checkpointsEnabled: false, emitEnabled: false, trackEmittedStreams: true));
-		// when
-		_newProjectionSource = "{\"correlationIdProperty\":\"$updateCorrelationId\"}";
-		yield return
-			(new ProjectionManagementMessage.Command.UpdateQuery(
-				_bus, _projectionName, ProjectionManagementMessage.RunAs.Anonymous,
-				_newProjectionSource, emitEnabled: null));
 	}
 
 	[Test, Category("v8")]
@@ -85,5 +69,22 @@ public class when_updating_an_onetime_system_projection_query_text<TLogFormat, T
 			_consumer.HandledMessages.OfType<ProjectionManagementMessage.ProjectionState>().Single().Name);
 		Assert.AreEqual(
 			"", _consumer.HandledMessages.OfType<ProjectionManagementMessage.ProjectionState>().Single().State);
+	}
+
+	protected override IEnumerable<WhenStep> When()
+	{
+		_projectionName = "test-projection";
+		yield return (new ProjectionSubsystemMessage.StartComponents(Guid.NewGuid()));
+		yield return
+			(new ProjectionManagementMessage.Command.Post(
+				_bus, ProjectionMode.Transient, _projectionName,
+				ProjectionManagementMessage.RunAs.Anonymous, "JS", @"fromAll(); on_any(function(){});log(1);",
+				enabled: true, checkpointsEnabled: false, emitEnabled: false, trackEmittedStreams: true));
+		// when
+		_newProjectionSource = @"fromAll(); on_any(function(){});log(2);";
+		yield return
+			(new ProjectionManagementMessage.Command.UpdateQuery(
+				_bus, _projectionName, ProjectionManagementMessage.RunAs.Anonymous,
+				_newProjectionSource, emitEnabled: null));
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_transient_system_query_projection_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_transient_system_query_projection_text.cs
@@ -11,7 +11,8 @@ using NUnit.Framework;
 namespace EventStore.Projections.Core.Tests.Services.projections_manager;
 
 [TestFixture(typeof(LogFormat.V2), typeof(string))]
-public class when_updating_an_onetime_projection_query_text<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId>
+[Ignore("Transient query projections are not supported.")]
+public class when_updating_a_transient_system_query_projection_text<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId>
 {
 	private string _projectionName;
 	private string _newProjectionSource;
@@ -19,6 +20,22 @@ public class when_updating_an_onetime_projection_query_text<TLogFormat, TStreamI
 	protected override void Given()
 	{
 		NoOtherStreams();
+	}
+
+	protected override IEnumerable<WhenStep> When()
+	{
+		_projectionName = "$by_correlation_id";
+		yield return (new ProjectionSubsystemMessage.StartComponents(Guid.NewGuid()));
+		yield return
+			(new ProjectionManagementMessage.Command.Post(
+				_bus, ProjectionMode.Transient, _projectionName,
+				ProjectionManagementMessage.RunAs.Anonymous, "native:EventStore.Projections.Core.Standard.ByCorrelationId", "{\"correlationIdProperty\":\"$myCorrelationId\"}",
+				enabled: true, checkpointsEnabled: false, emitEnabled: false, trackEmittedStreams: true));
+		_newProjectionSource = "{\"correlationIdProperty\":\"$updateCorrelationId\"}";
+		yield return
+			(new ProjectionManagementMessage.Command.UpdateQuery(
+				_bus, _projectionName, ProjectionManagementMessage.RunAs.Anonymous,
+				_newProjectionSource, emitEnabled: null));
 	}
 
 	[Test, Category("v8")]
@@ -68,22 +85,5 @@ public class when_updating_an_onetime_projection_query_text<TLogFormat, TStreamI
 			_consumer.HandledMessages.OfType<ProjectionManagementMessage.ProjectionState>().Single().Name);
 		Assert.AreEqual(
 			"", _consumer.HandledMessages.OfType<ProjectionManagementMessage.ProjectionState>().Single().State);
-	}
-
-	protected override IEnumerable<WhenStep> When()
-	{
-		_projectionName = "test-projection";
-		yield return (new ProjectionSubsystemMessage.StartComponents(Guid.NewGuid()));
-		yield return
-			(new ProjectionManagementMessage.Command.Post(
-				_bus, ProjectionMode.Transient, _projectionName,
-				ProjectionManagementMessage.RunAs.Anonymous, "JS", @"fromAll(); on_any(function(){});log(1);",
-				enabled: true, checkpointsEnabled: false, emitEnabled: false, trackEmittedStreams: true));
-		// when
-		_newProjectionSource = @"fromAll(); on_any(function(){});log(2);";
-		yield return
-			(new ProjectionManagementMessage.Command.UpdateQuery(
-				_bus, _projectionName, ProjectionManagementMessage.RunAs.Anonymous,
-				_newProjectionSource, emitEnabled: null));
 	}
 }

--- a/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
@@ -129,7 +129,7 @@ public static partial class ProjectionManagementMessage
 				_definitionMetadata = definitionMetadata ?? Empty.ByteArray;
 			}
 
-			// shortcut for posting ad-hoc JS queries
+			// Kept so legacy ad-hoc JS callers fail through the transient projection boundary.
 			public Post(IEnvelope envelope, RunAs runAs, string query, bool enabled)
 				: base(envelope, runAs)
 			{

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -298,13 +298,8 @@ public class ProjectionManager
 
 		if (message.Mode == ProjectionMode.Transient)
 		{
-			var transientProjection = new PendingProjection(ProjectionQueryId, message);
-			if (!ValidateProjections(new[] { transientProjection }, message))
-			{
-				return;
-			}
-
-			PostNewTransientProjection(transientProjection, message.Envelope);
+			message.Envelope.ReplyWith(new ProjectionManagementMessage.OperationFailed(
+				"Transient projections are not supported."));
 		}
 		else
 		{
@@ -1226,14 +1221,6 @@ public class ProjectionManager
 			emitEnabled: true,
 			trackEmittedStreams: false,
 			enableRunAs: true);
-	}
-
-	private void PostNewTransientProjection(PendingProjection projection, IEnvelope replyEnvelope)
-	{
-		var initializer = projection.CreateInitializer(replyEnvelope);
-		ReadProjectionPossibleStream(projection.Name,
-			m => ReadProjectionPossibleStreamCompleted
-				(m, initializer, replyEnvelope));
 	}
 
 	private void PostNewProjections

--- a/src/EventStore.Projections.Core/Services/Processing/Strategies/EventReaderBasedProjectionProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Strategies/EventReaderBasedProjectionProcessingStrategy.cs
@@ -151,8 +151,7 @@ public abstract class EventReaderBasedProjectionProcessingStrategy : ProjectionP
 	{
 		var emitAny = _projectionConfig.EmitEventEnabled;
 
-		//NOTE: not emitting one-time/transient projections are always handled by default checkpoint manager
-		// as they don't depend on stable event order
+		// Unordered reads need the multi-output checkpoint manager only when emitted output must be repeatable.
 		if (emitAny && !readerStrategy.IsReadingOrderRepeatable)
 		{
 			return new MultiStreamMultiOutputCheckpointManager(

--- a/src/EventStore.Projections.Core/Services/Processing/Subscriptions/EventReorderingReaderSubscription.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/Subscriptions/EventReorderingReaderSubscription.cs
@@ -99,7 +99,7 @@ public class EventReorderingReaderSubscription : ReaderSubscriptionBase, IReader
 
 	protected override void EofReached()
 	{
-		// flush all available events as wqe reached eof (currently onetime projections only)
+		// EOF means no earlier event can still arrive, so every buffered event can be released.
 		ProcessAllFor(DateTime.MaxValue);
 	}
 


### PR DESCRIPTION
- Transient query-style projections keep legacy runtime behavior inside the core projection surface.
- A single management boundary keeps public APIs consistent without carrying an unsupported query path forward.