### PR TITLE
chore(deps): refresh nunit packages

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -56,8 +56,8 @@
     <PackageVersion Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />
-    <PackageVersion Include="NUnit" Version="3.14.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.16.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />

--- a/src/EventStore.BufferManagement.Tests/EventStore.BufferManagement.Tests.csproj
+++ b/src/EventStore.BufferManagement.Tests/EventStore.BufferManagement.Tests.csproj
@@ -11,6 +11,8 @@
 		<PackageReference Include="Newtonsoft.Json" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="NUnit" />
-		<PackageReference Include="NUnit3TestAdapter" />
+		<PackageReference Include="NUnit3TestAdapter">
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
 </Project>

--- a/src/EventStore.Common/Utils/VersionInfo.cs
+++ b/src/EventStore.Common/Utils/VersionInfo.cs
@@ -36,9 +36,13 @@ public static class VersionInfo
 
 		VersionPrefix = versionPrefix;
 
-		var versionFilePath = Path.Join(
-			Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory),
-			"version.properties");
+		var versionFilePath = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "version.properties");
+		if (!File.Exists(versionFilePath))
+		{
+			versionFilePath = Path.Join(
+				Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory),
+				"version.properties");
+		}
 		var properties = LoadProperties(versionFilePath);
 
 		if (properties.TryGetValue("version_suffix", out var versionSuffix))

--- a/src/EventStore.Core.Tests/Caching/DynamicCacheManagerTests.cs
+++ b/src/EventStore.Core.Tests/Caching/DynamicCacheManagerTests.cs
@@ -345,6 +345,6 @@ public class DynamicCacheManagerTests
 			{"es-cache-test2-utilizationPercent", 100.0 * 10 / 15},
 		};
 
-		CollectionAssert.AreEquivalent(expectedStats, msg.Stats);
+		Assert.That(msg.Stats, Is.EquivalentTo(expectedStats));
 	}
 }

--- a/src/EventStore.Core.Tests/ClientAPI/append_to_stream_with_hash_collision.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/append_to_stream_with_hash_collision.cs
@@ -42,7 +42,7 @@ public class append_to_stream_with_hash_collision<TLogFormat, TStreamId> : Speci
 		await base.TestFixtureTearDown();
 	}
 
-	[Test, Timeout(LongRunningTimeout)]
+	[Test, HardTimeout(LongRunningTimeout)]
 	public async Task should_throw_wrong_expected_version()
 	{
 		const string stream1 = "account--696193173";

--- a/src/EventStore.Core.Tests/ClientAPI/appending_to_streams_across_restart.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/appending_to_streams_across_restart.cs
@@ -31,7 +31,7 @@ public class appending_to_streams_across_restart<TLogFormat, TStreamId> : Specif
 
 	[Test]
 	[Category("Network")]
-	[Timeout(80000)]
+	[HardTimeout(80000)]
 	public async Task detect_existing_streams_flush()
 	{
 		void CreateNode()

--- a/src/EventStore.Core.Tests/ClientAPI/catchup_filtered_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/catchup_filtered_subscription.cs
@@ -176,7 +176,7 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public void only_return_events_with_a_given_stream_prefix()
 	{
 		var filter = Filter.StreamId.Prefix("stream-a");
@@ -198,7 +198,7 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public void only_return_events_with_a_given_event_prefix()
 	{
 		var filter = Filter.EventType.Prefix("AE");
@@ -220,7 +220,7 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public void only_return_events_that_satisfy_a_given_stream_regex()
 	{
 		var filter = Filter.StreamId.Regex(new Regex(@"^.*eam-b.*$"));
@@ -242,7 +242,7 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public void only_return_events_that_satisfy_a_given_event_regex()
 	{
 		var filter = Filter.EventType.Regex(new Regex(@"^.*BEv.*$"));
@@ -264,7 +264,7 @@ public class catchup_filtered_subscription<TLogFormat, TStreamId> : Specificatio
 		}
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public void only_return_events_that_are_not_system_events()
 	{
 		var filter = Filter.ExcludeSystemEvents;

--- a/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_catching_up_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_catching_up_should.cs
@@ -74,7 +74,7 @@ public class subscribe_to_all_catching_up_should<TLogFormat, TStreamId> : Specif
 		return TestConnection.Create(node.TcpEndPoint);
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public async Task call_dropped_callback_after_stop_method_call()
 	{
 		using (var store = BuildConnection(_node))
@@ -94,7 +94,7 @@ public class subscribe_to_all_catching_up_should<TLogFormat, TStreamId> : Specif
 		}
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public async Task call_dropped_callback_when_an_error_occurs_while_processing_an_event()
 	{
 		const string stream = "call_dropped_callback_when_an_error_occurs_while_processing_an_event";
@@ -113,7 +113,7 @@ public class subscribe_to_all_catching_up_should<TLogFormat, TStreamId> : Specif
 		}
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public async Task be_able_to_subscribe_to_empty_db()
 	{
 		using (var store = BuildConnection(_node))
@@ -147,7 +147,7 @@ public class subscribe_to_all_catching_up_should<TLogFormat, TStreamId> : Specif
 		}
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public async Task read_all_existing_events_and_keep_listening_to_new_ones()
 	{
 		using (var store = BuildConnection(_node))
@@ -202,7 +202,7 @@ public class subscribe_to_all_catching_up_should<TLogFormat, TStreamId> : Specif
 		}
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public async Task filter_events_and_keep_listening_to_new_ones()
 	{
 		using (var store = BuildConnection(_node))
@@ -269,7 +269,7 @@ public class subscribe_to_all_catching_up_should<TLogFormat, TStreamId> : Specif
 		}
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public async Task filter_events_and_work_if_nothing_was_written_after_subscription()
 	{
 		using (var store = BuildConnection(_node))

--- a/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_filtered_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_filtered_should.cs
@@ -60,7 +60,7 @@ public class subscribe_to_all_filtered_should<TLogFormat, TStreamId> : Specifica
 			.ToList();
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public async Task only_return_events_with_a_given_stream_prefix()
 	{
 		var filter = Filter.StreamId.Prefix("stream-a");
@@ -98,7 +98,7 @@ public class subscribe_to_all_filtered_should<TLogFormat, TStreamId> : Specifica
 		}
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public async Task only_return_events_with_a_given_event_prefix()
 	{
 		var filter = Filter.EventType.Prefix("AE");
@@ -141,7 +141,7 @@ public class subscribe_to_all_filtered_should<TLogFormat, TStreamId> : Specifica
 		}
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public async Task only_return_events_that_satisfy_a_given_stream_regex()
 	{
 		var filter = Filter.StreamId.Regex(new Regex(@"^.*eam-b.*$"));
@@ -179,7 +179,7 @@ public class subscribe_to_all_filtered_should<TLogFormat, TStreamId> : Specifica
 		}
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public async Task only_return_events_that_satisfy_a_given_event_regex()
 	{
 		var filter = Filter.EventType.Regex(new Regex(@"^.*BEv.*$"));
@@ -217,7 +217,7 @@ public class subscribe_to_all_filtered_should<TLogFormat, TStreamId> : Specifica
 		}
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public async Task only_return_events_that_are_not_system_events()
 	{
 		var filter = Filter.ExcludeSystemEvents;
@@ -277,7 +277,7 @@ public class subscribe_to_all_filtered_should<TLogFormat, TStreamId> : Specifica
 		}
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public async Task calls_checkpoint_reached_according_to_checkpoint_message_count()
 	{
 		var filter = Filter.ExcludeSystemEvents;

--- a/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_should.cs
@@ -76,7 +76,7 @@ public class subscribe_to_all_should<TLogFormat, TStreamId> : SpecificationWithD
 		}
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public async Task catch_deleted_events_as_well()
 	{
 		const string stream = "subscribe_to_all_should_catch_created_and_deleted_events_as_well";

--- a/src/EventStore.Core.Tests/ClientAPI/when_committing_empty_transaction.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/when_committing_empty_transaction.cs
@@ -68,7 +68,7 @@ public class when_committing_empty_transaction<TLogFormat, TStreamId> : Specific
 		return TestConnection.Create(node.TcpEndPoint);
 	}
 
-	[Test, Timeout(LongRunningTimeout)]
+	[Test, HardTimeout(LongRunningTimeout)]
 	public async Task following_append_with_correct_expected_version_are_commited_correctly()
 	{
 		Assert.AreEqual(4,
@@ -85,7 +85,7 @@ public class when_committing_empty_transaction<TLogFormat, TStreamId> : Specific
 		}
 	}
 
-	[Test, Timeout(LongRunningTimeout)]
+	[Test, HardTimeout(LongRunningTimeout)]
 	public async Task following_append_with_expected_version_any_are_commited_correctly()
 	{
 		Assert.AreEqual(4,
@@ -101,7 +101,7 @@ public class when_committing_empty_transaction<TLogFormat, TStreamId> : Specific
 		}
 	}
 
-	[Test, Timeout(LongRunningTimeout)]
+	[Test, HardTimeout(LongRunningTimeout)]
 	public async Task committing_first_event_with_expected_version_no_stream_is_idempotent()
 	{
 		Assert.AreEqual(0,
@@ -117,7 +117,7 @@ public class when_committing_empty_transaction<TLogFormat, TStreamId> : Specific
 		}
 	}
 
-	[Test, Timeout(LongRunningTimeout)]
+	[Test, HardTimeout(LongRunningTimeout)]
 	public async Task trying_to_append_new_events_with_expected_version_no_stream_fails()
 	{
 		await AssertEx.ThrowsAsync<WrongExpectedVersionException>(() =>

--- a/src/EventStore.Core.Tests/DataStructures/bloom_filter_integrity_should.cs
+++ b/src/EventStore.Core.Tests/DataStructures/bloom_filter_integrity_should.cs
@@ -105,10 +105,10 @@ public class bloom_filter_integrity_should
 		Assert.True(BloomFilterIntegrity.ValidateHash(cacheLine));
 
 		// same data
-		CollectionAssert.AreEqual(copy[..^4], cacheLine[..^4]);
+		Assert.That(cacheLine[..^4], Is.EqualTo(copy[..^4]));
 
 		// changed hash
-		CollectionAssert.AreNotEqual(copy[^4..], cacheLine[^4..]);
+		Assert.That(cacheLine[^4..], Is.Not.EqualTo(copy[^4..]));
 	}
 
 	[TestCase]

--- a/src/EventStore.Core.Tests/DataStructures/persistent_stream_bloom_filter.cs
+++ b/src/EventStore.Core.Tests/DataStructures/persistent_stream_bloom_filter.cs
@@ -241,7 +241,7 @@ public class persistent_stream_bloom_filter : SpecificationWithDirectoryPerTestF
 		Assert.GreaterOrEqual(falsePositives, Math.Max(0, expectedFalsePositives - threeStandardDeviations));
 	}
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public void always_returns_true_when_an_item_was_added([Range(10_000, 100_000, 13337)] long size)
 	{
 		using var filter = GenSut(GetTempFilePath(), create: true, size, hasher: null);

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -13,7 +13,9 @@
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="NUnit" />
-		<PackageReference Include="NUnit3TestAdapter" />
+		<PackageReference Include="NUnit3TestAdapter">
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 		<PackageReference Include="Google.Protobuf" />
 		<PackageReference Include="Grpc.Tools">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/EventStore.Core.Tests/HardTimeoutAttribute.cs
+++ b/src/EventStore.Core.Tests/HardTimeoutAttribute.cs
@@ -1,0 +1,5 @@
+namespace NUnit.Framework;
+
+#pragma warning disable CS0618
+public sealed class HardTimeoutAttribute(int timeout) : TimeoutAttribute(timeout);
+#pragma warning restore CS0618

--- a/src/EventStore.Core.Tests/Helpers/HelperExtensions.cs
+++ b/src/EventStore.Core.Tests/Helpers/HelperExtensions.cs
@@ -42,7 +42,7 @@ public static class HelperExtensions
 			{
 				if (response.TryGetValue(propertyName.Substring(0, propertyName.Length - "___".Length), out _))
 				{
-					Assert.Fail("{0}/{1} found, but it is explicitly forbidden", path, propertyName);
+					Assert.Fail($"{path}/{propertyName} found, but it is explicitly forbidden");
 				}
 			}
 			else if (propertyName.EndsWith("___exists"))
@@ -50,12 +50,12 @@ public static class HelperExtensions
 				if (!response.TryGetValue(propertyName.Substring(0, propertyName.Length - "___exists".Length),
 					out _))
 				{
-					Assert.Fail("{0}/{1} not found, but it is explicitly required", path, propertyName);
+					Assert.Fail($"{path}/{propertyName} not found, but it is explicitly required");
 				}
 			}
 			else if (!response.TryGetValue(propertyName, out vv))
 			{
-				Assert.Fail("{0}/{1} not found in '{2}'", path, propertyName, response.ToString());
+				Assert.Fail($"{path}/{propertyName} not found in '{response}'");
 			}
 			else
 			{

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/rolling_manual_only_merges.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/rolling_manual_only_merges.cs
@@ -11,7 +11,7 @@ public class rolling_manual_only_merges : when_max_auto_merge_level_is_set
 	{
 	}
 
-	[Test, Timeout(LongRunningTimeout)]
+	[Test, HardTimeout(LongRunningTimeout)]
 	public void alternating_table_dumps_and_manual_merges_should_merge_correctly()
 	{
 		AddTables(1);

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_max_auto_merge_level_is_reduced.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_max_auto_merge_level_is_reduced.cs
@@ -10,7 +10,7 @@ public class when_max_auto_merge_level_is_reduced : when_max_auto_merge_level_is
 	{
 	}
 
-	[Test, Timeout(LongRunningTimeout)]
+	[Test, HardTimeout(LongRunningTimeout)]
 	public void should_merge_levels_above_max_level()
 	{
 		AddTables(201); //gives 1 level 0, 1 level 3 and 6 level 5s

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_tables_available_for_manual_merge.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_tables_available_for_manual_merge.cs
@@ -6,7 +6,7 @@ namespace EventStore.Core.Tests.Index.AutoMergeLevelTests;
 
 public class when_tables_available_for_manual_merge : when_max_auto_merge_level_is_set
 {
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public void should_merge_pending_tables_at_max_auto_merge_level()
 	{
 		AddTables(100);

--- a/src/EventStore.Core.Tests/Index/IndexV1/ptable_midpoint_cache_should.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/ptable_midpoint_cache_should.cs
@@ -100,7 +100,7 @@ public class ptable_midpoint_cache_should : SpecificationWithDirectory
 		construct_valid_cache_for_any_combination_of_params(4096);
 	}
 
-	[Test, Timeout(LongRunningTimeout)]
+	[Test, HardTimeout(LongRunningTimeout)]
 	public void construct_valid_cache_for_any_combination_of_params_small()
 	{
 		construct_valid_cache_for_any_combination_of_params(20);

--- a/src/EventStore.Core.Tests/Integration/when_node_becomes_leader_with_unindexed_data.cs
+++ b/src/EventStore.Core.Tests/Integration/when_node_becomes_leader_with_unindexed_data.cs
@@ -281,7 +281,7 @@ public class when_node_becomes_leader_with_unindexed_data<TLogFormat, TStreamId>
 
 	[TestCase(true)]
 	[TestCase(false)]
-	[Explicit, Category("LongRunning"), Timeout(80000), NonParallelizable]
+	[Explicit, Category("LongRunning"), HardTimeout(80000), NonParallelizable]
 	public async Task new_events_should_have_correct_event_numbers(bool appendInitialEvent)
 	{
 		await WaitForAllNodesToBeLive();

--- a/src/EventStore.Core.Tests/Services/Replication/ReplicationTestHelper.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/ReplicationTestHelper.cs
@@ -67,7 +67,7 @@ public static class ReplicationTestHelper
 
 			if (readResult.Result == ReadAllResult.Error)
 			{
-				Assert.Fail("Failed to read forwards. Read result error: {0}", readResult.Error);
+				Assert.Fail($"Failed to read forwards. Read result error: {readResult.Error}");
 				return null;
 			}
 
@@ -105,7 +105,7 @@ public static class ReplicationTestHelper
 
 			if (readResult.Result == ReadAllResult.Error)
 			{
-				Assert.Fail("Failed to read backwards. Read result error: {0}", readResult.Error);
+				Assert.Fail($"Failed to read backwards. Read result error: {readResult.Error}");
 				return null;
 			}
 

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_an_epoch_manager_and_empty_tf_log.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_an_epoch_manager_and_empty_tf_log.cs
@@ -139,7 +139,7 @@ public class
 			epoch = epoch.Next;
 		}
 
-		CollectionAssert.IsOrdered(epochs);
+		Assert.That(epochs, Is.Ordered);
 
 		// can_write_more_epochs_than_cache_size
 
@@ -159,7 +159,7 @@ public class
 			epoch = epoch.Next;
 		}
 
-		CollectionAssert.IsOrdered(epochs);
+		Assert.That(epochs, Is.Ordered);
 
 		// has written epoch information
 		var epochsWritten = _published.OfType<SystemMessage.EpochWritten>().ToArray();

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -257,8 +257,8 @@ public abstract class ReadIndexTestScenario<TLogFormat, TStreamId> : Specificati
 
 				if (await Writer.Write(prepare, token) is (false, _))
 				{
-					Assert.Fail("Second write try failed when first writing prepare at {0}, then at {1}.", firstPos,
-						prepare.LogPosition);
+					Assert.Fail(
+						$"Second write try failed when first writing prepare at {firstPos}, then at {prepare.LogPosition}.");
 				}
 			}
 		}
@@ -280,8 +280,8 @@ public abstract class ReadIndexTestScenario<TLogFormat, TStreamId> : Specificati
 					eventNumber);
 				if (await Writer.Write(commit, token) is (false, _))
 				{
-					Assert.Fail("Second write try failed when first writing prepare at {0}, then at {1}.", firstPos,
-						prepare.LogPosition);
+					Assert.Fail(
+						$"Second write try failed when first writing prepare at {firstPos}, then at {prepare.LogPosition}.");
 				}
 			}
 		}
@@ -398,8 +398,8 @@ public abstract class ReadIndexTestScenario<TLogFormat, TStreamId> : Specificati
 					transactionPosition: tPos);
 				if (await Writer.Write(prepare, token) is (false, _))
 				{
-					Assert.Fail("Second write try failed when first writing prepare at {0}, then at {1}.", firstPos,
-						prepare.LogPosition);
+					Assert.Fail(
+						$"Second write try failed when first writing prepare at {firstPos}, then at {prepare.LogPosition}.");
 				}
 			}
 

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/GetInfoTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/GetInfoTests.cs
@@ -173,7 +173,7 @@ public class GetInfoTests
 		[Test]
 		public void should_receive_the_correct_stats()
 		{
-			CollectionAssert.AreEquivalent(_expectedSubscriptionInfo, _actualSubscriptionInfo);
+			Assert.That(_actualSubscriptionInfo, Is.EquivalentTo(_expectedSubscriptionInfo));
 		}
 	}
 
@@ -330,7 +330,7 @@ public class GetInfoTests
 			// Set the buffer counts to 0 to make comparison easier
 			_actualSubscriptionInfo.ForEach(x => x.LiveBufferCount = 0);
 			_actualSubscriptionInfo.ForEach(x => x.ReadBufferCount = 0);
-			CollectionAssert.AreEquivalent(_expectedSubscriptionInfo, _actualSubscriptionInfo);
+			Assert.That(_actualSubscriptionInfo, Is.EquivalentTo(_expectedSubscriptionInfo));
 		}
 	}
 
@@ -418,7 +418,7 @@ public class GetInfoTests
 			// Set the buffer counts to 0 to make comparison easier
 			_actualSubscriptionInfo.ForEach(x => x.LiveBufferCount = 0);
 			_actualSubscriptionInfo.ForEach(x => x.ReadBufferCount = 0);
-			CollectionAssert.AreEquivalent(_expectedSubscriptionInfo, _actualSubscriptionInfo);
+			Assert.That(_actualSubscriptionInfo, Is.EquivalentTo(_expectedSubscriptionInfo));
 		}
 	}
 
@@ -469,7 +469,7 @@ public class GetInfoTests
 		{
 			_actualSubscriptionInfo.ForEach(x => x.LiveBufferCount = 0);
 			_actualSubscriptionInfo.ForEach(x => x.ReadBufferCount = 0);
-			CollectionAssert.AreEquivalent(new[] { _expectedSubscriptionInfo }, _actualSubscriptionInfo);
+			Assert.That(_actualSubscriptionInfo, Is.EquivalentTo(new[] { _expectedSubscriptionInfo }));
 		}
 	}
 

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/ReplayParkedTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/ReplayParkedTests.cs
@@ -117,7 +117,7 @@ public class ReplayParkedTests
 		public void should_receive_replayed_messages()
 		{
 			_expectedEventVersions = Enumerable.Range(0, _eventCount).Select(x => (ulong)x).ToList();
-			CollectionAssert.AreEqual(_expectedEventVersions, _actualEventVersions);
+			Assert.That(_actualEventVersions, Is.EqualTo(_expectedEventVersions));
 		}
 
 		[TearDown]
@@ -251,7 +251,7 @@ public class ReplayParkedTests
 		public void should_receive_one_replayed_message_and_new_message()
 		{
 			_expectedEventVersions = new List<ulong> { 0, 10 };
-			CollectionAssert.AreEqual(_expectedEventVersions, _actualEventVersions);
+			Assert.That(_actualEventVersions, Is.EqualTo(_expectedEventVersions));
 		}
 
 		[TearDown]

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/ServerFeaturesTests/ServerFeaturesTest.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/ServerFeaturesTests/ServerFeaturesTest.cs
@@ -90,7 +90,7 @@ public class ServerFeaturesTest
 		[Test]
 		public void should_receive_expected_endpoints()
 		{
-			CollectionAssert.AreEquivalent(_expectedEndPoints, _supportedEndPoints);
+			Assert.That(_supportedEndPoints, Is.EquivalentTo(_expectedEndPoints));
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/UsersTests/CurrentTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/UsersTests/CurrentTests.cs
@@ -58,7 +58,7 @@ public class CurrentTests
 		{
 			Assert.AreEqual("ops", _current.UserDetails.LoginName);
 			Assert.AreEqual("Event Store Operations", _current.UserDetails.FullName);
-			CollectionAssert.Contains(_current.UserDetails.Groups, "$ops");
+			Assert.That(_current.UserDetails.Groups, Does.Contain("$ops"));
 		}
 	}
 

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/UsersTests/DetailsTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/UsersTests/DetailsTests.cs
@@ -92,8 +92,8 @@ public class DetailsTests
 		public void streams_the_user_list()
 		{
 			var loginNames = _details.Select(x => x.UserDetails.LoginName).ToArray();
-			CollectionAssert.Contains(loginNames, "details-list-test-user-1");
-			CollectionAssert.Contains(loginNames, "details-list-test-user-2");
+			Assert.That(loginNames, Does.Contain("details-list-test-user-1"));
+			Assert.That(loginNames, Does.Contain("details-list-test-user-2"));
 
 			var enabledUser = _details.Single(x => x.UserDetails.LoginName == "details-list-test-user-1");
 			Assert.AreEqual("Details Test User", enabledUser.UserDetails.FullName);

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionSslTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionSslTests.cs
@@ -31,7 +31,7 @@ public class TcpConnectionSslTests
 		return data;
 	}
 
-	[Test, Timeout(120000)]
+	[Test, HardTimeout(120000)]
 	public async Task no_data_should_be_dispatched_after_tcp_connection_closed()
 	{
 		for (int i = 0; i < 1000; i++)
@@ -110,7 +110,7 @@ public class TcpConnectionSslTests
 		}
 	}
 
-	[Test, Timeout(120000)]
+	[Test, HardTimeout(120000)]
 	public void when_connection_closed_quickly_socket_should_be_properly_disposed()
 	{
 		for (int i = 0; i < 1000; i++)

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionTests.cs
@@ -27,7 +27,7 @@ public class TcpConnectionTests
 		return data;
 	}
 
-	[Test, Timeout(120000)]
+	[Test, HardTimeout(120000)]
 	public async Task no_data_should_be_dispatched_after_tcp_connection_closed()
 	{
 		for (int i = 0; i < 1000; i++)
@@ -97,7 +97,7 @@ public class TcpConnectionTests
 		}
 	}
 
-	[Test, Timeout(120000)]
+	[Test, HardTimeout(120000)]
 	public void when_connection_closed_quickly_socket_should_be_properly_disposed()
 	{
 		for (int i = 0; i < 1000; i++)

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/when_invalid_data_is_sent_over_tcp.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/when_invalid_data_is_sent_over_tcp.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp;
 public class when_invalid_data_is_sent_over_tcp<TLogFormat, TStreamId> : specification_with_cluster<TLogFormat, TStreamId>
 {
 
-	[Timeout(15000)]
+	[HardTimeout(15000)]
 	[TestCase("InternalTcpEndPoint", false)]
 	[TestCase("ExternalTcpEndPoint", false)]
 	public async Task connection_should_be_closed_by_remote_party(string endpointProperty, bool secure)

--- a/src/EventStore.Core.Tests/Services/VNode/vnode_fsm_should.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/vnode_fsm_should.cs
@@ -32,7 +32,7 @@ public class vnode_fsm_should
 		var fsm = new VNodeFSMBuilder(new ValueReference<VNodeState>(VNodeState.Leader))
 			.InAnyState()
 			.When<P>().Ignore()
-			.WhenOther().Do(x => Assert.Fail("{0} slipped through", x.GetType().Name))
+			.WhenOther().Do(x => Assert.Fail($"{x.GetType().Name} slipped through"))
 			.Build();
 
 		await fsm.HandleAsync(new A());
@@ -47,7 +47,7 @@ public class vnode_fsm_should
 			.InAnyState()
 			.When<P>().Ignore()
 			.When<A>().Do(x => aHandled = true)
-			.WhenOther().Do(x => Assert.Fail("{0} slipped through", x.GetType().Name))
+			.WhenOther().Do(x => Assert.Fail($"{x.GetType().Name} slipped through"))
 			.Build();
 
 		await fsm.HandleAsync(new A());

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_database.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_database.cs
@@ -14,7 +14,7 @@ public class when_truncating_database<TLogFormat, TStreamId> : SpecificationWith
 {
 	private const int LongRunningTimeout = 120000;
 
-	[Test, Category("LongRunning"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), HardTimeout(LongRunningTimeout)]
 	public async Task everything_should_go_fine()
 	{
 		var miniNode = new MiniNode<TLogFormat, TStreamId>(PathName);
@@ -69,7 +69,7 @@ public class when_truncating_database<TLogFormat, TStreamId> : SpecificationWith
 		await miniNode.Shutdown();
 	}
 
-	[Test, Category("LongRunning"), Category("Network"), Timeout(LongRunningTimeout)]
+	[Test, Category("LongRunning"), Category("Network"), HardTimeout(LongRunningTimeout)]
 	public async Task with_truncate_position_in_completed_chunk_everything_should_go_fine()
 	{
 		const int chunkSize = 1024 * 1024;

--- a/src/EventStore.Core.Tests/Transforms/TransformTests.cs
+++ b/src/EventStore.Core.Tests/Transforms/TransformTests.cs
@@ -29,7 +29,7 @@ public class TransformTests<TLogFormat, TStreamId> : SpecificationWithDirectoryP
 	[TestCase("bitflip")]
 	[TestCase("bytedup")]
 	[TestCase("withheader")]
-	[Timeout(600000)]
+	[HardTimeout(600000)]
 	public async Task transform_works(string transform)
 	{
 		MiniNode<TLogFormat, TStreamId> node = null;

--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterNodeOptionsTests/when_building/with_cluster_node_and_custom_settings.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterNodeOptionsTests/when_building/with_cluster_node_and_custom_settings.cs
@@ -95,7 +95,7 @@ public class with_dns_discovery_disabled_and_gossip_seeds_defined<TLogFormat, TS
 	[Test]
 	public void should_set_the_gossip_seeds()
 	{
-		CollectionAssert.AreEqual(_gossipSeeds, _options.Cluster.GossipSeed);
+		Assert.That(_options.Cluster.GossipSeed, Is.EqualTo(_gossipSeeds));
 	}
 }
 
@@ -116,7 +116,7 @@ public class with_custom_gossip_seeds<TLogFormat, TStreamId> : ClusterMemberScen
 	[Test]
 	public void should_set_the_gossip_seeds()
 	{
-		CollectionAssert.AreEqual(_gossipSeeds, _options.Cluster.GossipSeed);
+		Assert.That(_options.Cluster.GossipSeed, Is.EqualTo(_gossipSeeds));
 	}
 }
 

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
@@ -250,10 +250,10 @@ public abstract class specification_with_standard_projections_runnning<TLogForma
 		switch (result.Status)
 		{
 			case SliceReadStatus.StreamDeleted:
-				Assert.Fail("Stream '{0}' is deleted", streamId);
+				Assert.Fail($"Stream '{streamId}' is deleted");
 				break;
 			case SliceReadStatus.StreamNotFound:
-				Assert.Fail("Stream '{0}' does not exist", streamId);
+				Assert.Fail($"Stream '{streamId}' does not exist");
 				break;
 			case SliceReadStatus.Success:
 				var resultEventsReversed = result.Events.Reverse().ToArray();
@@ -294,10 +294,10 @@ public abstract class specification_with_standard_projections_runnning<TLogForma
 		switch (result.Status)
 		{
 			case SliceReadStatus.StreamDeleted:
-				Assert.Fail("Stream '{0}' is deleted", streamId);
+				Assert.Fail($"Stream '{streamId}' is deleted");
 				break;
 			case SliceReadStatus.StreamNotFound:
-				Assert.Fail("Stream '{0}' does not exist", streamId);
+				Assert.Fail($"Stream '{streamId}' does not exist");
 				break;
 			case SliceReadStatus.Success:
 				Dump("Dumping..", streamId, result.Events.Reverse().ToArray());
@@ -318,9 +318,7 @@ public abstract class specification_with_standard_projections_runnning<TLogForma
 
 
 		Assert.Fail(
-			"Stream: '{0}'\r\n{1}\r\n\r\nExisting events: \r\n{2}\r\n Expected events: \r\n{3}\r\n\r\nActual metas:{4}",
-			streamId,
-			message, actual, expected, actualMeta);
+			$"Stream: '{streamId}'\r\n{message}\r\n\r\nExisting events: \r\n{actual}\r\n Expected events: \r\n{expected}\r\n\r\nActual metas:{actualMeta}");
 	}
 
 	private void Dump(string message, string streamId, ResolvedEvent[] resultEvents)

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
@@ -223,10 +223,10 @@ public abstract class specification_with_standard_projections_runnning<TLogForma
 		switch (result.Status)
 		{
 			case SliceReadStatus.StreamDeleted:
-				Assert.Fail("Stream '{0}' is deleted", streamId);
+				Assert.Fail($"Stream '{streamId}' is deleted");
 				break;
 			case SliceReadStatus.StreamNotFound:
-				Assert.Fail("Stream '{0}' does not exist", streamId);
+				Assert.Fail($"Stream '{streamId}' does not exist");
 				break;
 			case SliceReadStatus.Success:
 				var resultEventsReversed = result.Events.Reverse().ToArray();
@@ -267,10 +267,10 @@ public abstract class specification_with_standard_projections_runnning<TLogForma
 		switch (result.Status)
 		{
 			case SliceReadStatus.StreamDeleted:
-				Assert.Fail("Stream '{0}' is deleted", streamId);
+				Assert.Fail($"Stream '{streamId}' is deleted");
 				break;
 			case SliceReadStatus.StreamNotFound:
-				Assert.Fail("Stream '{0}' does not exist", streamId);
+				Assert.Fail($"Stream '{streamId}' does not exist");
 				break;
 			case SliceReadStatus.Success:
 				Dump("Dumping..", streamId, result.Events.Reverse().ToArray());
@@ -291,9 +291,7 @@ public abstract class specification_with_standard_projections_runnning<TLogForma
 
 
 		Assert.Fail(
-			"Stream: '{0}'\r\n{1}\r\n\r\nExisting events: \r\n{2}\r\n Expected events: \r\n{3}\r\n\r\nActual metas:{4}",
-			streamId,
-			message, actual, expected, actualMeta);
+			$"Stream: '{streamId}'\r\n{message}\r\n\r\nExisting events: \r\n{actual}\r\n Expected events: \r\n{expected}\r\n\r\nActual metas:{actualMeta}");
 	}
 
 	protected void Dump(string message, string streamId, ResolvedEvent[] resultEvents)

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -21,7 +21,9 @@
 		<PackageReference Include="Newtonsoft.Json" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="NUnit" />
-		<PackageReference Include="NUnit3TestAdapter" />
+		<PackageReference Include="NUnit3TestAdapter">
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 		<PackageReference Include="Serilog.Sinks.TextWriter" />
 		<PackageReference Include="Google.Protobuf" />
 		<PackageReference Include="Grpc.AspNetCore.HealthChecks" />

--- a/src/EventStore.Projections.Core.Tests/Services/Jint/when_running_a_js_projection_emitting_invalid_events.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/Jint/when_running_a_js_projection_emitting_invalid_events.cs
@@ -33,12 +33,12 @@ public abstract class when_running_a_js_projection_emitting_invalid_events : Tes
 	{
 		string state;
 		EmittedEventEnvelope[] emittedEvents;
-		TestDelegate td = () =>
+		Action action = () =>
 			_stateHandler.ProcessEvent(
 				"", CheckpointTag.FromPosition(0, 20, 10), "stream1", "type1", "category", Guid.NewGuid(), 0,
 				"metadata",
 				@"{""a"":""b""}", out state, out emittedEvents);
-		var ae = IsNull ? Assert.Throws<ArgumentNullException>(td) : Assert.Throws<ArgumentException>(td);
+		var ae = IsNull ? Assert.Throws<ArgumentNullException>(action) : Assert.Throws<ArgumentException>(action);
 		Assert.AreEqual(ParameterName, ae.ParamName);
 	}
 

--- a/src/EventStore.Projections.Core.Tests/Services/Jint/when_specifying_meta_data_for_linked_event.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/Jint/when_specifying_meta_data_for_linked_event.cs
@@ -37,6 +37,6 @@ public class when_specifying_meta_data_for_linked_event : TestFixtureWithInterpr
 		Assert.IsNotNull(emittedEvents[0].Event);
 
 		var metaData = emittedEvents[0].Event.ExtraMetaData();
-		CollectionAssert.AreEquivalent(new Dictionary<string, string> { { "meta", "\"data\"" } }, metaData);
+		Assert.That(metaData, Is.EquivalentTo(new Dictionary<string, string> { { "meta", "\"data\"" } }));
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_projection_state_is_too_large.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_projection_state_is_too_large.cs
@@ -73,7 +73,7 @@ public class when_projection_state_is_too_large<TLogFormat, TStreamId> :
 		var failedMessages = _consumer.HandledMessages.OfType<CoreProjectionProcessingMessage.Failed>().ToArray();
 
 		Assert.AreEqual(1, failedMessages.Length);
-		StringAssert.Contains("exceeds the configured MaxProjectionStateSize", failedMessages[0].Reason);
+		Assert.That(failedMessages[0].Reason, Does.Contain("exceeds the configured MaxProjectionStateSize"));
 	}
 
 	[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/grpc_service/ServerFeaturesTests.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/grpc_service/ServerFeaturesTests.cs
@@ -52,6 +52,6 @@ public class ServerFeaturesTests<TLogFormat, TStreamId> : SpecificationWithNodeA
 	[Test]
 	public void should_receive_expected_endpoints()
 	{
-		CollectionAssert.AreEquivalent(_expectedEndPoints, _supportedEndPoints);
+		Assert.That(_supportedEndPoints, Is.EquivalentTo(_expectedEndPoints));
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
@@ -51,7 +51,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
 			{
 				var failure = HandledMessages.OfType<ProjectionManagementMessage.OperationFailed>().Single();
 
-				StringAssert.Contains("Transient projections are not supported", failure.Reason);
+				Assert.That(failure.Reason, Does.Contain("Transient projections are not supported"));
 			}
 
 			[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_writes_succeed.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_writes_succeed.cs
@@ -68,7 +68,7 @@ public class
 			.Events[0];
 
 		Assert.IsTrue(writtenEvent.IsPropertyMetadata);
-		CollectionAssert.AreEqual(DefinitionMetadata, writtenEvent.Metadata);
+		Assert.That(writtenEvent.Metadata, Is.EqualTo(DefinitionMetadata));
 	}
 
 	[Test, Category("v8")]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_projection_with_oversized_definition.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_projection_with_oversized_definition.cs
@@ -43,7 +43,7 @@ public class when_posting_a_projection_with_oversized_definition<TLogFormat, TSt
 	public void the_operation_fails_as_record_too_large()
 	{
 		var failure = _consumer.HandledMessages.OfType<ProjectionManagementMessage.RecordTooLarge>().Single();
-		StringAssert.Contains("exceeds the maximum", failure.Reason);
+		Assert.That(failure.Reason, Does.Contain("exceeds the maximum"));
 	}
 
 	[Test, Category("v8")]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_transient_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_transient_projection.cs
@@ -41,7 +41,7 @@ public class when_posting_a_transient_projection<TLogFormat, TStreamId> : TestFi
 	{
 		var failure = HandledMessages.OfType<ProjectionManagementMessage.OperationFailed>().Single();
 
-		StringAssert.Contains("Transient projections are not supported", failure.Reason);
+		Assert.That(failure.Reason, Does.Contain("Transient projections are not supported"));
 	}
 
 	[Test, Category("v8")]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_query_text.cs
@@ -126,6 +126,6 @@ public class when_updating_a_persistent_projection_query_text<TLogFormat, TStrea
 			.Events[0];
 
 		Assert.IsTrue(writtenEvent.IsPropertyMetadata);
-		CollectionAssert.AreEqual(UpdatedDefinitionMetadata, writtenEvent.Metadata);
+		Assert.That(writtenEvent.Metadata, Is.EqualTo(UpdatedDefinitionMetadata));
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_projection_with_oversized_definition.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_projection_with_oversized_definition.cs
@@ -47,7 +47,7 @@ public class when_updating_a_projection_with_oversized_definition<TLogFormat, TS
 	public void the_operation_fails_as_record_too_large()
 	{
 		var failure = _consumer.HandledMessages.OfType<ProjectionManagementMessage.RecordTooLarge>().Single();
-		StringAssert.Contains("exceeds the maximum", failure.Reason);
+		Assert.That(failure.Reason, Does.Contain("exceeds the maximum"));
 	}
 
 	[Test, Category("v8")]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/when_requesting_state_from_a_faulted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/when_requesting_state_from_a_faulted_projection.cs
@@ -49,7 +49,6 @@ class when_requesting_state_from_a_faulted_projection<TLogFormat, TStreamId> : w
 		Assert.That(state.Position.Streams.Count == 1);
 		Assert.That(state.Position.Streams.Keys.First() == "message1");
 		Assert.That(state.Position.Streams["message1"] == -1);
-		Assert.That(
-			state.Position.Position <= _message1Position, "{0} <= {1}", state.Position.Position, _message1Position);
+		Assert.That(state.Position.Position, Is.LessThanOrEqualTo(_message1Position));
 	}
 }


### PR DESCRIPTION
- keep the test runner stack aligned with the supported .NET toolchain
- reduce dependency drift without changing runtime package behavior