### PR TITLE
feat(grpc): allow response compression tuning

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using EventStore.Common.Configuration;
@@ -70,6 +71,24 @@ public class ClusterVNodeOptionsTests
 
 		var values = options.Unknown.Options;
 		Assert.Empty(values);
+	}
+
+	[Fact]
+	public void grpc_compression_level_defaults_to_optimal()
+	{
+		var configuration = EventStoreConfiguration.Build(Array.Empty<string>());
+		var options = ClusterVNodeOptions.FromConfiguration(configuration);
+
+		options.Grpc.CompressionLevel.Should().Be(CompressionLevel.Optimal);
+	}
+
+	[Fact]
+	public void grpc_compression_level_is_configurable()
+	{
+		var options = GetOptions("--compression-level NoCompression");
+
+		options.Grpc.CompressionLevel.Should().Be(CompressionLevel.NoCompression);
+		Assert.Empty(options.Unknown.Options);
 	}
 
 	[Fact]

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
 using EventStore.Common.Configuration;
@@ -15,6 +16,7 @@ using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Plugins;
 using EventStore.Plugins.Authentication;
 using EventStore.Plugins.Authorization;
+using Grpc.Net.Compression;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
@@ -238,6 +240,19 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 			.AddGrpc(options =>
 			{
 				options.Interceptors.Add<RetryInterceptor>();
+
+				var eventStoreConfiguration = _configuration.GetSection("EventStore");
+				var compressionLevel = (eventStoreConfiguration.Exists()
+						? eventStoreConfiguration
+						: _configuration)
+					.BindOptions<ClusterVNodeOptions.GrpcOptions>()
+					.CompressionLevel;
+				options.CompressionProviders.Add(new GzipCompressionProvider(compressionLevel));
+				if (compressionLevel != CompressionLevel.NoCompression)
+				{
+					options.ResponseCompressionAlgorithm = "gzip";
+					options.ResponseCompressionLevel = compressionLevel;
+				}
 			})
 			.AddServiceOptions<Streams<TStreamId>>(options =>
 				options.MaxReceiveMessageSize = TFConsts.EffectiveMaxLogRecordSize)

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
@@ -510,6 +511,9 @@ public partial record ClusterVNodeOptions
 	[Description("gRPC Options")]
 	public record GrpcOptions
 	{
+		[Description("The gzip compression level applied to gRPC responses when clients advertise gzip support.")]
+		public CompressionLevel CompressionLevel { get; init; } = CompressionLevel.Optimal;
+
 		[Description("Controls the period (in milliseconds) after which a keepalive ping " +
 					 "is sent on the transport."),
 		 Unit("ms")]
@@ -523,6 +527,7 @@ public partial record ClusterVNodeOptions
 
 		internal static GrpcOptions FromConfiguration(IConfiguration configurationRoot) => new()
 		{
+			CompressionLevel = configurationRoot.GetValue<CompressionLevel>(nameof(CompressionLevel)),
 			KeepAliveInterval = configurationRoot.GetValue<int>(nameof(KeepAliveInterval)),
 			KeepAliveTimeout = configurationRoot.GetValue<int>(nameof(KeepAliveTimeout))
 		};


### PR DESCRIPTION
- give operators a way to balance gRPC response size against CPU cost
- allow response compression to be disabled without rejecting compressed client requests