### PR TITLE
feat(auth): support built-in OAuth methods

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -572,11 +572,68 @@ You can, however, disable TLS for both internal and external TCP.
 
 ## Authentication
 
-EventStoreDB supports authentication based on usernames and passwords out of the box. The Enterprise version
-also supports LDAP as the authentication source.
+EventStoreDB supports authentication based on usernames and passwords out of the box. Nodes can also enable
+OAuth bearer-token authentication as a built-in authentication method. This follows PostgreSQL's model of
+making the database authentication method explicit, so password and OAuth access can be reasoned about side by side.
 
 Authentication is applied to all HTTP endpoints by default, except `/-/liveness`, `/-/readiness`, static web
 content, and redirects.
+
+### Authentication methods
+
+Use `Auth:Methods` to choose the authentication methods enabled by the node. If `Auth:Methods` is not set, the
+legacy `Auth:AuthenticationType` setting is still honored for compatibility.
+
+| Format               | Syntax                      |
+|:---------------------|:----------------------------|
+| Command line         | `--auth:methods:0 password --auth:methods:1 oauth` |
+| YAML                 | `Auth:Methods`              |
+| Environment variable | `EVENTSTORE__AUTH__METHODS__0`, `EVENTSTORE__AUTH__METHODS__1`, ... |
+
+Supported built-in values are:
+
+- `password` enables username and password authentication against the node user store.
+- `oauth` enables bearer-token authentication against the configured OAuth or OIDC issuer.
+
+For example, to enable both methods:
+
+```yaml
+Auth:
+  Methods:
+    - password
+    - oauth
+```
+
+### OAuth authentication
+
+OAuth authentication validates bearer tokens issued by the configured OAuth or OIDC identity provider. The node
+requires an issuer and at least one accepted audience.
+
+```yaml
+Auth:
+  Methods:
+    - password
+    - oauth
+  OAuth:
+    Issuer: https://identity.example.com
+    Audiences:
+      - eventstore
+```
+
+The browser sign-in flow is available when the OAuth authorization endpoint, token endpoint, client id, and scopes
+are configured. The flow stores only access tokens that the node can validate as JWT bearer tokens.
+
+```yaml
+Auth:
+  OAuth:
+    AuthorizationEndpoint: https://identity.example.com/oauth2/authorize
+    TokenEndpoint: https://identity.example.com/oauth2/token
+    ClientId: eventstore-ui
+    Scopes:
+      - openid
+      - profile
+      - email
+```
 
 ### Default users
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -50,6 +50,8 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.2" />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.19.2" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Mono.Posix.NETStandard" Version="1.0.0" />

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -270,9 +270,16 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable
 					Log.Information(
 						"Loaded authentication plugin: {plugin} version {version} (Command Line: {commandLine})",
 						potentialPlugin.Name, potentialPlugin.Version, commandLine);
-					authenticationMethodFactories.Add(commandLine,
+					if (!authenticationMethodFactories.TryAdd(commandLine,
 						new AuthenticationProviderFactory(_ =>
-							potentialPlugin.GetAuthenticationProviderFactory(authenticationConfig)));
+							potentialPlugin.GetAuthenticationProviderFactory(authenticationConfig))))
+					{
+						throw new ApplicationInitializationException(
+							$"The authentication plugin {potentialPlugin.Name} uses command-line name {commandLine}, " +
+							"which conflicts with an existing authentication method." +
+							Environment.NewLine +
+							$"Valid options for authentication are: {string.Join(", ", authenticationMethodFactories.Keys)}.");
+					}
 				}
 				catch (CompositionException ex)
 				{

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -249,10 +249,6 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable
 
 			var authenticationMethodFactories = new Dictionary<string, AuthenticationProviderFactory> {
 				{
-					AuthenticationMethodNames.LegacyInternal, new AuthenticationProviderFactory(components =>
-						new InternalAuthenticationProviderFactory(components, _options.DefaultUser))
-				},
-				{
 					AuthenticationMethodNames.Password, new AuthenticationProviderFactory(components =>
 						new InternalAuthenticationProviderFactory(components, _options.DefaultUser))
 				},

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -14,6 +14,7 @@ using EventStore.Common.Utils;
 using EventStore.Core;
 using EventStore.Core.Authentication;
 using EventStore.Core.Authentication.InternalAuthentication;
+using EventStore.Core.Authentication.OAuth;
 using EventStore.Core.Authentication.PassthroughAuthentication;
 using EventStore.Core.Authorization;
 using EventStore.Core.Certificates;
@@ -246,10 +247,18 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable
 				return new AuthenticationProviderFactory(_ => new PassthroughAuthenticationProviderFactory());
 			}
 
-			var authenticationTypeToPlugin = new Dictionary<string, AuthenticationProviderFactory> {
+			var authenticationMethodFactories = new Dictionary<string, AuthenticationProviderFactory> {
 				{
-					"internal", new AuthenticationProviderFactory(components =>
+					AuthenticationMethodNames.LegacyInternal, new AuthenticationProviderFactory(components =>
 						new InternalAuthenticationProviderFactory(components, _options.DefaultUser))
+				},
+				{
+					AuthenticationMethodNames.Password, new AuthenticationProviderFactory(components =>
+						new InternalAuthenticationProviderFactory(components, _options.DefaultUser))
+				},
+				{
+					AuthenticationMethodNames.OAuth, new AuthenticationProviderFactory(_ =>
+						new OAuthAuthenticationProviderFactory(_options.Auth.OAuth))
 				}
 			};
 
@@ -261,7 +270,7 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable
 					Log.Information(
 						"Loaded authentication plugin: {plugin} version {version} (Command Line: {commandLine})",
 						potentialPlugin.Name, potentialPlugin.Version, commandLine);
-					authenticationTypeToPlugin.Add(commandLine,
+					authenticationMethodFactories.Add(commandLine,
 						new AuthenticationProviderFactory(_ =>
 							potentialPlugin.GetAuthenticationProviderFactory(authenticationConfig)));
 				}
@@ -271,14 +280,22 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable
 				}
 			}
 
-			return authenticationTypeToPlugin.TryGetValue(_options.Auth.AuthenticationType.ToLowerInvariant(),
-				out var factory)
-				? factory
-				: throw new ApplicationInitializationException(
-					$"The authentication type {_options.Auth.AuthenticationType} is not recognised. If this is supposed " +
-					$"to be provided by an authentication plugin, confirm the plugin DLL is located in {Locations.PluginsDirectory}." +
-					Environment.NewLine +
-					$"Valid options for authentication are: {string.Join(", ", authenticationTypeToPlugin.Keys)}.");
+			var methods = AuthenticationMethodNames.FromOptions(_options.Auth);
+			foreach (var method in methods)
+			{
+				if (!authenticationMethodFactories.ContainsKey(method))
+				{
+					throw new ApplicationInitializationException(
+						$"The authentication method {method} is not recognised. If this is supposed " +
+						$"to be provided by an authentication plugin, confirm the plugin DLL is located in {Locations.PluginsDirectory}." +
+						Environment.NewLine +
+						$"Valid options for authentication are: {string.Join(", ", authenticationMethodFactories.Keys)}.");
+				}
+			}
+
+			return new AuthenticationProviderFactory(components =>
+				new CompositeAuthenticationProviderFactory(methods.Select(method =>
+					authenticationMethodFactories[method].GetFactory(components)).ToArray()));
 		}
 
 		static ClusterVNodeOptions LoadSubsystemsPlugins(PluginLoader pluginLoader, ClusterVNodeOptions options)

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -301,8 +301,18 @@ public class ClusterVNodeHostedService : IHostedService, IDisposable
 			}
 
 			return new AuthenticationProviderFactory(components =>
-				new CompositeAuthenticationProviderFactory(methods.Select(method =>
-					authenticationMethodFactories[method].GetFactory(components)).ToArray()));
+			{
+				var factories = methods.Select(method =>
+					authenticationMethodFactories[method].GetFactory(components)).ToList();
+				if (methods.Contains(AuthenticationMethodNames.OAuth, StringComparer.OrdinalIgnoreCase) &&
+					!methods.Contains(AuthenticationMethodNames.Password, StringComparer.OrdinalIgnoreCase))
+				{
+					factories.Add(new UserCertificateAuthenticationProviderFactory(
+						authenticationMethodFactories[AuthenticationMethodNames.Password].GetFactory(components)));
+				}
+
+				return new CompositeAuthenticationProviderFactory(factories);
+			});
 		}
 
 		static ClusterVNodeOptions LoadSubsystemsPlugins(PluginLoader pluginLoader, ClusterVNodeOptions options)

--- a/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
@@ -137,7 +137,8 @@
 	private static bool IsOAuthCallback(HttpRequest request) =>
 		request.Query.ContainsKey("code") ||
 		request.Query.ContainsKey("state") ||
-		request.Query.ContainsKey("error");
+		request.Query.ContainsKey("error") ||
+		request.Query.ContainsKey("oauth_error");
 
 	private async Task SignInUser() {
 		try {

--- a/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
@@ -110,6 +110,7 @@
 	private SecurityAuthenticationInfo Authentication { get; set; } = SecurityAuthenticationInfo.Unavailable();
 	private bool AuthenticationAvailable { get; set; } = true;
 	private string Message { get; set; } = "";
+	private string DisplayedOAuthError { get; set; } = "";
 	private string Destination => SecurityBrowserService.NormalizeReturnUrl(ReturnUrl);
 
 	protected override void OnParametersSet() {
@@ -118,12 +119,19 @@
 		try {
 			Authentication = Security.AuthenticationInfo();
 			AuthenticationAvailable = true;
-			Message = string.IsNullOrWhiteSpace(OAuthError)
-				? ""
-				: OAuthErrorMessage(OAuthError);
+			if (string.IsNullOrWhiteSpace(OAuthError)) {
+				if (!string.IsNullOrWhiteSpace(DisplayedOAuthError)) {
+					Message = "";
+					DisplayedOAuthError = "";
+				}
+			} else {
+				Message = OAuthErrorMessage(OAuthError);
+				DisplayedOAuthError = OAuthError;
+			}
 		} catch (Exception ex) {
 			Authentication = SecurityAuthenticationInfo.Unavailable();
 			AuthenticationAvailable = false;
+			DisplayedOAuthError = "";
 			Message = $"Unable to load authentication information: {UserInterfaceMessages.Friendly(ex)}";
 		}
 
@@ -145,6 +153,7 @@
 			"invalid_state" => "The OAuth sign-in session expired or could not be verified. Try again.",
 			"missing_callback" => "The identity provider did not return the expected OAuth callback data.",
 			"missing_token" => "The identity provider did not return an OAuth access token.",
+			"unsupported_token" => "The identity provider did not return a token this node can validate.",
 			"provider_error" => "The identity provider rejected the OAuth sign-in request.",
 			_ => "The OAuth sign-in flow could not be completed."
 		};
@@ -153,12 +162,14 @@
 		try {
 			var result = await Security.Validate(Input.Username, Input.Password);
 			if (!result.Success) {
+				DisplayedOAuthError = "";
 				Message = result.Message;
 				return;
 			}
 
 			var context = HttpContextAccessor.HttpContext;
 			if (context is null) {
+				DisplayedOAuthError = "";
 				Message = "The sign-in response is no longer available.";
 				return;
 			}
@@ -166,9 +177,11 @@
 			UiCredentialCookie.DeleteOAuthToken(context.Response);
 			UiCredentialCookie.AppendBasic(context.Response, new UiCredentials(Input.Username.Trim(), Input.Password));
 		} catch (OperationCanceledException) {
+			DisplayedOAuthError = "";
 			Message = "Sign-in was canceled.";
 			return;
 		} catch (Exception ex) {
+			DisplayedOAuthError = "";
 			Message = $"Failed to sign in: {UserInterfaceMessages.Friendly(ex)}";
 			return;
 		}

--- a/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
@@ -120,7 +120,7 @@
 			AuthenticationAvailable = true;
 			Message = string.IsNullOrWhiteSpace(OAuthError)
 				? ""
-				: "The OAuth sign-in flow could not be completed.";
+				: OAuthErrorMessage(OAuthError);
 		} catch (Exception ex) {
 			Authentication = SecurityAuthenticationInfo.Unavailable();
 			AuthenticationAvailable = false;
@@ -138,6 +138,16 @@
 		request.Query.ContainsKey("code") ||
 		request.Query.ContainsKey("state") ||
 		request.Query.ContainsKey("error");
+
+	private static string OAuthErrorMessage(string error) =>
+		error switch
+		{
+			"invalid_state" => "The OAuth sign-in session expired or could not be verified. Try again.",
+			"missing_callback" => "The identity provider did not return the expected OAuth callback data.",
+			"missing_token" => "The identity provider did not return an OAuth access token.",
+			"provider_error" => "The identity provider rejected the OAuth sign-in request.",
+			_ => "The OAuth sign-in flow could not be completed."
+		};
 
 	private async Task SignInUser() {
 		try {

--- a/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
@@ -137,8 +137,7 @@
 	private static bool IsOAuthCallback(HttpRequest request) =>
 		request.Query.ContainsKey("code") ||
 		request.Query.ContainsKey("state") ||
-		request.Query.ContainsKey("error") ||
-		request.Query.ContainsKey("oauth_error");
+		request.Query.ContainsKey("error");
 
 	private async Task SignInUser() {
 		try {

--- a/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
+++ b/src/EventStore.ClusterNode/Components/Pages/SignIn.razor
@@ -37,16 +37,34 @@
 			<p class="mt-3 text-sm leading-6 text-es-muted">This node is running with insecure access, so there is no credential exchange to perform.</p>
 			<a class="mt-6 inline-flex rounded-2xl bg-es-ink px-5 py-3 text-sm font-black text-white shadow-lg shadow-es-ink/15 transition hover:bg-es-green" href="@Destination">Continue to UI</a>
 		}
-		else if (!Authentication.SupportsBasic)
+		else if (!Authentication.SupportsBasic && !Authentication.SupportsOAuthBrowserFlow)
 		{
 			<StatusBadge Label="@Authentication.TypeLabel" Tone="warn" />
-			<h2 class="mt-4 text-3xl font-black tracking-tight text-es-ink">Continue with the configured provider.</h2>
-			<p class="mt-3 text-sm leading-6 text-es-muted">This node does not advertise Basic authentication, so sign-in is delegated to the configured browser authentication flow.</p>
-			<button class="mt-6 rounded-2xl bg-es-ink px-5 py-3 text-sm font-black text-white shadow-lg shadow-es-ink/15 transition hover:bg-es-green" type="button" data-ui-oauth-signin data-ui-oauth-return="@Destination" data-ui-oauth-type="@Authentication.Type" data-ui-oauth-properties="@Authentication.PropertiesJson">Continue</button>
-			<p class="mt-4 hidden rounded-2xl border border-red-200 bg-red-50 p-4 text-sm font-bold text-red-800" data-ui-oauth-status></p>
+			<h2 class="mt-4 text-3xl font-black tracking-tight text-es-ink">Sign-in needs more configuration.</h2>
+			<p class="mt-3 text-sm leading-6 text-es-muted">This node does not advertise Basic authentication or a browser OAuth flow.</p>
+			@if (!string.IsNullOrWhiteSpace(Message))
+			{
+				<p class="mt-4 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm font-bold text-red-800">@Message</p>
+			}
 		}
 		else
 		{
+			@if (Authentication.SupportsOAuthBrowserFlow)
+			{
+				<div class="mb-6 rounded-[1.5rem] border border-es-ink/10 bg-es-cloud/70 p-5">
+					<h2 class="text-2xl font-black tracking-tight text-es-ink">Continue with OAuth</h2>
+					<p class="mt-2 text-sm leading-6 text-es-muted">Use the configured browser sign-in flow for this node.</p>
+					<button class="mt-4 rounded-2xl bg-es-ink px-5 py-3 text-sm font-black text-white shadow-lg shadow-es-ink/15 transition hover:bg-es-green" type="button" data-ui-oauth-signin data-ui-oauth-return="@Destination" data-ui-oauth-type="@Authentication.Type" data-ui-oauth-properties="@Authentication.PropertiesJson">Continue with OAuth</button>
+					@if (!string.IsNullOrWhiteSpace(Message))
+					{
+						<p class="mt-4 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm font-bold text-red-800">@Message</p>
+					}
+					<p class="mt-4 hidden rounded-2xl border border-red-200 bg-red-50 p-4 text-sm font-bold text-red-800" data-ui-oauth-status></p>
+				</div>
+			}
+
+			@if (Authentication.SupportsBasic)
+			{
 			<EditForm Model="Input" FormName="ui-signin" OnValidSubmit="SignInUser">
 				<AntiforgeryToken />
 				<DataAnnotationsValidator />
@@ -74,6 +92,7 @@
 					<a class="rounded-2xl border border-es-ink/10 bg-white px-5 py-3 text-sm font-black text-es-ink transition hover:border-es-green/30 hover:text-es-forest" href="/ui">Back to UI</a>
 				</div>
 			</EditForm>
+			}
 		}
 	</article>
 </section>
@@ -81,6 +100,9 @@
 @code {
 	[SupplyParameterFromQuery(Name = "returnUrl")]
 	private string ReturnUrl { get; set; } = "";
+
+	[SupplyParameterFromQuery(Name = "oauth_error")]
+	private string OAuthError { get; set; } = "";
 
 	[SupplyParameterFromForm(FormName = "ui-signin")]
 	private SignInInput Input { get; set; }
@@ -96,6 +118,9 @@
 		try {
 			Authentication = Security.AuthenticationInfo();
 			AuthenticationAvailable = true;
+			Message = string.IsNullOrWhiteSpace(OAuthError)
+				? ""
+				: "The OAuth sign-in flow could not be completed.";
 		} catch (Exception ex) {
 			Authentication = SecurityAuthenticationInfo.Unavailable();
 			AuthenticationAvailable = false;

--- a/src/EventStore.ClusterNode/Components/Services/ConfigurationBrowserService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/ConfigurationBrowserService.cs
@@ -5,6 +5,7 @@ using System.Net;
 using EventStore.Common.Options;
 using EventStore.Common.Utils;
 using EventStore.Core;
+using EventStore.Core.Authentication;
 using EventStore.Core.Data;
 using EventStore.Core.Services;
 using EventStore.Core.Util;
@@ -22,7 +23,7 @@ public sealed class ConfigurationBrowserService(
 		var features = new[] {
 			new ConfigurationFeature("Projections", options.Projection.RunProjections != ProjectionType.None || options.DevMode.Dev),
 			new ConfigurationFeature("User management",
-				options.Auth.AuthenticationType == Opts.AuthenticationTypeDefault && !options.Application.AuthDisabled())
+				AuthenticationMethodNames.IncludesPassword(options.Auth) && !options.Application.AuthDisabled())
 		};
 
 		var subsystems = hostedService.EnabledNodeSubsystems
@@ -44,7 +45,7 @@ public sealed class ConfigurationBrowserService(
 			canInspectRuntimeDetails ? new IPEndPoint(options.Interface.NodeIp, options.Interface.NodePort).ToString() : "",
 			canInspectRuntimeDetails ? options.Database.Db : "",
 			canInspectRuntimeDetails ? options.Database.DbLogFormat.ToString() : "",
-			canInspectRuntimeDetails ? options.Auth.AuthenticationType : "",
+			canInspectRuntimeDetails ? string.Join(", ", AuthenticationMethodNames.FromOptions(options.Auth)) : "",
 			canInspectRuntimeDetails ? options.Auth.AuthorizationType : "",
 			options.Application.Insecure,
 			options.Application.TlsDisabled(),

--- a/src/EventStore.ClusterNode/Components/Services/ConfigurationBrowserService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/ConfigurationBrowserService.cs
@@ -23,7 +23,7 @@ public sealed class ConfigurationBrowserService(
 		var features = new[] {
 			new ConfigurationFeature("Projections", options.Projection.RunProjections != ProjectionType.None || options.DevMode.Dev),
 			new ConfigurationFeature("User management",
-				AuthenticationMethodNames.IncludesPassword(options.Auth) && !options.Application.AuthDisabled())
+				AuthenticationMethodNames.IncludesBuiltInUserStore(options.Auth) && !options.Application.AuthDisabled())
 		};
 
 		var subsystems = hostedService.EnabledNodeSubsystems

--- a/src/EventStore.ClusterNode/Components/Services/OAuthBrowserFlowEndpoints.cs
+++ b/src/EventStore.ClusterNode/Components/Services/OAuthBrowserFlowEndpoints.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Security.Cryptography;
@@ -10,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 
@@ -21,8 +21,8 @@ internal static class OAuthBrowserFlowEndpoints
 		this IEndpointRouteBuilder app,
 		ClusterVNodeOptions.OAuthOptions options)
 	{
-		app.MapGet(options.CodeChallengePath, (OAuthBrowserFlowService service) =>
-			Results.Json(service.CreateCodeChallenge(), OAuthBrowserFlowService.JsonOptions));
+		app.MapGet(options.CodeChallengePath, (HttpContext context, OAuthBrowserFlowService service) =>
+			Results.Json(service.CreateCodeChallenge(context), OAuthBrowserFlowService.JsonOptions));
 
 		app.MapGet(options.RedirectPath, async (
 			HttpContext context,
@@ -36,20 +36,25 @@ internal static class OAuthBrowserFlowEndpoints
 public sealed class OAuthBrowserFlowService(
 	ClusterVNodeOptions.OAuthOptions options,
 	HttpClient httpClient,
-	TimeProvider timeProvider) : IDisposable
+	TimeProvider timeProvider,
+	IDataProtectionProvider dataProtectionProvider) : IDisposable
 {
 	public static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
-	private readonly ConcurrentDictionary<string, PendingChallenge> _pendingChallenges = new();
+	private const string ChallengeCookieName = "eventstore-ui-oauth-pkce";
+	private static readonly TimeSpan ChallengeLifetime = TimeSpan.FromMinutes(5);
+	private readonly IDataProtector _challengeProtector = dataProtectionProvider.CreateProtector("EventStore.ClusterNode.Components.Services.OAuthBrowserFlowService.Pkce");
 
-	public OAuthCodeChallenge CreateCodeChallenge()
+	public OAuthCodeChallenge CreateCodeChallenge(HttpContext context)
 	{
-		PruneExpired();
-
 		var verifier = Base64Url(RandomNumberGenerator.GetBytes(32));
 		var challenge = Base64Url(SHA256.HashData(Encoding.ASCII.GetBytes(verifier)));
 		var correlationId = Base64Url(RandomNumberGenerator.GetBytes(32));
+		var payload = new OAuthChallengeCookie(verifier, correlationId, timeProvider.GetUtcNow().Add(ChallengeLifetime));
 
-		_pendingChallenges[correlationId] = new PendingChallenge(verifier, timeProvider.GetUtcNow().AddMinutes(5));
+		context.Response.Cookies.Append(
+			ChallengeCookieName,
+			_challengeProtector.Protect(JsonSerializer.Serialize(payload, JsonOptions)),
+			ChallengeCookieOptions(context.Request));
 		return new OAuthCodeChallenge(correlationId, challenge, "S256");
 	}
 
@@ -59,25 +64,27 @@ public sealed class OAuthBrowserFlowService(
 		var state = context.Request.Query["state"].ToString();
 		if (string.IsNullOrWhiteSpace(code) || string.IsNullOrWhiteSpace(state))
 		{
-			return SignInRedirect("missing_callback");
+			return SignInRedirect("missing_callback", "");
 		}
 
-		if (!TryReadCorrelationId(state, out var correlationId) ||
-			!_pendingChallenges.TryRemove(correlationId, out var pending) ||
-			pending.ExpiresAt <= timeProvider.GetUtcNow())
+		if (!TryReadState(state, out var correlationId, out var returnUrl) ||
+			!TryReadChallenge(context.Request, correlationId, out var challenge) ||
+			challenge.ExpiresAt <= timeProvider.GetUtcNow())
 		{
-			return SignInRedirect("invalid_state");
+			DeleteChallengeCookie(context.Response);
+			return SignInRedirect("invalid_state", "");
 		}
 
-		var token = await ExchangeCode(code, pending.CodeVerifier, PublicBaseUri(context.Request), cancellationToken);
+		DeleteChallengeCookie(context.Response);
+		var token = await ExchangeCode(code, challenge.CodeVerifier, PublicBaseUri(context.Request), cancellationToken);
 		if (string.IsNullOrWhiteSpace(token))
 		{
-			return SignInRedirect("missing_token");
+			return SignInRedirect("missing_token", returnUrl);
 		}
 
 		UiCredentialCookie.Delete(context.Response);
 		UiCredentialCookie.AppendOAuthToken(context.Response, token);
-		return Results.Redirect("/ui/signin");
+		return Results.Redirect(SignInLocation(returnUrl));
 	}
 
 	private async Task<string> ExchangeCode(
@@ -124,24 +131,37 @@ public sealed class OAuthBrowserFlowService(
 		return tokenResponse?.AccessToken ?? "";
 	}
 
-	private void PruneExpired()
+	private bool TryReadChallenge(HttpRequest request, string correlationId, out OAuthChallengeCookie challenge)
 	{
-		var now = timeProvider.GetUtcNow();
-		foreach (var (key, value) in _pendingChallenges)
+		challenge = new OAuthChallengeCookie("", "", DateTimeOffset.MinValue);
+		try
 		{
-			if (value.ExpiresAt <= now)
+			if (!request.Cookies.TryGetValue(ChallengeCookieName, out var value))
 			{
-				_pendingChallenges.TryRemove(key, out _);
+				return false;
 			}
+
+			var json = _challengeProtector.Unprotect(value);
+			challenge = JsonSerializer.Deserialize<OAuthChallengeCookie>(json, JsonOptions) ?? challenge;
+			return !string.IsNullOrWhiteSpace(challenge.CodeVerifier) &&
+				string.Equals(challenge.CorrelationId, correlationId, StringComparison.Ordinal);
+		}
+		catch (Exception ex) when (ex is CryptographicException or JsonException)
+		{
+			return false;
 		}
 	}
 
-	private static IResult SignInRedirect(string error) =>
-		Results.Redirect($"/ui/signin?oauth_error={Uri.EscapeDataString(error)}");
+	private static IResult SignInRedirect(string error, string returnUrl)
+	{
+		var signInLocation = SignInLocation(returnUrl);
+		return Results.Redirect($"{signInLocation}{(signInLocation.Contains('?') ? '&' : '?')}oauth_error={Uri.EscapeDataString(error)}");
+	}
 
-	private static bool TryReadCorrelationId(string state, out string correlationId)
+	private static bool TryReadState(string state, out string correlationId, out string returnUrl)
 	{
 		correlationId = "";
+		returnUrl = "";
 		try
 		{
 			var json = Encoding.UTF8.GetString(Convert.FromBase64String(state));
@@ -152,6 +172,11 @@ public sealed class OAuthBrowserFlowService(
 			}
 
 			correlationId = element.GetString() ?? "";
+			if (document.RootElement.TryGetProperty("return_url", out var returnUrlElement))
+			{
+				returnUrl = SecurityBrowserService.NormalizeReturnUrl(returnUrlElement.GetString() ?? "");
+			}
+
 			return !string.IsNullOrWhiteSpace(correlationId);
 		}
 		catch (Exception ex) when (ex is FormatException or JsonException)
@@ -162,6 +187,26 @@ public sealed class OAuthBrowserFlowService(
 
 	private static string PublicBaseUri(HttpRequest request) =>
 		$"{request.Scheme}://{request.Host}";
+
+	private static string SignInLocation(string returnUrl) =>
+		string.IsNullOrWhiteSpace(returnUrl) || returnUrl == "/ui"
+			? "/ui/signin"
+			: $"/ui/signin?returnUrl={Uri.EscapeDataString(returnUrl)}";
+
+	private void DeleteChallengeCookie(HttpResponse response) =>
+		response.Cookies.Delete(ChallengeCookieName, new CookieOptions
+		{
+			Path = "/"
+		});
+
+	private CookieOptions ChallengeCookieOptions(HttpRequest request) => new()
+	{
+		HttpOnly = true,
+		Secure = request.IsHttps,
+		SameSite = SameSiteMode.Lax,
+		Path = "/",
+		MaxAge = ChallengeLifetime
+	};
 
 	private static string TokenEndpoint(ClusterVNodeOptions.OAuthOptions options) =>
 		options.TokenEndpoint;
@@ -175,7 +220,7 @@ public sealed class OAuthBrowserFlowService(
 	public void Dispose() =>
 		httpClient.Dispose();
 
-	private sealed record PendingChallenge(string CodeVerifier, DateTimeOffset ExpiresAt);
+	private sealed record OAuthChallengeCookie(string CodeVerifier, string CorrelationId, DateTimeOffset ExpiresAt);
 }
 
 public sealed record OAuthCodeChallenge(

--- a/src/EventStore.ClusterNode/Components/Services/OAuthBrowserFlowEndpoints.cs
+++ b/src/EventStore.ClusterNode/Components/Services/OAuthBrowserFlowEndpoints.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace EventStore.ClusterNode.Components.Services;
+
+internal static class OAuthBrowserFlowEndpoints
+{
+	public static IEndpointRouteBuilder MapOAuthBrowserFlowEndpoints(
+		this IEndpointRouteBuilder app,
+		ClusterVNodeOptions.OAuthOptions options)
+	{
+		app.MapGet(options.CodeChallengePath, (OAuthBrowserFlowService service) =>
+			Results.Json(service.CreateCodeChallenge(), OAuthBrowserFlowService.JsonOptions));
+
+		app.MapGet(options.RedirectPath, async (
+			HttpContext context,
+			OAuthBrowserFlowService service) =>
+			await service.HandleCallback(context, context.RequestAborted));
+
+		return app;
+	}
+}
+
+public sealed class OAuthBrowserFlowService(
+	ClusterVNodeOptions.OAuthOptions options,
+	HttpClient httpClient,
+	TimeProvider timeProvider) : IDisposable
+{
+	public static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+	private readonly ConcurrentDictionary<string, PendingChallenge> _pendingChallenges = new();
+
+	public OAuthCodeChallenge CreateCodeChallenge()
+	{
+		PruneExpired();
+
+		var verifier = Base64Url(RandomNumberGenerator.GetBytes(32));
+		var challenge = Base64Url(SHA256.HashData(Encoding.ASCII.GetBytes(verifier)));
+		var correlationId = Base64Url(RandomNumberGenerator.GetBytes(32));
+
+		_pendingChallenges[correlationId] = new PendingChallenge(verifier, timeProvider.GetUtcNow().AddMinutes(5));
+		return new OAuthCodeChallenge(correlationId, challenge, "S256");
+	}
+
+	public async Task<IResult> HandleCallback(HttpContext context, CancellationToken cancellationToken)
+	{
+		var code = context.Request.Query["code"].ToString();
+		var state = context.Request.Query["state"].ToString();
+		if (string.IsNullOrWhiteSpace(code) || string.IsNullOrWhiteSpace(state))
+		{
+			return SignInRedirect("missing_callback");
+		}
+
+		if (!TryReadCorrelationId(state, out var correlationId) ||
+			!_pendingChallenges.TryRemove(correlationId, out var pending) ||
+			pending.ExpiresAt <= timeProvider.GetUtcNow())
+		{
+			return SignInRedirect("invalid_state");
+		}
+
+		var token = await ExchangeCode(code, pending.CodeVerifier, PublicBaseUri(context.Request), cancellationToken);
+		if (string.IsNullOrWhiteSpace(token))
+		{
+			return SignInRedirect("missing_token");
+		}
+
+		UiCredentialCookie.Delete(context.Response);
+		UiCredentialCookie.AppendOAuthToken(context.Response, token);
+		return Results.Redirect("/ui/signin");
+	}
+
+	private async Task<string> ExchangeCode(
+		string code,
+		string codeVerifier,
+		string baseUri,
+		CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(options.ClientId))
+		{
+			return "";
+		}
+
+		if (string.IsNullOrWhiteSpace(options.TokenEndpoint))
+		{
+			return "";
+		}
+
+		var values = new Dictionary<string, string>
+		{
+			["grant_type"] = "authorization_code",
+			["client_id"] = options.ClientId,
+			["code"] = code,
+			["redirect_uri"] = $"{baseUri}{options.RedirectPath}",
+			["code_verifier"] = codeVerifier
+		};
+
+		if (!string.IsNullOrWhiteSpace(options.ClientSecret))
+		{
+			values["client_secret"] = options.ClientSecret;
+		}
+
+		using var response = await httpClient.PostAsync(
+			TokenEndpoint(options),
+			new FormUrlEncodedContent(values),
+			cancellationToken);
+		if (!response.IsSuccessStatusCode)
+		{
+			return "";
+		}
+
+		await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+		var tokenResponse = await JsonSerializer.DeserializeAsync<OAuthTokenResponse>(stream, JsonOptions, cancellationToken);
+		return tokenResponse?.AccessToken ?? "";
+	}
+
+	private void PruneExpired()
+	{
+		var now = timeProvider.GetUtcNow();
+		foreach (var (key, value) in _pendingChallenges)
+		{
+			if (value.ExpiresAt <= now)
+			{
+				_pendingChallenges.TryRemove(key, out _);
+			}
+		}
+	}
+
+	private static IResult SignInRedirect(string error) =>
+		Results.Redirect($"/ui/signin?oauth_error={Uri.EscapeDataString(error)}");
+
+	private static bool TryReadCorrelationId(string state, out string correlationId)
+	{
+		correlationId = "";
+		try
+		{
+			var json = Encoding.UTF8.GetString(Convert.FromBase64String(state));
+			using var document = JsonDocument.Parse(json);
+			if (!document.RootElement.TryGetProperty("code_challenge_correlation_id", out var element))
+			{
+				return false;
+			}
+
+			correlationId = element.GetString() ?? "";
+			return !string.IsNullOrWhiteSpace(correlationId);
+		}
+		catch (Exception ex) when (ex is FormatException or JsonException)
+		{
+			return false;
+		}
+	}
+
+	private static string PublicBaseUri(HttpRequest request) =>
+		$"{request.Scheme}://{request.Host}";
+
+	private static string TokenEndpoint(ClusterVNodeOptions.OAuthOptions options) =>
+		options.TokenEndpoint;
+
+	private static string Base64Url(byte[] bytes) =>
+		Convert.ToBase64String(bytes)
+			.TrimEnd('=')
+			.Replace('+', '-')
+			.Replace('/', '_');
+
+	public void Dispose() =>
+		httpClient.Dispose();
+
+	private sealed record PendingChallenge(string CodeVerifier, DateTimeOffset ExpiresAt);
+}
+
+public sealed record OAuthCodeChallenge(
+	[property: JsonPropertyName("code_challenge_correlation_id")]
+	string CodeChallengeCorrelationId,
+	[property: JsonPropertyName("code_challenge")]
+	string CodeChallenge,
+	[property: JsonPropertyName("code_challenge_method")]
+	string CodeChallengeMethod);
+
+public sealed record OAuthTokenResponse([property: JsonPropertyName("access_token")] string AccessToken);

--- a/src/EventStore.ClusterNode/Components/Services/OAuthBrowserFlowEndpoints.cs
+++ b/src/EventStore.ClusterNode/Components/Services/OAuthBrowserFlowEndpoints.cs
@@ -66,30 +66,30 @@ public sealed class OAuthBrowserFlowService(
 		var hasState = TryReadState(state, out var correlationId, out var returnUrl, out var redirectUri);
 		if (!string.IsNullOrWhiteSpace(providerError))
 		{
-			DeleteChallengeCookie(context.Response);
+			DeleteChallengeCookie(context);
 			return SignInRedirect("provider_error", hasState ? returnUrl : "");
 		}
 
 		if (string.IsNullOrWhiteSpace(code) || string.IsNullOrWhiteSpace(state))
 		{
-			DeleteChallengeCookie(context.Response);
+			DeleteChallengeCookie(context);
 			return SignInRedirect("missing_callback", "");
 		}
 
 		if (!hasState)
 		{
-			DeleteChallengeCookie(context.Response);
+			DeleteChallengeCookie(context);
 			return SignInRedirect("invalid_state", "");
 		}
 
 		if (!TryReadChallenge(context.Request, correlationId, out var challenge) ||
 			challenge.ExpiresAt <= timeProvider.GetUtcNow())
 		{
-			DeleteChallengeCookie(context.Response);
+			DeleteChallengeCookie(context);
 			return SignInRedirect("invalid_state", returnUrl);
 		}
 
-		DeleteChallengeCookie(context.Response);
+		DeleteChallengeCookie(context);
 		var token = await ExchangeCode(
 			code,
 			challenge.CodeVerifier,
@@ -237,19 +237,19 @@ public sealed class OAuthBrowserFlowService(
 			? "/ui/signin"
 			: $"/ui/signin?returnUrl={Uri.EscapeDataString(returnUrl)}";
 
-	private void DeleteChallengeCookie(HttpResponse response) =>
-		response.Cookies.Delete(ChallengeCookieName, new CookieOptions
-		{
-			Path = "/"
-		});
+	private void DeleteChallengeCookie(HttpContext context) =>
+		context.Response.Cookies.Delete(ChallengeCookieName, ChallengeCookieOptions(context.Request, maxAge: null));
 
-	private CookieOptions ChallengeCookieOptions(HttpRequest request) => new()
+	private CookieOptions ChallengeCookieOptions(HttpRequest request) =>
+		ChallengeCookieOptions(request, ChallengeLifetime);
+
+	private CookieOptions ChallengeCookieOptions(HttpRequest request, TimeSpan? maxAge) => new()
 	{
 		HttpOnly = true,
 		Secure = request.IsHttps,
 		SameSite = SameSiteMode.Lax,
 		Path = "/",
-		MaxAge = ChallengeLifetime
+		MaxAge = maxAge
 	};
 
 	private static string TokenEndpoint(ClusterVNodeOptions.OAuthOptions options) =>

--- a/src/EventStore.ClusterNode/Components/Services/OAuthBrowserFlowEndpoints.cs
+++ b/src/EventStore.ClusterNode/Components/Services/OAuthBrowserFlowEndpoints.cs
@@ -37,7 +37,8 @@ public sealed class OAuthBrowserFlowService(
 	ClusterVNodeOptions.OAuthOptions options,
 	HttpClient httpClient,
 	TimeProvider timeProvider,
-	IDataProtectionProvider dataProtectionProvider) : IDisposable
+	IDataProtectionProvider dataProtectionProvider,
+	bool adminUiEnabled) : IDisposable
 {
 	public static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 	private const string ChallengeCookieName = "eventstore-ui-oauth-pkce";
@@ -67,26 +68,26 @@ public sealed class OAuthBrowserFlowService(
 		if (!string.IsNullOrWhiteSpace(providerError))
 		{
 			DeleteChallengeCookie(context);
-			return SignInRedirect("provider_error", hasState ? returnUrl : "");
+			return ErrorRedirect("provider_error", hasState ? returnUrl : "");
 		}
 
 		if (string.IsNullOrWhiteSpace(code) || string.IsNullOrWhiteSpace(state))
 		{
 			DeleteChallengeCookie(context);
-			return SignInRedirect("missing_callback", "");
+			return ErrorRedirect("missing_callback", "");
 		}
 
 		if (!hasState)
 		{
 			DeleteChallengeCookie(context);
-			return SignInRedirect("invalid_state", "");
+			return ErrorRedirect("invalid_state", "");
 		}
 
 		if (!TryReadChallenge(context.Request, correlationId, out var challenge) ||
 			challenge.ExpiresAt <= timeProvider.GetUtcNow())
 		{
 			DeleteChallengeCookie(context);
-			return SignInRedirect("invalid_state", returnUrl);
+			return ErrorRedirect("invalid_state", returnUrl);
 		}
 
 		DeleteChallengeCookie(context);
@@ -97,12 +98,12 @@ public sealed class OAuthBrowserFlowService(
 			cancellationToken);
 		if (string.IsNullOrWhiteSpace(token))
 		{
-			return SignInRedirect("missing_token", returnUrl);
+			return ErrorRedirect("missing_token", returnUrl);
 		}
 
 		UiCredentialCookie.Delete(context.Response);
 		UiCredentialCookie.AppendOAuthToken(context.Response, token);
-		return Results.Redirect(SignInLocation(returnUrl));
+		return Results.Redirect(adminUiEnabled ? SignInLocation(returnUrl) : DirectReturnLocation(returnUrl));
 	}
 
 	private async Task<string> ExchangeCode(
@@ -170,10 +171,10 @@ public sealed class OAuthBrowserFlowService(
 		}
 	}
 
-	private static IResult SignInRedirect(string error, string returnUrl)
+	private IResult ErrorRedirect(string error, string returnUrl)
 	{
-		var signInLocation = SignInLocation(returnUrl);
-		return Results.Redirect($"{signInLocation}{(signInLocation.Contains('?') ? '&' : '?')}oauth_error={Uri.EscapeDataString(error)}");
+		var location = adminUiEnabled ? SignInLocation(returnUrl) : DirectReturnLocation(returnUrl);
+		return Results.Redirect($"{location}{(location.Contains('?') ? '&' : '?')}oauth_error={Uri.EscapeDataString(error)}");
 	}
 
 	private bool TryReadState(string state, out string correlationId, out string returnUrl, out string redirectUri)
@@ -236,6 +237,11 @@ public sealed class OAuthBrowserFlowService(
 		string.IsNullOrWhiteSpace(returnUrl) || returnUrl == "/ui"
 			? "/ui/signin"
 			: $"/ui/signin?returnUrl={Uri.EscapeDataString(returnUrl)}";
+
+	private static string DirectReturnLocation(string returnUrl) =>
+		string.IsNullOrWhiteSpace(returnUrl) || returnUrl == "/ui"
+			? "/"
+			: returnUrl;
 
 	private void DeleteChallengeCookie(HttpContext context) =>
 		context.Response.Cookies.Delete(ChallengeCookieName, ChallengeCookieOptions(context.Request, maxAge: null));

--- a/src/EventStore.ClusterNode/Components/Services/OAuthBrowserFlowEndpoints.cs
+++ b/src/EventStore.ClusterNode/Components/Services/OAuthBrowserFlowEndpoints.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core;
+using EventStore.Core.Authentication.OAuth;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
@@ -39,6 +40,7 @@ public sealed class OAuthBrowserFlowService(
 	HttpClient httpClient,
 	TimeProvider timeProvider,
 	IDataProtectionProvider dataProtectionProvider,
+	OAuthTokenValidator tokenValidator,
 	bool adminUiEnabled) : IDisposable
 {
 	public static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
@@ -105,6 +107,12 @@ public sealed class OAuthBrowserFlowService(
 		if (!LooksLikeJwt(token))
 		{
 			return ErrorRedirect("unsupported_token", returnUrl);
+		}
+
+		var validationResult = await tokenValidator.ValidateTokenAsync(token, cancellationToken);
+		if (!validationResult.IsValid)
+		{
+			return ErrorRedirect("invalid_token", returnUrl);
 		}
 
 		UiCredentialCookie.Delete(context.Response);

--- a/src/EventStore.ClusterNode/Components/Services/OAuthBrowserFlowEndpoints.cs
+++ b/src/EventStore.ClusterNode/Components/Services/OAuthBrowserFlowEndpoints.cs
@@ -63,7 +63,7 @@ public sealed class OAuthBrowserFlowService(
 		var code = context.Request.Query["code"].ToString();
 		var state = context.Request.Query["state"].ToString();
 		var providerError = context.Request.Query["error"].ToString();
-		var hasState = TryReadState(state, out var correlationId, out var returnUrl);
+		var hasState = TryReadState(state, out var correlationId, out var returnUrl, out var redirectUri);
 		if (!string.IsNullOrWhiteSpace(providerError))
 		{
 			DeleteChallengeCookie(context.Response);
@@ -72,6 +72,7 @@ public sealed class OAuthBrowserFlowService(
 
 		if (string.IsNullOrWhiteSpace(code) || string.IsNullOrWhiteSpace(state))
 		{
+			DeleteChallengeCookie(context.Response);
 			return SignInRedirect("missing_callback", "");
 		}
 
@@ -89,7 +90,11 @@ public sealed class OAuthBrowserFlowService(
 		}
 
 		DeleteChallengeCookie(context.Response);
-		var token = await ExchangeCode(code, challenge.CodeVerifier, PublicBaseUri(context.Request), cancellationToken);
+		var token = await ExchangeCode(
+			code,
+			challenge.CodeVerifier,
+			RedirectUri(context.Request, redirectUri),
+			cancellationToken);
 		if (string.IsNullOrWhiteSpace(token))
 		{
 			return SignInRedirect("missing_token", returnUrl);
@@ -121,7 +126,7 @@ public sealed class OAuthBrowserFlowService(
 			["grant_type"] = "authorization_code",
 			["client_id"] = options.ClientId,
 			["code"] = code,
-			["redirect_uri"] = $"{baseUri}{options.RedirectPath}",
+			["redirect_uri"] = baseUri,
 			["code_verifier"] = codeVerifier
 		};
 
@@ -171,10 +176,11 @@ public sealed class OAuthBrowserFlowService(
 		return Results.Redirect($"{signInLocation}{(signInLocation.Contains('?') ? '&' : '?')}oauth_error={Uri.EscapeDataString(error)}");
 	}
 
-	private static bool TryReadState(string state, out string correlationId, out string returnUrl)
+	private bool TryReadState(string state, out string correlationId, out string returnUrl, out string redirectUri)
 	{
 		correlationId = "";
 		returnUrl = "";
+		redirectUri = "";
 		try
 		{
 			var json = Encoding.UTF8.GetString(Convert.FromBase64String(state));
@@ -190,6 +196,11 @@ public sealed class OAuthBrowserFlowService(
 				returnUrl = SecurityBrowserService.NormalizeReturnUrl(returnUrlElement.GetString() ?? "");
 			}
 
+			if (document.RootElement.TryGetProperty("redirect_uri", out var redirectUriElement))
+			{
+				redirectUri = NormalizeRedirectUri(redirectUriElement.GetString() ?? "");
+			}
+
 			return !string.IsNullOrWhiteSpace(correlationId);
 		}
 		catch (Exception ex) when (ex is FormatException or JsonException)
@@ -198,8 +209,28 @@ public sealed class OAuthBrowserFlowService(
 		}
 	}
 
-	private static string PublicBaseUri(HttpRequest request) =>
-		$"{request.Scheme}://{request.Host}";
+	private string RedirectUri(HttpRequest request, string redirectUri) =>
+		string.IsNullOrWhiteSpace(redirectUri)
+			? $"{request.Scheme}://{request.Host}{options.RedirectPath}"
+			: redirectUri;
+
+	private string NormalizeRedirectUri(string redirectUri)
+	{
+		if (!Uri.TryCreate(redirectUri, UriKind.Absolute, out var uri))
+		{
+			return "";
+		}
+
+		if (!uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+			!uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+		{
+			return "";
+		}
+
+		return uri.AbsolutePath.Equals(options.RedirectPath, StringComparison.Ordinal)
+			? uri.GetLeftPart(UriPartial.Path)
+			: "";
+	}
 
 	private static string SignInLocation(string returnUrl) =>
 		string.IsNullOrWhiteSpace(returnUrl) || returnUrl == "/ui"

--- a/src/EventStore.ClusterNode/Components/Services/OAuthBrowserFlowEndpoints.cs
+++ b/src/EventStore.ClusterNode/Components/Services/OAuthBrowserFlowEndpoints.cs
@@ -62,17 +62,30 @@ public sealed class OAuthBrowserFlowService(
 	{
 		var code = context.Request.Query["code"].ToString();
 		var state = context.Request.Query["state"].ToString();
+		var providerError = context.Request.Query["error"].ToString();
+		var hasState = TryReadState(state, out var correlationId, out var returnUrl);
+		if (!string.IsNullOrWhiteSpace(providerError))
+		{
+			DeleteChallengeCookie(context.Response);
+			return SignInRedirect("provider_error", hasState ? returnUrl : "");
+		}
+
 		if (string.IsNullOrWhiteSpace(code) || string.IsNullOrWhiteSpace(state))
 		{
 			return SignInRedirect("missing_callback", "");
 		}
 
-		if (!TryReadState(state, out var correlationId, out var returnUrl) ||
-			!TryReadChallenge(context.Request, correlationId, out var challenge) ||
-			challenge.ExpiresAt <= timeProvider.GetUtcNow())
+		if (!hasState)
 		{
 			DeleteChallengeCookie(context.Response);
 			return SignInRedirect("invalid_state", "");
+		}
+
+		if (!TryReadChallenge(context.Request, correlationId, out var challenge) ||
+			challenge.ExpiresAt <= timeProvider.GetUtcNow())
+		{
+			DeleteChallengeCookie(context.Response);
+			return SignInRedirect("invalid_state", returnUrl);
 		}
 
 		DeleteChallengeCookie(context.Response);

--- a/src/EventStore.ClusterNode/Components/Services/OAuthBrowserFlowEndpoints.cs
+++ b/src/EventStore.ClusterNode/Components/Services/OAuthBrowserFlowEndpoints.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
@@ -101,6 +102,11 @@ public sealed class OAuthBrowserFlowService(
 			return ErrorRedirect("missing_token", returnUrl);
 		}
 
+		if (!LooksLikeJwt(token))
+		{
+			return ErrorRedirect("unsupported_token", returnUrl);
+		}
+
 		UiCredentialCookie.Delete(context.Response);
 		UiCredentialCookie.AppendOAuthToken(context.Response, token);
 		return Results.Redirect(adminUiEnabled ? SignInLocation(returnUrl) : DirectReturnLocation(returnUrl));
@@ -148,6 +154,17 @@ public sealed class OAuthBrowserFlowService(
 		await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
 		var tokenResponse = await JsonSerializer.DeserializeAsync<OAuthTokenResponse>(stream, JsonOptions, cancellationToken);
 		return tokenResponse?.AccessToken ?? "";
+	}
+
+	private static bool LooksLikeJwt(string token)
+	{
+		if (string.IsNullOrWhiteSpace(token))
+		{
+			return false;
+		}
+
+		var segments = token.Split('.');
+		return segments.Length is 3 or 5 && segments.All(segment => !string.IsNullOrWhiteSpace(segment));
 	}
 
 	private bool TryReadChallenge(HttpRequest request, string correlationId, out OAuthChallengeCookie challenge)
@@ -239,7 +256,9 @@ public sealed class OAuthBrowserFlowService(
 			: $"/ui/signin?returnUrl={Uri.EscapeDataString(returnUrl)}";
 
 	private static string DirectReturnLocation(string returnUrl) =>
-		string.IsNullOrWhiteSpace(returnUrl) || returnUrl == "/ui"
+		string.IsNullOrWhiteSpace(returnUrl) ||
+		returnUrl.Equals("/ui", StringComparison.OrdinalIgnoreCase) ||
+		returnUrl.StartsWith("/ui/", StringComparison.OrdinalIgnoreCase)
 			? "/"
 			: returnUrl;
 

--- a/src/EventStore.ClusterNode/Components/Services/SecurityBrowserService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/SecurityBrowserService.cs
@@ -31,7 +31,8 @@ public sealed class SecurityBrowserService(IAuthenticationProvider authenticatio
 			properties.ContainsKey("code_challenge_uri") &&
 			properties.ContainsKey("redirect_uri") &&
 			properties.ContainsKey("response_type") &&
-			properties.ContainsKey("scope"),
+			properties.TryGetValue("scope", out var scope) &&
+			!string.IsNullOrWhiteSpace(scope),
 			schemes.Any(x => string.Equals(x, "Insecure", StringComparison.OrdinalIgnoreCase)),
 			properties);
 	}

--- a/src/EventStore.ClusterNode/Components/Services/SecurityBrowserService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/SecurityBrowserService.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Http;
 
 namespace EventStore.ClusterNode.Components.Services;
 
-public sealed class SecurityBrowserService(IAuthenticationProvider authenticationProvider)
+public sealed class SecurityBrowserService(IAuthenticationProvider authenticationProvider, bool supportsPassword)
 {
 	private static readonly Uri LocalBaseUri = new("http://localhost", UriKind.Absolute);
 
@@ -24,7 +24,7 @@ public sealed class SecurityBrowserService(IAuthenticationProvider authenticatio
 
 		return new SecurityAuthenticationInfo(
 			authenticationProvider.Name,
-			schemes.Any(x => string.Equals(x, "Basic", StringComparison.OrdinalIgnoreCase)),
+			supportsPassword,
 			schemes.Any(x => string.Equals(x, "Bearer", StringComparison.OrdinalIgnoreCase)) &&
 			properties.ContainsKey("authorization_endpoint") &&
 			properties.ContainsKey("client_id") &&

--- a/src/EventStore.ClusterNode/Components/Services/SecurityBrowserService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/SecurityBrowserService.cs
@@ -29,7 +29,9 @@ public sealed class SecurityBrowserService(IAuthenticationProvider authenticatio
 			properties.ContainsKey("authorization_endpoint") &&
 			properties.ContainsKey("client_id") &&
 			properties.ContainsKey("code_challenge_uri") &&
-			properties.ContainsKey("redirect_uri"),
+			properties.ContainsKey("redirect_uri") &&
+			properties.ContainsKey("response_type") &&
+			properties.ContainsKey("scope"),
 			schemes.Any(x => string.Equals(x, "Insecure", StringComparison.OrdinalIgnoreCase)),
 			properties);
 	}

--- a/src/EventStore.ClusterNode/Components/Services/SecurityBrowserService.cs
+++ b/src/EventStore.ClusterNode/Components/Services/SecurityBrowserService.cs
@@ -25,6 +25,11 @@ public sealed class SecurityBrowserService(IAuthenticationProvider authenticatio
 		return new SecurityAuthenticationInfo(
 			authenticationProvider.Name,
 			schemes.Any(x => string.Equals(x, "Basic", StringComparison.OrdinalIgnoreCase)),
+			schemes.Any(x => string.Equals(x, "Bearer", StringComparison.OrdinalIgnoreCase)) &&
+			properties.ContainsKey("authorization_endpoint") &&
+			properties.ContainsKey("client_id") &&
+			properties.ContainsKey("code_challenge_uri") &&
+			properties.ContainsKey("redirect_uri"),
 			schemes.Any(x => string.Equals(x, "Insecure", StringComparison.OrdinalIgnoreCase)),
 			properties);
 	}
@@ -87,11 +92,12 @@ public sealed class SecurityBrowserService(IAuthenticationProvider authenticatio
 public sealed record SecurityAuthenticationInfo(
 	string Type,
 	bool SupportsBasic,
+	bool SupportsOAuthBrowserFlow,
 	bool IsInsecure,
 	IReadOnlyDictionary<string, string> Properties)
 {
 	public static SecurityAuthenticationInfo Unavailable() =>
-		new("Unavailable", SupportsBasic: false, IsInsecure: false, new Dictionary<string, string>());
+		new("Unavailable", SupportsBasic: false, SupportsOAuthBrowserFlow: false, IsInsecure: false, new Dictionary<string, string>());
 
 	public string TypeLabel => string.IsNullOrWhiteSpace(Type) ? "External authentication" : Type;
 	public string PropertiesJson => JsonSerializer.Serialize(Properties);

--- a/src/EventStore.ClusterNode/Components/Services/UiCredentialCookie.cs
+++ b/src/EventStore.ClusterNode/Components/Services/UiCredentialCookie.cs
@@ -14,10 +14,16 @@ public sealed record UiCredentials(string Username, string Password)
 public static class UiCredentialCookie
 {
 	public const string BasicCookieName = "es-creds";
-	public const string OAuthCookieName = "oauth_id_token";
+	public const string OAuthCookieName = "oauth_token";
 
 	public static void AppendBasic(HttpResponse response, UiCredentials credentials) =>
 		AppendBasicValue(response, credentials.BasicValue);
+
+	public static void AppendOAuthToken(HttpResponse response, string token) =>
+		response.Cookies.Append(
+			OAuthCookieName,
+			token,
+			Options(response.HttpContext.Request.IsHttps));
 
 	private static void AppendBasicValue(HttpResponse response, string value) =>
 		response.Cookies.Append(

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -20,6 +20,7 @@ using EventStore.Core.Authentication;
 using EventStore.Core.Certificates;
 using EventStore.Core.Configuration;
 using EventStore.Core.Services.Transport.Http;
+using EventStore.Plugins.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
@@ -294,7 +295,9 @@ internal static class Program
 					builder.Services.AddScoped<StreamBrowserService>();
 					builder.Services.AddScoped<SubscriptionBrowserService>();
 					builder.Services.AddScoped<UserBrowserService>();
-					builder.Services.AddScoped<SecurityBrowserService>();
+					builder.Services.AddScoped(serviceProvider => new SecurityBrowserService(
+						serviceProvider.GetRequiredService<IAuthenticationProvider>(),
+						AuthenticationMethodNames.IncludesPassword(options.Auth)));
 					builder.Services.AddScoped<AdminOperationsService>();
 					builder.Services.AddScoped<ConfigurationBrowserService>();
 					var oauthEnabled = AuthenticationMethodNames.IncludesOAuth(options.Auth);

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -16,6 +16,7 @@ using EventStore.Common.Exceptions;
 using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using EventStore.Core;
+using EventStore.Core.Authentication;
 using EventStore.Core.Certificates;
 using EventStore.Core.Configuration;
 using EventStore.Core.Services.Transport.Http;
@@ -296,13 +297,17 @@ internal static class Program
 					builder.Services.AddScoped<SecurityBrowserService>();
 					builder.Services.AddScoped<AdminOperationsService>();
 					builder.Services.AddScoped<ConfigurationBrowserService>();
-					var oauthHttpHandler = new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(15) };
-					builder.Services.AddSingleton(serviceProvider =>
-						new OAuthBrowserFlowService(
-							options.Auth.OAuth,
-							new HttpClient(oauthHttpHandler),
-							TimeProvider.System,
-							serviceProvider.GetRequiredService<IDataProtectionProvider>()));
+					var oauthEnabled = AuthenticationMethodNames.IncludesOAuth(options.Auth);
+					if (oauthEnabled)
+					{
+						var oauthHttpHandler = new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(15) };
+						builder.Services.AddSingleton(serviceProvider =>
+							new OAuthBrowserFlowService(
+								options.Auth.OAuth,
+								new HttpClient(oauthHttpHandler),
+								TimeProvider.System,
+								serviceProvider.GetRequiredService<IDataProtectionProvider>()));
+					}
 					builder.Services.AddSingleton(hostedService);
 					builder.Services.AddSingleton<IHostedService>(hostedService);
 
@@ -325,7 +330,11 @@ internal static class Program
 					if (adminUiEnabled)
 					{
 						app.MapAdminOperationsEndpoints();
-						app.MapOAuthBrowserFlowEndpoints(options.Auth.OAuth);
+						if (oauthEnabled)
+						{
+							app.MapOAuthBrowserFlowEndpoints(options.Auth.OAuth);
+						}
+
 						app.MapQueueDashboardEndpoints();
 						app.MapStaticAssets();
 						app.MapRazorComponents<App>();

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -330,14 +330,14 @@ internal static class Program
 						Log.Warning("UI assets directory {UiAssetsDirectory} is not available.", Locations.UiAssetsDirectory);
 					}
 					hostedService.Node.Startup.Configure(app);
+					if (oauthEnabled)
+					{
+						app.MapOAuthBrowserFlowEndpoints(options.Auth.OAuth);
+					}
+
 					if (adminUiEnabled)
 					{
 						app.MapAdminOperationsEndpoints();
-						if (oauthEnabled)
-						{
-							app.MapOAuthBrowserFlowEndpoints(options.Auth.OAuth);
-						}
-
 						app.MapQueueDashboardEndpoints();
 						app.MapStaticAssets();
 						app.MapRazorComponents<App>();

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Net.Security;
 using System.Runtime;
 using System.Security.Authentication;
@@ -293,6 +294,7 @@ internal static class Program
 					builder.Services.AddScoped<SecurityBrowserService>();
 					builder.Services.AddScoped<AdminOperationsService>();
 					builder.Services.AddScoped<ConfigurationBrowserService>();
+					builder.Services.AddSingleton(new OAuthBrowserFlowService(options.Auth.OAuth, new HttpClient(), TimeProvider.System));
 					builder.Services.AddSingleton(hostedService);
 					builder.Services.AddSingleton<IHostedService>(hostedService);
 
@@ -315,6 +317,7 @@ internal static class Program
 					if (adminUiEnabled)
 					{
 						app.MapAdminOperationsEndpoints();
+						app.MapOAuthBrowserFlowEndpoints(options.Auth.OAuth);
 						app.MapQueueDashboardEndpoints();
 						app.MapStaticAssets();
 						app.MapRazorComponents<App>();

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -301,6 +301,7 @@ internal static class Program
 					builder.Services.AddScoped<AdminOperationsService>();
 					builder.Services.AddScoped<ConfigurationBrowserService>();
 					var oauthEnabled = AuthenticationMethodNames.IncludesOAuth(options.Auth);
+					var adminUiEnabled = !options.Interface.DisableAdminUi;
 					if (oauthEnabled)
 					{
 						var oauthHttpHandler = new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(15) };
@@ -309,14 +310,14 @@ internal static class Program
 								options.Auth.OAuth,
 								new HttpClient(oauthHttpHandler),
 								TimeProvider.System,
-								serviceProvider.GetRequiredService<IDataProtectionProvider>()));
+								serviceProvider.GetRequiredService<IDataProtectionProvider>(),
+								adminUiEnabled));
 					}
 					builder.Services.AddSingleton(hostedService);
 					builder.Services.AddSingleton<IHostedService>(hostedService);
 
 					var app = builder.Build();
 					app.UseMiddleware<UiCredentialsMiddleware>();
-					var adminUiEnabled = !options.Interface.DisableAdminUi;
 					if (adminUiEnabled && Directory.Exists(Locations.UiAssetsDirectory))
 					{
 						app.UseStaticFiles(new StaticFileOptions

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -20,6 +20,7 @@ using EventStore.Core.Certificates;
 using EventStore.Core.Configuration;
 using EventStore.Core.Services.Transport.Http;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
@@ -283,6 +284,7 @@ internal static class Program
 
 					hostedService.Node.Startup.ConfigureServicesOnly(builder.Services);
 					builder.Services.AddHttpContextAccessor();
+					builder.Services.AddDataProtection();
 					builder.Services.AddRazorComponents();
 					builder.Services.AddScoped<ProjectionBrowserService>();
 					builder.Services.AddSingleton<QueueDashboardService>();
@@ -294,7 +296,13 @@ internal static class Program
 					builder.Services.AddScoped<SecurityBrowserService>();
 					builder.Services.AddScoped<AdminOperationsService>();
 					builder.Services.AddScoped<ConfigurationBrowserService>();
-					builder.Services.AddSingleton(new OAuthBrowserFlowService(options.Auth.OAuth, new HttpClient(), TimeProvider.System));
+					var oauthHttpHandler = new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(15) };
+					builder.Services.AddSingleton(serviceProvider =>
+						new OAuthBrowserFlowService(
+							options.Auth.OAuth,
+							new HttpClient(oauthHttpHandler),
+							TimeProvider.System,
+							serviceProvider.GetRequiredService<IDataProtectionProvider>()));
 					builder.Services.AddSingleton(hostedService);
 					builder.Services.AddSingleton<IHostedService>(hostedService);
 

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -17,6 +17,7 @@ using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using EventStore.Core;
 using EventStore.Core.Authentication;
+using EventStore.Core.Authentication.OAuth;
 using EventStore.Core.Certificates;
 using EventStore.Core.Configuration;
 using EventStore.Core.Services.Transport.Http;
@@ -311,6 +312,7 @@ internal static class Program
 								new HttpClient(oauthHttpHandler),
 								TimeProvider.System,
 								serviceProvider.GetRequiredService<IDataProtectionProvider>(),
+								new OAuthTokenValidator(options.Auth.OAuth),
 								adminUiEnabled));
 					}
 					builder.Services.AddSingleton(hostedService);

--- a/src/EventStore.ClusterNode/ui-assets/js/ui-auth.js
+++ b/src/EventStore.ClusterNode/ui-assets/js/ui-auth.js
@@ -30,7 +30,7 @@
 	}
 
 	function readAuthorization() {
-		var token = safeDecode(readCookie("oauth_id_token"));
+		var token = safeDecode(readCookie("oauth_token"));
 		if (isHeaderSafe(token))
 			return "Bearer " + token;
 
@@ -81,7 +81,7 @@
 
 	function clearReadableAuthCookies() {
 		clearCookie("es-creds");
-		clearCookie("oauth_id_token");
+		clearCookie("oauth_token");
 	}
 
 	function setStatus(message) {
@@ -103,10 +103,9 @@
 
 	async function beginOAuthSignIn(button) {
 		try {
-			var providerType = (button.getAttribute("data-ui-oauth-type") || "").toLowerCase();
 			var properties = readJsonAttribute(button, "data-ui-oauth-properties");
-			if (providerType !== "oauth")
-				throw new Error("The configured provider is not an OAuth browser flow.");
+			if (!properties.authorization_endpoint || !properties.client_id)
+				throw new Error("The configured provider does not advertise an OAuth browser flow.");
 
 			var baseUrl = window.location.protocol + "//" + window.location.host;
 			var challengeResponse = await originalFetch(baseUrl + properties.code_challenge_uri);

--- a/src/EventStore.ClusterNode/ui-assets/js/ui-auth.js
+++ b/src/EventStore.ClusterNode/ui-assets/js/ui-auth.js
@@ -119,15 +119,16 @@
 
 			var challenge = await challengeResponse.json();
 			var returnUrl = button.getAttribute("data-ui-oauth-return") || "";
+			var redirectUri = baseUrl + properties.redirect_uri;
 			var state = btoa(JSON.stringify({
 				code_challenge_correlation_id: challenge.code_challenge_correlation_id,
-				return_url: returnUrl
+				return_url: returnUrl,
+				redirect_uri: redirectUri
 			}));
-			var redirectUri = encodeURIComponent(baseUrl + properties.redirect_uri);
 			var target = properties.authorization_endpoint +
 				"?response_type=" + encodeURIComponent(properties.response_type) +
 				"&client_id=" + encodeURIComponent(properties.client_id) +
-				"&redirect_uri=" + redirectUri +
+				"&redirect_uri=" + encodeURIComponent(redirectUri) +
 				"&scope=" + encodeURIComponent(properties.scope) +
 				"&code_challenge=" + encodeURIComponent(challenge.code_challenge) +
 				"&code_challenge_method=" + encodeURIComponent(challenge.code_challenge_method) +

--- a/src/EventStore.ClusterNode/ui-assets/js/ui-auth.js
+++ b/src/EventStore.ClusterNode/ui-assets/js/ui-auth.js
@@ -104,7 +104,12 @@
 	async function beginOAuthSignIn(button) {
 		try {
 			var properties = readJsonAttribute(button, "data-ui-oauth-properties");
-			if (!properties.authorization_endpoint || !properties.client_id)
+			if (!properties.authorization_endpoint ||
+				!properties.client_id ||
+				!properties.code_challenge_uri ||
+				!properties.redirect_uri ||
+				!properties.response_type ||
+				!properties.scope)
 				throw new Error("The configured provider does not advertise an OAuth browser flow.");
 
 			var baseUrl = window.location.protocol + "//" + window.location.host;
@@ -113,8 +118,10 @@
 				throw new Error("Code challenge endpoint returned " + challengeResponse.status + " " + challengeResponse.statusText);
 
 			var challenge = await challengeResponse.json();
+			var returnUrl = button.getAttribute("data-ui-oauth-return") || "";
 			var state = btoa(JSON.stringify({
-				code_challenge_correlation_id: challenge.code_challenge_correlation_id
+				code_challenge_correlation_id: challenge.code_challenge_correlation_id,
+				return_url: returnUrl
 			}));
 			var redirectUri = encodeURIComponent(baseUrl + properties.redirect_uri);
 			var target = properties.authorization_endpoint +
@@ -126,7 +133,6 @@
 				"&code_challenge_method=" + encodeURIComponent(challenge.code_challenge_method) +
 				"&state=" + encodeURIComponent(state);
 
-			var returnUrl = button.getAttribute("data-ui-oauth-return");
 			if (returnUrl)
 				sessionStorage.setItem("eventstore-ui-return-url", returnUrl);
 

--- a/src/EventStore.Core.Tests/Authentication/CompositeAuthenticationProviderTests.cs
+++ b/src/EventStore.Core.Tests/Authentication/CompositeAuthenticationProviderTests.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using EventStore.Core.Authentication;
+using EventStore.Plugins.Authentication;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Authentication;
+
+[TestFixture]
+public class CompositeAuthenticationProviderTests
+{
+	[Test]
+	public async Task routes_bearer_requests_to_bearer_provider()
+	{
+		var basicProvider = new RecordingAuthenticationProvider(["Basic"]);
+		var bearerProvider = new RecordingAuthenticationProvider(["Bearer"]);
+		var provider = new CompositeAuthenticationProvider([basicProvider, bearerProvider]);
+		var request = new HttpAuthenticationRequest(new DefaultHttpContext(), "jwt-token");
+
+		provider.Authenticate(request);
+		await request.AuthenticateAsync();
+
+		Assert.AreEqual(0, basicProvider.Calls);
+		Assert.AreEqual(1, bearerProvider.Calls);
+	}
+
+	[Test]
+	public async Task routes_password_requests_to_basic_provider()
+	{
+		var basicProvider = new RecordingAuthenticationProvider(["Basic"]);
+		var bearerProvider = new RecordingAuthenticationProvider(["Bearer"]);
+		var provider = new CompositeAuthenticationProvider([basicProvider, bearerProvider]);
+		var request = new HttpAuthenticationRequest(new DefaultHttpContext(), "admin", "changeit");
+
+		provider.Authenticate(request);
+		await request.AuthenticateAsync();
+
+		Assert.AreEqual(1, basicProvider.Calls);
+		Assert.AreEqual(0, bearerProvider.Calls);
+	}
+
+	private sealed class RecordingAuthenticationProvider(IReadOnlyList<string> schemes) : AuthenticationProviderBase
+	{
+		public int Calls { get; private set; }
+
+		public override void Authenticate(AuthenticationRequest authenticationRequest)
+		{
+			Calls++;
+			authenticationRequest.Authenticated(
+				new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "test")], "test")));
+		}
+
+		public override IReadOnlyList<string> GetSupportedAuthenticationSchemes() => schemes;
+	}
+}

--- a/src/EventStore.Core.Tests/Authentication/CompositeAuthenticationProviderTests.cs
+++ b/src/EventStore.Core.Tests/Authentication/CompositeAuthenticationProviderTests.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using EventStore.Core.Authentication;
 using EventStore.Plugins.Authentication;
@@ -39,6 +42,45 @@ public class CompositeAuthenticationProviderTests
 
 		Assert.AreEqual(1, basicProvider.Calls);
 		Assert.AreEqual(0, bearerProvider.Calls);
+	}
+
+	[Test]
+	public async Task routes_certificate_requests_to_user_certificate_provider()
+	{
+		var bearerProvider = new RecordingAuthenticationProvider(["Bearer"]);
+		var certificateProvider = new RecordingAuthenticationProvider(["UserCertificate"]);
+		var provider = new CompositeAuthenticationProvider([bearerProvider, certificateProvider]);
+		var context = new DefaultHttpContext();
+		var request = HttpAuthenticationRequest.CreateWithValidCertificate(context, "admin", CreateCertificate());
+
+		provider.Authenticate(request);
+		await request.AuthenticateAsync();
+
+		Assert.AreEqual(0, bearerProvider.Calls);
+		Assert.AreEqual(1, certificateProvider.Calls);
+	}
+
+	[Test]
+	public async Task does_not_route_password_requests_to_user_certificate_provider()
+	{
+		var bearerProvider = new RecordingAuthenticationProvider(["Bearer"]);
+		var certificateProvider = new RecordingAuthenticationProvider(["UserCertificate"]);
+		var provider = new CompositeAuthenticationProvider([bearerProvider, certificateProvider]);
+		var request = new HttpAuthenticationRequest(new DefaultHttpContext(), "admin", "changeit");
+
+		provider.Authenticate(request);
+		var status = await request.AuthenticateAsync();
+
+		Assert.AreEqual(HttpAuthenticationRequestStatus.Unauthenticated, status.Item1);
+		Assert.AreEqual(0, bearerProvider.Calls);
+		Assert.AreEqual(0, certificateProvider.Calls);
+	}
+
+	private static X509Certificate2 CreateCertificate()
+	{
+		using var rsa = RSA.Create();
+		var request = new CertificateRequest("CN=test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+		return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow.AddMinutes(1));
 	}
 
 	private sealed class RecordingAuthenticationProvider(IReadOnlyList<string> schemes) : AuthenticationProviderBase

--- a/src/EventStore.Core.Tests/Authentication/CompositeAuthenticationProviderTests.cs
+++ b/src/EventStore.Core.Tests/Authentication/CompositeAuthenticationProviderTests.cs
@@ -76,6 +76,36 @@ public class CompositeAuthenticationProviderTests
 		Assert.AreEqual(0, certificateProvider.Calls);
 	}
 
+	[Test]
+	public async Task user_certificate_wrapper_allows_certificate_requests_over_basic_http_path()
+	{
+		var innerProvider = new RecordingAuthenticationProvider(["Basic", "UserCertificate"]);
+		var certificateProvider = new UserCertificateAuthenticationProvider(innerProvider);
+		var provider = new CompositeAuthenticationProvider([new RecordingAuthenticationProvider(["Bearer"]), certificateProvider]);
+		var context = new DefaultHttpContext();
+		var request = HttpAuthenticationRequest.CreateWithValidCertificate(context, "admin", CreateCertificate());
+
+		provider.Authenticate(request);
+		await request.AuthenticateAsync();
+
+		Assert.AreEqual(1, innerProvider.Calls);
+	}
+
+	[Test]
+	public async Task user_certificate_wrapper_rejects_basic_password_requests()
+	{
+		var innerProvider = new RecordingAuthenticationProvider(["Basic", "UserCertificate"]);
+		var certificateProvider = new UserCertificateAuthenticationProvider(innerProvider);
+		var provider = new CompositeAuthenticationProvider([new RecordingAuthenticationProvider(["Bearer"]), certificateProvider]);
+		var request = new HttpAuthenticationRequest(new DefaultHttpContext(), "admin", "changeit");
+
+		provider.Authenticate(request);
+		var status = await request.AuthenticateAsync();
+
+		Assert.AreEqual(HttpAuthenticationRequestStatus.Unauthenticated, status.Item1);
+		Assert.AreEqual(0, innerProvider.Calls);
+	}
+
 	private static X509Certificate2 CreateCertificate()
 	{
 		using var rsa = RSA.Create();

--- a/src/EventStore.Core.Tests/Authentication/OAuthAuthenticationProviderTests.cs
+++ b/src/EventStore.Core.Tests/Authentication/OAuthAuthenticationProviderTests.cs
@@ -66,6 +66,52 @@ public class OAuthAuthenticationProviderTests
 		Assert.AreEqual(HttpAuthenticationRequestStatus.Unauthenticated, status);
 	}
 
+	[Test]
+	public void does_not_advertise_browser_flow_without_client_id()
+	{
+		var provider = new OAuthAuthenticationProvider(
+			new()
+			{
+				Issuer = "https://login.example.test",
+				Audiences = ["eventstore"]
+			},
+			logFailedAuthenticationAttempts: false,
+			_ => new ValueTask<TokenValidationParameters>(CreateValidationParameters(new SymmetricSecurityKey(new byte[32]))));
+
+		var properties = provider.GetPublicProperties().ToDictionary(x => x.Key, x => x.Value);
+
+		Assert.That(properties.ContainsKey("authorization_endpoint"), Is.False);
+		Assert.That(properties.ContainsKey("client_id"), Is.False);
+	}
+
+	[Test]
+	public void advertises_configured_browser_flow_properties()
+	{
+		var provider = new OAuthAuthenticationProvider(
+			new()
+			{
+				Issuer = "https://login.example.test",
+				Audiences = ["eventstore"],
+				AuthorizationEndpoint = "https://login.example.test/oauth2/auth",
+				TokenEndpoint = "https://login.example.test/oauth2/token",
+				ClientId = "eventstore-ui",
+				Scopes = ["openid", "profile", "roles"],
+				CodeChallengePath = "/custom/challenge",
+				RedirectPath = "/custom/callback"
+			},
+			logFailedAuthenticationAttempts: false,
+			_ => new ValueTask<TokenValidationParameters>(CreateValidationParameters(new SymmetricSecurityKey(new byte[32]))));
+
+		var properties = provider.GetPublicProperties().ToDictionary(x => x.Key, x => x.Value);
+
+		Assert.AreEqual("https://login.example.test/oauth2/auth", properties["authorization_endpoint"]);
+		Assert.AreEqual("eventstore-ui", properties["client_id"]);
+		Assert.AreEqual("/custom/challenge", properties["code_challenge_uri"]);
+		Assert.AreEqual("/custom/callback", properties["redirect_uri"]);
+		Assert.AreEqual("code", properties["response_type"]);
+		Assert.AreEqual("openid profile roles", properties["scope"]);
+	}
+
 	private static string CreateToken(SecurityKey signingKey, string audience)
 	{
 		var descriptor = new SecurityTokenDescriptor

--- a/src/EventStore.Core.Tests/Authentication/OAuthAuthenticationProviderTests.cs
+++ b/src/EventStore.Core.Tests/Authentication/OAuthAuthenticationProviderTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Authentication.OAuth;
+using EventStore.Core.Services;
+using EventStore.Plugins.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Authentication;
+
+[TestFixture]
+public class OAuthAuthenticationProviderTests
+{
+	[Test]
+	public async Task authenticates_valid_bearer_token_and_maps_roles()
+	{
+		var signingKey = new SymmetricSecurityKey(Guid.NewGuid().ToByteArray().Concat(Guid.NewGuid().ToByteArray()).ToArray());
+		var token = CreateToken(signingKey, audience: "eventstore");
+		var provider = new OAuthAuthenticationProvider(
+			new()
+			{
+				Issuer = "https://login.example.test",
+				Audiences = ["eventstore"],
+				NameClaimType = "sub",
+				RoleClaimType = "roles"
+			},
+			logFailedAuthenticationAttempts: false,
+			_ => new ValueTask<TokenValidationParameters>(CreateValidationParameters(signingKey)));
+
+		var request = new HttpAuthenticationRequest(new DefaultHttpContext(), token);
+		provider.Authenticate(request);
+
+		var (status, principal) = await request.AuthenticateAsync();
+
+		Assert.AreEqual(HttpAuthenticationRequestStatus.Authenticated, status);
+		Assert.AreEqual("alice", principal.Identity?.Name);
+		Assert.That(principal.HasClaim(ClaimTypes.Role, SystemRoles.Admins), Is.True);
+	}
+
+	[Test]
+	public async Task rejects_token_with_wrong_audience()
+	{
+		var signingKey = new SymmetricSecurityKey(Guid.NewGuid().ToByteArray().Concat(Guid.NewGuid().ToByteArray()).ToArray());
+		var token = CreateToken(signingKey, audience: "other-service");
+		var provider = new OAuthAuthenticationProvider(
+			new()
+			{
+				Issuer = "https://login.example.test",
+				Audiences = ["eventstore"],
+				NameClaimType = "sub",
+				RoleClaimType = "roles"
+			},
+			logFailedAuthenticationAttempts: false,
+			_ => new ValueTask<TokenValidationParameters>(CreateValidationParameters(signingKey)));
+
+		var request = new HttpAuthenticationRequest(new DefaultHttpContext(), token);
+		provider.Authenticate(request);
+
+		var (status, _) = await request.AuthenticateAsync();
+
+		Assert.AreEqual(HttpAuthenticationRequestStatus.Unauthenticated, status);
+	}
+
+	private static string CreateToken(SecurityKey signingKey, string audience)
+	{
+		var descriptor = new SecurityTokenDescriptor
+		{
+			Issuer = "https://login.example.test",
+			Audience = audience,
+			Subject = new ClaimsIdentity([
+				new Claim("sub", "alice"),
+				new Claim("roles", SystemRoles.Admins)
+			]),
+			NotBefore = DateTime.UtcNow.AddMinutes(-1),
+			Expires = DateTime.UtcNow.AddMinutes(5),
+			SigningCredentials = new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256)
+		};
+
+		return new JsonWebTokenHandler().CreateToken(descriptor);
+	}
+
+	private static TokenValidationParameters CreateValidationParameters(SecurityKey signingKey) =>
+		new()
+		{
+			ValidateIssuer = true,
+			ValidIssuer = "https://login.example.test",
+			ValidateAudience = true,
+			ValidAudiences = ["eventstore"],
+			ValidateIssuerSigningKey = true,
+			IssuerSigningKey = signingKey,
+			ValidateLifetime = true,
+			ClockSkew = TimeSpan.Zero,
+			NameClaimType = "sub",
+			RoleClaimType = "roles"
+		};
+}

--- a/src/EventStore.Core.Tests/Authentication/OAuthAuthenticationProviderTests.cs
+++ b/src/EventStore.Core.Tests/Authentication/OAuthAuthenticationProviderTests.cs
@@ -85,6 +85,28 @@ public class OAuthAuthenticationProviderTests
 	}
 
 	[Test]
+	public void does_not_advertise_browser_flow_without_scopes()
+	{
+		var provider = new OAuthAuthenticationProvider(
+			new()
+			{
+				Issuer = "https://login.example.test",
+				Audiences = ["eventstore"],
+				AuthorizationEndpoint = "https://login.example.test/oauth2/auth",
+				TokenEndpoint = "https://login.example.test/oauth2/token",
+				ClientId = "eventstore-ui",
+				Scopes = []
+			},
+			logFailedAuthenticationAttempts: false,
+			_ => new ValueTask<TokenValidationParameters>(CreateValidationParameters(new SymmetricSecurityKey(new byte[32]))));
+
+		var properties = provider.GetPublicProperties().ToDictionary(x => x.Key, x => x.Value);
+
+		Assert.That(properties.ContainsKey("authorization_endpoint"), Is.False);
+		Assert.That(properties.ContainsKey("scope"), Is.False);
+	}
+
+	[Test]
 	public void advertises_configured_browser_flow_properties()
 	{
 		var provider = new OAuthAuthenticationProvider(

--- a/src/EventStore.Core.Tests/Authentication/OAuthBrowserFlowServiceTests.cs
+++ b/src/EventStore.Core.Tests/Authentication/OAuthBrowserFlowServiceTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.ClusterNode.Components.Services;
+using EventStore.Core;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Authentication;
+
+[TestFixture]
+public class OAuthBrowserFlowServiceTests
+{
+	[Test]
+	public void creates_code_challenge_using_browser_contract_names()
+	{
+		var service = new OAuthBrowserFlowService(Options(), new HttpClient(new TokenHandler()), TimeProvider.System);
+
+		var challenge = service.CreateCodeChallenge();
+		var json = JsonSerializer.Serialize(challenge, OAuthBrowserFlowService.JsonOptions);
+
+		Assert.That(json, Does.Contain("code_challenge_correlation_id"));
+		Assert.That(json, Does.Contain("code_challenge"));
+		Assert.That(json, Does.Contain("code_challenge_method"));
+		Assert.AreEqual("S256", challenge.CodeChallengeMethod);
+		Assert.That(challenge.CodeChallenge, Is.Not.Empty);
+		Assert.That(challenge.CodeChallengeCorrelationId, Is.Not.Empty);
+	}
+
+	[Test]
+	public async Task callback_exchanges_code_and_sets_oauth_token_cookie()
+	{
+		var handler = new TokenHandler();
+		var service = new OAuthBrowserFlowService(Options(), new HttpClient(handler), TimeProvider.System);
+		var challenge = service.CreateCodeChallenge();
+		var context = new DefaultHttpContext();
+		context.RequestServices = new ServiceCollection().AddLogging().BuildServiceProvider();
+		context.Request.Scheme = "https";
+		context.Request.Host = new HostString("node.example.test");
+		context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+		{
+			["code"] = new StringValues("authorization-code"),
+			["state"] = new StringValues(State(challenge.CodeChallengeCorrelationId))
+		});
+
+		var result = await service.HandleCallback(context, CancellationToken.None);
+		await result.ExecuteAsync(context);
+
+		Assert.AreEqual(HttpStatusCode.Redirect, (HttpStatusCode)context.Response.StatusCode);
+		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/signin"));
+		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Contain($"{UiCredentialCookie.OAuthCookieName}=access-token"));
+		Assert.That(handler.Body, Does.Contain("grant_type=authorization_code"));
+		Assert.That(handler.Body, Does.Contain("client_id=eventstore-ui"));
+		Assert.That(handler.Body, Does.Contain("redirect_uri=https%3A%2F%2Fnode.example.test%2Fui%2Fauth%2Foauth%2Fcallback"));
+		Assert.That(handler.Body, Does.Contain("code_verifier="));
+	}
+
+	private static ClusterVNodeOptions.OAuthOptions Options() => new()
+	{
+		Issuer = "https://login.example.test",
+		Audiences = ["eventstore"],
+		TokenEndpoint = "https://login.example.test/token",
+		ClientId = "eventstore-ui"
+	};
+
+	private static string State(string correlationId) =>
+		Convert.ToBase64String(Encoding.UTF8.GetBytes($$"""{"code_challenge_correlation_id":"{{correlationId}}"}"""));
+
+	private sealed class TokenHandler : HttpMessageHandler
+	{
+		public string Body { get; private set; } = "";
+
+		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			Body = await request.Content.ReadAsStringAsync(cancellationToken);
+			return new(HttpStatusCode.OK)
+			{
+				Content = new StringContent("""{"access_token":"access-token"}""", Encoding.UTF8, "application/json")
+			};
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Authentication/OAuthBrowserFlowServiceTests.cs
+++ b/src/EventStore.Core.Tests/Authentication/OAuthBrowserFlowServiceTests.cs
@@ -66,6 +66,29 @@ public class OAuthBrowserFlowServiceTests
 	}
 
 	[Test]
+	public async Task callback_redirects_to_return_url_when_admin_ui_is_disabled()
+	{
+		var handler = new TokenHandler();
+		var service = Service(handler, adminUiEnabled: false);
+		var challengeContext = HttpsContext();
+		var challenge = service.CreateCodeChallenge(challengeContext);
+		var context = HttpsContext();
+		context.Request.Headers.Cookie = challengeContext.Response.Headers.SetCookie.ToString().Split(';')[0];
+		context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+		{
+			["code"] = new StringValues("authorization-code"),
+			["state"] = new StringValues(State(challenge.CodeChallengeCorrelationId))
+		});
+
+		var result = await service.HandleCallback(context, CancellationToken.None);
+		await result.ExecuteAsync(context);
+
+		Assert.AreEqual(HttpStatusCode.Redirect, (HttpStatusCode)context.Response.StatusCode);
+		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/streams"));
+		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Contain($"{UiCredentialCookie.OAuthCookieName}=access-token"));
+	}
+
+	[Test]
 	public async Task callback_without_matching_challenge_cookie_does_not_exchange_code()
 	{
 		var handler = new TokenHandler();
@@ -106,6 +129,30 @@ public class OAuthBrowserFlowServiceTests
 
 		Assert.AreEqual(HttpStatusCode.Redirect, (HttpStatusCode)context.Response.StatusCode);
 		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/signin?returnUrl=%2Fui%2Fstreams&oauth_error=provider_error"));
+		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Not.Contain($"{UiCredentialCookie.OAuthCookieName}=access-token"));
+		Assert.That(handler.Body, Is.Empty);
+	}
+
+	[Test]
+	public async Task callback_with_provider_error_redirects_to_return_url_when_admin_ui_is_disabled()
+	{
+		var handler = new TokenHandler();
+		var service = Service(handler, adminUiEnabled: false);
+		var challengeContext = HttpsContext();
+		var challenge = service.CreateCodeChallenge(challengeContext);
+		var context = HttpsContext();
+		context.Request.Headers.Cookie = challengeContext.Response.Headers.SetCookie.ToString().Split(';')[0];
+		context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+		{
+			["error"] = new StringValues("access_denied"),
+			["state"] = new StringValues(State(challenge.CodeChallengeCorrelationId))
+		});
+
+		var result = await service.HandleCallback(context, CancellationToken.None);
+		await result.ExecuteAsync(context);
+
+		Assert.AreEqual(HttpStatusCode.Redirect, (HttpStatusCode)context.Response.StatusCode);
+		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/streams?oauth_error=provider_error"));
 		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Not.Contain($"{UiCredentialCookie.OAuthCookieName}=access-token"));
 		Assert.That(handler.Body, Is.Empty);
 	}
@@ -170,7 +217,7 @@ public class OAuthBrowserFlowServiceTests
 	private static string State(string correlationId, string redirectUri = "https://node.example.test/ui/auth/oauth/callback") =>
 		Convert.ToBase64String(Encoding.UTF8.GetBytes($$"""{"code_challenge_correlation_id":"{{correlationId}}","return_url":"/ui/streams","redirect_uri":"{{redirectUri}}"}"""));
 
-	private static OAuthBrowserFlowService Service(TokenHandler handler)
+	private static OAuthBrowserFlowService Service(TokenHandler handler, bool adminUiEnabled = true)
 	{
 		var services = new ServiceCollection()
 			.AddLogging()
@@ -181,7 +228,8 @@ public class OAuthBrowserFlowServiceTests
 			Options(),
 			new HttpClient(handler),
 			TimeProvider.System,
-			services.GetRequiredService<IDataProtectionProvider>());
+			services.GetRequiredService<IDataProtectionProvider>(),
+			adminUiEnabled);
 	}
 
 	private static DefaultHttpContext HttpsContext()

--- a/src/EventStore.Core.Tests/Authentication/OAuthBrowserFlowServiceTests.cs
+++ b/src/EventStore.Core.Tests/Authentication/OAuthBrowserFlowServiceTests.cs
@@ -3,16 +3,20 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.ClusterNode.Components.Services;
 using EventStore.Core;
+using EventStore.Core.Authentication.OAuth;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Authentication;
@@ -20,7 +24,10 @@ namespace EventStore.Core.Tests.Authentication;
 [TestFixture]
 public class OAuthBrowserFlowServiceTests
 {
-	private const string JwtToken = "header.payload.signature";
+	private static readonly SymmetricSecurityKey SigningKey =
+		new(Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").ToByteArray().Concat(
+			Guid.Parse("11111111-2222-3333-4444-555555555555").ToByteArray()).ToArray());
+	private static readonly string JwtToken = CreateToken(audience: "eventstore");
 
 	[Test]
 	public void creates_code_challenge_using_browser_contract_names()
@@ -110,6 +117,29 @@ public class OAuthBrowserFlowServiceTests
 
 		Assert.AreEqual(HttpStatusCode.Redirect, (HttpStatusCode)context.Response.StatusCode);
 		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/signin?returnUrl=%2Fui%2Fstreams&oauth_error=unsupported_token"));
+		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Not.Contain($"{UiCredentialCookie.OAuthCookieName}="));
+	}
+
+	[Test]
+	public async Task callback_rejects_token_that_fails_validation()
+	{
+		var handler = new TokenHandler($$"""{"access_token":"{{CreateToken(audience: "other-service")}}"}""");
+		var service = Service(handler);
+		var challengeContext = HttpsContext();
+		var challenge = service.CreateCodeChallenge(challengeContext);
+		var context = HttpsContext();
+		context.Request.Headers.Cookie = challengeContext.Response.Headers.SetCookie.ToString().Split(';')[0];
+		context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+		{
+			["code"] = new StringValues("authorization-code"),
+			["state"] = new StringValues(State(challenge.CodeChallengeCorrelationId))
+		});
+
+		var result = await service.HandleCallback(context, CancellationToken.None);
+		await result.ExecuteAsync(context);
+
+		Assert.AreEqual(HttpStatusCode.Redirect, (HttpStatusCode)context.Response.StatusCode);
+		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/signin?returnUrl=%2Fui%2Fstreams&oauth_error=invalid_token"));
 		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Not.Contain($"{UiCredentialCookie.OAuthCookieName}="));
 	}
 
@@ -254,8 +284,39 @@ public class OAuthBrowserFlowServiceTests
 			new HttpClient(handler),
 			TimeProvider.System,
 			services.GetRequiredService<IDataProtectionProvider>(),
+			new OAuthTokenValidator(Options(), _ => new ValueTask<TokenValidationParameters>(CreateValidationParameters())),
 			adminUiEnabled);
 	}
+
+	private static string CreateToken(string audience)
+	{
+		var descriptor = new SecurityTokenDescriptor
+		{
+			Issuer = "https://login.example.test",
+			Audience = audience,
+			Subject = new ClaimsIdentity([new Claim("sub", "alice")]),
+			NotBefore = DateTime.UtcNow.AddMinutes(-1),
+			Expires = DateTime.UtcNow.AddMinutes(5),
+			SigningCredentials = new SigningCredentials(SigningKey, SecurityAlgorithms.HmacSha256)
+		};
+
+		return new JsonWebTokenHandler().CreateToken(descriptor);
+	}
+
+	private static TokenValidationParameters CreateValidationParameters() =>
+		new()
+		{
+			ValidateIssuer = true,
+			ValidIssuer = "https://login.example.test",
+			ValidateAudience = true,
+			ValidAudiences = ["eventstore"],
+			ValidateIssuerSigningKey = true,
+			IssuerSigningKey = SigningKey,
+			ValidateLifetime = true,
+			ClockSkew = TimeSpan.Zero,
+			NameClaimType = "sub",
+			RoleClaimType = "roles"
+		};
 
 	private static DefaultHttpContext HttpsContext()
 	{
@@ -273,7 +334,12 @@ public class OAuthBrowserFlowServiceTests
 		private readonly string _response;
 		public string Body { get; private set; } = "";
 
-		public TokenHandler(string response = $$"""{"access_token":"{{JwtToken}}"}""") =>
+		public TokenHandler()
+			: this($$"""{"access_token":"{{JwtToken}}"}""")
+		{
+		}
+
+		public TokenHandler(string response) =>
 			_response = response;
 
 		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/EventStore.Core.Tests/Authentication/OAuthBrowserFlowServiceTests.cs
+++ b/src/EventStore.Core.Tests/Authentication/OAuthBrowserFlowServiceTests.cs
@@ -20,6 +20,8 @@ namespace EventStore.Core.Tests.Authentication;
 [TestFixture]
 public class OAuthBrowserFlowServiceTests
 {
+	private const string JwtToken = "header.payload.signature";
+
 	[Test]
 	public void creates_code_challenge_using_browser_contract_names()
 	{
@@ -58,7 +60,7 @@ public class OAuthBrowserFlowServiceTests
 
 		Assert.AreEqual(HttpStatusCode.Redirect, (HttpStatusCode)context.Response.StatusCode);
 		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/signin?returnUrl=%2Fui%2Fstreams"));
-		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Contain($"{UiCredentialCookie.OAuthCookieName}=access-token"));
+		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Contain($"{UiCredentialCookie.OAuthCookieName}={JwtToken}"));
 		Assert.That(handler.Body, Does.Contain("grant_type=authorization_code"));
 		Assert.That(handler.Body, Does.Contain("client_id=eventstore-ui"));
 		Assert.That(handler.Body, Does.Contain("redirect_uri=https%3A%2F%2Fnode.example.test%2Fui%2Fauth%2Foauth%2Fcallback"));
@@ -84,8 +86,31 @@ public class OAuthBrowserFlowServiceTests
 		await result.ExecuteAsync(context);
 
 		Assert.AreEqual(HttpStatusCode.Redirect, (HttpStatusCode)context.Response.StatusCode);
-		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/streams"));
-		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Contain($"{UiCredentialCookie.OAuthCookieName}=access-token"));
+		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/"));
+		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Contain($"{UiCredentialCookie.OAuthCookieName}={JwtToken}"));
+	}
+
+	[Test]
+	public async Task callback_rejects_opaque_token_response()
+	{
+		var handler = new TokenHandler("""{"access_token":"opaque-token"}""");
+		var service = Service(handler);
+		var challengeContext = HttpsContext();
+		var challenge = service.CreateCodeChallenge(challengeContext);
+		var context = HttpsContext();
+		context.Request.Headers.Cookie = challengeContext.Response.Headers.SetCookie.ToString().Split(';')[0];
+		context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+		{
+			["code"] = new StringValues("authorization-code"),
+			["state"] = new StringValues(State(challenge.CodeChallengeCorrelationId))
+		});
+
+		var result = await service.HandleCallback(context, CancellationToken.None);
+		await result.ExecuteAsync(context);
+
+		Assert.AreEqual(HttpStatusCode.Redirect, (HttpStatusCode)context.Response.StatusCode);
+		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/signin?returnUrl=%2Fui%2Fstreams&oauth_error=unsupported_token"));
+		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Not.Contain($"{UiCredentialCookie.OAuthCookieName}="));
 	}
 
 	[Test]
@@ -152,7 +177,7 @@ public class OAuthBrowserFlowServiceTests
 		await result.ExecuteAsync(context);
 
 		Assert.AreEqual(HttpStatusCode.Redirect, (HttpStatusCode)context.Response.StatusCode);
-		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/streams?oauth_error=provider_error"));
+		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/?oauth_error=provider_error"));
 		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Not.Contain($"{UiCredentialCookie.OAuthCookieName}=access-token"));
 		Assert.That(handler.Body, Is.Empty);
 	}
@@ -245,14 +270,18 @@ public class OAuthBrowserFlowServiceTests
 
 	private sealed class TokenHandler : HttpMessageHandler
 	{
+		private readonly string _response;
 		public string Body { get; private set; } = "";
+
+		public TokenHandler(string response = $$"""{"access_token":"{{JwtToken}}"}""") =>
+			_response = response;
 
 		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
 		{
 			Body = await request.Content.ReadAsStringAsync(cancellationToken);
 			return new(HttpStatusCode.OK)
 			{
-				Content = new StringContent("""{"access_token":"access-token"}""", Encoding.UTF8, "application/json")
+				Content = new StringContent(_response, Encoding.UTF8, "application/json")
 			};
 		}
 	}

--- a/src/EventStore.Core.Tests/Authentication/OAuthBrowserFlowServiceTests.cs
+++ b/src/EventStore.Core.Tests/Authentication/OAuthBrowserFlowServiceTests.cs
@@ -81,7 +81,31 @@ public class OAuthBrowserFlowServiceTests
 		await result.ExecuteAsync(context);
 
 		Assert.AreEqual(HttpStatusCode.Redirect, (HttpStatusCode)context.Response.StatusCode);
-		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/signin?oauth_error=invalid_state"));
+		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/signin?returnUrl=%2Fui%2Fstreams&oauth_error=invalid_state"));
+		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Not.Contain($"{UiCredentialCookie.OAuthCookieName}=access-token"));
+		Assert.That(handler.Body, Is.Empty);
+	}
+
+	[Test]
+	public async Task callback_with_provider_error_preserves_return_url_without_exchanging_code()
+	{
+		var handler = new TokenHandler();
+		var service = Service(handler);
+		var challengeContext = HttpsContext();
+		var challenge = service.CreateCodeChallenge(challengeContext);
+		var context = HttpsContext();
+		context.Request.Headers.Cookie = challengeContext.Response.Headers.SetCookie.ToString().Split(';')[0];
+		context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+		{
+			["error"] = new StringValues("access_denied"),
+			["state"] = new StringValues(State(challenge.CodeChallengeCorrelationId))
+		});
+
+		var result = await service.HandleCallback(context, CancellationToken.None);
+		await result.ExecuteAsync(context);
+
+		Assert.AreEqual(HttpStatusCode.Redirect, (HttpStatusCode)context.Response.StatusCode);
+		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/signin?returnUrl=%2Fui%2Fstreams&oauth_error=provider_error"));
 		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Not.Contain($"{UiCredentialCookie.OAuthCookieName}=access-token"));
 		Assert.That(handler.Body, Is.Empty);
 	}

--- a/src/EventStore.Core.Tests/Authentication/OAuthBrowserFlowServiceTests.cs
+++ b/src/EventStore.Core.Tests/Authentication/OAuthBrowserFlowServiceTests.cs
@@ -125,7 +125,12 @@ public class OAuthBrowserFlowServiceTests
 
 		Assert.AreEqual(HttpStatusCode.Redirect, (HttpStatusCode)context.Response.StatusCode);
 		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/signin?oauth_error=missing_callback"));
-		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Contain("eventstore-ui-oauth-pkce=;"));
+		var setCookie = context.Response.Headers.SetCookie.ToString();
+		Assert.That(setCookie, Does.Contain("eventstore-ui-oauth-pkce=;"));
+		Assert.That(setCookie, Does.Contain("path=/"));
+		Assert.That(setCookie, Does.Contain("secure"));
+		Assert.That(setCookie, Does.Contain("samesite=lax"));
+		Assert.That(setCookie, Does.Contain("httponly"));
 		Assert.That(handler.Body, Is.Empty);
 	}
 

--- a/src/EventStore.Core.Tests/Authentication/OAuthBrowserFlowServiceTests.cs
+++ b/src/EventStore.Core.Tests/Authentication/OAuthBrowserFlowServiceTests.cs
@@ -110,6 +110,50 @@ public class OAuthBrowserFlowServiceTests
 		Assert.That(handler.Body, Is.Empty);
 	}
 
+	[Test]
+	public async Task callback_deletes_pkce_cookie_when_callback_data_is_missing()
+	{
+		var handler = new TokenHandler();
+		var service = Service(handler);
+		var challengeContext = HttpsContext();
+		service.CreateCodeChallenge(challengeContext);
+		var context = HttpsContext();
+		context.Request.Headers.Cookie = challengeContext.Response.Headers.SetCookie.ToString().Split(';')[0];
+
+		var result = await service.HandleCallback(context, CancellationToken.None);
+		await result.ExecuteAsync(context);
+
+		Assert.AreEqual(HttpStatusCode.Redirect, (HttpStatusCode)context.Response.StatusCode);
+		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/signin?oauth_error=missing_callback"));
+		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Contain("eventstore-ui-oauth-pkce=;"));
+		Assert.That(handler.Body, Is.Empty);
+	}
+
+	[Test]
+	public async Task callback_exchanges_code_with_redirect_uri_from_state()
+	{
+		var handler = new TokenHandler();
+		var service = Service(handler);
+		var challengeContext = HttpsContext();
+		var challenge = service.CreateCodeChallenge(challengeContext);
+		var context = HttpsContext();
+		context.Request.Scheme = "http";
+		context.Request.Host = new HostString("internal-node:2113");
+		context.Request.Headers.Cookie = challengeContext.Response.Headers.SetCookie.ToString().Split(';')[0];
+		context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+		{
+			["code"] = new StringValues("authorization-code"),
+			["state"] = new StringValues(State(challenge.CodeChallengeCorrelationId, "https://public.example.test/ui/auth/oauth/callback"))
+		});
+
+		var result = await service.HandleCallback(context, CancellationToken.None);
+		await result.ExecuteAsync(context);
+
+		Assert.AreEqual(HttpStatusCode.Redirect, (HttpStatusCode)context.Response.StatusCode);
+		Assert.That(handler.Body, Does.Contain("redirect_uri=https%3A%2F%2Fpublic.example.test%2Fui%2Fauth%2Foauth%2Fcallback"));
+		Assert.That(handler.Body, Does.Not.Contain("redirect_uri=http%3A%2F%2Finternal-node%3A2113"));
+	}
+
 	private static ClusterVNodeOptions.OAuthOptions Options() => new()
 	{
 		Issuer = "https://login.example.test",
@@ -118,8 +162,8 @@ public class OAuthBrowserFlowServiceTests
 		ClientId = "eventstore-ui"
 	};
 
-	private static string State(string correlationId) =>
-		Convert.ToBase64String(Encoding.UTF8.GetBytes($$"""{"code_challenge_correlation_id":"{{correlationId}}","return_url":"/ui/streams"}"""));
+	private static string State(string correlationId, string redirectUri = "https://node.example.test/ui/auth/oauth/callback") =>
+		Convert.ToBase64String(Encoding.UTF8.GetBytes($$"""{"code_challenge_correlation_id":"{{correlationId}}","return_url":"/ui/streams","redirect_uri":"{{redirectUri}}"}"""));
 
 	private static OAuthBrowserFlowService Service(TokenHandler handler)
 	{

--- a/src/EventStore.Core.Tests/Authentication/OAuthBrowserFlowServiceTests.cs
+++ b/src/EventStore.Core.Tests/Authentication/OAuthBrowserFlowServiceTests.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EventStore.ClusterNode.Components.Services;
 using EventStore.Core;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
@@ -22,9 +23,10 @@ public class OAuthBrowserFlowServiceTests
 	[Test]
 	public void creates_code_challenge_using_browser_contract_names()
 	{
-		var service = new OAuthBrowserFlowService(Options(), new HttpClient(new TokenHandler()), TimeProvider.System);
+		var service = Service(new TokenHandler());
+		var context = HttpsContext();
 
-		var challenge = service.CreateCodeChallenge();
+		var challenge = service.CreateCodeChallenge(context);
 		var json = JsonSerializer.Serialize(challenge, OAuthBrowserFlowService.JsonOptions);
 
 		Assert.That(json, Does.Contain("code_challenge_correlation_id"));
@@ -33,18 +35,18 @@ public class OAuthBrowserFlowServiceTests
 		Assert.AreEqual("S256", challenge.CodeChallengeMethod);
 		Assert.That(challenge.CodeChallenge, Is.Not.Empty);
 		Assert.That(challenge.CodeChallengeCorrelationId, Is.Not.Empty);
+		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Contain("eventstore-ui-oauth-pkce="));
 	}
 
 	[Test]
 	public async Task callback_exchanges_code_and_sets_oauth_token_cookie()
 	{
 		var handler = new TokenHandler();
-		var service = new OAuthBrowserFlowService(Options(), new HttpClient(handler), TimeProvider.System);
-		var challenge = service.CreateCodeChallenge();
-		var context = new DefaultHttpContext();
-		context.RequestServices = new ServiceCollection().AddLogging().BuildServiceProvider();
-		context.Request.Scheme = "https";
-		context.Request.Host = new HostString("node.example.test");
+		var service = Service(handler);
+		var challengeContext = HttpsContext();
+		var challenge = service.CreateCodeChallenge(challengeContext);
+		var context = HttpsContext();
+		context.Request.Headers.Cookie = challengeContext.Response.Headers.SetCookie.ToString().Split(';')[0];
 		context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
 		{
 			["code"] = new StringValues("authorization-code"),
@@ -55,12 +57,33 @@ public class OAuthBrowserFlowServiceTests
 		await result.ExecuteAsync(context);
 
 		Assert.AreEqual(HttpStatusCode.Redirect, (HttpStatusCode)context.Response.StatusCode);
-		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/signin"));
+		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/signin?returnUrl=%2Fui%2Fstreams"));
 		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Contain($"{UiCredentialCookie.OAuthCookieName}=access-token"));
 		Assert.That(handler.Body, Does.Contain("grant_type=authorization_code"));
 		Assert.That(handler.Body, Does.Contain("client_id=eventstore-ui"));
 		Assert.That(handler.Body, Does.Contain("redirect_uri=https%3A%2F%2Fnode.example.test%2Fui%2Fauth%2Foauth%2Fcallback"));
 		Assert.That(handler.Body, Does.Contain("code_verifier="));
+	}
+
+	[Test]
+	public async Task callback_without_matching_challenge_cookie_does_not_exchange_code()
+	{
+		var handler = new TokenHandler();
+		var service = Service(handler);
+		var context = HttpsContext();
+		context.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+		{
+			["code"] = new StringValues("authorization-code"),
+			["state"] = new StringValues(State("not-this-browser"))
+		});
+
+		var result = await service.HandleCallback(context, CancellationToken.None);
+		await result.ExecuteAsync(context);
+
+		Assert.AreEqual(HttpStatusCode.Redirect, (HttpStatusCode)context.Response.StatusCode);
+		Assert.That(context.Response.Headers.Location.ToString(), Is.EqualTo("/ui/signin?oauth_error=invalid_state"));
+		Assert.That(context.Response.Headers.SetCookie.ToString(), Does.Not.Contain($"{UiCredentialCookie.OAuthCookieName}=access-token"));
+		Assert.That(handler.Body, Is.Empty);
 	}
 
 	private static ClusterVNodeOptions.OAuthOptions Options() => new()
@@ -72,7 +95,32 @@ public class OAuthBrowserFlowServiceTests
 	};
 
 	private static string State(string correlationId) =>
-		Convert.ToBase64String(Encoding.UTF8.GetBytes($$"""{"code_challenge_correlation_id":"{{correlationId}}"}"""));
+		Convert.ToBase64String(Encoding.UTF8.GetBytes($$"""{"code_challenge_correlation_id":"{{correlationId}}","return_url":"/ui/streams"}"""));
+
+	private static OAuthBrowserFlowService Service(TokenHandler handler)
+	{
+		var services = new ServiceCollection()
+			.AddLogging()
+			.AddDataProtection()
+			.Services
+			.BuildServiceProvider();
+		return new OAuthBrowserFlowService(
+			Options(),
+			new HttpClient(handler),
+			TimeProvider.System,
+			services.GetRequiredService<IDataProtectionProvider>());
+	}
+
+	private static DefaultHttpContext HttpsContext()
+	{
+		var context = new DefaultHttpContext
+		{
+			RequestServices = new ServiceCollection().AddLogging().BuildServiceProvider()
+		};
+		context.Request.Scheme = "https";
+		context.Request.Host = new HostString("node.example.test");
+		return context;
+	}
 
 	private sealed class TokenHandler : HttpMessageHandler
 	{

--- a/src/EventStore.Core.Tests/Authentication/SecurityBrowserServiceTests.cs
+++ b/src/EventStore.Core.Tests/Authentication/SecurityBrowserServiceTests.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Security.Claims;
+using EventStore.ClusterNode.Components.Services;
+using EventStore.Plugins.Authentication;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Authentication;
+
+[TestFixture]
+public class SecurityBrowserServiceTests
+{
+	[Test]
+	public void does_not_enable_oauth_browser_flow_with_blank_scope()
+	{
+		var service = new SecurityBrowserService(new BrowserFlowAuthenticationProvider([
+			new("authorization_endpoint", "https://login.example.test/oauth2/auth"),
+			new("client_id", "eventstore-ui"),
+			new("code_challenge_uri", "/oauth/challenge"),
+			new("redirect_uri", "/oauth/callback"),
+			new("response_type", "code"),
+			new("scope", "")
+		]));
+
+		var info = service.AuthenticationInfo();
+
+		Assert.That(info.SupportsOAuthBrowserFlow, Is.False);
+	}
+
+	private sealed class BrowserFlowAuthenticationProvider(
+		IReadOnlyList<KeyValuePair<string, string>> publicProperties)
+		: AuthenticationProviderBase(name: "test")
+	{
+		public override void Authenticate(AuthenticationRequest authenticationRequest) =>
+			authenticationRequest.Authenticated(
+				new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "test")], "test")));
+
+		public override IReadOnlyList<string> GetSupportedAuthenticationSchemes() => ["Bearer"];
+
+		public override IEnumerable<KeyValuePair<string, string>> GetPublicProperties() => publicProperties;
+	}
+}

--- a/src/EventStore.Core.Tests/Authentication/SecurityBrowserServiceTests.cs
+++ b/src/EventStore.Core.Tests/Authentication/SecurityBrowserServiceTests.cs
@@ -20,22 +20,47 @@ public class SecurityBrowserServiceTests
 			new("redirect_uri", "/oauth/callback"),
 			new("response_type", "code"),
 			new("scope", "")
-		]));
+		]), supportsPassword: false);
 
 		var info = service.AuthenticationInfo();
 
 		Assert.That(info.SupportsOAuthBrowserFlow, Is.False);
 	}
 
+	[Test]
+	public void does_not_enable_basic_for_certificate_only_transport_scheme()
+	{
+		var service = new SecurityBrowserService(
+			new BrowserFlowAuthenticationProvider([], ["Basic", "UserCertificate"]),
+			supportsPassword: false);
+
+		var info = service.AuthenticationInfo();
+
+		Assert.That(info.SupportsBasic, Is.False);
+	}
+
+	[Test]
+	public void enables_basic_when_password_authentication_is_configured()
+	{
+		var service = new SecurityBrowserService(
+			new BrowserFlowAuthenticationProvider([], ["Basic", "UserCertificate"]),
+			supportsPassword: true);
+
+		var info = service.AuthenticationInfo();
+
+		Assert.That(info.SupportsBasic, Is.True);
+	}
+
 	private sealed class BrowserFlowAuthenticationProvider(
-		IReadOnlyList<KeyValuePair<string, string>> publicProperties)
+		IReadOnlyList<KeyValuePair<string, string>> publicProperties,
+		IReadOnlyList<string> schemes = null)
 		: AuthenticationProviderBase(name: "test")
 	{
 		public override void Authenticate(AuthenticationRequest authenticationRequest) =>
 			authenticationRequest.Authenticated(
 				new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "test")], "test")));
 
-		public override IReadOnlyList<string> GetSupportedAuthenticationSchemes() => ["Bearer"];
+		public override IReadOnlyList<string> GetSupportedAuthenticationSchemes() => schemes ?? ["Bearer"];
 
 		public override IEnumerable<KeyValuePair<string, string>> GetPublicProperties() => publicProperties;
 	}

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -26,6 +26,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj" />
 		<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
+		<ProjectReference Include="..\EventStore.ClusterNode\EventStore.ClusterNode.csproj" />
 		<ProjectReference Include="..\EventStore.PluginHosting\EventStore.PluginHosting.csproj" />
 		<ProjectReference Include="..\EventStore.Transport.Tcp\EventStore.Transport.Tcp.csproj" />
 	</ItemGroup>

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -26,7 +26,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj" />
 		<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
-		<ProjectReference Include="..\EventStore.ClusterNode\EventStore.ClusterNode.csproj" />
+		<ProjectReference Include="..\EventStore.ClusterNode\EventStore.ClusterNode.csproj" PrivateAssets="all" />
 		<ProjectReference Include="..\EventStore.PluginHosting\EventStore.PluginHosting.csproj" />
 		<ProjectReference Include="..\EventStore.Transport.Tcp\EventStore.Transport.Tcp.csproj" />
 	</ItemGroup>

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/authentication_middleware_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/authentication_middleware_should.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using EventStore.Core.Services.Transport.Http;
@@ -48,6 +49,22 @@ public class authentication_middleware_should
 		Assert.AreEqual(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
 		Assert.False(context.Response.Headers.ContainsKey(HeaderNames.Location));
 		Assert.AreEqual("X-Basic realm=\"ESDB\"", context.Response.Headers.WWWAuthenticate);
+	}
+
+	[Test]
+	public async Task includes_every_supported_authentication_scheme_in_challenge()
+	{
+		var context = new DefaultHttpContext();
+		var middleware = new AuthenticationMiddleware(
+			[],
+			new TestAuthenticationProvider(["Basic", "Bearer"]));
+
+		await middleware.InvokeAsync(context, _ => Task.CompletedTask);
+
+		Assert.That(context.Response.Headers.WWWAuthenticate.ToArray(), Is.EqualTo(new[] {
+			"X-Basic realm=\"ESDB\"",
+			"X-Bearer realm=\"ESDB\""
+		}));
 	}
 
 	[Test]
@@ -101,11 +118,11 @@ public class authentication_middleware_should
 		}
 	}
 
-	private sealed class TestAuthenticationProvider : AuthenticationProviderBase
+	private sealed class TestAuthenticationProvider(IReadOnlyList<string> schemes = null) : AuthenticationProviderBase
 	{
 		public override void Authenticate(AuthenticationRequest authenticationRequest) =>
 			throw new System.NotImplementedException();
 
-		public override IReadOnlyList<string> GetSupportedAuthenticationSchemes() => ["Basic"];
+		public override IReadOnlyList<string> GetSupportedAuthenticationSchemes() => schemes ?? ["Basic"];
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/bearer_http_authentication_provider_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/bearer_http_authentication_provider_should.cs
@@ -1,0 +1,54 @@
+using EventStore.Core.Services.Transport.Http.Authentication;
+using EventStore.Plugins.Authentication;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Transport.Http.Authentication;
+
+[TestFixture]
+public class bearer_http_authentication_provider_should
+{
+	[Test]
+	public void pass_bearer_token_as_jwt_to_authentication_provider()
+	{
+		var authenticationProvider = new RecordingAuthenticationProvider();
+		var provider = new BearerHttpAuthenticationProvider(authenticationProvider);
+		var context = new DefaultHttpContext();
+		context.Request.Headers.Authorization = "Bearer access-token";
+
+		var handled = provider.Authenticate(context, out var request);
+
+		Assert.True(handled);
+		Assert.NotNull(request);
+		Assert.AreEqual(1, authenticationProvider.Calls);
+		Assert.AreEqual("access-token", authenticationProvider.Token);
+	}
+
+	[Test]
+	public void ignore_non_bearer_authorization_header()
+	{
+		var authenticationProvider = new RecordingAuthenticationProvider();
+		var provider = new BearerHttpAuthenticationProvider(authenticationProvider);
+		var context = new DefaultHttpContext();
+		context.Request.Headers.Authorization = "Basic credentials";
+
+		var handled = provider.Authenticate(context, out var request);
+
+		Assert.False(handled);
+		Assert.Null(request);
+		Assert.AreEqual(0, authenticationProvider.Calls);
+	}
+
+	private sealed class RecordingAuthenticationProvider : AuthenticationProviderBase
+	{
+		public int Calls { get; private set; }
+		public string Token { get; private set; }
+
+		public override void Authenticate(AuthenticationRequest authenticationRequest)
+		{
+			Calls++;
+			Token = authenticationRequest.GetToken("jwt");
+			authenticationRequest.Unauthorized();
+		}
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Authentication/AuthenticationMethodNamesTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Authentication/AuthenticationMethodNamesTests.cs
@@ -1,0 +1,30 @@
+using EventStore.Core.Authentication;
+using FluentAssertions;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Authentication;
+
+public class AuthenticationMethodNamesTests
+{
+	[Fact]
+	public void defaults_to_password_method()
+	{
+		AuthenticationMethodNames.FromOptions(new()).Should().Equal(AuthenticationMethodNames.Password);
+	}
+
+	[Fact]
+	public void maps_legacy_internal_to_password()
+	{
+		AuthenticationMethodNames.FromOptions(new() { AuthenticationType = "internal" })
+			.Should()
+			.Equal(AuthenticationMethodNames.Password);
+	}
+
+	[Fact]
+	public void normalizes_multiple_methods()
+	{
+		AuthenticationMethodNames.FromOptions(new() { Methods = ["Password", "OAuth", "oauth"] })
+			.Should()
+			.Equal(AuthenticationMethodNames.Password, AuthenticationMethodNames.OAuth);
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Authentication/AuthenticationMethodNamesTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Authentication/AuthenticationMethodNamesTests.cs
@@ -45,6 +45,22 @@ public class AuthenticationMethodNamesTests
 	}
 
 	[Fact]
+	public void oauth_uses_the_built_in_user_store()
+	{
+		AuthenticationMethodNames.IncludesBuiltInUserStore(new() { Methods = ["OAuth"] })
+			.Should()
+			.BeTrue();
+	}
+
+	[Fact]
+	public void external_authentication_without_oauth_does_not_use_the_built_in_user_store()
+	{
+		AuthenticationMethodNames.IncludesBuiltInUserStore(new() { AuthenticationType = "ldaps" })
+			.Should()
+			.BeFalse();
+	}
+
+	[Fact]
 	public void keeps_legacy_authentication_type_when_methods_are_not_configured()
 	{
 		AuthenticationMethodNames.FromOptions(new() { AuthenticationType = "ldaps" })

--- a/src/EventStore.Core.XUnit.Tests/Authentication/AuthenticationMethodNamesTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Authentication/AuthenticationMethodNamesTests.cs
@@ -27,4 +27,20 @@ public class AuthenticationMethodNamesTests
 			.Should()
 			.Equal(AuthenticationMethodNames.Password, AuthenticationMethodNames.OAuth);
 	}
+
+	[Fact]
+	public void methods_override_legacy_authentication_type()
+	{
+		AuthenticationMethodNames.FromOptions(new() { AuthenticationType = "ldaps", Methods = ["Password", "OAuth"] })
+			.Should()
+			.Equal(AuthenticationMethodNames.Password, AuthenticationMethodNames.OAuth);
+	}
+
+	[Fact]
+	public void keeps_legacy_authentication_type_when_methods_are_not_configured()
+	{
+		AuthenticationMethodNames.FromOptions(new() { AuthenticationType = "ldaps" })
+			.Should()
+			.Equal("ldaps");
+	}
 }

--- a/src/EventStore.Core.XUnit.Tests/Authentication/AuthenticationMethodNamesTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Authentication/AuthenticationMethodNamesTests.cs
@@ -37,6 +37,14 @@ public class AuthenticationMethodNamesTests
 	}
 
 	[Fact]
+	public void detects_oauth_method()
+	{
+		AuthenticationMethodNames.IncludesOAuth(new() { Methods = ["Password", "OAuth"] })
+			.Should()
+			.BeTrue();
+	}
+
+	[Fact]
 	public void keeps_legacy_authentication_type_when_methods_are_not_configured()
 	{
 		AuthenticationMethodNames.FromOptions(new() { AuthenticationType = "ldaps" })

--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsTests.cs
@@ -254,6 +254,87 @@ public class ClusterVNodeOptionsTests
 		});
 	}
 
+	[Fact]
+	public void can_set_authentication_methods_from_auth_section()
+	{
+		var config = new ConfigurationBuilder()
+			.AddEventStoreDefaultValues()
+			.AddSection(EventStoreConfigurationKeys.Prefix, builder => builder
+				.AddInMemoryCollection([
+					new KeyValuePair<string, string?>("Auth:Methods:0", "password"),
+					new KeyValuePair<string, string?>("Auth:Methods:1", "oauth"),
+				]))
+			.Build();
+
+		var options = ClusterVNodeOptions.FromConfiguration(config);
+
+		options.Auth.Methods.Should().Equal("password", "oauth");
+	}
+
+	[Fact]
+	public void can_set_authentication_methods_from_environment_variables()
+	{
+		var config = new ConfigurationBuilder()
+			.AddEventStoreDefaultValues()
+			.AddEventStoreEnvironmentVariables(
+				("EVENTSTORE__AUTH__METHODS__0", "password"),
+				("EVENTSTORE__AUTH__METHODS__1", "oauth"))
+			.Build();
+
+		var options = ClusterVNodeOptions.FromConfiguration(config);
+
+		options.Auth.Methods.Should().Equal("password", "oauth");
+	}
+
+	[Fact]
+	public void can_set_authentication_methods_from_command_line()
+	{
+		var config = new ConfigurationBuilder()
+			.AddEventStoreDefaultValues()
+			.AddEventStoreCommandLine("--auth:methods:0", "password", "--auth:methods:1", "oauth")
+			.Build();
+
+		var options = ClusterVNodeOptions.FromConfiguration(config);
+
+		options.Auth.Methods.Should().Equal("password", "oauth");
+	}
+
+	[Fact]
+	public void can_set_oauth_options_from_auth_section()
+	{
+		var config = new ConfigurationBuilder()
+			.AddEventStoreDefaultValues()
+			.AddSection(EventStoreConfigurationKeys.Prefix, builder => builder
+				.AddInMemoryCollection([
+					new KeyValuePair<string, string?>("Auth:OAuth:Issuer", "https://identity.example.com"),
+					new KeyValuePair<string, string?>("Auth:OAuth:Audiences:0", "eventstore"),
+				]))
+			.Build();
+
+		var options = ClusterVNodeOptions.FromConfiguration(config);
+
+		options.Auth.OAuth.Issuer.Should().Be("https://identity.example.com");
+		options.Auth.OAuth.Audiences.Should().Equal("eventstore");
+	}
+
+	[Fact]
+	public void auth_section_preserves_flat_authentication_type()
+	{
+		var config = new ConfigurationBuilder()
+			.AddEventStoreDefaultValues()
+			.AddSection(EventStoreConfigurationKeys.Prefix, builder => builder
+				.AddInMemoryCollection([
+					new KeyValuePair<string, string?>("AuthenticationType", "external"),
+					new KeyValuePair<string, string?>("Auth:OAuth:Issuer", "https://identity.example.com"),
+				]))
+			.Build();
+
+		var options = ClusterVNodeOptions.FromConfiguration(config);
+
+		options.Auth.AuthenticationType.Should().Be("external");
+		options.Auth.OAuth.Issuer.Should().Be("https://identity.example.com");
+	}
+
 	[Theory]
 	[InlineData("127.0.0.1", "You must specify the ports in the gossip seed.")]
 	[InlineData("127.0.0.1:3.1415", "Invalid format for gossip seed port: 3.1415.")]

--- a/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsValidatorTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Configuration/ClusterVNodeOptionsValidatorTests.cs
@@ -1,5 +1,7 @@
 using System;
 using EventStore.Common.Exceptions;
+using EventStore.Core.Authentication;
+using EventStore.Core.Services;
 using Xunit;
 
 namespace EventStore.Core.XUnit.Tests.Configuration;
@@ -80,5 +82,66 @@ public class ClusterVNodeOptionsValidatorTests
 		{
 			ClusterVNodeOptionsValidator.Validate(options);
 		});
+	}
+
+	[Fact]
+	public void startup_allows_default_user_passwords_when_oauth_needs_certificate_users()
+	{
+		var options = new ClusterVNodeOptions
+		{
+			Auth = new()
+			{
+				Methods = [AuthenticationMethodNames.OAuth]
+			},
+			DefaultUser = new()
+			{
+				DefaultAdminPassword = "admin-password",
+				DefaultOpsPassword = "ops-password"
+			}
+		};
+
+		Assert.True(ClusterVNodeOptionsValidator.ValidateForStartup(options));
+	}
+
+	[Fact]
+	public void startup_rejects_default_user_passwords_when_builtin_user_store_is_not_used()
+	{
+		var options = new ClusterVNodeOptions
+		{
+			Auth = new()
+			{
+				Methods = ["external"]
+			},
+			DefaultUser = new()
+			{
+				DefaultAdminPassword = "admin-password",
+				DefaultOpsPassword = "ops-password"
+			}
+		};
+
+		Assert.False(ClusterVNodeOptionsValidator.ValidateForStartup(options));
+	}
+
+	[Fact]
+	public void startup_rejects_default_user_passwords_when_auth_is_disabled()
+	{
+		var options = new ClusterVNodeOptions
+		{
+			Application = new()
+			{
+				Insecure = true
+			},
+			Auth = new()
+			{
+				Methods = [AuthenticationMethodNames.OAuth]
+			},
+			DefaultUser = new()
+			{
+				DefaultAdminPassword = "admin-password",
+				DefaultOpsPassword = SystemUsers.DefaultOpsPassword
+			}
+		};
+
+		Assert.False(ClusterVNodeOptionsValidator.ValidateForStartup(options));
 	}
 }

--- a/src/EventStore.Core/Authentication/AuthenticationMethodNames.cs
+++ b/src/EventStore.Core/Authentication/AuthenticationMethodNames.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EventStore.Core.Authentication;
+
+public static class AuthenticationMethodNames
+{
+	public const string LegacyInternal = "internal";
+	public const string Password = "password";
+	public const string OAuth = "oauth";
+
+	public static IReadOnlyList<string> FromOptions(ClusterVNodeOptions.AuthOptions options)
+	{
+		if (!IsLegacyInternal(options.AuthenticationType))
+		{
+			return [Normalize(options.AuthenticationType)];
+		}
+
+		var methods = options.Methods
+			.Where(method => !string.IsNullOrWhiteSpace(method))
+			.Select(Normalize)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.ToArray();
+
+		return methods.Length == 0 ? [Password] : methods;
+	}
+
+	public static bool IncludesPassword(ClusterVNodeOptions.AuthOptions options) =>
+		FromOptions(options).Any(IsPassword);
+
+	public static string Normalize(string method) =>
+		IsLegacyInternal(method) ? Password : method.Trim().ToLowerInvariant();
+
+	public static bool IsPassword(string method) =>
+		string.Equals(Normalize(method), Password, StringComparison.OrdinalIgnoreCase);
+
+	private static bool IsLegacyInternal(string method) =>
+		string.Equals(method?.Trim(), LegacyInternal, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/EventStore.Core/Authentication/AuthenticationMethodNames.cs
+++ b/src/EventStore.Core/Authentication/AuthenticationMethodNames.cs
@@ -29,6 +29,9 @@ public static class AuthenticationMethodNames
 	public static bool IncludesPassword(ClusterVNodeOptions.AuthOptions options) =>
 		FromOptions(options).Any(IsPassword);
 
+	public static bool IncludesOAuth(ClusterVNodeOptions.AuthOptions options) =>
+		FromOptions(options).Any(method => string.Equals(Normalize(method), OAuth, StringComparison.OrdinalIgnoreCase));
+
 	public static string Normalize(string method) =>
 		IsLegacyInternal(method) ? Password : method?.Trim().ToLowerInvariant() ?? string.Empty;
 

--- a/src/EventStore.Core/Authentication/AuthenticationMethodNames.cs
+++ b/src/EventStore.Core/Authentication/AuthenticationMethodNames.cs
@@ -32,6 +32,9 @@ public static class AuthenticationMethodNames
 	public static bool IncludesOAuth(ClusterVNodeOptions.AuthOptions options) =>
 		FromOptions(options).Any(method => string.Equals(Normalize(method), OAuth, StringComparison.OrdinalIgnoreCase));
 
+	public static bool IncludesBuiltInUserStore(ClusterVNodeOptions.AuthOptions options) =>
+		IncludesPassword(options) || IncludesOAuth(options);
+
 	public static string Normalize(string method) =>
 		IsLegacyInternal(method) ? Password : method?.Trim().ToLowerInvariant() ?? string.Empty;
 

--- a/src/EventStore.Core/Authentication/AuthenticationMethodNames.cs
+++ b/src/EventStore.Core/Authentication/AuthenticationMethodNames.cs
@@ -6,9 +6,9 @@ namespace EventStore.Core.Authentication;
 
 public static class AuthenticationMethodNames
 {
-	public const string LegacyInternal = "internal";
 	public const string Password = "password";
 	public const string OAuth = "oauth";
+	private const string LegacyInternal = "internal";
 
 	public static IReadOnlyList<string> FromOptions(ClusterVNodeOptions.AuthOptions options)
 	{

--- a/src/EventStore.Core/Authentication/AuthenticationMethodNames.cs
+++ b/src/EventStore.Core/Authentication/AuthenticationMethodNames.cs
@@ -12,7 +12,7 @@ public static class AuthenticationMethodNames
 
 	public static IReadOnlyList<string> FromOptions(ClusterVNodeOptions.AuthOptions options)
 	{
-		var methods = options.Methods
+		var methods = (options.Methods ?? [])
 			.Where(method => !string.IsNullOrWhiteSpace(method))
 			.Select(Normalize)
 			.Distinct(StringComparer.OrdinalIgnoreCase)
@@ -30,7 +30,7 @@ public static class AuthenticationMethodNames
 		FromOptions(options).Any(IsPassword);
 
 	public static string Normalize(string method) =>
-		IsLegacyInternal(method) ? Password : method.Trim().ToLowerInvariant();
+		IsLegacyInternal(method) ? Password : method?.Trim().ToLowerInvariant() ?? string.Empty;
 
 	public static bool IsPassword(string method) =>
 		string.Equals(Normalize(method), Password, StringComparison.OrdinalIgnoreCase);

--- a/src/EventStore.Core/Authentication/AuthenticationMethodNames.cs
+++ b/src/EventStore.Core/Authentication/AuthenticationMethodNames.cs
@@ -12,18 +12,18 @@ public static class AuthenticationMethodNames
 
 	public static IReadOnlyList<string> FromOptions(ClusterVNodeOptions.AuthOptions options)
 	{
-		if (!IsLegacyInternal(options.AuthenticationType))
-		{
-			return [Normalize(options.AuthenticationType)];
-		}
-
 		var methods = options.Methods
 			.Where(method => !string.IsNullOrWhiteSpace(method))
 			.Select(Normalize)
 			.Distinct(StringComparer.OrdinalIgnoreCase)
 			.ToArray();
 
-		return methods.Length == 0 ? [Password] : methods;
+		if (methods.Length > 0)
+		{
+			return methods;
+		}
+
+		return IsLegacyInternal(options.AuthenticationType) ? [Password] : [Normalize(options.AuthenticationType)];
 	}
 
 	public static bool IncludesPassword(ClusterVNodeOptions.AuthOptions options) =>

--- a/src/EventStore.Core/Authentication/CompositeAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/CompositeAuthenticationProvider.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventStore.Core.Authentication;
+
+public class CompositeAuthenticationProvider(IReadOnlyList<IAuthenticationProvider> providers)
+	: AuthenticationProviderBase(name: "methods", diagnosticsName: "CompositeAuthentication")
+{
+	public override Task Initialize() =>
+		Task.WhenAll(providers.Select(provider => provider.Initialize()));
+
+	public override void Authenticate(AuthenticationRequest authenticationRequest)
+	{
+		var scheme = SelectScheme(authenticationRequest);
+		var provider = providers.FirstOrDefault(candidate =>
+			candidate.GetSupportedAuthenticationSchemes()?.Contains(scheme, StringComparer.OrdinalIgnoreCase) == true);
+
+		if (provider is null)
+		{
+			authenticationRequest.Unauthorized();
+			return;
+		}
+
+		provider.Authenticate(authenticationRequest);
+	}
+
+	public override IEnumerable<KeyValuePair<string, string>> GetPublicProperties() =>
+		providers.SelectMany(provider => provider.GetPublicProperties() ?? []);
+
+	public override void ConfigureEndpoints(IEndpointRouteBuilder endpointRouteBuilder)
+	{
+		foreach (var provider in providers)
+		{
+			provider.ConfigureEndpoints(endpointRouteBuilder);
+		}
+	}
+
+	public override void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+	{
+		foreach (var provider in providers)
+		{
+			provider.ConfigureServices(services, configuration);
+		}
+	}
+
+	public override void ConfigureApplication(IApplicationBuilder app, IConfiguration configuration)
+	{
+		foreach (var provider in providers)
+		{
+			provider.ConfigureApplication(app, configuration);
+		}
+	}
+
+	public override IReadOnlyList<string> GetSupportedAuthenticationSchemes() =>
+		providers
+			.SelectMany(provider => provider.GetSupportedAuthenticationSchemes() ?? [])
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.ToArray();
+
+	private static string SelectScheme(AuthenticationRequest authenticationRequest)
+	{
+		if (!string.IsNullOrWhiteSpace(authenticationRequest.GetToken("jwt")))
+		{
+			return "Bearer";
+		}
+
+		return authenticationRequest.HasValidClientCertificate ? "UserCertificate" : "Basic";
+	}
+}

--- a/src/EventStore.Core/Authentication/CompositeAuthenticationProviderFactory.cs
+++ b/src/EventStore.Core/Authentication/CompositeAuthenticationProviderFactory.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Plugins.Authentication;
+
+namespace EventStore.Core.Authentication;
+
+public class CompositeAuthenticationProviderFactory(IReadOnlyList<IAuthenticationProviderFactory> factories)
+	: IAuthenticationProviderFactory
+{
+	public IAuthenticationProvider Build(bool logFailedAuthenticationAttempts)
+	{
+		var providers = factories
+			.Select(factory => factory.Build(logFailedAuthenticationAttempts))
+			.ToArray();
+
+		return providers.Length == 1 ? providers[0] : new CompositeAuthenticationProvider(providers);
+	}
+}

--- a/src/EventStore.Core/Authentication/OAuth/OAuthAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/OAuth/OAuthAuthenticationProvider.cs
@@ -1,0 +1,193 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Common.Exceptions;
+using EventStore.Plugins.Authentication;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using Serilog;
+
+namespace EventStore.Core.Authentication.OAuth;
+
+public class OAuthAuthenticationProvider : AuthenticationProviderBase
+{
+	private static readonly ILogger Log = Serilog.Log.ForContext<OAuthAuthenticationProvider>();
+
+	private readonly ClusterVNodeOptions.OAuthOptions _options;
+	private readonly bool _logFailedAuthenticationAttempts;
+	private readonly JsonWebTokenHandler _tokenHandler = new() { MapInboundClaims = false };
+	private readonly Func<CancellationToken, ValueTask<TokenValidationParameters>> _validationParametersFactory;
+
+	public OAuthAuthenticationProvider(
+		ClusterVNodeOptions.OAuthOptions options,
+		bool logFailedAuthenticationAttempts,
+		Func<CancellationToken, ValueTask<TokenValidationParameters>>? validationParametersFactory = null)
+		: base(name: "oauth", diagnosticsName: "OAuthAuthentication")
+	{
+		_options = options;
+		_logFailedAuthenticationAttempts = logFailedAuthenticationAttempts;
+		_validationParametersFactory = validationParametersFactory ?? CreateValidationParametersFactory(options);
+	}
+
+	public override void Authenticate(AuthenticationRequest authenticationRequest) =>
+		_ = AuthenticateAsync(authenticationRequest);
+
+	public override IReadOnlyList<string> GetSupportedAuthenticationSchemes() => ["Bearer"];
+
+	public override IEnumerable<KeyValuePair<string, string>> GetPublicProperties()
+	{
+		if (!string.IsNullOrWhiteSpace(_options.Issuer))
+		{
+			yield return new("oauth_issuer", _options.Issuer);
+		}
+
+		if (_options.Audiences.Length > 0)
+		{
+			yield return new("oauth_audiences", string.Join(",", _options.Audiences));
+		}
+	}
+
+	private async Task AuthenticateAsync(AuthenticationRequest authenticationRequest)
+	{
+		try
+		{
+			var token = authenticationRequest.GetToken("jwt");
+			if (string.IsNullOrWhiteSpace(token))
+			{
+				authenticationRequest.Unauthorized();
+				return;
+			}
+
+			var validationParameters = await _validationParametersFactory(CancellationToken.None);
+			var result = await _tokenHandler.ValidateTokenAsync(token, validationParameters);
+			if (!result.IsValid)
+			{
+				if (_logFailedAuthenticationAttempts)
+				{
+					Log.Warning("Authentication Failed for {Id}: {Reason}", authenticationRequest.Id, result.Exception?.Message ?? "Invalid OAuth token.");
+				}
+
+				authenticationRequest.Unauthorized();
+				return;
+			}
+
+			authenticationRequest.Authenticated(CreatePrincipal(result.ClaimsIdentity));
+		}
+		catch (Exception ex)
+		{
+			Log.Error(ex, "OAuth authentication failed unexpectedly.");
+			authenticationRequest.Error();
+		}
+	}
+
+	private ClaimsPrincipal CreatePrincipal(ClaimsIdentity claimsIdentity)
+	{
+		var claims = claimsIdentity.Claims.ToList();
+		var name = claimsIdentity.FindFirst(_options.NameClaimType)?.Value;
+		if (!string.IsNullOrWhiteSpace(name) && claims.All(claim => claim.Type != ClaimTypes.Name))
+		{
+			claims.Add(new Claim(ClaimTypes.Name, name));
+		}
+
+		foreach (var role in ExpandRoleClaims(claimsIdentity))
+		{
+			if (claims.All(claim => claim.Type != ClaimTypes.Role || claim.Value != role))
+			{
+				claims.Add(new Claim(ClaimTypes.Role, role));
+			}
+		}
+
+		return new(new ClaimsIdentity(claims, "OAuth", ClaimTypes.Name, ClaimTypes.Role));
+	}
+
+	private IEnumerable<string> ExpandRoleClaims(ClaimsIdentity claimsIdentity)
+	{
+		foreach (var claim in claimsIdentity.FindAll(_options.RoleClaimType))
+		{
+			if (claim.Value.StartsWith("[", StringComparison.Ordinal))
+			{
+				foreach (var role in ParseJsonArrayClaim(claim.Value))
+				{
+					yield return role;
+				}
+
+				continue;
+			}
+
+			yield return claim.Value;
+		}
+	}
+
+	private static IEnumerable<string> ParseJsonArrayClaim(string value)
+	{
+		string[]? values;
+		try
+		{
+			values = JsonSerializer.Deserialize<string[]>(value);
+		}
+		catch (JsonException)
+		{
+			yield break;
+		}
+
+		if (values is null)
+		{
+			yield break;
+		}
+
+		foreach (var item in values.Where(item => !string.IsNullOrWhiteSpace(item)))
+		{
+			yield return item;
+		}
+	}
+
+	private static Func<CancellationToken, ValueTask<TokenValidationParameters>> CreateValidationParametersFactory(
+		ClusterVNodeOptions.OAuthOptions options)
+	{
+		if (string.IsNullOrWhiteSpace(options.Issuer))
+		{
+			throw new InvalidConfigurationException("OAuth authentication requires Auth:OAuth:Issuer.");
+		}
+
+		if (options.Audiences.Length == 0)
+		{
+			throw new InvalidConfigurationException("OAuth authentication requires at least one Auth:OAuth:Audiences value.");
+		}
+
+		var metadataAddress = string.IsNullOrWhiteSpace(options.MetadataAddress)
+			? $"{options.Issuer.TrimEnd('/')}/.well-known/openid-configuration"
+			: options.MetadataAddress;
+
+		var retriever = new HttpDocumentRetriever { RequireHttps = options.RequireHttpsMetadata };
+		var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+			metadataAddress,
+			new OpenIdConnectConfigurationRetriever(),
+			retriever);
+
+		return async cancellationToken =>
+		{
+			var configuration = await configurationManager.GetConfigurationAsync(cancellationToken);
+			return new TokenValidationParameters
+			{
+				ValidateIssuer = true,
+				ValidIssuer = configuration.Issuer ?? options.Issuer,
+				ValidateAudience = true,
+				ValidAudiences = options.Audiences,
+				ValidateIssuerSigningKey = true,
+				IssuerSigningKeys = configuration.SigningKeys,
+				ValidateLifetime = true,
+				ClockSkew = TimeSpan.FromSeconds(options.ClockSkewSeconds),
+				NameClaimType = options.NameClaimType,
+				RoleClaimType = options.RoleClaimType
+			};
+		};
+	}
+}

--- a/src/EventStore.Core/Authentication/OAuth/OAuthAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/OAuth/OAuthAuthenticationProvider.cs
@@ -204,7 +204,8 @@ public class OAuthAuthenticationProvider : AuthenticationProviderBase
 	private static bool HasBrowserFlow(ClusterVNodeOptions.OAuthOptions options) =>
 		!string.IsNullOrWhiteSpace(options.ClientId) &&
 		!string.IsNullOrWhiteSpace(options.AuthorizationEndpoint) &&
-		!string.IsNullOrWhiteSpace(options.TokenEndpoint);
+		!string.IsNullOrWhiteSpace(options.TokenEndpoint) &&
+		options.Scopes.Any(scope => !string.IsNullOrWhiteSpace(scope));
 
 	private static string BrowserAuthorizationEndpoint(ClusterVNodeOptions.OAuthOptions options) =>
 		options.AuthorizationEndpoint!;

--- a/src/EventStore.Core/Authentication/OAuth/OAuthAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/OAuth/OAuthAuthenticationProvider.cs
@@ -23,8 +23,7 @@ public class OAuthAuthenticationProvider : AuthenticationProviderBase
 
 	private readonly ClusterVNodeOptions.OAuthOptions _options;
 	private readonly bool _logFailedAuthenticationAttempts;
-	private readonly JsonWebTokenHandler _tokenHandler = new() { MapInboundClaims = false };
-	private readonly Func<CancellationToken, ValueTask<TokenValidationParameters>> _validationParametersFactory;
+	private readonly OAuthTokenValidator _tokenValidator;
 
 	public OAuthAuthenticationProvider(
 		ClusterVNodeOptions.OAuthOptions options,
@@ -34,7 +33,7 @@ public class OAuthAuthenticationProvider : AuthenticationProviderBase
 	{
 		_options = options;
 		_logFailedAuthenticationAttempts = logFailedAuthenticationAttempts;
-		_validationParametersFactory = validationParametersFactory ?? CreateValidationParametersFactory(options);
+		_tokenValidator = new OAuthTokenValidator(options, validationParametersFactory);
 	}
 
 	public override void Authenticate(AuthenticationRequest authenticationRequest) =>
@@ -76,8 +75,7 @@ public class OAuthAuthenticationProvider : AuthenticationProviderBase
 				return;
 			}
 
-			var validationParameters = await _validationParametersFactory(CancellationToken.None);
-			var result = await _tokenHandler.ValidateTokenAsync(token, validationParameters);
+			var result = await _tokenValidator.ValidateTokenAsync(token, CancellationToken.None);
 			if (!result.IsValid)
 			{
 				if (_logFailedAuthenticationAttempts)
@@ -159,6 +157,32 @@ public class OAuthAuthenticationProvider : AuthenticationProviderBase
 		}
 	}
 
+	private static bool HasBrowserFlow(ClusterVNodeOptions.OAuthOptions options) =>
+		!string.IsNullOrWhiteSpace(options.ClientId) &&
+		!string.IsNullOrWhiteSpace(options.AuthorizationEndpoint) &&
+		!string.IsNullOrWhiteSpace(options.TokenEndpoint) &&
+		options.Scopes.Any(scope => !string.IsNullOrWhiteSpace(scope));
+
+	private static string BrowserAuthorizationEndpoint(ClusterVNodeOptions.OAuthOptions options) =>
+		options.AuthorizationEndpoint!;
+}
+
+public sealed class OAuthTokenValidator
+{
+	private readonly JsonWebTokenHandler _tokenHandler = new() { MapInboundClaims = false };
+	private readonly Func<CancellationToken, ValueTask<TokenValidationParameters>> _validationParametersFactory;
+
+	public OAuthTokenValidator(
+		ClusterVNodeOptions.OAuthOptions options,
+		Func<CancellationToken, ValueTask<TokenValidationParameters>>? validationParametersFactory = null) =>
+		_validationParametersFactory = validationParametersFactory ?? CreateValidationParametersFactory(options);
+
+	public async ValueTask<TokenValidationResult> ValidateTokenAsync(string token, CancellationToken cancellationToken)
+	{
+		var validationParameters = await _validationParametersFactory(cancellationToken);
+		return await _tokenHandler.ValidateTokenAsync(token, validationParameters);
+	}
+
 	private static Func<CancellationToken, ValueTask<TokenValidationParameters>> CreateValidationParametersFactory(
 		ClusterVNodeOptions.OAuthOptions options)
 	{
@@ -200,13 +224,4 @@ public class OAuthAuthenticationProvider : AuthenticationProviderBase
 			};
 		};
 	}
-
-	private static bool HasBrowserFlow(ClusterVNodeOptions.OAuthOptions options) =>
-		!string.IsNullOrWhiteSpace(options.ClientId) &&
-		!string.IsNullOrWhiteSpace(options.AuthorizationEndpoint) &&
-		!string.IsNullOrWhiteSpace(options.TokenEndpoint) &&
-		options.Scopes.Any(scope => !string.IsNullOrWhiteSpace(scope));
-
-	private static string BrowserAuthorizationEndpoint(ClusterVNodeOptions.OAuthOptions options) =>
-		options.AuthorizationEndpoint!;
 }

--- a/src/EventStore.Core/Authentication/OAuth/OAuthAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/OAuth/OAuthAuthenticationProvider.cs
@@ -53,6 +53,16 @@ public class OAuthAuthenticationProvider : AuthenticationProviderBase
 		{
 			yield return new("oauth_audiences", string.Join(",", _options.Audiences));
 		}
+
+		if (HasBrowserFlow(_options))
+		{
+			yield return new("authorization_endpoint", BrowserAuthorizationEndpoint(_options));
+			yield return new("client_id", _options.ClientId!);
+			yield return new("code_challenge_uri", _options.CodeChallengePath);
+			yield return new("redirect_uri", _options.RedirectPath);
+			yield return new("response_type", "code");
+			yield return new("scope", string.Join(" ", _options.Scopes));
+		}
 	}
 
 	private async Task AuthenticateAsync(AuthenticationRequest authenticationRequest)
@@ -190,4 +200,12 @@ public class OAuthAuthenticationProvider : AuthenticationProviderBase
 			};
 		};
 	}
+
+	private static bool HasBrowserFlow(ClusterVNodeOptions.OAuthOptions options) =>
+		!string.IsNullOrWhiteSpace(options.ClientId) &&
+		!string.IsNullOrWhiteSpace(options.AuthorizationEndpoint) &&
+		!string.IsNullOrWhiteSpace(options.TokenEndpoint);
+
+	private static string BrowserAuthorizationEndpoint(ClusterVNodeOptions.OAuthOptions options) =>
+		options.AuthorizationEndpoint!;
 }

--- a/src/EventStore.Core/Authentication/OAuth/OAuthAuthenticationProviderFactory.cs
+++ b/src/EventStore.Core/Authentication/OAuth/OAuthAuthenticationProviderFactory.cs
@@ -1,0 +1,9 @@
+using EventStore.Plugins.Authentication;
+
+namespace EventStore.Core.Authentication.OAuth;
+
+public class OAuthAuthenticationProviderFactory(ClusterVNodeOptions.OAuthOptions options) : IAuthenticationProviderFactory
+{
+	public IAuthenticationProvider Build(bool logFailedAuthenticationAttempts) =>
+		new OAuthAuthenticationProvider(options, logFailedAuthenticationAttempts);
+}

--- a/src/EventStore.Core/Authentication/UserCertificateAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/UserCertificateAuthenticationProvider.cs
@@ -37,5 +37,5 @@ public class UserCertificateAuthenticationProvider(IAuthenticationProvider inner
 	public override void ConfigureApplication(IApplicationBuilder app, IConfiguration configuration) =>
 		inner.ConfigureApplication(app, configuration);
 
-	public override IReadOnlyList<string> GetSupportedAuthenticationSchemes() => ["UserCertificate"];
+	public override IReadOnlyList<string> GetSupportedAuthenticationSchemes() => ["Basic", "UserCertificate"];
 }

--- a/src/EventStore.Core/Authentication/UserCertificateAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/UserCertificateAuthenticationProvider.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using EventStore.Plugins.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventStore.Core.Authentication;
+
+public class UserCertificateAuthenticationProvider(IAuthenticationProvider inner)
+	: AuthenticationProviderBase(name: "user-certificate", diagnosticsName: "UserCertificateAuthentication")
+{
+	public override Task Initialize() =>
+		inner.Initialize();
+
+	public override void Authenticate(AuthenticationRequest authenticationRequest)
+	{
+		if (!authenticationRequest.HasValidClientCertificate)
+		{
+			authenticationRequest.Unauthorized();
+			return;
+		}
+
+		inner.Authenticate(authenticationRequest);
+	}
+
+	public override IEnumerable<KeyValuePair<string, string>> GetPublicProperties() =>
+		inner.GetPublicProperties() ?? [];
+
+	public override void ConfigureEndpoints(IEndpointRouteBuilder endpointRouteBuilder) =>
+		inner.ConfigureEndpoints(endpointRouteBuilder);
+
+	public override void ConfigureServices(IServiceCollection services, IConfiguration configuration) =>
+		inner.ConfigureServices(services, configuration);
+
+	public override void ConfigureApplication(IApplicationBuilder app, IConfiguration configuration) =>
+		inner.ConfigureApplication(app, configuration);
+
+	public override IReadOnlyList<string> GetSupportedAuthenticationSchemes() => ["UserCertificate"];
+}

--- a/src/EventStore.Core/Authentication/UserCertificateAuthenticationProviderFactory.cs
+++ b/src/EventStore.Core/Authentication/UserCertificateAuthenticationProviderFactory.cs
@@ -1,0 +1,10 @@
+using EventStore.Plugins.Authentication;
+
+namespace EventStore.Core.Authentication;
+
+public class UserCertificateAuthenticationProviderFactory(IAuthenticationProviderFactory innerFactory)
+	: IAuthenticationProviderFactory
+{
+	public IAuthenticationProvider Build(bool logFailedAuthenticationAttempts) =>
+		new UserCertificateAuthenticationProvider(innerFactory.Build(logFailedAuthenticationAttempts));
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1105,7 +1105,7 @@ public class ClusterVNode<TStreamId> :
 			{
 				["projections"] = options.Projection.RunProjections != ProjectionType.None || options.DevMode.Dev,
 				["userManagement"] =
-					AuthenticationMethodNames.IncludesPassword(options.Auth) &&
+					AuthenticationMethodNames.IncludesBuiltInUserStore(options.Auth) &&
 					!options.Application.AuthDisabled()
 			},
 			_authenticationProvider

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1105,7 +1105,7 @@ public class ClusterVNode<TStreamId> :
 			{
 				["projections"] = options.Projection.RunProjections != ProjectionType.None || options.DevMode.Dev,
 				["userManagement"] =
-					options.Auth.AuthenticationType == Opts.AuthenticationTypeDefault &&
+					AuthenticationMethodNames.IncludesPassword(options.Auth) &&
 					!options.Application.AuthDisabled()
 			},
 			_authenticationProvider

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -235,10 +235,10 @@ public partial record ClusterVNodeOptions
 		[Description("Path to the configuration file for authorization configuration (if applicable).")]
 		public string? AuthorizationConfig { get; init; }
 
-		[Description("The type of Authentication to use.")]
+		[Description("Legacy authentication provider name. Prefer Authentication:Methods for new configurations.")]
 		public string AuthenticationType { get; init; } = "internal";
 
-		[Description("Authentication methods enabled by the node. PostgreSQL also models client authentication as a set of methods, which keeps password and OAuth authentication explicit.")]
+		[Description("Authentication methods enabled by the node. PostgreSQL also models client authentication this way, keeping password and OAuth explicit.")]
 		public string[] Methods { get; init; } = [];
 
 		[Description("Path to the configuration file for Authentication configuration (if applicable).")]

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -239,7 +239,7 @@ public partial record ClusterVNodeOptions
 		public string AuthenticationType { get; init; } = "internal";
 
 		[Description("Authentication methods enabled by the node. PostgreSQL also models client authentication as a set of methods, which keeps password and OAuth authentication explicit.")]
-		public string[] Methods { get; init; } = ["Password"];
+		public string[] Methods { get; init; } = [];
 
 		[Description("Path to the configuration file for Authentication configuration (if applicable).")]
 		public string? AuthenticationConfig { get; init; }

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -78,7 +78,7 @@ public partial record ClusterVNodeOptions
 			DevMode = configuration.BindOptions<DevModeOptions>(),
 			DefaultUser = configuration.BindOptions<DefaultUserOptions>(),
 			Logging = configuration.BindOptions<LoggingOptions>(),
-			Auth = configuration.BindOptions<AuthOptions>(),
+			Auth = BindOptions<AuthOptions>(configuration, nameof(Auth)),
 			Certificate = configuration.BindOptions<CertificateOptions>(),
 			CertificateFile = configuration.BindOptions<CertificateFileOptions>(),
 			CertificateStore = configuration.BindOptions<CertificateStoreOptions>(),
@@ -94,6 +94,18 @@ public partial record ClusterVNodeOptions
 		};
 
 		return options;
+
+		static T BindOptions<T>(IConfiguration configuration, string sectionName) where T : new()
+		{
+			var options = configuration.BindOptions<T>();
+			var section = configuration.GetSection(sectionName);
+			if (section.Exists())
+			{
+				section.Bind(options);
+			}
+
+			return options;
+		}
 	}
 
 	[Description("Default User Options")]
@@ -235,7 +247,7 @@ public partial record ClusterVNodeOptions
 		[Description("Path to the configuration file for authorization configuration (if applicable).")]
 		public string? AuthorizationConfig { get; init; }
 
-		[Description("Legacy authentication provider name. Prefer Authentication:Methods for new configurations.")]
+		[Description("Legacy authentication provider name. Prefer Auth:Methods for new configurations.")]
 		public string AuthenticationType { get; init; } = "internal";
 
 		[Description("Authentication methods enabled by the node. PostgreSQL also models client authentication this way, keeping password and OAuth explicit.")]

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -238,9 +238,39 @@ public partial record ClusterVNodeOptions
 		[Description("The type of Authentication to use.")]
 		public string AuthenticationType { get; init; } = "internal";
 
+		[Description("Authentication methods enabled by the node. PostgreSQL also models client authentication as a set of methods, which keeps password and OAuth authentication explicit.")]
+		public string[] Methods { get; init; } = ["Password"];
+
 		[Description("Path to the configuration file for Authentication configuration (if applicable).")]
 		public string? AuthenticationConfig { get; init; }
 
+		[Description("OAuth authentication options.")]
+		public OAuthOptions OAuth { get; init; } = new();
+
+	}
+
+	public record OAuthOptions
+	{
+		[Description("OpenID Connect issuer URL that signs accepted access tokens.")]
+		public string? Issuer { get; init; }
+
+		[Description("OpenID Connect discovery document URL. Defaults to '<Issuer>/.well-known/openid-configuration'.")]
+		public string? MetadataAddress { get; init; }
+
+		[Description("Accepted token audiences for this node.")]
+		public string[] Audiences { get; init; } = [];
+
+		[Description("Claim used as the authenticated user name.")]
+		public string NameClaimType { get; init; } = "sub";
+
+		[Description("Claim whose values are mapped to EventStore role claims.")]
+		public string RoleClaimType { get; init; } = "roles";
+
+		[Description("Require HTTPS for OpenID Connect metadata.")]
+		public bool RequireHttpsMetadata { get; init; } = true;
+
+		[Description("Allowed token clock skew in seconds.")]
+		public int ClockSkewSeconds { get; init; } = 300;
 	}
 
 	[Description("Certificate Options (from file)")]

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptions.cs
@@ -260,6 +260,28 @@ public partial record ClusterVNodeOptions
 		[Description("Accepted token audiences for this node.")]
 		public string[] Audiences { get; init; } = [];
 
+		[Description("OAuth authorization endpoint used by the browser sign-in flow.")]
+		public string? AuthorizationEndpoint { get; init; }
+
+		[Description("OAuth token endpoint used by the browser sign-in flow.")]
+		public string? TokenEndpoint { get; init; }
+
+		[Description("OAuth public client id used by the browser sign-in flow.")]
+		public string? ClientId { get; init; }
+
+		[Description("OAuth client secret used by confidential browser sign-in clients."),
+		 Sensitive]
+		public string? ClientSecret { get; init; }
+
+		[Description("OAuth scopes requested by the browser sign-in flow.")]
+		public string[] Scopes { get; init; } = ["openid", "profile"];
+
+		[Description("Path that receives the OAuth authorization-code callback.")]
+		public string RedirectPath { get; init; } = "/ui/auth/oauth/callback";
+
+		[Description("Path that creates PKCE code challenges for the OAuth browser sign-in flow.")]
+		public string CodeChallengePath { get; init; } = "/ui/auth/oauth/code-challenge";
+
 		[Description("Claim used as the authenticated user name.")]
 		public string NameClaimType { get; init; } = "sub";
 

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
@@ -150,8 +150,7 @@ public static class ClusterVNodeOptionsValidator
 			return false;
 		}
 
-		var needsDefaultUsers = AuthenticationMethodNames.IncludesPassword(options.Auth) ||
-								AuthenticationMethodNames.IncludesOAuth(options.Auth);
+		var needsDefaultUsers = AuthenticationMethodNames.IncludesBuiltInUserStore(options.Auth);
 		if (options.Application.AuthDisabled() || !needsDefaultUsers)
 		{
 			if (options.DefaultUser.DefaultAdminPassword != SystemUsers.DefaultAdminPassword)

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
@@ -150,7 +150,9 @@ public static class ClusterVNodeOptionsValidator
 			return false;
 		}
 
-		if (options.Application.AuthDisabled() || !AuthenticationMethodNames.IncludesPassword(options.Auth))
+		var needsDefaultUsers = AuthenticationMethodNames.IncludesPassword(options.Auth) ||
+								AuthenticationMethodNames.IncludesOAuth(options.Auth);
+		if (options.Application.AuthDisabled() || !needsDefaultUsers)
 		{
 			if (options.DefaultUser.DefaultAdminPassword != SystemUsers.DefaultAdminPassword)
 			{

--- a/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
+++ b/src/EventStore.Core/Configuration/ClusterVNodeOptionsValidator.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using EventStore.Common.Exceptions;
+using EventStore.Core.Authentication;
 using EventStore.Core.Services;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.Util;
@@ -149,17 +150,17 @@ public static class ClusterVNodeOptionsValidator
 			return false;
 		}
 
-		if (options.Application.AuthDisabled() || options.Auth.AuthenticationType != Opts.AuthenticationTypeDefault)
+		if (options.Application.AuthDisabled() || !AuthenticationMethodNames.IncludesPassword(options.Auth))
 		{
 			if (options.DefaultUser.DefaultAdminPassword != SystemUsers.DefaultAdminPassword)
 			{
-				Log.Error("Cannot set default admin password when not using the internal authentication.");
+				Log.Error("Cannot set default admin password when password authentication is not enabled.");
 				return false;
 			}
 
 			if (options.DefaultUser.DefaultOpsPassword != SystemUsers.DefaultOpsPassword)
 			{
-				Log.Error("Cannot set default ops password when not using the internal authentication.");
+				Log.Error("Cannot set default ops password when password authentication is not enabled.");
 				return false;
 			}
 		}

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -18,6 +18,8 @@
 		</PackageReference>
 		<PackageReference Include="JetBrains.Annotations" />
 		<PackageReference Include="librdkafka.redist" />
+		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+		<PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
 		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
 		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" />

--- a/src/EventStore.Core/Services/Transport/Http/AuthenticationMiddleware.cs
+++ b/src/EventStore.Core/Services/Transport/Http/AuthenticationMiddleware.cs
@@ -147,8 +147,11 @@ public class AuthenticationMiddleware : IMiddleware
 		var authSchemes = _authenticationProvider.GetSupportedAuthenticationSchemes();
 		if (authSchemes != null && authSchemes.Any())
 		{
-			//add "X-" in front to prevent any default browser behaviour e.g Basic Auth popups
-			context.Response.Headers.Append("WWW-Authenticate", $"X-{authSchemes.First()} realm=\"ESDB\"");
+			foreach (var scheme in authSchemes)
+			{
+				context.Response.Headers.Append("WWW-Authenticate", $"X-{scheme} realm=\"ESDB\"");
+			}
+
 			var properties = _authenticationProvider.GetPublicProperties();
 			if (properties != null && properties.Any())
 			{

--- a/src/EventStore.Core/Telemetry/TelemetryService.cs
+++ b/src/EventStore.Core/Telemetry/TelemetryService.cs
@@ -11,6 +11,7 @@ using DotNext;
 using DotNext.Collections.Generic;
 using DotNext.Runtime.CompilerServices;
 using EventStore.Common.Utils;
+using EventStore.Core.Authentication;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
@@ -223,7 +224,7 @@ public sealed class TelemetryService :
 				["disableTls"] = _nodeOptions.Application.DisableTls,
 				["runProjections"] = _nodeOptions.Projection.RunProjections.ToString(),
 				["authorizationType"] = _nodeOptions.Auth.AuthorizationType,
-				["authenticationType"] = _nodeOptions.Auth.AuthenticationType
+				["authenticationMethods"] = JsonSerializer.SerializeToNode(AuthenticationMethodNames.FromOptions(_nodeOptions.Auth))
 			}));
 
 		message.Envelope.ReplyWith(new TelemetryMessage.Response(

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -21,8 +21,6 @@ namespace EventStore.Core.Util
 
 		public const byte IndexBitnessVersionDefault = Index.PTableVersions.IndexV4;
 
-		public static readonly string AuthenticationTypeDefault = "internal";
-
 		public const bool SkipIndexScanOnReadsDefault = false;
 
 		public const long StreamExistenceFilterSizeDefault = 256_000_000;


### PR DESCRIPTION
- PostgreSQL's method-oriented authentication model gives operators a familiar way to reason about password and OAuth access side by side.
- Modern deployments need external IdP bearer-token authentication without making database auth depend on plugin-only extension points.
- Password authentication should remain available while OAuth is introduced so operators can migrate deliberately.