### PR TITLE
chore(deps): refresh annotations package

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Grpc.HealthCheck" Version="2.80.0" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.82.0" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2026.2.0" />
     <PackageVersion Include="Jint" Version="4.12.0" />
     <PackageVersion Include="librdkafka.redist" Version="2.15.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />


### PR DESCRIPTION
- keep compile-time metadata aligned with the supported dependency set
- reduce dependency drift without bundling runtime package migrations