### PR TITLE
feat(persistent-subscriptions): allow parked message truncation

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -4327,6 +4327,51 @@
             "name": "ReplayParkedResp"
           },
           {
+            "name": "TruncateParkedReq",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "Options"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Options",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "group_name",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "stream_identifier",
+                    "type": "event_store.client.StreamIdentifier"
+                  },
+                  {
+                    "id": 3,
+                    "name": "all",
+                    "type": "event_store.client.Empty"
+                  },
+                  {
+                    "id": 4,
+                    "name": "stop_at",
+                    "type": "int64"
+                  },
+                  {
+                    "id": 5,
+                    "name": "no_limit",
+                    "type": "event_store.client.Empty"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "TruncateParkedResp"
+          },
+          {
             "name": "ListReq",
             "fields": [
               {
@@ -4440,6 +4485,11 @@
                 "name": "ReplayParked",
                 "in_type": "ReplayParkedReq",
                 "out_type": "ReplayParkedResp"
+              },
+              {
+                "name": "TruncateParked",
+                "in_type": "TruncateParkedReq",
+                "out_type": "TruncateParkedResp"
               },
               {
                 "name": "List",

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionMessageParkerTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionMessageParkerTests.cs
@@ -361,6 +361,63 @@ public class PersistentSubscriptionMessageParkerTests
 
 
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class given_messages_are_parked_and_then_truncated<TLogFormat, TStreamId> : TestFixtureWithExistingEvents<TLogFormat, TStreamId>
+	{
+		private PersistentSubscriptionMessageParker _messageParker;
+		private string _streamId = Guid.NewGuid().ToString();
+		private TaskCompletionSource<bool> _parked;
+		private TaskCompletionSource<bool> _done = new TaskCompletionSource<bool>();
+
+		protected override void Given()
+		{
+			base.Given();
+
+			AllWritesSucceed();
+
+			_parked = new TaskCompletionSource<bool>();
+			_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
+			_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", (_, __) =>
+			{
+				_messageParker.BeginParkMessage(CreateResolvedEvent(1, 100), "testing", (_, __) =>
+				{
+					_parked.SetResult(true);
+				});
+			});
+		}
+
+		[Test]
+		public async Task should_have_no_parked_messages()
+		{
+			await _parked.Task;
+			_messageParker.BeginMarkParkedMessagesTruncated(2, _ =>
+			{
+				Assert.Zero(_messageParker.ParkedMessageCount);
+				Assert.Null(_messageParker.GetOldestParkedMessage);
+				Assert.Zero(_messageParker.ParkedMessageReplays);
+				_done.TrySetResult(true);
+			});
+			await _done.Task.WithTimeout();
+		}
+
+		[Test]
+		public async Task should_not_lower_the_truncate_before_watermark()
+		{
+			await _parked.Task;
+			_messageParker.BeginMarkParkedMessagesTruncated(2, _ =>
+			{
+				_messageParker.BeginMarkParkedMessagesTruncated(0, __ =>
+				{
+					Assert.Zero(_messageParker.ParkedMessageCount);
+					Assert.Null(_messageParker.GetOldestParkedMessage);
+					_done.TrySetResult(true);
+				});
+			});
+			await _done.Task.WithTimeout();
+		}
+	}
+
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	public class given_read_backwards_fails_when_getting_stats<TLogFormat, TStreamId> : TestFixtureWithExistingEvents<TLogFormat, TStreamId>
 	{
 		private PersistentSubscriptionMessageParker _messageParker;

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionServiceNotReadyTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionServiceNotReadyTests.cs
@@ -172,6 +172,18 @@ public class PersistentSubscriptionServiceNotReadyTests
 		AssertNotReady(envelope, correlationId);
 	}
 
+	[Test]
+	public void truncate_parked_replies_not_ready()
+	{
+		var envelope = new FakeEnvelope();
+		var correlationId = Guid.NewGuid();
+
+		_sut.Handle(new ClientMessage.TruncateParkedMessages(
+			Guid.NewGuid(), correlationId, envelope, "stream", "group", null, ClaimsPrincipal.Current));
+
+		AssertNotReady(envelope, correlationId);
+	}
+
 	private static void AssertNotReady(FakeEnvelope envelope, Guid correlationId)
 	{
 		Assert.That(envelope.Replies, Has.Count.EqualTo(1));

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -2980,6 +2980,16 @@ class FakeMessageParker : IPersistentSubscriptionMessageParker
 		}
 	}
 
+	public void RecordParkedMessageReplay()
+	{
+		ParkedMessageReplays++;
+	}
+
+	public void RecordParkedMessageTruncate()
+	{
+		ParkedMessageTruncates++;
+	}
+
 	public void BeginParkMessage(ResolvedEvent ev, string reason,
 		Action<ResolvedEvent, OperationResult> completed)
 	{
@@ -2988,23 +2998,30 @@ class FakeMessageParker : IPersistentSubscriptionMessageParker
 		_parkMessageCompleted = completed;
 	}
 
-	public void BeginReadEndSequence(Action<long?> completed)
+	public void BeginReadEndSequence(Action<ParkedStreamEndReadResult> completed)
 	{
 		BeginReadEndSequenceCount++;
-		ParkedMessageReplays++;
 		if (_lastParkedEventNumber == -1)
 		{
-			completed(null); //NoStream
+			completed(ParkedStreamEndReadResult.Success(null)); //NoStream
 		}
 		else
 		{
-			completed(_lastParkedEventNumber);
+			completed(ParkedStreamEndReadResult.Success(_lastParkedEventNumber));
 		}
 	}
 
 	public void BeginMarkParkedMessagesReprocessed(long sequence, DateTime? dateTime, bool updateOldestParkedMessage)
 	{
 		MarkedAsProcessed = sequence;
+		_lastTruncateBefore = sequence;
+	}
+
+	public void BeginMarkParkedMessagesTruncated(long sequence, Action<OperationResult> completed)
+	{
+		MarkedAsProcessed = sequence;
+		_lastTruncateBefore = sequence;
+		completed?.Invoke(OperationResult.Success);
 	}
 
 	public void BeginDelete(Action<IPersistentSubscriptionMessageParker> completed)
@@ -3031,6 +3048,7 @@ class FakeMessageParker : IPersistentSubscriptionMessageParker
 	public long ParkedDueToClientNak { get; private set; }
 	public long ParkedDueToMaxRetries { get; private set; }
 	public long ParkedMessageReplays { get; private set; }
+	public long ParkedMessageTruncates { get; private set; }
 }
 
 

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/ReplayParkedTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/ReplayParkedTests.cs
@@ -263,6 +263,185 @@ public class ReplayParkedTests
 
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	public class
+		when_truncating_parked_messages_with_no_limit_for_existing_subscription<TLogFormat, TStreamId>
+			: GrpcSpecification<TLogFormat, TStreamId>
+	{
+		private string _groupName = "test-group";
+		private string _streamName = "test-stream";
+		private int _eventCount = 10;
+		private PersistentSubscriptions.PersistentSubscriptionsClient _persistentSubscriptionsClient;
+		private AsyncDuplexStreamingCall<ReadReq, ReadResp> _subscriptionStream;
+		private ulong _actualEventVersion;
+		private long _parkedMessageCount;
+
+		protected override async Task Given()
+		{
+			_persistentSubscriptionsClient = new PersistentSubscriptions.PersistentSubscriptionsClient(Channel);
+
+			await CreateTestPersistentSubscription(_persistentSubscriptionsClient, _streamName, _groupName, GetCallOptions(AdminCredentials));
+
+			_subscriptionStream = await SubscribeToPersistentSubscription(
+				_persistentSubscriptionsClient, _groupName, _streamName, GetCallOptions(AdminCredentials));
+
+			var writeRes = await AppendToStreamBatch(new BatchAppendReq
+			{
+				Options = new()
+				{
+					Any = new(),
+					StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(_streamName) }
+				},
+				IsFinal = true,
+				ProposedMessages = { CreateEvents(_eventCount) },
+				CorrelationId = Uuid.NewUuid().ToDto(),
+			});
+			Assert.NotNull(writeRes.Success);
+
+			await ParkMessages(_subscriptionStream, _eventCount);
+
+			await WaitForEventsInStream(
+				StreamsClient, $"$persistentsubscription-{_streamName}::{_groupName}-parked", _eventCount, GetCallOptions(AdminCredentials));
+		}
+
+		protected override async Task When()
+		{
+			await _persistentSubscriptionsClient.TruncateParkedAsync(new TruncateParkedReq
+			{
+				Options = new TruncateParkedReq.Types.Options
+				{
+					GroupName = _groupName,
+					StreamIdentifier = new StreamIdentifier
+					{
+						StreamName = ByteString.CopyFromUtf8(_streamName)
+					},
+					NoLimit = new()
+				}
+			}, GetCallOptions(AdminCredentials));
+
+			var info = await _persistentSubscriptionsClient.GetInfoAsync(GetInfoRequest(_streamName, _groupName), GetCallOptions(AdminCredentials));
+			_parkedMessageCount = info.SubscriptionInfo.ParkedMessageCount;
+
+			var writeRes = await AppendToStreamBatch(new BatchAppendReq
+			{
+				Options = new()
+				{
+					Any = new(),
+					StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(_streamName) }
+				},
+				IsFinal = true,
+				ProposedMessages = { CreateEvents(1) },
+				CorrelationId = Uuid.NewUuid().ToDto(),
+			});
+			Assert.NotNull(writeRes.Success);
+
+			Assert.True(await _subscriptionStream.ResponseStream.MoveNext());
+			var curr = _subscriptionStream.ResponseStream.Current;
+			Assert.AreEqual(ReadResp.ContentOneofCase.Event, curr.ContentCase);
+			_actualEventVersion = curr.Event.Event.StreamRevision;
+
+			await _subscriptionStream.RequestStream.WriteAsync(new ReadReq
+			{
+				Ack = new ReadReq.Types.Ack
+				{
+					Ids = {
+						curr.Event.Event.Id
+					},
+				}
+			});
+		}
+
+		[Test]
+		public void should_remove_all_parked_messages()
+		{
+			Assert.AreEqual(0, _parkedMessageCount);
+		}
+
+		[Test]
+		public void should_not_replay_truncated_messages()
+		{
+			Assert.AreEqual((ulong)_eventCount, _actualEventVersion);
+		}
+
+		[TearDown]
+		public void Teardown()
+		{
+			_subscriptionStream.Dispose();
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class
+		when_truncating_parked_messages_with_a_stop_at_for_existing_subscription<TLogFormat, TStreamId>
+			: GrpcSpecification<TLogFormat, TStreamId>
+	{
+		private string _groupName = "test-group";
+		private string _streamName = "test-stream";
+		private int _eventCount = 10;
+		private PersistentSubscriptions.PersistentSubscriptionsClient _persistentSubscriptionsClient;
+		private AsyncDuplexStreamingCall<ReadReq, ReadResp> _subscriptionStream;
+		private long _parkedMessageCount;
+
+		protected override async Task Given()
+		{
+			_persistentSubscriptionsClient = new PersistentSubscriptions.PersistentSubscriptionsClient(Channel);
+
+			await CreateTestPersistentSubscription(_persistentSubscriptionsClient, _streamName, _groupName, GetCallOptions(AdminCredentials));
+
+			_subscriptionStream = await SubscribeToPersistentSubscription(
+				_persistentSubscriptionsClient, _groupName, _streamName, GetCallOptions(AdminCredentials));
+
+			var writeRes = await AppendToStreamBatch(new BatchAppendReq
+			{
+				Options = new()
+				{
+					Any = new(),
+					StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(_streamName) }
+				},
+				IsFinal = true,
+				ProposedMessages = { CreateEvents(_eventCount) },
+				CorrelationId = Uuid.NewUuid().ToDto(),
+			});
+			Assert.NotNull(writeRes.Success);
+
+			await ParkMessages(_subscriptionStream, _eventCount);
+
+			await WaitForEventsInStream(
+				StreamsClient, $"$persistentsubscription-{_streamName}::{_groupName}-parked", _eventCount, GetCallOptions(AdminCredentials));
+		}
+
+		protected override async Task When()
+		{
+			await _persistentSubscriptionsClient.TruncateParkedAsync(new TruncateParkedReq
+			{
+				Options = new TruncateParkedReq.Types.Options
+				{
+					GroupName = _groupName,
+					StreamIdentifier = new StreamIdentifier
+					{
+						StreamName = ByteString.CopyFromUtf8(_streamName)
+					},
+					StopAt = 1
+				}
+			}, GetCallOptions(AdminCredentials));
+
+			var info = await _persistentSubscriptionsClient.GetInfoAsync(GetInfoRequest(_streamName, _groupName), GetCallOptions(AdminCredentials));
+			_parkedMessageCount = info.SubscriptionInfo.ParkedMessageCount;
+		}
+
+		[Test]
+		public void should_keep_messages_from_stop_at()
+		{
+			Assert.AreEqual(_eventCount - 1, _parkedMessageCount);
+		}
+
+		[TearDown]
+		public void Teardown()
+		{
+			_subscriptionStream.Dispose();
+		}
+	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class
 		when_replaying_parked_messages_for_non_existent_subscription<TLogFormat, TStreamId>
 			: GrpcSpecification<TLogFormat, TStreamId>
 	{
@@ -307,6 +486,86 @@ public class ReplayParkedTests
 			Assert.AreEqual(StatusCode.NotFound, ((RpcException)_exception).Status.StatusCode);
 		}
 	}
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	public class
+		when_truncating_parked_messages_for_non_existent_subscription<TLogFormat, TStreamId>
+			: GrpcSpecification<TLogFormat, TStreamId>
+	{
+		private string _groupName = "test-group";
+		private string _streamName = "test-stream";
+		private PersistentSubscriptions.PersistentSubscriptionsClient _persistentSubscriptionsClient;
+		private Exception _exception;
+
+		protected override Task Given()
+		{
+			_persistentSubscriptionsClient = new PersistentSubscriptions.PersistentSubscriptionsClient(Channel);
+			return Task.CompletedTask;
+		}
+
+		protected override async Task When()
+		{
+			try
+			{
+				await _persistentSubscriptionsClient.TruncateParkedAsync(new TruncateParkedReq
+				{
+					Options = new TruncateParkedReq.Types.Options
+					{
+						GroupName = _groupName,
+						StreamIdentifier = new StreamIdentifier
+						{
+							StreamName = ByteString.CopyFromUtf8(_streamName)
+						},
+						NoLimit = new()
+					}
+				}, GetCallOptions(AdminCredentials));
+			}
+			catch (Exception e)
+			{
+				_exception = e;
+			}
+		}
+
+		[Test]
+		public void should_receive_not_found_error()
+		{
+			Assert.IsInstanceOf<RpcException>(_exception);
+			Assert.AreEqual(StatusCode.NotFound, ((RpcException)_exception).Status.StatusCode);
+		}
+	}
+
+	private static async Task ParkMessages(AsyncDuplexStreamingCall<ReadReq, ReadResp> subscriptionStream, int count)
+	{
+		for (var i = 0; i < count; i++)
+		{
+			Assert.True(await subscriptionStream.ResponseStream.MoveNext());
+			Assert.AreEqual(ReadResp.ContentOneofCase.Event, subscriptionStream.ResponseStream.Current.ContentCase);
+			var evnt = subscriptionStream.ResponseStream.Current.Event;
+			await subscriptionStream.RequestStream.WriteAsync(new ReadReq
+			{
+				Nack = new ReadReq.Types.Nack
+				{
+					Action = ReadReq.Types.Nack.Types.Action.Park,
+					Ids = {
+						evnt.Event.Id
+					},
+					Reason = "testing"
+				}
+			});
+		}
+	}
+
+	private static GetInfoReq GetInfoRequest(string streamName, string groupName) => new()
+	{
+		Options = new GetInfoReq.Types.Options
+		{
+			StreamIdentifier = new StreamIdentifier
+			{
+				StreamName = ByteString.CopyFromUtf8(streamName)
+			},
+			GroupName = groupName
+		}
+	};
 
 	private static async Task<AsyncDuplexStreamingCall<ReadReq, ReadResp>> SubscribeToPersistentSubscription(
 		PersistentSubscriptions.PersistentSubscriptionsClient client, string groupName, string streamName, CallOptions callOptions)

--- a/src/EventStore.Core.XUnit.Tests/Metrics/PersistentSubscriptionMetricsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/PersistentSubscriptionMetricsTests.cs
@@ -39,6 +39,7 @@ public class PersistentSubscriptionMetricsTests
 			ParkedDueToClientNak = 1015,
 			ParkedDueToMaxRetries = 1016,
 			ParkedMessageReplays = 1017,
+			ParkedMessageTruncates = 1021,
 			ParkedMessageCount = 1003,
 			ReadBatchSize = 20,
 			ReadBufferCount = 0,
@@ -75,6 +76,7 @@ public class PersistentSubscriptionMetricsTests
 			ParkedDueToClientNak = 1018,
 			ParkedDueToMaxRetries = 1019,
 			ParkedMessageReplays = 1020,
+			ParkedMessageTruncates = 1022,
 			ParkedMessageCount = 1004,
 			ReadBatchSize = 20,
 			ReadBufferCount = 0,
@@ -128,6 +130,15 @@ public class PersistentSubscriptionMetricsTests
 		Assert.Collection(measurements,
 			AssertMeasurement("test", "testGroup", 1017),
 			AssertMeasurement("$all", "testGroup", 1020));
+	}
+
+	[Fact]
+	public void ObserveParkedMessageTruncates()
+	{
+		var measurements = _sut.ObserveParkedMessageTruncates();
+		Assert.Collection(measurements,
+			AssertMeasurement("test", "testGroup", 1021),
+			AssertMeasurement("$all", "testGroup", 1022));
 	}
 
 	[Fact]

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1230,6 +1230,7 @@ public class ClusterVNode<TStreamId> :
 		_mainBus.Subscribe<ClientMessage.PersistentSubscriptionAckEvents>(perSubscrQueue);
 		_mainBus.Subscribe<ClientMessage.PersistentSubscriptionNackEvents>(perSubscrQueue);
 		_mainBus.Subscribe<ClientMessage.ReplayParkedMessages>(perSubscrQueue);
+		_mainBus.Subscribe<ClientMessage.TruncateParkedMessages>(perSubscrQueue);
 		_mainBus.Subscribe<ClientMessage.ReplayParkedMessage>(perSubscrQueue);
 		_mainBus.Subscribe<ClientMessage.ReadNextNPersistentMessages>(perSubscrQueue);
 		_mainBus.Subscribe<StorageMessage.EventCommitted>(perSubscrQueue);
@@ -1264,6 +1265,7 @@ public class ClusterVNode<TStreamId> :
 		perSubscrBus.Subscribe<ClientMessage.UpdatePersistentSubscriptionToAll>(persistentSubscription);
 		perSubscrBus.Subscribe<ClientMessage.DeletePersistentSubscriptionToAll>(persistentSubscription);
 		perSubscrBus.Subscribe<ClientMessage.ReplayParkedMessages>(persistentSubscription);
+		perSubscrBus.Subscribe<ClientMessage.TruncateParkedMessages>(persistentSubscription);
 		perSubscrBus.Subscribe<ClientMessage.ReplayParkedMessage>(persistentSubscription);
 		perSubscrBus.Subscribe<ClientMessage.ReadNextNPersistentMessages>(persistentSubscription);
 		perSubscrBus.Subscribe<MonitoringMessage.GetAllPersistentSubscriptionStats>(persistentSubscription);

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -1779,6 +1779,23 @@ public static partial class ClientMessage
 	}
 
 	[DerivedMessage(CoreMessage.Client)]
+	public partial class TruncateParkedMessages : ReadRequestMessage
+	{
+		public readonly string EventStreamId;
+		public readonly string GroupName;
+		public readonly long? StopAt;
+
+		public TruncateParkedMessages(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
+			string eventStreamId, string groupName, long? stopAt, ClaimsPrincipal user, DateTime? expires = null)
+			: base(internalCorrId, correlationId, envelope, user, expires)
+		{
+			EventStreamId = eventStreamId;
+			GroupName = groupName;
+			StopAt = stopAt;
+		}
+	}
+
+	[DerivedMessage(CoreMessage.Client)]
 	public partial class ReplayParkedMessage : ReadRequestMessage
 	{
 		public readonly string EventStreamId;
@@ -1792,6 +1809,30 @@ public static partial class ClientMessage
 			EventStreamId = streamId;
 			GroupName = groupName;
 			Event = @event;
+		}
+	}
+
+	[DerivedMessage(CoreMessage.Client)]
+	public partial class TruncateParkedMessagesCompleted : ReadResponseMessage
+	{
+		public readonly Guid CorrelationId;
+		public readonly string Reason;
+		public readonly TruncateParkedMessagesResult Result;
+
+		public TruncateParkedMessagesCompleted(Guid correlationId, TruncateParkedMessagesResult result, string reason)
+		{
+			Ensure.NotEmptyGuid(correlationId, "correlationId");
+			CorrelationId = correlationId;
+			Result = result;
+			Reason = reason;
+		}
+
+		public enum TruncateParkedMessagesResult
+		{
+			Success,
+			DoesNotExist,
+			Fail,
+			AccessDenied,
 		}
 	}
 

--- a/src/EventStore.Core/Messages/MonitoringMessage.cs
+++ b/src/EventStore.Core/Messages/MonitoringMessage.cs
@@ -152,6 +152,7 @@ namespace EventStore.Core.Messages
 			public long ParkedDueToClientNak { get; set; }
 			public long ParkedDueToMaxRetries { get; set; }
 			public long ParkedMessageReplays { get; set; }
+			public long ParkedMessageTruncates { get; set; }
 			public long OldestParkedMessage { get; set; }
 		}
 

--- a/src/EventStore.Core/Metrics/PersistentSubscriptionTracker.cs
+++ b/src/EventStore.Core/Metrics/PersistentSubscriptionTracker.cs
@@ -50,6 +50,13 @@ public class PersistentSubscriptionTracker : IPersistentSubscriptionTracker
 				new("group_name", x.GroupName)
 			]));
 
+	public IEnumerable<Measurement<long>> ObserveParkedMessageTruncates() =>
+		_currentStats.Select(x =>
+			new Measurement<long>(x.ParkedMessageTruncates, [
+				new("event_stream_id", x.EventSource),
+				new("group_name", x.GroupName)
+			]));
+
 	public IEnumerable<Measurement<long>> ObserveInFlightMessages() =>
 		_currentStats.Select(x =>
 			new Measurement<long>(x.TotalInFlightMessages, [

--- a/src/EventStore.Core/MetricsBootstrapper.cs
+++ b/src/EventStore.Core/MetricsBootstrapper.cs
@@ -198,6 +198,7 @@ public static class MetricsBootstrapper
 
 			coreMeter.CreateObservableCounter("eventstore-persistent-sub-park-message-requests", tracker.ObserveParkMessageRequests);
 			coreMeter.CreateObservableCounter("eventstore-persistent-sub-parked-message-replays", tracker.ObserveParkedMessageReplays);
+			coreMeter.CreateObservableCounter("eventstore-persistent-sub-parked-message-truncates", tracker.ObserveParkedMessageTruncates);
 			coreMeter.CreateObservableCounter("eventstore-persistent-sub-items-processed", tracker.ObserveItemsProcessed);
 			coreMeter.CreateObservableCounter("eventstore-persistent-sub-last-known-event-number", tracker.ObserveLastKnownEvent);
 			coreMeter.CreateObservableCounter("eventstore-persistent-sub-last-known-event-commit-position", tracker.ObserveLastKnownEventCommitPosition);

--- a/src/EventStore.Core/Services/AuthorizationGateway.cs
+++ b/src/EventStore.Core/Services/AuthorizationGateway.cs
@@ -90,6 +90,10 @@ namespace EventStore.Core.Services
 			msg => new ClientMessage.ReplayMessagesReceived(msg.CorrelationId,
 				ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.AccessDenied, AccessDenied);
 
+		private static readonly Func<ClientMessage.TruncateParkedMessages, Message> TruncateParkedMessagesDenied =
+			msg => new ClientMessage.TruncateParkedMessagesCompleted(msg.CorrelationId,
+				ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesResult.AccessDenied, AccessDenied);
+
 		private static readonly Func<ClientMessage.DeletePersistentSubscriptionToStream, Message>
 			DeletePersistentSubscriptionDenied =
 				msg => new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(msg.CorrelationId,
@@ -185,6 +189,9 @@ namespace EventStore.Core.Services
 				case ClientMessage.ReplayParkedMessages msg:
 					Authorize(msg, destination);
 					break;
+				case ClientMessage.TruncateParkedMessages msg:
+					Authorize(msg, destination);
+					break;
 				case ClientMessage.ReadEvent msg:
 					Authorize(msg, destination);
 					break;
@@ -268,6 +275,11 @@ namespace EventStore.Core.Services
 		private void Authorize(ClientMessage.ReplayParkedMessages msg, IPublisher destination)
 		{
 			Authorize(msg.User, ReplayAllParkedMessages, msg.Envelope, destination, msg, ReplayAllParkedMessagesDenied);
+		}
+
+		private void Authorize(ClientMessage.TruncateParkedMessages msg, IPublisher destination)
+		{
+			Authorize(msg.User, ReplayAllParkedMessages, msg.Envelope, destination, msg, TruncateParkedMessagesDenied);
 		}
 
 		private void Authorize(ClientMessage.ReadAllEventsForward msg, IPublisher destination)

--- a/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
@@ -7,9 +7,12 @@ namespace EventStore.Core.Services.PersistentSubscription
 	public interface IPersistentSubscriptionMessageParker
 	{
 		void RecordParkMessageRequest(ParkReason parkReason);
+		void RecordParkedMessageReplay();
+		void RecordParkedMessageTruncate();
 		void BeginParkMessage(ResolvedEvent ev, string reason, Action<ResolvedEvent, OperationResult> completed);
-		void BeginReadEndSequence(Action<long?> completed);
+		void BeginReadEndSequence(Action<ParkedStreamEndReadResult> completed);
 		void BeginMarkParkedMessagesReprocessed(long sequence, DateTime? oldestParkedMessageTimestamp, bool updateOldestParkedMessage);
+		void BeginMarkParkedMessagesTruncated(long sequence, Action<OperationResult> completed);
 		void BeginDelete(Action<IPersistentSubscriptionMessageParker> completed);
 		long ParkedMessageCount { get; }
 		public void BeginLoadStats(Action completed);
@@ -17,6 +20,16 @@ namespace EventStore.Core.Services.PersistentSubscription
 		long ParkedDueToClientNak { get; }
 		long ParkedDueToMaxRetries { get; }
 		long ParkedMessageReplays { get; }
+		long ParkedMessageTruncates { get; }
+	}
+
+	public readonly record struct ParkedStreamEndReadResult(long? LastEventNumber, string Error)
+	{
+		public bool Succeeded => Error is null;
+
+		public static ParkedStreamEndReadResult Success(long? lastEventNumber) => new(lastEventNumber, null);
+
+		public static ParkedStreamEndReadResult Failure(string error) => new(null, error);
 	}
 
 	public enum ParkReason

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -740,16 +740,89 @@ namespace EventStore.Core.Services.PersistentSubscription
 				}
 
 				_state |= PersistentSubscriptionState.ReplayingParkedMessages;
+				_settings.MessageParker.RecordParkedMessageReplay();
 				_settings.MessageParker.BeginReadEndSequence(end =>
 				{
-					if (!end.HasValue)
+					long? stopRead = null;
+					lock (_lock)
 					{
-						_state ^= PersistentSubscriptionState.ReplayingParkedMessages;
-						return; //nothing to do.
+						if (!end.Succeeded || !end.LastEventNumber.HasValue)
+						{
+							_state &= ~PersistentSubscriptionState.ReplayingParkedMessages;
+							return;
+						}
+
+						stopRead = stopAt.HasValue ? Math.Min(stopAt.Value, end.LastEventNumber.Value + 1) :
+							end.LastEventNumber.Value + 1;
 					}
 
-					var stopRead = stopAt.HasValue ? Math.Min(stopAt.Value, end.Value + 1) : end.Value + 1;
-					TryReadingParkedMessagesFrom(0, stopRead);
+					TryReadingParkedMessagesFrom(0, stopRead.Value);
+				});
+			}
+		}
+
+		public void TruncateParkedMessages(long? stopAt,
+			Action<ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesResult, string> completed)
+		{
+			lock (_lock)
+			{
+				if (_state == PersistentSubscriptionState.NotReady)
+				{
+					completed?.Invoke(ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesResult.Fail,
+						"Persistent subscription is not ready.");
+					return;
+				}
+
+				if ((_state & PersistentSubscriptionState.ReplayingParkedMessages) > 0)
+				{
+					completed?.Invoke(ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesResult.Fail,
+						"Parked messages are already being replayed or truncated.");
+					return;
+				}
+
+				_state |= PersistentSubscriptionState.ReplayingParkedMessages;
+				_settings.MessageParker.RecordParkedMessageTruncate();
+				_settings.MessageParker.BeginReadEndSequence(end =>
+				{
+					long? truncateBefore = null;
+					lock (_lock)
+					{
+						if (!end.Succeeded)
+						{
+							_state &= ~PersistentSubscriptionState.ReplayingParkedMessages;
+							completed?.Invoke(ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesResult.Fail,
+								end.Error);
+							return;
+						}
+
+						if (!end.LastEventNumber.HasValue)
+						{
+							_state &= ~PersistentSubscriptionState.ReplayingParkedMessages;
+							completed?.Invoke(ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesResult.Success,
+								"");
+							return;
+						}
+
+						truncateBefore = stopAt.HasValue ? Math.Min(stopAt.Value, end.LastEventNumber.Value + 1) :
+							end.LastEventNumber.Value + 1;
+					}
+
+					_settings.MessageParker.BeginMarkParkedMessagesTruncated(truncateBefore.Value, result =>
+					{
+						lock (_lock)
+						{
+							_state &= ~PersistentSubscriptionState.ReplayingParkedMessages;
+							if (result == OperationResult.Success)
+							{
+								completed?.Invoke(ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesResult.Success,
+									"");
+								return;
+							}
+
+							completed?.Invoke(ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesResult.Fail,
+								$"Unable to truncate parked messages: {result}.");
+						}
+					});
 				});
 			}
 		}
@@ -831,7 +904,7 @@ namespace EventStore.Core.Services.PersistentSubscription
 						_settings.MessageParker.BeginMarkParkedMessagesReprocessed(replayedEnd, replayedEndTimeStamp, updateOldestParkedMessageTimeStamp);
 					}
 
-					_state ^= PersistentSubscriptionState.ReplayingParkedMessages;
+					_state &= ~PersistentSubscriptionState.ReplayingParkedMessages;
 				}
 				else
 				{

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
@@ -20,6 +20,7 @@ namespace EventStore.Core.Services.PersistentSubscription
 		private long _parkedDueToClientNak;
 		private long _parkedDueToMaxRetries;
 		private long _parkedMessageReplays;
+		private long _parkedMessageTruncates;
 		private DateTime? _oldestParkedMessage;
 		public long ParkedMessageCount
 		{
@@ -36,6 +37,8 @@ namespace EventStore.Core.Services.PersistentSubscription
 		public long ParkedDueToMaxRetries => Interlocked.Read(ref _parkedDueToMaxRetries);
 
 		public long ParkedMessageReplays => Interlocked.Read(ref _parkedMessageReplays);
+
+		public long ParkedMessageTruncates => Interlocked.Read(ref _parkedMessageTruncates);
 
 		private static readonly ILogger Log = Serilog.Log.ForContext<PersistentSubscriptionMessageParker>();
 
@@ -99,6 +102,16 @@ namespace EventStore.Core.Services.PersistentSubscription
 			}
 		}
 
+		public void RecordParkedMessageReplay()
+		{
+			Interlocked.Increment(ref _parkedMessageReplays);
+		}
+
+		public void RecordParkedMessageTruncate()
+		{
+			Interlocked.Increment(ref _parkedMessageTruncates);
+		}
+
 		public void BeginParkMessage(ResolvedEvent ev, string reason,
 			Action<ResolvedEvent, OperationResult> completed)
 		{
@@ -148,10 +161,8 @@ namespace EventStore.Core.Services.PersistentSubscription
 			});
 		}
 
-		public void BeginReadEndSequence(Action<long?> completed)
+		public void BeginReadEndSequence(Action<ParkedStreamEndReadResult> completed)
 		{
-			Interlocked.Increment(ref _parkedMessageReplays);
-
 			_ioDispatcher.ReadBackward(ParkedStreamId,
 				long.MaxValue,
 				1,
@@ -161,16 +172,19 @@ namespace EventStore.Core.Services.PersistentSubscription
 					switch (comp.Result)
 					{
 						case ReadStreamResult.Success:
-							completed?.Invoke(comp.LastEventNumber);
+							completed?.Invoke(ParkedStreamEndReadResult.Success(comp.LastEventNumber));
 							break;
 						case ReadStreamResult.NoStream:
-							completed?.Invoke(null);
+							completed?.Invoke(ParkedStreamEndReadResult.Success(null));
 							break;
 						default:
+							var reason =
+								$"Unable to read the last event in the parked message stream due to {comp.Result}.";
 							Log.Error(
 								"An error occured reading the last event in the parked message stream {stream} due to {e}.",
 								ParkedStreamId, comp.Result);
 							Log.Error("Messages were not removed on retry");
+							completed?.Invoke(ParkedStreamEndReadResult.Failure(reason));
 							break;
 					}
 				});
@@ -262,10 +276,17 @@ namespace EventStore.Core.Services.PersistentSubscription
 
 		public void BeginMarkParkedMessagesReprocessed(long sequence, DateTime? timestamp, bool updateOldestParkedMessage)
 		{
-			BeginMarkParkedMessagesReprocessed(sequence, timestamp, updateOldestParkedMessage, null);
+			BeginMarkParkedMessagesReprocessed(sequence, timestamp, updateOldestParkedMessage, _ => { });
 		}
 
-		public void BeginMarkParkedMessagesReprocessed(long sequence, DateTime? timestamp, bool updateOldestParkedMessage, Action completed)
+		public void BeginMarkParkedMessagesReprocessed(long sequence, DateTime? timestamp, bool updateOldestParkedMessage,
+			Action completed)
+		{
+			BeginMarkParkedMessagesReprocessed(sequence, timestamp, updateOldestParkedMessage, _ => completed?.Invoke());
+		}
+
+		private void BeginMarkParkedMessagesReprocessed(long sequence, DateTime? timestamp, bool updateOldestParkedMessage,
+			Action<OperationResult> completed)
 		{
 			var metaStreamId = SystemStreams.MetastreamOf(ParkedStreamId);
 			_ioDispatcher.WriteEvent(
@@ -281,16 +302,35 @@ namespace EventStore.Core.Services.PersistentSubscription
 								_oldestParkedMessage = timestamp;
 							}
 
-							completed?.Invoke();
+							completed?.Invoke(OperationResult.Success);
 							break;
 						default:
 							Log.Error("An error occured truncating the parked message stream {stream} due to {e}.",
 								ParkedStreamId, msg.Result);
 							Log.Error("Messages were not removed on retry");
-							completed?.Invoke();
+							completed?.Invoke(msg.Result);
 							break;
 					}
 				});
+		}
+
+		public void BeginMarkParkedMessagesTruncated(long sequence, Action<OperationResult> completed)
+		{
+			var truncateBefore = Math.Max(sequence, _lastTruncateBefore);
+			BeginMarkParkedMessagesReprocessed(truncateBefore, null, false, result =>
+			{
+				if (result != OperationResult.Success)
+				{
+					completed?.Invoke(result);
+					return;
+				}
+
+				BeginReadFirstEvent(truncateBefore, (_, timestamp) =>
+				{
+					_oldestParkedMessage = timestamp;
+					completed?.Invoke(OperationResult.Success);
+				});
+			});
 		}
 
 		class ParkedMessageMetadata

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -35,6 +35,7 @@ public class PersistentSubscriptionService<TStreamId> :
 	IHandle<SubscriptionMessage.PersistentSubscriptionTimerTick>,
 	IHandle<SubscriptionMessage.PersistentSubscriptionPushToClients>,
 	IHandle<ClientMessage.ReplayParkedMessages>,
+	IHandle<ClientMessage.TruncateParkedMessages>,
 	IHandle<ClientMessage.ReplayParkedMessage>,
 	IHandle<SystemMessage.StateChangeMessage>,
 	IAsyncHandle<ClientMessage.ConnectToPersistentSubscriptionToStream>,
@@ -1398,6 +1399,41 @@ public class PersistentSubscriptionService<TStreamId> :
 		subscription.RetryParkedMessages(message.StopAt);
 		message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,
 			ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Success, ""));
+	}
+
+	public void Handle(ClientMessage.TruncateParkedMessages message)
+	{
+		if (!_started)
+		{
+			ReplyWithNotReady(message.Envelope, message.CorrelationId);
+			return;
+		}
+
+		PersistentSubscription subscription;
+		var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
+		Log.Debug("Truncating parked messages for persistent subscription {subscriptionKey} {to}",
+			key,
+			message.StopAt.HasValue ? $" (To: '{message.StopAt.ToString()}')" : " (All)");
+
+		if (message.StopAt.HasValue && message.StopAt.Value < 0)
+		{
+			message.Envelope.ReplyWith(new ClientMessage.TruncateParkedMessagesCompleted(message.CorrelationId,
+				ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesResult.Fail,
+				"Cannot stop truncating parked messages at a negative version."));
+			return;
+		}
+
+		if (!_subscriptionsById.TryGetValue(key, out subscription))
+		{
+			message.Envelope.ReplyWith(new ClientMessage.TruncateParkedMessagesCompleted(message.CorrelationId,
+				ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesResult.DoesNotExist,
+				"Unable to locate '" + key + "'"));
+			return;
+		}
+
+		subscription.TruncateParkedMessages(message.StopAt, (result, reason) =>
+			message.Envelope.ReplyWith(new ClientMessage.TruncateParkedMessagesCompleted(message.CorrelationId,
+				result, reason)));
 	}
 
 	public void Handle(ClientMessage.ReplayParkedMessage message)

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
@@ -132,6 +132,7 @@ namespace EventStore.Core.Services.PersistentSubscription
 				ParkedDueToClientNak = _settings.MessageParker.ParkedDueToClientNak,
 				ParkedDueToMaxRetries = _settings.MessageParker.ParkedDueToMaxRetries,
 				ParkedMessageReplays = _settings.MessageParker.ParkedMessageReplays,
+				ParkedMessageTruncates = _settings.MessageParker.ParkedMessageTruncates,
 				OldestParkedMessage = oldestParkedMessage
 			};
 		}

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.TruncateParked.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.TruncateParked.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Threading.Tasks;
+using EventStore.Client.PersistentSubscriptions;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Plugins.Authorization;
+using Grpc.Core;
+
+namespace EventStore.Core.Services.Transport.Grpc;
+
+internal partial class PersistentSubscriptions
+{
+	public override async Task<TruncateParkedResp> TruncateParked(TruncateParkedReq request, ServerCallContext context)
+	{
+		var truncateParkedMessagesSource = new TaskCompletionSource<TruncateParkedResp>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var correlationId = Guid.NewGuid();
+
+		var user = context.GetHttpContext().User;
+
+		if (!await _authorizationProvider.CheckAccessAsync(user,
+			ReplayParkedOperation, context.CancellationToken))
+		{
+			throw RpcExceptions.AccessDenied();
+		}
+
+		string streamId = request.Options.StreamOptionCase switch
+		{
+			TruncateParkedReq.Types.Options.StreamOptionOneofCase.All => "$all",
+			TruncateParkedReq.Types.Options.StreamOptionOneofCase.StreamIdentifier => request.Options.StreamIdentifier,
+			_ => throw new InvalidOperationException()
+		};
+
+		long? stopAt = request.Options.StopAtOptionCase switch
+		{
+			TruncateParkedReq.Types.Options.StopAtOptionOneofCase.StopAt => request.Options.StopAt,
+			TruncateParkedReq.Types.Options.StopAtOptionOneofCase.NoLimit => null,
+			_ => throw new InvalidOperationException()
+		};
+
+		_publisher.Publish(new ClientMessage.TruncateParkedMessages(
+			correlationId,
+			correlationId,
+			new CallbackEnvelope(HandleTruncateParkedMessagesCompleted),
+			streamId,
+			request.Options.GroupName,
+			stopAt,
+			user));
+		return await truncateParkedMessagesSource.Task;
+
+		void HandleTruncateParkedMessagesCompleted(Message message)
+		{
+			if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex))
+			{
+				truncateParkedMessagesSource.TrySetException(ex);
+				return;
+			}
+
+			if (message is ClientMessage.TruncateParkedMessagesCompleted completed)
+			{
+				switch (completed.Result)
+				{
+					case ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesResult.Success:
+						truncateParkedMessagesSource.TrySetResult(new TruncateParkedResp());
+						return;
+					case ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesResult.DoesNotExist:
+						truncateParkedMessagesSource.TrySetException(
+							RpcExceptions.PersistentSubscriptionDoesNotExist(streamId,
+								request.Options.GroupName));
+						return;
+					case ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesResult.AccessDenied:
+						truncateParkedMessagesSource.TrySetException(
+							RpcExceptions.AccessDenied());
+						return;
+					case ClientMessage.TruncateParkedMessagesCompleted.TruncateParkedMessagesResult.Fail:
+						truncateParkedMessagesSource.TrySetException(
+							RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
+								completed.Reason));
+						return;
+
+					default:
+						truncateParkedMessagesSource.TrySetException(
+							RpcExceptions.UnknownError(completed.Result));
+						return;
+				}
+			}
+			truncateParkedMessagesSource.TrySetException(
+				RpcExceptions.UnknownMessage<ClientMessage.TruncateParkedMessagesCompleted>(
+					message));
+		}
+	}
+}

--- a/src/Protos/Grpc/persistent.proto
+++ b/src/Protos/Grpc/persistent.proto
@@ -11,6 +11,7 @@ service PersistentSubscriptions {
 	rpc Read (stream ReadReq) returns (stream ReadResp);
 	rpc GetInfo (GetInfoReq) returns (GetInfoResp);
 	rpc ReplayParked (ReplayParkedReq) returns (ReplayParkedResp);
+	rpc TruncateParked (TruncateParkedReq) returns (TruncateParkedResp);
 	rpc List (ListReq) returns (ListResp);
 	rpc RestartSubsystem (event_store.client.Empty) returns (event_store.client.Empty);
 }
@@ -347,6 +348,25 @@ message ReplayParkedReq {
 }
 
 message ReplayParkedResp {
+}
+
+message TruncateParkedReq {
+	Options options = 1;
+
+	message Options {
+		string group_name = 1;
+		oneof stream_option {
+			event_store.client.StreamIdentifier stream_identifier = 2;
+			event_store.client.Empty all = 3;
+		}
+		oneof stop_at_option {
+			int64 stop_at = 4;
+			event_store.client.Empty no_limit = 5;
+		}
+	}
+}
+
+message TruncateParkedResp {
 }
 
 message ListReq {


### PR DESCRIPTION
- give operators a safe way to discard parked messages without redelivering them
- keep persistent subscription parked-message metrics aligned with operator cleanup actions
- expose the cleanup path through gRPC so automation does not need to mutate parked streams directly