### PR TITLE
chore(docs): align product documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,6 @@ the [User Documentation](https://developers.trogondb.com/).
 
 Follow the [getting started guide](https://developers.trogondb.com/latest.html).
 
-## Getting started with Event Store Cloud
-
-Event Store can manage TrogonDB for you, so you don't have to run your own
-clusters.
-See the online documentation:
-[Getting started with Event Store Cloud](https://developers.trogondb.com/cloud/).
-
 ## Client libraries
 
 This guide shows you how to get started with TrogonDB by setting up an instance

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,78 +1,69 @@
 # Introduction
 
-Welcome to the EventStoreDB documentation.
+Welcome to the TrogonEventStore documentation.
 
-EventStoreDB is a database designed for [Event Sourcing](https://eventstore.com/blog/what-is-event-sourcing/). This documentation introduces key concepts of EventStoreDB and explains its installation, configuration, and operational concerns.
+TrogonEventStore is the open-source event database behind TrogonDB. It stores
+business events durably, streams them to consumers, and exposes operational
+surfaces for running a node or cluster.
 
-EventStoreDB is available in both an Open-Source and a Commercial version:
+## Current product direction
 
-- EventStoreDB OSS is the [open-source](https://github.com/EventStore/EventStore) and free-to-use edition of EventStoreDB.
-- EventStoreDB Commercial is available for customers with an EventStoreDB [paid support subscription](https://eventstore.com/support/). EventStoreDB Commercial adds enterprise-focused features such as LDAP and X.509 authentication, OpenTelemetry Exporter, correlation event sequence visualisation, and management CLI tool.
+TrogonEventStore keeps the database node focused on the durable event log:
 
-## What's new
+- Application event access is gRPC-first.
+- HTTP is reserved for the Admin UI, health probes, metrics, and other
+  infrastructure-level concerns.
+- The project is FOSS-only. The documentation does not describe unsupported
+  proprietary server features.
+- Rich read models, user-defined query engines, connector runtimes, and
+  projection execution are expected to live outside the database node unless a
+  local product decision says otherwise.
 
-Find out [what's new](whatsnew.md) in this release to get details on new features and other changes.
+Read the [architecture direction](architecture.md) before adding new runtime
+surfaces to the core node.
 
 ## Getting started
 
-Check the [installation guide](installation.md) for database setup and first-run guidance.
+Use the [installation guide](installation.md) for local development, Docker, and
+cluster startup guidance.
 
-## Architecture direction
+For a production node, review:
 
-Read the [architecture direction](architecture.md) before expanding database-node features. The project keeps
-the core node focused on durable event-log behavior and treats projection execution, rich read models, and
-custom query surfaces as external component work by default.
+- [Configuration](configuration.md)
+- [Networking](networking.md)
+- [Security](security.md)
+- [Operations](operations.md)
+- [Diagnostics](diagnostics/README.md)
 
-## Support
+## Protocols and clients
 
-### EventStoreDB community
+The supported application protocol is gRPC. Existing TrogonEventStore-compatible
+gRPC clients can be useful while the TrogonDB client libraries continue to
+evolve, but the server documentation should be treated as authoritative for this
+repository.
 
-Users of EventStoreDB OSS can use the [community forum](https://discuss.eventstore.com) for questions, discussions and getting help from community members.
+HTTP endpoints are not an application event API. They are used for browser UI,
+health, metrics, and infrastructure integration.
 
-### Enterprise customers
+## Admin UI
 
-Customers with the paid [support plan](https://eventstore.com/support/) can open tickets using the [support portal](https://eventstore.freshdesk.com).
+The embedded Admin UI is served from the node and is documented in
+[Admin UI](admin-ui.md). It is browser plumbing for operators, not a replacement
+for the gRPC application API.
 
-### Issues
+## Observability
 
-Since EventStoreDB is an open-source product, we track most of the issues openly in the EventStoreDB [repository on GitHub](https://github.com/EventStore/EventStore). Before opening an issue, please ensure that a similar issue hasn't been opened already. Also, try searching closed issues that might contain a solution or workaround for your problem.
+Use [metrics](diagnostics/metrics.md), [logs](diagnostics/logs.md), and
+[OpenTelemetry integration](diagnostics/integrations.md) for production
+observability.
 
-When opening an issue, follow our [guidelines](https://github.com/EventStore/EventStore/blob/master/CONTRIBUTING.md) for bug reports and feature requests. By doing so, you will greatly help us to solve your concerns most efficiently.
+The HTTP probe endpoints are:
 
-## Protocols, clients, and SDKs
+- `/-/liveness`
+- `/-/readiness`
+- `/-/metrics`
 
-EventStoreDB supports one client protocol, which is described below. The older TCP client API has been deprecated in version 20.2 and removed in version 24.2. The final version with TCP API support is 23.10. More information can be found in our [blog post](https://www.eventstore.com/blog/sunsetting-eventstoredb-tcp-based-client-protocol).
+## Support and issues
 
-Since version 24.6, the legacy protocol is available as a [commercial plugin](networking.md#external-tcp) available for Event Store customers.
-
-### Client protocol
-
-The client protocol is based on [open standards](https://grpc.io/) and is widely supported by many programming languages. EventStoreDB uses gRPC to communicate between the cluster nodes as well as for client-server communication.
-
-When developing software that uses EventStoreDB, we recommend using one of the official SDKs.
-
-#### EventStoreDB supported clients
-
-- Python: [pyeventsourcing/esdbclient](https://pypi.org/project/esdbclient/)
-- Node.js (JavaScript/TypeScript): [EventStore/EventStore-Client-NodeJS](https://github.com/EventStore/EventStore-Client-NodeJS)
-- Java: [EventStore/EventStoreDB-Client-Java](https://github.com/EventStore/EventStoreDB-Client-Java)
-- .NET: [EventStore/EventStore-Client-Dotnet](https://github.com/EventStore/EventStore-Client-Dotnet)
-- Go: [EventStore/EventStore-Client-Go](https://github.com/EventStore/EventStore-Client-Go)
-- Rust: [EventStore/EventStoreDB-Client-Rust](https://github.com/EventStore/EventStoreDB-Client-Rust)
-
-Use the official SDK documentation for language-specific gRPC client guidance.
-
-#### Community developed clients
-
-- [Ruby (yousty/event_store_client)](https://github.com/yousty/event_store_client)
-- [Elixir (NFIBrokerage/spear)](https://github.com/NFIBrokerage/spear)
-
-### HTTP
-
-EventStoreDB also offers HTTP surfaces for the Admin UI, management workflows, health probes, gossip, and diagnostics. Application event access uses the gRPC clients listed above.
-
-Find out more about configuring the HTTP protocol on the [HTTP configuration](networking.md#http-configuration) page.
-
-#### Community developed clients
-
-- [Ruby (yousty/event_store_client)](https://github.com/yousty/event_store_client)
+Use the TrogonStack repository and community channels for issues, discussions,
+and feature requests for this distribution.

--- a/docs/admin-ui.md
+++ b/docs/admin-ui.md
@@ -4,7 +4,7 @@ title: Admin UI
 
 # Admin UI
 
-The EventStoreDB Admin UI is available at `http://SERVER_IP:2113/ui` and helps operators inspect and manage a node or cluster from the browser.
+The TrogonEventStore Admin UI is available at `http://SERVER_IP:2113/ui` and helps operators inspect and manage a node or cluster from the browser.
 
 ## Dashboard
 

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -217,6 +217,10 @@ You can add read-only replica nodes, which will not become cluster members and w
 
 A cluster asynchronously replicates data one way to a node with the read-only replica role. The read-only replica node is not part of the cluster, so does not add to the replication requirements needed to acknowledge a write. For this reason a node with a read-only replica role does not add much overhead to the other nodes.
 
+Do not include read-only replicas in `ClusterSize`. On every node, including each read-only replica, set
+`ClusterSize` to the number of voting Leader and Follower nodes. For example, a deployment with three voting
+nodes and one read-only replica uses `ClusterSize: 3` on all four nodes.
+
 You need to explicitly configure the node as a read-only replica using this setting:
 
 | Format               | Syntax                         |

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -4,22 +4,22 @@ title: Clustering
 
 ## Highly-available cluster
 
-EventStoreDB allows you to run more than one node in a cluster for high availability.
+TrogonEventStore allows you to run more than one node in a cluster for high availability.
 
 ::: info Cluster member authentication
-EventStoreDB starts in secure mode by default, which requires configuration [settings for certificates](security.md#certificates-configuration).
+TrogonEventStore starts in secure mode by default, which requires configuration [settings for certificates](security.md#certificates-configuration).
 Cluster members authenticate each other using the certificate Common Name. All the cluster nodes must have the same common name in their certificates.
 :::
 
 ### Cluster nodes
 
-EventStoreDB clusters follow a "shared nothing" philosophy, meaning that clustering requires no shared disks. Instead, each node has a copy of the data to ensure it is not lost in case of a drive failure or a node crashing. 
+TrogonEventStore clusters follow a "shared nothing" philosophy, meaning that clustering requires no shared disks. Instead, each node has a copy of the data to ensure it is not lost in case of a drive failure or a node crashing.
 
 ::: tip
 Lean more about [node roles](#node-roles).
 :::
 
-EventStoreDB uses a quorum-based replication model, in which a majority of nodes in the cluster must acknowledge that they have received a copy of the write before the write is acknowledged to the client. This means that to be able to tolerate the failure of _n_ nodes, the cluster must be of size _(2n + 1)_. A three node cluster can continue to accept writes if one node is unavailable. A five node cluster can continue to accept writes if two nodes are unavailable, and so forth.
+TrogonEventStore uses a quorum-based replication model, in which a majority of nodes in the cluster must acknowledge that they have received a copy of the write before the write is acknowledged to the client. This means that to be able to tolerate the failure of _n_ nodes, the cluster must be of size _(2n + 1)_. A three node cluster can continue to accept writes if one node is unavailable. A five node cluster can continue to accept writes if two nodes are unavailable, and so forth.
 
 ### Cluster size
 
@@ -45,7 +45,7 @@ Common values for the `ClusterSize` setting are three or five (to have a majorit
 
 Cluster nodes use the gossip protocol to discover each other and elect the cluster leader.
 
-Cluster nodes need to know about one another to gossip. To start this process, you provide gossip seeds for each node. 
+Cluster nodes need to know about one another to gossip. To start this process, you provide gossip seeds for each node.
 
 Configure cluster nodes to discover other nodes in one of two ways:
 - [via a DNS entry](#cluster-with-dns) and a well-known [gossip port](#gossip-port)
@@ -61,7 +61,7 @@ Learn more about [internal TCP configuration](networking.md#replication-protocol
 
 ## Cluster with DNS
 
-When you tell EventStoreDB to use DNS for its gossip, the server will resolve the DNS name to a list of IP addresses and connect to each of those addresses to find other nodes. This method is very flexible because you can change the list of nodes on your DNS server without changing the cluster configuration. The DNS method is also useful in automated deployment scenarios when you control both the cluster deployment and the DNS server from your infrastructure-as-code scripts.
+When you tell TrogonEventStore to use DNS for its gossip, the server will resolve the DNS name to a list of IP addresses and connect to each of those addresses to find other nodes. This method is very flexible because you can change the list of nodes on your DNS server without changing the cluster configuration. The DNS method is also useful in automated deployment scenarios when you control both the cluster deployment and the DNS server from your infrastructure-as-code scripts.
 
 To use DNS discovery, you need to set the `ClusterDns` option to the DNS name that allows making an HTTP call to it. When the server starts, it will attempt to make a gRPC call using the `https://<cluster-dns>:<gossip-port>` URL (`http` if the cluster is insecure).
 
@@ -105,7 +105,7 @@ The setting accepts a comma-separated list of IP addresses or host names with th
 
 ## Gossip protocol
 
-EventStoreDB uses a quorum-based replication model. When working normally, a cluster has one node known as a leader, and the remaining nodes are followers. The leader node is responsible for coordinating writes while it is the leader. Cluster nodes use a consensus algorithm to determine which node should be the leader and which should be followers. EventStoreDB bases the decision as to which node should be the leader on a number of factors.
+TrogonEventStore uses a quorum-based replication model. When working normally, a cluster has one node known as a leader, and the remaining nodes are followers. The leader node is responsible for coordinating writes while it is the leader. Cluster nodes use a consensus algorithm to determine which node should be the leader and which should be followers. TrogonEventStore bases the decision as to which node should be the leader on a number of factors.
 
 For a cluster node to have this information available to them, the nodes gossip with other nodes in the cluster. Gossip runs over HTTP interfaces of cluster nodes.
 
@@ -143,7 +143,7 @@ The default value is two seconds (2000 ms).
 
 ### Time difference toleration
 
-EventStoreDB expects the time on cluster nodes to be in sync within a given tolerance.
+TrogonEventStore expects the time on cluster nodes to be in sync within a given tolerance.
 
 If different nodes have their clock out of sync for a number of milliseconds that exceeds the value of this setting, the gossip is rejected and the node will not be accepted as a cluster member.
 
@@ -171,7 +171,7 @@ If your cluster network is congested, you might increase the gossip timeout usin
 
 ### Gossip on single node
 
-You can connect using gossip seeds regardless of whether you have a cluster or not. In the previous versions of EventStoreDB gossip on a single node was disabled. Starting from 21.2 it is enabled by default.
+You can connect using gossip seeds regardless of whether you have a cluster or not. In the previous versions of TrogonEventStore gossip on a single node was disabled. Starting from 21.2 it is enabled by default.
 
 ::: warning
 Please note that the `GossipOnSingleNode` option is deprecated and will be removed in a future version. The client gossip read operation is now unconditionally available for any deployment topology.
@@ -201,7 +201,7 @@ In some cases the leader election messages may be delayed, which can result in e
 
 ## Node roles
 
-Every node in a stable EventStoreDB deployment settles into one of three roles: Leader, Follower, and ReadOnlyReplica. The cluster is composed of the Leader and Followers.
+Every node in a stable TrogonEventStore deployment settles into one of three roles: Leader, Follower, and ReadOnlyReplica. The cluster is composed of the Leader and Followers.
 
 ### Leader
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,7 @@ server installation directory on Windows. You can either change this file or cre
 TrogonEventStore to use it.
 
 To tell the TrogonEventStore server to use a different configuration file, you pass the file path on the command
-line with `--config=filename`, or use the `CONFIG`
+line with `--config=filename`, or use the `EVENTSTORE_CONFIG`
 environment variable.
 
 ### Environment variables
@@ -102,190 +102,8 @@ When you run TrogonEventStore with this option, it will print out the effective 
 available sources (default and custom configuration file, environment variables and command line parameters)
 and print it out to the console.
 
-::: details Click here to see a WhatIf example
-
-```
-$ eventstored --what-if
-[68443, 1,17:38:39.178,INF] 
-[68443, 1,17:38:39.186,INF] "OS ARCHITECTURE:"        X64 
-[68443, 1,17:38:39.207,INF] "OS:"                     Linux ("Unix 5.19.0.1025")
-[68443, 1,17:38:39.210,INF] "RUNTIME:"                ".NET 6.0.21/e40b3abf1" (64-bit)
-[68443, 1,17:38:39.211,INF] "GC:"                     "3 GENERATIONS" "IsServerGC: True" "Latency Mode: Interactive"
-[68443, 1,17:38:39.212,INF] "LOGS:"                   "/var/log/eventstore"
-[68443, 1,17:38:39.251,INF] 
-MODIFIED OPTIONS:
-    Application Options:
-         WHAT IF:                                 true (Command Line)
-
-
-DEFAULT OPTIONS:
-    Application Options:
-         ALLOW ANONYMOUS ENDPOINT ACCESS:         True (<DEFAULT>)
-         ALLOW ANONYMOUS STREAM ACCESS:           True (<DEFAULT>)
-         ALLOW UNKNOWN OPTIONS:                   False (<DEFAULT>)
-         CONFIG:                                  /etc/eventstore/eventstore.conf (<DEFAULT>)
-         DISABLE HTTP CACHING:                    False (<DEFAULT>)
-         HELP:                                    False (<DEFAULT>)
-         LOG FAILED AUTHENTICATION ATTEMPTS:      False (<DEFAULT>)
-         LOG HTTP REQUESTS:                       False (<DEFAULT>)
-         MAX APPEND SIZE:                         1048576 (<DEFAULT>)
-         SKIP INDEX SCAN ON READS:                False (<DEFAULT>)
-         STATS PERIOD SEC:                        30 (<DEFAULT>)
-         VERSION:                                 False (<DEFAULT>)
-         WORKER THREADS:                          0 (<DEFAULT>)
-
-    Authentication/Authorization Options:
-         AUTHENTICATION CONFIG:                   <empty> (<DEFAULT>)
-         AUTHENTICATION TYPE:                     internal (<DEFAULT>)
-         AUTHORIZATION CONFIG:                    <empty> (<DEFAULT>)
-         AUTHORIZATION TYPE:                      internal (<DEFAULT>)
-         DISABLE FIRST LEVEL HTTP AUTHORIZATION:  False (<DEFAULT>)
-
-    Certificate Options:
-         CERTIFICATE RESERVED NODE COMMON NAME:   eventstoredb-node (<DEFAULT>)
-         TRUSTED ROOT CERTIFICATES PATH:          /etc/ssl/certs (<DEFAULT>)
-
-    Certificate Options (from file):
-         CERTIFICATE FILE:                        <empty> (<DEFAULT>)
-         CERTIFICATE PASSWORD:                    <empty> (<DEFAULT>)
-         CERTIFICATE PRIVATE KEY FILE:            <empty> (<DEFAULT>)
-         CERTIFICATE PRIVATE KEY PASSWORD:        <empty> (<DEFAULT>)
-
-    Certificate Options (from store):
-         CERTIFICATE STORE LOCATION:              <empty> (<DEFAULT>)
-         CERTIFICATE STORE NAME:                  <empty> (<DEFAULT>)
-         CERTIFICATE SUBJECT NAME:                <empty> (<DEFAULT>)
-         CERTIFICATE THUMBPRINT:                  <empty> (<DEFAULT>)
-         TRUSTED ROOT CERTIFICATE STORE LOCATION: <empty> (<DEFAULT>)
-         TRUSTED ROOT CERTIFICATE STORE NAME:     <empty> (<DEFAULT>)
-         TRUSTED ROOT CERTIFICATE SUBJECT NAME:   <empty> (<DEFAULT>)
-         TRUSTED ROOT CERTIFICATE THUMBPRINT:     <empty> (<DEFAULT>)
-
-    Cluster Options:
-         CLUSTER DNS:                             fake.dns (<DEFAULT>)
-         CLUSTER GOSSIP PORT:                     2113 (<DEFAULT>)
-         CLUSTER SIZE:                            1 (<DEFAULT>)
-         DEAD MEMBER REMOVAL PERIOD SEC:          1800 (<DEFAULT>)
-         DISCOVER VIA DNS:                        True (<DEFAULT>)
-         GOSSIP ALLOWED DIFFERENCE MS:            60000 (<DEFAULT>)
-         GOSSIP INTERVAL MS:                      2000 (<DEFAULT>)
-         GOSSIP SEED:                             <empty> (<DEFAULT>)
-         GOSSIP TIMEOUT MS:                       2500 (<DEFAULT>)
-         LEADER ELECTION TIMEOUT MS:              1000 (<DEFAULT>)
-         NODE PRIORITY:                           0 (<DEFAULT>)
-         QUORUM SIZE:                             1 (<DEFAULT>)
-         READ ONLY REPLICA:                       False (<DEFAULT>)
-         STREAM INFO CACHE CAPACITY:              0 (<DEFAULT>)
-         UNSAFE ALLOW SURPLUS NODES:              False (<DEFAULT>)
-
-    Database Options:
-         ALWAYS KEEP SCAVENGED:                   False (<DEFAULT>)
-         CACHED CHUNKS:                           -1 (<DEFAULT>)
-         CHUNK INITIAL READER COUNT:              5 (<DEFAULT>)
-         CHUNK SIZE:                              268435456 (<DEFAULT>)
-         CHUNKS CACHE SIZE:                       536871424 (<DEFAULT>)
-         COMMIT TIMEOUT MS:                       2000 (<DEFAULT>)
-         DB:                                      /var/lib/eventstore (<DEFAULT>)
-         DB LOG FORMAT:                           V2 (<DEFAULT>)
-         DISABLE SCAVENGE MERGING:                False (<DEFAULT>)
-         HASH COLLISION READ LIMIT:               100 (<DEFAULT>)
-         INDEX:                                   <empty> (<DEFAULT>)
-         INDEX CACHE DEPTH:                       16 (<DEFAULT>)
-         INDEX CACHE SIZE:                        0 (<DEFAULT>)
-         INITIALIZATION THREADS:                  1 (<DEFAULT>)
-         MAX AUTO MERGE INDEX LEVEL:              2147483647 (<DEFAULT>)
-         MAX MEM TABLE SIZE:                      1000000 (<DEFAULT>)
-         MAX TRUNCATION:                          268435456 (<DEFAULT>)
-         MIN FLUSH DELAY MS:                      2 (<DEFAULT>)
-         OPTIMIZE INDEX MERGE:                    False (<DEFAULT>)
-         PREPARE TIMEOUT MS:                      2000 (<DEFAULT>)
-         READER THREADS COUNT:                    0 (<DEFAULT>)
-         REDUCE FILE CACHE PRESSURE:              False (<DEFAULT>)
-         SCAVENGE BACKEND CACHE SIZE:             67108864 (<DEFAULT>)
-         SCAVENGE BACKEND PAGE SIZE:              16384 (<DEFAULT>)
-         SCAVENGE HASH USERS CACHE CAPACITY:      100000 (<DEFAULT>)
-         SCAVENGE HISTORY MAX AGE:                30 (<DEFAULT>)
-         SKIP DB VERIFY:                          False (<DEFAULT>)
-         SKIP INDEX VERIFY:                       False (<DEFAULT>)
-         STATS STORAGE:                           File (<DEFAULT>)
-         STREAM EXISTENCE FILTER SIZE:            256000000 (<DEFAULT>)
-         UNBUFFERED:                              False (<DEFAULT>)
-         UNSAFE DISABLE FLUSH TO DISK:            False (<DEFAULT>)
-         UNSAFE IGNORE HARD DELETE:               False (<DEFAULT>)
-         USE INDEX BLOOM FILTERS:                 True (<DEFAULT>)
-         WRITE STATS TO DB:                       False (<DEFAULT>)
-         WRITE THROUGH:                           False (<DEFAULT>)
-         WRITE TIMEOUT MS:                        2000 (<DEFAULT>)
-
-    Default User Options:
-         DEFAULT ADMIN PASSWORD:                  **** (<DEFAULT>)
-         DEFAULT OPS PASSWORD:                    **** (<DEFAULT>)
-
-    Dev mode Options:
-         DEV:                                     False (<DEFAULT>)
-         REMOVE DEV CERTS:                        False (<DEFAULT>)
-
-    gRPC Options:
-         KEEP ALIVE INTERVAL:                     10000 (<DEFAULT>)
-         KEEP ALIVE TIMEOUT:                      10000 (<DEFAULT>)
-
-    Interface Options:
-         ADVERTISE HOST TO CLIENT AS:             <empty> (<DEFAULT>)
-         ADVERTISE HTTP PORT TO CLIENT AS:        0 (<DEFAULT>)
-         ADVERTISE NODE PORT TO CLIENT AS:        0 (<DEFAULT>)
-         CONNECTION PENDING SEND BYTES THRESHOLD: 10485760 (<DEFAULT>)
-         CONNECTION QUEUE SIZE THRESHOLD:         50000 (<DEFAULT>)
-         DISABLE ADMIN UI:                        False (<DEFAULT>)
-         DISABLE INTERNAL TCP TLS:                False (<DEFAULT>)
-         DISABLE STATS ON HTTP:                   False (<DEFAULT>)
-         ENABLE ATOM PUB OVER HTTP:               False (<DEFAULT>)
-         ENABLE TRUSTED AUTH:                     False (<DEFAULT>)
-         ENABLE UNIX SOCKET:                      False (<DEFAULT>)
-         EXT HOST ADVERTISE AS:                   <empty> (<DEFAULT>)
-         EXT IP:                                  127.0.0.1 (<DEFAULT>)
-         GOSSIP ON SINGLE NODE:                   <empty> (<DEFAULT>)
-         HTTP PORT:                               2113 (<DEFAULT>)
-         HTTP PORT ADVERTISE AS:                  0 (<DEFAULT>)
-         INT HOST ADVERTISE AS:                   <empty> (<DEFAULT>)
-         INT IP:                                  127.0.0.1 (<DEFAULT>)
-         INT TCP HEARTBEAT INTERVAL:              700 (<DEFAULT>)
-         INT TCP HEARTBEAT TIMEOUT:               700 (<DEFAULT>)
-         INT TCP PORT:                            1112 (<DEFAULT>)
-         INT TCP PORT ADVERTISE AS:               0 (<DEFAULT>)
-         NODE HEARTBEAT INTERVAL:                 2000 (<DEFAULT>)
-         NODE HEARTBEAT TIMEOUT:                  1000 (<DEFAULT>)
-         NODE HOST ADVERTISE AS:                  <empty> (<DEFAULT>)
-         NODE IP:                                 127.0.0.1 (<DEFAULT>)
-         NODE PORT:                               2113 (<DEFAULT>)
-         NODE PORT ADVERTISE AS:                  0 (<DEFAULT>)
-         REPLICATION HEARTBEAT INTERVAL:          700 (<DEFAULT>)
-         REPLICATION HEARTBEAT TIMEOUT:           700 (<DEFAULT>)
-         REPLICATION HOST ADVERTISE AS:           <empty> (<DEFAULT>)
-         REPLICATION IP:                          127.0.0.1 (<DEFAULT>)
-         REPLICATION PORT:                        1112 (<DEFAULT>)
-         REPLICATION TCP PORT ADVERTISE AS:       0 (<DEFAULT>)
-
-    Logging Options:
-         DISABLE LOG FILE:                        False (<DEFAULT>)
-         LOG:                                     /var/log/eventstore (<DEFAULT>)
-         LOG CONFIG:                              logconfig.json (<DEFAULT>)
-         LOG CONSOLE FORMAT:                      Plain (<DEFAULT>)
-         LOG FILE INTERVAL:                       Day (<DEFAULT>)
-         LOG FILE RETENTION COUNT:                31 (<DEFAULT>)
-         LOG FILE SIZE:                           1073741824 (<DEFAULT>)
-         LOG LEVEL:                               Default (<DEFAULT>)
-
-    Projection Options:
-         FAULT OUT OF ORDER PROJECTIONS:          False (<DEFAULT>)
-         PROJECTION COMPILATION TIMEOUT:          500 (<DEFAULT>)
-         PROJECTION EXECUTION TIMEOUT:            250 (<DEFAULT>)
-         PROJECTION THREADS:                      3 (<DEFAULT>)
-         PROJECTIONS QUERY EXPIRY:                5 (<DEFAULT>)
-         RUN PROJECTIONS:                         None (<DEFAULT>)
-         START STANDARD PROJECTIONS:              False (<DEFAULT>)
-
-```
-:::
+The exact output is generated from the current option model and lists each effective value and its
+configuration source.
 
 ::: note 
 Version 21.6 introduced a stricter configuration check: the server will _not start_ when an unknown
@@ -308,7 +126,9 @@ machines.
 
 These options are `StreamInfoCacheCapacity`, `ReadConcurrencyLimit`, and `WorkerThreads`.
 
-Autoconfiguration does not apply in containerized environments.
+When these options remain `0`, non-container deployments derive defaults from available resources. Containers
+use fixed defaults of 100,000 stream-info entries, 4 reader threads, and 5 worker threads. Explicit positive
+values take precedence.
 
 ### StreamInfoCacheCapacity
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,29 +4,29 @@ title: "How-to"
 
 ## Configuration options
 
-EventStoreDB has a number of configuration options that can be changed. You can find all the options described
+TrogonEventStore has a number of configuration options that can be changed. You can find all the options described
 in details in this section.
 
-When you don't change the configuration, EventStoreDB will use sensible defaults, but they might not suit your
-needs. You can always instruct EventStoreDB to use a different set of options. There are multiple ways to
-configure EventStoreDB server, described below.
+When you don't change the configuration, TrogonEventStore will use sensible defaults, but they might not suit your
+needs. You can always instruct TrogonEventStore to use a different set of options. There are multiple ways to
+configure TrogonEventStore server, described below.
 
 ### Version and help
 
-You can check what version of EventStoreDB you have installed by using the `--version` parameter in the
+You can check what version of TrogonEventStore you have installed by using the `--version` parameter in the
 command line. For example:
 
 :::: code-group
 ::: code Linux
 ```bash:no-line-numbers
 $ eventstored --version
-EventStoreDB version 24.6.0.0 (v24.6.0-alpha-16-g8e06f9f77/8e06f9f77, 2023-10-24T22:05:57-05:00)
+TrogonEventStore version <version>
 ```
 :::
 ::: code Windows
 ```powershell:no-line-numbers
 > EventStore.ClusterNode.exe --version
-EventStoreDB version 24.6.0.0 (v24.6.0-alpha-16-g8e06f9f77/8e06f9f77, 2023-10-24T22:05:57-05:00)
+TrogonEventStore version <version>
 ```
 :::
 ::::
@@ -42,7 +42,7 @@ them from a configuration management system.
 
 The default configuration file name is `eventstore.conf` and it's located in
 - **Linux:** `/etc/eventstore/`
-- **Windows:** EventStoreDB installation directory
+- **Windows:** TrogonEventStore installation directory
 
 The configuration file has YAML-compatible format. The basic format of the YAML configuration file is as
 follows:
@@ -59,9 +59,9 @@ You need to use the three dashes and spacing in your YAML file.
 
 The default configuration file name is `eventstore.conf`. It is located in `/etc/eventstore/` on Linux and the
 server installation directory on Windows. You can either change this file or create another file and instruct
-EventStoreDB to use it.
+TrogonEventStore to use it.
 
-To tell the EventStoreDB server to use a different configuration file, you pass the file path on the command
+To tell the TrogonEventStore server to use a different configuration file, you pass the file path on the command
 line with `--config=filename`, or use the `CONFIG`
 environment variable.
 
@@ -77,7 +77,7 @@ Environment variables override all the options specified in configuration files.
 
 You can also override options from both configuration files and environment variables using the command line.
 
-For example, starting EventStoreDB with the `--log` option will override the default log files location:
+For example, starting TrogonEventStore with the `--log` option will override the default log files location:
 
 :::: code-group
 ::: code-group-item Linux
@@ -98,7 +98,7 @@ If more than one method is used to configure the server, it might be hard to fin
 configuration will be when the server starts. To help to find out just that, you can use the `--what-if`
 option.
 
-When you run EventStoreDB with this option, it will print out the effective configuration applied from all
+When you run TrogonEventStore with this option, it will print out the effective configuration applied from all
 available sources (default and custom configuration file, environment variables and command line parameters)
 and print it out to the console.
 
@@ -325,7 +325,7 @@ By default, the cache dynamically resizes according to the amount of free memory
 | Environment variable | `EVENTSTORE_STREAM_INFO_CACHE_CAPACITY` |
 
 The option is set to 0 by default, which enables dynamic resizing. The default on previous versions of
-EventStoreDb was 100,000 entries.
+TrogonEventStore was 100,000 entries.
 
 ::: note
 The default value of 0 for `StreamInfoCacheCapacity` might not always be the best value for optimal performance. Ideally, it should be set to double the number of streams in the anticipated working set.
@@ -337,7 +337,7 @@ It should be noted that the total number of streams does not necessarily give yo
 
 ### ReadConcurrencyLimit
 
-This option configures the number of read requests EventStoreDb can process concurrently. Having more reader threads
+This option configures the number of read requests TrogonEventStore can process concurrently. Having more reader threads
 allows more concurrent reads to be processed.
 
 The reader threads count will be set at startup to twice the number of available processors, with a minimum of
@@ -350,7 +350,7 @@ The reader threads count will be set at startup to twice the number of available
 | Environment variable | `EVENTSTORE_READ_CONCURRENCY_LIMIT` |
 
 The option is set to 0 by default, which enables autoconfiguration. The default on previous versions of
-EventStoreDb was 4 threads.
+TrogonEventStore was 4 threads.
 
 ::: warning 
 Increasing the reader threads count too high can cause read timeouts if your disk cannot handle the
@@ -371,45 +371,16 @@ it will be set to have 5 threads available.
 | Environment variable | `EVENTSTORE_WORKER_THREADS` |
 
 The option is set to 0 by default, which enables autoconfiguration. The default on previous versions of
-EventStoreDb was 5 threads.
+TrogonEventStore was 5 threads.
 
-## Plugins configuration
+## Component configuration
 
-The commercial edition of EventStoreDB ships with several plugins that augment the behavior of the open source server. Each plugin is documented in relevant sections. For example, under Security, you will find the User Certificates plugin documentation.
+The supported server configuration surface is documented in this guide and in
+the feature-specific pages linked from it.
 
-The plugins (apart from the `ldap` plugin) are configured separately to the main server configuration and can be configured via `json` files and `environment variables`.
+Some runtime configuration keys retain the inherited `EventStore` prefix for
+compatibility. Do not treat undocumented plugin keys as supported product
+features.
 
-Environment variables take precedence.
-
-#### JSON files
-
-Each configurable plugin comes with a sample JSON file in the `<installation-directory>/plugins/<plugin-name>` directory.
-Here is an example file called `user-certificates-plugin-example.json` to enable the user certificates plugin.
-
-```json
-{
-  "EventStore": {
-    "Plugins": {
-      "UserCertificates": {
-        "Enabled": true
-      }
-    }
-  }
-}
-```
-
-The system looks for JSON configuration files in a `<installation-directory>/config/` directory, and on Linux and OS X, the server additionally looks in `/etc/eventstore/config/`. To take effect, JSON configuration must be saved to one of these locations.
-
-The JSON configuration may be split across multiple files or combined into a single file. Apart from the `.json` extension, the names of the files is not important.
-
-#### Environment variables
-
-Any configuration can alternatively be provided via environment variables.
-
-Use `__` as the level delimiter.
-
-For example, the key configured above in json can also be set with the following environment variable:
-
-```:no-line-numbers
-EventStore__Plugins__UserCertificates__Enabled
-```
+Environment variables can configure nested sections by using `__` as the level
+delimiter.

--- a/docs/db-config.md
+++ b/docs/db-config.md
@@ -4,13 +4,13 @@ title: Database
 
 ## Database settings
 
-On this page, you find settings that tune the database server behaviour. Only modify these settings if you know what you are doing or when requested by Event Store support personnel.
+On this page, you find settings that tune the database server behaviour. Only modify these settings if you know what you are doing or when requested by project maintainers.
 
 ### Database location
 
-EventStoreDB has a single database, which is spread across ever-growing number of physical files on the file system. Those files are called chunks and new data is always appended to the end of the latest chunk. When the chunk grows over 256 MiB, the server closes the chunk and opens a new one.
+TrogonEventStore has a single database, which is spread across ever-growing number of physical files on the file system. Those files are called chunks and new data is always appended to the end of the latest chunk. When the chunk grows over 256 MiB, the server closes the chunk and opens a new one.
 
-Normally, you'd want to keep the database files separated from the OS and other application files. The `Db` setting tells EventStoreDB where to put those chunk files. If the database server doesn't find anything at the specified location, it will create a new database.
+Normally, you'd want to keep the database files separated from the OS and other application files. The `Db` setting tells TrogonEventStore where to put those chunk files. If the database server doesn't find anything at the specified location, it will create a new database.
 
 | Format               | Syntax          |
 |:---------------------|:----------------|
@@ -18,11 +18,11 @@ Normally, you'd want to keep the database files separated from the OS and other 
 | YAML                 | `Db`            |
 | Environment variable | `EVENTSTORE_DB` |
 
-**Default**: the default database location is platform specific. On Windows, the database will be stored in the `data` directory inside the EventStoreDB installation location. On Linux, it will be `/var/lib/eventstore`.
+**Default**: the default database location is platform specific. On Windows, the database will be stored in the `data` directory inside the TrogonEventStore installation location. On Linux, it will be `/var/lib/eventstore`.
 
 ### Skip database verification
 
-When the database node restarts, it checks the database files to ensure they aren't corrupted. It is a lengthy process and can take hours on a large database. EventStoreDB normally flushes every write to disk, so database files are unlikely to get corrupted. In an environment where nodes restart often for some reason, you might want to disable the database verification to allow faster startup of the node.
+When the database node restarts, it checks the database files to ensure they aren't corrupted. It is a lengthy process and can take hours on a large database. TrogonEventStore normally flushes every write to disk, so database files are unlikely to get corrupted. In an environment where nodes restart often for some reason, you might want to disable the database verification to allow faster startup of the node.
 
 | Format               | Syntax                      |
 |:---------------------|:----------------------------|
@@ -90,9 +90,9 @@ Depending on your client operation timeout settings (default is 7 seconds), incr
 Using this option might cause data loss.
 :::
 
-This will prevent EventStoreDB from forcing the flush to disk after writes. Please note that this is unsafe in case of a power outage.
+This will prevent TrogonEventStore from forcing the flush to disk after writes. Please note that this is unsafe in case of a power outage.
 
-With this option enabled, EventStoreDB will still write data to the disk at the application level but not necessarily at the OS level. Usually, the OS should flush its buffers at regular intervals or when a process exits but it is something that's opaque to EventStoreDB.
+With this option enabled, TrogonEventStore will still write data to the disk at the application level but not necessarily at the OS level. Usually, the OS should flush its buffers at regular intervals or when a process exits but it is something that's opaque to TrogonEventStore.
 
 | Format               | Syntax                                    |
 |:---------------------|:------------------------------------------|
@@ -161,10 +161,10 @@ Increasing the count of reader threads can improve performance up to a point, bu
 
 ### Garbage collection
 
-EventStoreDB runs with .NET Server GC enabled. Server GC improves throughput for database workloads by using multiple GC threads, but it can also let the managed heap grow larger before a collection runs.
+TrogonEventStore runs with .NET Server GC enabled. Server GC improves throughput for database workloads by using multiple GC threads, but it can also let the managed heap grow larger before a collection runs.
 
-To keep memory available for the operating system page cache and other database buffers, EventStoreDB sets the .NET `System.GC.HeapHardLimitPercent` runtime option to `60` by default. The runtime interprets this as a percentage of the available process memory limit. In containers, that means the container memory limit when one is configured.
+To keep memory available for the operating system page cache and other database buffers, TrogonEventStore sets the .NET `System.GC.HeapHardLimitPercent` runtime option to `60` by default. The runtime interprets this as a percentage of the available process memory limit. In containers, that means the container memory limit when one is configured.
 
-The heap limit is separate from EventStoreDB cache settings such as `StreamInfoCacheCapacity`, `CachedChunks`, and `ChunksCacheSize`. Tune those cache settings first when adjusting database memory usage. Lower the .NET heap limit only when the process still competes with other important workloads on the same host.
+The heap limit is separate from TrogonEventStore cache settings such as `StreamInfoCacheCapacity`, `CachedChunks`, and `ChunksCacheSize`. Tune those cache settings first when adjusting database memory usage. Lower the .NET heap limit only when the process still competes with other important workloads on the same host.
 
 If you override .NET GC settings with environment variables or runtime configuration, keep enough memory headroom for file-system cache and native allocations. For example, disabling Server GC with `DOTNET_gcServer=0` can reduce CPU contention on shared hosts, but may reduce database throughput.

--- a/docs/diagnostics/README.md
+++ b/docs/diagnostics/README.md
@@ -1,16 +1,16 @@
 # Diagnostics
 
-EventStoreDB provides several ways to diagnose and troubleshoot issues.
+TrogonEventStore provides several ways to diagnose and troubleshoot issues.
 
 - [Logging](logs.md): structured or plain-text logs on the console and in log files.
 - [Metrics](metrics.md): collect standard metrics using Prometheus or OpenTelemetry.
 - [Stats](#statistics): runtime statistics exposed through the monitoring gRPC service.
 
-You can also use external tools to measure the performance of EventStoreDB and monitor the cluster health. Learn more on the [Integrations](./integrations.md) page.
+You can also use external tools to measure the performance of TrogonEventStore and monitor the cluster health. Learn more on the [Integrations](./integrations.md) page.
 
 ## Statistics
 
-EventStoreDB servers collect internal statistics and make them available through the monitoring gRPC service.
+TrogonEventStore servers collect internal statistics and make them available through the monitoring gRPC service.
 Use the `Monitoring.Stats` RPC when you need the structured runtime view that used to be exposed through the
 legacy `/stats` HTTP endpoint. That RPC only exposes information about the node you query and does not include
 cluster-wide state.
@@ -336,7 +336,7 @@ deleted.
 
 Using this setting you can control how often stats events are generated. By default, the node will produce one
 event in 30 seconds. If you want to decrease network pressure on subscribers to the `$all` stream, you can
-tell EventStoreDB to produce stats less often.
+tell TrogonEventStore to produce stats less often.
 
 | Format               | Syntax                        |
 | :------------------- | :---------------------------- |

--- a/docs/diagnostics/README.md
+++ b/docs/diagnostics/README.md
@@ -15,10 +15,11 @@ Use the `Monitoring.Stats` RPC when you need the structured runtime view that us
 legacy `/stats` HTTP endpoint. That RPC only exposes information about the node you query and does not include
 cluster-wide state.
 
-What you see in the `Monitoring.Stats` response is the last collected state of the server. The server collects
-this information using events that are appended to the statistics stream. Each node has one. We use a reserved
-name for the stats stream, `$stats-<host:port>`. For example, for a single node running locally the stream
-name would be `$stats-127.0.0.1:2113`.
+`Monitoring.Stats` collects fresh node-local statistics and memoizes the result for up to one second. It does
+not read persisted statistics events.
+
+When statistics persistence is enabled, each node writes events to a reserved `$stats-<host:port>` stream. For
+example, a single local node writes to `$stats-127.0.0.1:2113`.
 
 As all other events, stats events are also linked in the `$all` stream. These events have a reserved event
 type `$statsCollected`.
@@ -329,12 +330,13 @@ type `$statsCollected`.
 
 :::
 
-Stats stream has the max time-to-live set to 24 hours, so all the events that are older than 24 hours will be
+Stats stream has the max time-to-live set to 10 days, so all the events that are older than 10 days will be
 deleted.
 
 ### Stats period
 
-Using this setting you can control how often stats events are generated. By default, the node will produce one
+Using this setting you can control how often statistics are persisted to files and, when enabled, to the stats
+stream. It does not control how frequently `Monitoring.Stats` refreshes its response. By default, the node will produce one
 event in 30 seconds. If you want to decrease network pressure on subscribers to the `$all` stream, you can
 tell TrogonEventStore to produce stats less often.
 
@@ -352,7 +354,7 @@ As mentioned before, stats events are quite large and whilst it is sometimes ben
 history, it is most of the time not necessary. Therefore, we do not write stats events to the database by
 default. When this option is set to `true`, all the stats events will be persisted.
 
-As mentioned before, stats events have a TTL of 24 hours and when writing stats to the database is enabled,
+As mentioned before, stats events have a TTL of 10 days and when writing stats to the database is enabled,
 you'd need to scavenge more often to release the disk space.
 
 | Format               | Syntax                         |

--- a/docs/diagnostics/integrations.md
+++ b/docs/diagnostics/integrations.md
@@ -4,26 +4,26 @@ title: "Integrations"
 
 # Monitoring integrations
 
-EventStoreDB supports several methods to integrate with external monitoring and observability tools. Those include:
+TrogonEventStore supports several methods to integrate with external monitoring and observability tools. Those include:
 
 - [OpenTelemetry](#opentelemetry-exporter): export telemetry to an OpenTelemetry-compatible endpoint
 - [Prometheus](#prometheus): collect metrics in Prometheus
 - [Datadog](#datadog): monitor and measure the cluster with Datadog
-- [ElasticSearch](#elasticsearch): this section describes how to collect EventStoreDB logs in ElasticSearch
+- [ElasticSearch](#elasticsearch): this section describes how to collect TrogonEventStore logs in ElasticSearch
 - [Vector](#vector): collect metrics and logs to your APM tool using Vector
 
 ## Prometheus
 
-You can collect EventStoreDB metrics to Prometheus and configure Grafana dashboards to monitor your deployment.
-Event Store provides Prometheus support out of the box since version 23.6. Refer to [metrics](metrics.md) documentation to learn more.
+You can collect TrogonEventStore metrics to Prometheus and configure Grafana dashboards to monitor your deployment.
+TrogonEventStore exposes Prometheus metrics on `/-/metrics`. Refer to [metrics](metrics.md) documentation to learn more.
 
 Older versions can be monitored by Prometheus using the community-supported exporter available in the [GitHub repository](https://github.com/marcinbudny/eventstore_exporter).
 
 ## OpenTelemetry Exporter
 
-EventStoreDB passively exposes metrics for scraping on the `/-/metrics` endpoint. It can also actively export logs, metrics, and traces using the [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otel/protocol/) (OTLP).
+TrogonEventStore passively exposes metrics for scraping on the `/-/metrics` endpoint. It can also actively export logs, metrics, and traces using the [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otel/protocol/) (OTLP).
 
-A number of APM providers natively support OTLP, so you might be able to send EventStoreDB telemetry directly to your APM provider. Alternatively, you can export to the OpenTelemetry Collector, which can then fan out to a variety of backends. You can find out more about the [OpenTelemetry collector](https://opentelemetry.io/docs/collector/).
+A number of APM providers natively support OTLP, so you might be able to send TrogonEventStore telemetry directly to your APM provider. Alternatively, you can export to the OpenTelemetry Collector, which can then fan out to a variety of backends. You can find out more about the [OpenTelemetry collector](https://opentelemetry.io/docs/collector/).
 
 ### Configuration
 
@@ -95,9 +95,9 @@ The interval is taken from the `ExpectedScrapeIntervalSeconds` value in `metrics
 
 ## Datadog
 
-The best way to integrate EventStoreDB telemetry with Datadog today is by using the built-in OpenTelemetry export support.
+The best way to integrate TrogonEventStore telemetry with Datadog today is by using the built-in OpenTelemetry export support.
 
-You can use the community-supported integration to collect EventStoreDB logs and metrics in Datadog.
+You can use the community-supported integration to collect TrogonEventStore logs and metrics in Datadog.
 
 Find out more details about the integration
 in [Datadog documentation](https://docs.datadoghq.com/integrations/eventstore/).
@@ -107,17 +107,14 @@ in [Datadog documentation](https://docs.datadoghq.com/integrations/eventstore/).
 > Vector is a lightweight and ultra-fast tool for building observability pipelines.
 > (from Vector website)
 
-You can use [Vector] for extracting metrics or logs from your self-managed EventStore server.
-
-It's also possible to collect metrics from the Event Store Cloud managed cluster or instance, as long as the
-Vector agent is running on a machine that has a direct connection to the EventStoreDB server. You cannot,
-however, fetch logs from Event Store Cloud using your own Vector agent.
+You can use [Vector] for extracting metrics or logs from a self-managed
+TrogonEventStore server.
 
 ### Installation
 
 Follow the [installation instructions](https://vector.dev/docs/setup/installation/) provided by Vector to
-deploy the agent. You can deploy and run it on the same machine where you run EventStoreDB server. If you run
-EventStoreDB in Kubernetes, you can run Vector as a sidecar for each of the EventStoreDB pods.
+deploy the agent. You can deploy and run it on the same machine where you run TrogonEventStore server. If you run
+TrogonEventStore in Kubernetes, you can run Vector as a sidecar for each of the TrogonEventStore pods.
 
 ### Configuration
 
@@ -137,8 +134,8 @@ need grouped stats or queue-level detail.
 
 #### Collecting logs
 
-To collect logs, you can use the [file source] and configure it to target EventStoreDB log file. For log
-collection, Vector must run on the same machine as EventStoreDB server as it collects the logs from files on
+To collect logs, you can use the [file source] and configure it to target TrogonEventStore log file. For log
+collection, Vector must run on the same machine as TrogonEventStore server as it collects the logs from files on
 the local file system.
 
 ```toml
@@ -151,7 +148,7 @@ read_from = "end"
 
 #### Example
 
-In this example, Vector runs on the same machine as EventStoreDB, collects logs, and then sends them to
+In this example, Vector runs on the same machine as TrogonEventStore, collects logs, and then sends them to
 Datadog.
 
 ```toml
@@ -175,20 +172,20 @@ Elastic Stack is one of the most popular tools for ingesting and analyzing logs 
 - [Logstash](https://www.elastic.co/guide/en/logstash/current/getting-started-with-logstash.html) enables log transformations and processing pipelines.
 - [Kibana](https://www.elastic.co/guide/en/kibana/8.2/index.html) is a dashboard and visualization UI for Elasticsearch data.
 
-EventStoreDB exposes structured information through its logs and statistics, allowing straightforward integration with mentioned tooling.
+TrogonEventStore exposes structured information through its logs and statistics, allowing straightforward integration with mentioned tooling.
 
 ### Logstash
 
-Logstash is the plugin based data processing component of the Elastic Stack which sends incoming data to Elasticsearch. It's excellent for building a text-based processing pipeline. It can also gather logs from files (although Elastic recommends now Filebeat for that, see more in the following paragraphs). Logstash needs to either be installed on the EventStoreDB node or have access to logs storage. The processing pipeline can be configured through the configuration file (e.g. `logstash.conf`). This file contains the three essential building blocks:
+Logstash is the plugin based data processing component of the Elastic Stack which sends incoming data to Elasticsearch. It's excellent for building a text-based processing pipeline. It can also gather logs from files (although Elastic recommends now Filebeat for that, see more in the following paragraphs). Logstash needs to either be installed on the TrogonEventStore node or have access to logs storage. The processing pipeline can be configured through the configuration file (e.g. `logstash.conf`). This file contains the three essential building blocks:
 - input - source of logs, e.g. log files, system output, Filebeat.
 - filter - processing pipeline, e.g. to modify, enrich, tag log data,
 - output - place where we'd like to put transformed logs. Typically that contains Elasticsearch configuration.
 
-See the sample Logstash 8.2 configuration file. It shows how to take the EventStoreDB log files, split them based on the log type (regular and stats) and output them to separate indices to Elasticsearch:
+See the sample Logstash 8.2 configuration file. It shows how to take the TrogonEventStore log files, split them based on the log type (regular and stats) and output them to separate indices to Elasticsearch:
 
 ```ruby
 #######################################################
-#  EventStoreDB logs file input
+#  TrogonEventStore logs file input
 #######################################################
 input {
   file {
@@ -242,16 +239,16 @@ Logstash was an initial attempt by Elastic to provide a log harvester tool. Howe
 
 Filebeat can pipe logs directly to Elasticsearch and set up a Kibana data view.
 
-Filebeat needs to either be installed on the EventStoreDB node or have access to logs storage. The processing pipeline can be configured through the configuration file (e.g. `filebeat.yml`). This file contains the three essential building blocks:
+Filebeat needs to either be installed on the TrogonEventStore node or have access to logs storage. The processing pipeline can be configured through the configuration file (e.g. `filebeat.yml`). This file contains the three essential building blocks:
 - input - configuration for file source, e.g. if stored in JSON format.
 - output - place where we'd like to put transformed logs, e.g. Elasticsearch, Logstash,
 - setup - additional setup and simple transformations (e.g. Elasticsearch indices template, Kibana data view).
 
-See the sample Filebeat 8.2 configuration file. It shows how to take the EventStoreDB log files, output them to Elasticsearch prefixing index with `eventstoredb` and create a Kibana data view:
+See the sample Filebeat 8.2 configuration file. It shows how to take the TrogonEventStore log files, output them to Elasticsearch prefixing index with `eventstoredb` and create a Kibana data view:
 
 ```yml
 #######################################################
-#  EventStoreDB logs file input
+#  TrogonEventStore logs file input
 #######################################################
 filebeat.inputs:
   - type: log
@@ -291,13 +288,13 @@ You can play with such configuration through the [sample docker-compose](https:/
 
 ### Filebeat with Logstash
 
-Even though Filebeat can pipe logs directly to Elasticsearch and do a basic Kibana setup, you'd like to have more control and expand the processing pipeline. That's why for production, it's recommended to use both. Multiple Filebeat instances (e.g. from different EventStoreDB clusters) can collect logs and pipe them to Logstash, which will play an aggregator role. Filebeat can output logs to Logstash, and Logstash can receive and process these logs with the Beats input. Logstash can transform and route logs to Elasticsearch instance(s).
+Even though Filebeat can pipe logs directly to Elasticsearch and do a basic Kibana setup, you'd like to have more control and expand the processing pipeline. That's why for production, it's recommended to use both. Multiple Filebeat instances (e.g. from different TrogonEventStore clusters) can collect logs and pipe them to Logstash, which will play an aggregator role. Filebeat can output logs to Logstash, and Logstash can receive and process these logs with the Beats input. Logstash can transform and route logs to Elasticsearch instance(s).
 
-In that configuration, Filebeat should be installed on the EventStoreDB node (or have access to file logs) and define Logstash as output. See the sample Filebeat 8.2 configuration file.
+In that configuration, Filebeat should be installed on the TrogonEventStore node (or have access to file logs) and define Logstash as output. See the sample Filebeat 8.2 configuration file.
 
 ```yml
 #######################################################
-#  EventStoreDB logs file input
+#  TrogonEventStore logs file input
 #######################################################
 filebeat.inputs:
   - type: log
@@ -313,7 +310,7 @@ output.logstash:
   hosts: ["logstash:5044"]
 ```
 
-Then the sample Logstash 8.2 configuration file will look like the below. It shows how to take the EventStoreDB logs from Filebeat, split them based on the log type (regular and stats) and output them to separate indices to Elasticsearch:
+Then the sample Logstash 8.2 configuration file will look like the below. It shows how to take the TrogonEventStore logs from Filebeat, split them based on the log type (regular and stats) and output them to separate indices to Elasticsearch:
 
 ```ruby
 #######################################################
@@ -364,7 +361,7 @@ output {
 You can play with such configuration through the [sample docker-compose](https://github.com/EventStore/samples/blob/2829b0a90a6488e1eee73fad0be33a3ded7d13d2/Logging/Elastic/FilebeatWithLogstash/docker-compose.yml).
 
 [Vector]: https://vector.dev/docs/
-[EventStoreDB source]: https://vector.dev/docs/reference/configuration/sources/eventstoredb_metrics/
+[TrogonEventStore source]: https://vector.dev/docs/reference/configuration/sources/eventstoredb_metrics/
 [file source]: https://vector.dev/docs/reference/configuration/sources/file/
 [many different sinks]: https://vector.dev/docs/reference/configuration/sinks/
 [Console]: https://vector.dev/docs/reference/configuration/sinks/console/

--- a/docs/diagnostics/logs.md
+++ b/docs/diagnostics/logs.md
@@ -15,8 +15,8 @@ The TrogonEventStore logs may contain sensitive information such as stream names
 
 ## Log format
 
-TrogonEventStore uses the structured logging in JSON format that is more machine-friendly and can be ingested by
-vendor-specific tools like Logstash or Datadog agent.
+Log files use compact JSON that can be ingested by log-processing tools. Console output defaults to the
+human-readable `Plain` format.
 
 Here is how the structured log looks like:
 
@@ -197,7 +197,7 @@ Defines how many log files need to be kept on disk. By default, logs for the las
 |:---------------------|:---------------------------------|
 | Command line         | `--log-file-retention-count`     |
 | YAML                 | `LogFileRetentionCount`          |
-| Environment variable | `EVENTSTORE_LOG_RETENTION_COUNT` |
+| Environment variable | `EVENTSTORE_LOG_FILE_RETENTION_COUNT` |
 
 **Default**: `31`
 

--- a/docs/diagnostics/logs.md
+++ b/docs/diagnostics/logs.md
@@ -4,18 +4,18 @@ title: "Logs"
 
 # Database logs
 
-EventStoreDB logs its internal operations to the console (stdout) and to log files. The default location of
+TrogonEventStore logs its internal operations to the console (stdout) and to log files. The default location of
 the log files and the way to change it is described [below](#logs-location).
 
-There are a few options to change the way how EventStoreDB produces logs and how detailed the logs should be.
+There are a few options to change the way how TrogonEventStore produces logs and how detailed the logs should be.
 
 ::: warning
-The EventStoreDB logs may contain sensitive information such as stream names, usernames, and projection definitions.
+The TrogonEventStore logs may contain sensitive information such as stream names, usernames, and projection definitions.
 :::
 
 ## Log format
 
-EventStoreDB uses the structured logging in JSON format that is more machine-friendly and can be ingested by
+TrogonEventStore uses the structured logging in JSON format that is more machine-friendly and can be ingested by
 vendor-specific tools like Logstash or Datadog agent.
 
 Here is how the structured log looks like:
@@ -71,7 +71,7 @@ This format is aligned with [Serilog Compact JSON format](https://github.com/ser
 ## Logs location
 
 Log files are located in `/var/log/eventstore` for Linux and macOS, and in the `logs` subdirectory of the
-EventStoreDB installation directory on Windows. You can change the log files location using the `Log`
+TrogonEventStore installation directory on Windows. You can change the log files location using the `Log`
 configuration option.
 
 ::: tip
@@ -106,7 +106,7 @@ Acceptable values are: `Default`, `Verbose`, `Debug`, `Information`, `Warning`, 
 
 ## Logging options
 
-You can tune the EventStoreDB logging further by using the logging options described below.
+You can tune the TrogonEventStore logging further by using the logging options described below.
 
 ### Log configuration file
 
@@ -123,7 +123,7 @@ full path.
 
 ### HTTP requests logging
 
-EventStoreDB can also log all the incoming HTTP requests, like many HTTP servers do. Requests are logged
+TrogonEventStore can also log all the incoming HTTP requests, like many HTTP servers do. Requests are logged
 before being processed, so unsuccessful requests are logged too.
 
 Use one of the following ways to enable the HTTP requests logging:
@@ -213,79 +213,12 @@ You can completely disable logging to a file by changing the `DisableLogFile` op
 
 **Default**: `false`
 
-## Logs download <Badge type="warning" vertical="middle" text="Commercial"/>
+## Collecting logs
 
-The _Logs Download Plugin_ provides HTTP access to EventStoreDB logs so that they can be viewed without requiring file system access.
+TrogonEventStore does not document a remote log-download HTTP endpoint. Collect
+logs from the configured log directory, the container runtime, or the platform
+logging system.
 
-::: tip
-You can use this API to download log files from your managed EventStoreDB clusters in Event Store Cloud.
-:::
-
-On startup the server will log a message similar to:
-```:no-line-numbers
-LogsEndpoint: Serving logs from "<FULL-PATH-TO-LOGS>" at endpoint "/admin/logs"
-```
-
-Access the logs via the `/admin/logs` endpoint on your server. Construct the full URL as follows:
-
-```:no-line-numbers
-http(s)://<node ip or hostname>:<node port>/admin/logs
-```
-
-Example:
-```:no-line-numbers
-https://localhost:2113/admin/logs
-```
-
-Only authenticated users belonging to the `$admins` or `$ops` groups can use this endpoint.
-
-### Listing log files
-
-To list the current log files, issue a `GET` to the `/admin/logs` endpoint
-
-Example:
-```bash:no-line-numbers
-curl https://user:password@localhost:2113/admin/logs | jq
-```
-
-Sample response:
-```json
-[
-  {
-    "name": "log-stats20240205.json",
-    "lastModified": "2024-02-05T13:14:14.2789475+00:00",
-    "size": 1058614
-  },
-  {
-    "name": "log20240205.json",
-    "lastModified": "2024-02-05T13:14:37.0781601+00:00",
-    "size": 158542
-  }
-]
-```
-
-The response is ordered from most recent change first, is limited to a maximum of 1000 items, and includes:
-
-| Name         | Description                                                                                                                                                                                                                                       |
-|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| name         | File name of the log file                                                                                                                                                                                                                         |
-| createdAt    | Timestamp of when the log file was created in [round-trip format](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#the-round-trip-o-o-format-specifier) (local time with time zone information) |
-| lastModified | Timestamp of the last modification in [round-trip format](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#the-round-trip-o-o-format-specifier) (local time with time zone information)         |
-| size         | Size of the log file in bytes                                                                                                                                                                                                                     |
-
-### Downloading log files
-
-To download a specific log file, append its name to the URL:
-
-Example:
-```bash:no-line-numbers
-curl https://user:password@localhost:2113/admin/logs/log20240205.json --output log20240205.json
-```
-
-### Troubleshooting
-
-- **404 Not Found:** The plugin is only available in commercial editions. Verify the plugin is loaded by checking the server startup logs.
-
-- **401 Unauthorized:** Confirm the credentials are correct and the user belongs to the `$ops` or `$admins` group.
-
-- **Log Files Directory Not Found:** Check the `NodeIp` and `NodePort` settings are current and not using the deprecated settings `HttpIp` or `HttpPort`.
+For Kubernetes, prefer writing logs to standard output and collecting them with
+the cluster logging pipeline. For virtual machines or bare metal, ship the log
+directory with the host log agent.

--- a/docs/diagnostics/metrics.md
+++ b/docs/diagnostics/metrics.md
@@ -1,8 +1,8 @@
 # Metrics
 
-EventStoreDB collects metrics in [Prometheus format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format), available on the `/-/metrics` endpoint. Prometheus can be configured to scrape this endpoint directly. The metrics are configured in `metricsconfig.json`.
+TrogonEventStore collects metrics in [Prometheus format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format), available on the `/-/metrics` endpoint. Prometheus can be configured to scrape this endpoint directly. The metrics are configured in `metricsconfig.json`.
 
-In addition, EventStoreDB can actively export metrics to a specified endpoint using the [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otel/protocol/) (OTLP).
+In addition, TrogonEventStore can actively export metrics to a specified endpoint using the [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otel/protocol/) (OTLP).
 
 ## Metrics reference
 
@@ -10,7 +10,7 @@ In addition, EventStoreDB can actively export metrics to a specified endpoint us
 
 #### Cache hits and misses
 
-EventStoreDB tracks cache hits/misses metrics for `stream-info` and `chunk` caches.
+TrogonEventStore tracks cache hits/misses metrics for `stream-info` and `chunk` caches.
 
 | Time series                                                                | Type                     | Description                             |
 |:---------------------------------------------------------------------------|:-------------------------|:----------------------------------------|
@@ -33,7 +33,7 @@ eventstore_cache_hits_misses{cache="stream-info",kind="misses"} 117 168815748954
 
 #### Dynamic cache resources
 
-Certain caches that EventStoreDB uses are dynamic in nature i.e. their capacity scales up/down during their lifetime. EventStoreDB records metrics for resources being used by each such dynamic cache.
+Certain caches that TrogonEventStore uses are dynamic in nature i.e. their capacity scales up/down during their lifetime. TrogonEventStore records metrics for resources being used by each such dynamic cache.
 
 | Time series                                                                      | Type                   | Description                                          |
 |:---------------------------------------------------------------------------------|:-----------------------|:-----------------------------------------------------|
@@ -196,7 +196,7 @@ eventstore_incoming_grpc_calls{kind="failed"} 1 1687962877623
 
 #### Client protocol gRPC methods
 
-In addition, EventStoreDB also records metrics for each of client protocol gRPC methods: `StreamRead`, `StreamAppend`, `StreamBatchAppend`, `StreamDelete` and `StreamTombstone`. They are grouped together according to the mapping defined in the configuration.
+In addition, TrogonEventStore also records metrics for each of client protocol gRPC methods: `StreamRead`, `StreamAppend`, `StreamBatchAppend`, `StreamDelete` and `StreamTombstone`. They are grouped together according to the mapping defined in the configuration.
 
 | Time series                                                                                                    | Type                       | Description                                                                                      |
 |:---------------------------------------------------------------------------------------------------------------|:---------------------------|:-------------------------------------------------------------------------------------------------|
@@ -320,11 +320,11 @@ eventstore_persistent_sub_checkpointed_event_commit_position{event_stream_id="$a
 
 ### Process
 
-EventStoreDB collects key metrics about the running process.
+TrogonEventStore collects key metrics about the running process.
 
 | Time Series                                                                              | Type                     | Description                                                                                                                                                                                                                                                                                                                                                                          |
 |:-----------------------------------------------------------------------------------------|:-------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `eventstore_proc_up_time{pid=<PID>}`                                                     | [Counter](#common-types) | Time in seconds this process has been running for. _PID_ is process Id of EventStoreDB process                                                                                                                                                                                                                                                                                       |
+| `eventstore_proc_up_time{pid=<PID>}`                                                     | [Counter](#common-types) | Time in seconds this process has been running for. _PID_ is process Id of TrogonEventStore process                                                                                                                                                                                                                                                                                       |
 | `eventstore_proc_cpu`                                                                    | [Gauge](#common-types)   | Process CPU usage                                                                                                                                                                                                                                                                                                                                                                    |
 | `eventstore_proc_thread_count`                                                           | [Gauge](#common-types)   | Current number of threadpool threads ([ThreadPool.ThreadCount](https://learn.microsoft.com/en-us/dotnet/api/system.threading.threadpool.threadcount?view=net-6.0))                                                                                                                                                                                                                   |
 | `eventstore_proc_thread_pool_pending_work_item_count`                                    | [Gauge](#common-types)   | Current number of items that are queued to be processed by threadpool threads ([ThreadPool.PendingWorkItemCount](https://learn.microsoft.com/en-us/dotnet/api/system.threading.threadpool.pendingworkitemcount?view=net-6.0))                                                                                                                                                        |
@@ -434,7 +434,7 @@ eventstore_projection_status{projection="$by_category",status="Stopped"} 0 17195
 
 ### Queues
 
-EventStoreDB uses various queues for asynchronous processing for which it also collects different metrics. In addition, EventStoreDB allows users to group queues and monitor them as a unit.
+TrogonEventStore uses various queues for asynchronous processing for which it also collects different metrics. In addition, TrogonEventStore allows users to group queues and monitor them as a unit.
 
 | Time series                                                                                                         | Type                       | Description                                                                                                                                                                                      |
 |:--------------------------------------------------------------------------------------------------------------------|:---------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -484,7 +484,7 @@ eventstore_queue_queueing_duration_max_seconds{name="Others",range="16-20 second
 
 ### Status
 
-EventStoreDB tracks the current status of the `Node` role  as well as  progress of  `Index`, and `Scavenge` processes.
+TrogonEventStore tracks the current status of the `Node` role  as well as  progress of  `Index`, and `Scavenge` processes.
 
 | Time series                                        | Type                   | Description                                                                              |
 |:---------------------------------------------------|:-----------------------|:-----------------------------------------------------------------------------------------|

--- a/docs/indexes.md
+++ b/docs/indexes.md
@@ -9,7 +9,7 @@ TrogonEventStore stores indexes separately from the main data files, accessing r
 ### Overview
 
 TrogonEventStore creates index entries as it processes commit events. It holds these in memory (called
-_memtables_) until it reaches the `MaxMemTableSize` and then persisted on disk in the _index_ folder along
+_memtables_) until the entry count reaches or exceeds `MaxMemTableSize`, then persists them in the _index_ folder along
 with `.bloomfilter` files and an index map file. The index files are uniquely named, and the index map file
 called _indexmap_. The index map describes the order and the level of the index file as well as containing the
 data checkpoint for the last written file, the version of the index map file and a checksum for the index map
@@ -19,7 +19,7 @@ Indexes are sorted lists based on the hashes of stream names. To speed up seekin
 file of an entry for a stream, TrogonEventStore keeps midpoints to relate the stream hash to the physical offset
 in the file.
 
-As TrogonEventStore saves more files, they are automatically merged together whenever there are more than 2 files
+As TrogonEventStore saves more files, they are automatically merged together whenever there are two files
 at the same level into a single file at the next level. Each index entry is 24 bytes and the index file size
 is approximately 24Mb per 1M events. The Bloom filter files are approximately 1% of the size of the rest of
 the index.
@@ -60,8 +60,8 @@ The _indexmap_ structure is as follows:
 - `hash` - an md5 hash of the rest of the file
 - `version` - the version of the _indexmap_ file
 - `checkpoint` - the maximum prepare/commit position of the persisted _ptables_
-- `maxAutoMergeLevel` - either the value of `MaxAutoMergeLevel` or `int32.MaxValue` if it was not set. This is
-  primarily used to detect increases in `MaxAutoMergeLevel`, which is not supported.
+- `maxAutoMergeLevel` - either the value of `MaxAutoMergeIndexLevel` or `int32.MaxValue` if it was not set. This
+  is primarily used to detect increases in `MaxAutoMergeIndexLevel`, which is not supported.
 - `ptable`,`level`,`index`- List of all the _ptables_ used by this index map with the level of the _ptable_
   and it's order.
 
@@ -160,8 +160,8 @@ files from the last position in the `indexmap` file and rebuild the in memory in
 
 <!-- TODO: Polish a little more -->
 
-Increasing `MaxMemTableSize` also decreases the number of times TrogonEventStore writes index files to disk and
-how often it merges them together, which increases IO operations. It also reduces the number of seek
+Increasing `MaxMemTableSize` also decreases index write and merge frequency, although each flush is larger and
+recovery may take longer. It also reduces the number of seek
 operations when stream entries span multiple files as TrogonEventStore needs to search each file for the stream
 entries. This affects streams written to over longer periods of time more than streams written to over a
 shorter time, where time is measured by the number of events created, not time passed. This is because streams
@@ -228,7 +228,7 @@ index merges will use a large amount of disk IO.
 
 For example:
 
-> Merging 2 level 7 files results in at least 3072 MB reads (2 \* 1536 MB), and 3072 MB writes while merging 2 level 8 files together results in at least 6144 MB reads (2 \* 3072 MB) and 6144 MB writes. Setting `MaxAutoMergeLevel` to 7 allows all levels up to and including level 7 to be automatically merged, but to merge the level 8 files together, you need to trigger a manual merge. This manual merge allows better control over when these larger merges happen and which nodes they happen on. Due to the replication process, all nodes tend to merge at about the same time.
+> Merging 2 level 7 files results in at least 3072 MB reads (2 \* 1536 MB), and 3072 MB writes while merging 2 level 8 files together results in at least 6144 MB reads (2 \* 3072 MB) and 6144 MB writes. Setting `MaxAutoMergeIndexLevel` to 7 allows all levels up to and including level 7 to be automatically merged, but to merge the level 8 files together, you need to trigger a manual merge. This manual merge allows better control over when these larger merges happen and which nodes they happen on. Due to the replication process, all nodes tend to merge at about the same time.
 
 ### Stream existence filter size
 
@@ -295,7 +295,7 @@ For most TrogonEventStore clusters, the default settings are enough to give cons
 clusters with larger numbers of events, or those that run in constrained environments the configuration
 options allow for some tuning to meet operational constraints.
 
-The most common optimization needed is to set a `MaxAutoMergeLevel` to avoid large merges occurring across all
+The most common optimization needed is to set a `MaxAutoMergeIndexLevel` to avoid large merges occurring across all
 nodes at approximately the same time. Large index merges use a lot of IOPS and in IOPS constrained
 environments it is often desirable to have better control over when these happen. Because increasing this
 value requires an index rebuild you should start with a higher value and decrease until the desired balance
@@ -305,4 +305,4 @@ cluster.
 
 For example:
 
-> A cluster with 3000 256b IOPS can read/write about 0.73Gb/sec (This level of IOPS represents a small cloud instance). Assuming sustained read/write throughput of 0.73Gb/s. When an index merge of level 7 or above starts, it consumes as many IOPS up to all on the node until it completes. Because TrogonEventStore has a shared nothing architecture for clustering this operation is likely to cause all nodes to appear to stall simultaneously as they all try and perform an index merge at the same time. By setting `MaxAutoMergeLevel` to 6 or below you can avoid this, and you can run the merge on each node individually keeping read/write latency in the cluster consistent.
+> A cluster with 3000 256b IOPS can read/write about 0.73Gb/sec (This level of IOPS represents a small cloud instance). Assuming sustained read/write throughput of 0.73Gb/s. When an index merge of level 7 or above starts, it consumes as many IOPS up to all on the node until it completes. Because TrogonEventStore has a shared nothing architecture for clustering this operation is likely to cause all nodes to appear to stall simultaneously as they all try and perform an index merge at the same time. By setting `MaxAutoMergeIndexLevel` to 6 or below you can avoid this, and you can run the merge on each node individually keeping read/write latency in the cluster consistent.

--- a/docs/indexes.md
+++ b/docs/indexes.md
@@ -4,11 +4,11 @@ title: "Indexes"
 
 ## Indexing
 
-EventStoreDB stores indexes separately from the main data files, accessing records by stream name.
+TrogonEventStore stores indexes separately from the main data files, accessing records by stream name.
 
 ### Overview
 
-EventStoreDB creates index entries as it processes commit events. It holds these in memory (called 
+TrogonEventStore creates index entries as it processes commit events. It holds these in memory (called
 _memtables_) until it reaches the `MaxMemTableSize` and then persisted on disk in the _index_ folder along
 with `.bloomfilter` files and an index map file. The index files are uniquely named, and the index map file
 called _indexmap_. The index map describes the order and the level of the index file as well as containing the
@@ -16,10 +16,10 @@ data checkpoint for the last written file, the version of the index map file and
 file. The logs refer to the index files as a _PTable_.
 
 Indexes are sorted lists based on the hashes of stream names. To speed up seeking the correct location in the
-file of an entry for a stream, EventStoreDB keeps midpoints to relate the stream hash to the physical offset
+file of an entry for a stream, TrogonEventStore keeps midpoints to relate the stream hash to the physical offset
 in the file.
 
-As EventStoreDB saves more files, they are automatically merged together whenever there are more than 2 files
+As TrogonEventStore saves more files, they are automatically merged together whenever there are more than 2 files
 at the same level into a single file at the next level. Each index entry is 24 bytes and the index file size
 is approximately 24Mb per 1M events. The Bloom filter files are approximately 1% of the size of the rest of
 the index.
@@ -45,7 +45,7 @@ Each index entry is 24 bytes and the index file size is approximately 24Mb per M
 
 ## Indexing in depth
 
-For general operation of EventStoreDB the following information is not critical but useful for developers
+For general operation of TrogonEventStore the following information is not critical but useful for developers
 wanting to make changes in the indexing subsystem and for understanding crash recovery and tuning scenarios.
 
 ### Index map files
@@ -65,33 +65,33 @@ The _indexmap_ structure is as follows:
 - `ptable`,`level`,`index`- List of all the _ptables_ used by this index map with the level of the _ptable_
   and it's order.
 
-EventStoreDB writes _indexmap_ files to a temporary file and then deletes the original and renames the
-temporary file. EventStoreDB attempts this 5 times before failing. Because of the order, this operation can
+TrogonEventStore writes _indexmap_ files to a temporary file and then deletes the original and renames the
+temporary file. TrogonEventStore attempts this 5 times before failing. Because of the order, this operation can
 only fail if there is an issue with the underlying file system or the disk is full. This is a 2 phase process,
-and in the unlikely event of a crash during this process, EventStoreDB recovers by rebuilding the indexes
+and in the unlikely event of a crash during this process, TrogonEventStore recovers by rebuilding the indexes
 using the same process used if it detects corrupted files during startup.
 
 ### Writing and merging of index files
 
 Merging _ptables_, updating the _indexmap_ and persisting _memtable_ operations happen on a background thread.
 These operations are performed on a single thread with any additional operations queued and completed later.
-EventStoreDB runs these operations on a thread pool thread rather than a dedicated thread. Generally there is
+TrogonEventStore runs these operations on a thread pool thread rather than a dedicated thread. Generally there is
 only one operation queued at a time, but if merging to _ptables_ at one level causes 2 tables to be available
 at the next level, then the next merge operation is immediately queued. While merge operations are in
-progress, if EventStoreDB is appending large numbers of events, it may queue 1 or more _memtables_ for
+progress, if TrogonEventStore is appending large numbers of events, it may queue 1 or more _memtables_ for
 persistence. The number of pending operations is logged.
 
-For safety _ptables_ EventStoreDB is currently merging are only deleted after the new _ptable_ has persisted
-and the _indexmap_  updated. In the event of a crash, EventStoreDB recovers by deleting any files not in the
+For safety _ptables_ TrogonEventStore is currently merging are only deleted after the new _ptable_ has persisted
+and the _indexmap_  updated. In the event of a crash, TrogonEventStore recovers by deleting any files not in the
 _indexmap_ and reindexing from the prepare/commit position stored in the _indexmap_ file.
 
 ### Manual merging
 
 If you have set the maximum level ([`MaxAutoMergeIndexLevel`](#auto-merge-index-level)) for automatically
 merging indexes, then you need to trigger merging indexes above this level manually by using
-the gRPC `Operations.MergeIndexes` API, or the es-cli tool that is available with commercial support.
+the gRPC `Operations.MergeIndexes` API.
 
-Triggering a manual merge causes EventStoreDB to merge all tables that have a level equal to the maximum merge
+Triggering a manual merge causes TrogonEventStore to merge all tables that have a level equal to the maximum merge
 level or above into a single table. If there is only 1 table at the maximum level or above, no merge is
 performed.
 
@@ -107,7 +107,7 @@ where in the log the filter has processed up to. As per the documented backup pr
 to be backed up before the dat file.
 
 The Stream Existence Filter is used when reading and writing to quickly determine whether a stream _might
-exist_ or _definitely does not exist_. If a stream definitely does not exist then EventStoreDB can skip
+exist_ or _definitely does not exist_. If a stream definitely does not exist then TrogonEventStore can skip
 looking through the index to find information about it. This is particularly useful when creating new
 streams (i.e. appending to stream that did not previously exist).
 
@@ -136,7 +136,7 @@ Read more below to understand these options better.
 |:---------------------|:-------------------|
 | Command line         | `--index`          |
 | YAML                 | `Index`            |
-| Environment variable | `EVENTSTORE_INDEX` | 
+| Environment variable | `EVENTSTORE_INDEX` |
 
 **Default**: data files location
 
@@ -149,20 +149,20 @@ avoid competition for IO between the data, index and log files.
 |:---------------------|:--------------------------------|
 | Command line         | `--max-mem-table-size`          |
 | YAML                 | `MaxMemTableSize`               |
-| Environment variable | `EVENTSTORE_MAX_MEM_TABLE_SIZE` | 
+| Environment variable | `EVENTSTORE_MAX_MEM_TABLE_SIZE` |
 
 **Default**: `1000000`
 
-`MaxMemTableSize` affects disk IO when EventStoreDB writes files to disk, index seek time and database startup
+`MaxMemTableSize` affects disk IO when TrogonEventStore writes files to disk, index seek time and database startup
 time. The default size is a good tradeoff between low disk IO and startup time. Increasing
 the `MaxMemTableSize` results in longer database startup time because a node has to read through the data
 files from the last position in the `indexmap` file and rebuild the in memory index table before it starts.
 
 <!-- TODO: Polish a little more -->
 
-Increasing `MaxMemTableSize` also decreases the number of times EventStoreDB writes index files to disk and
+Increasing `MaxMemTableSize` also decreases the number of times TrogonEventStore writes index files to disk and
 how often it merges them together, which increases IO operations. It also reduces the number of seek
-operations when stream entries span multiple files as EventStoreDB needs to search each file for the stream
+operations when stream entries span multiple files as TrogonEventStore needs to search each file for the stream
 entries. This affects streams written to over longer periods of time more than streams written to over a
 shorter time, where time is measured by the number of events created, not time passed. This is because streams
 written to over longer time periods are more likely to have entries in multiple index files.
@@ -173,11 +173,11 @@ written to over longer time periods are more likely to have entries in multiple 
 |:---------------------|:-------------------------------|
 | Command line         | `--index-cache-depth`          |
 | YAML                 | `IndexCacheDepth`              |
-| Environment variable | `EVENTSTORE_INDEX_CACHE_DEPTH` | 
+| Environment variable | `EVENTSTORE_INDEX_CACHE_DEPTH` |
 
 **Default**: `16`
 
-`IndexCacheDepth` affects how many midpoints EventStoreDB calculates for an index file which affects file
+`IndexCacheDepth` affects how many midpoints TrogonEventStore calculates for an index file which affects file
 size slightly, but can affect lookup times significantly. Looking up a stream entry in a file requires a
 binary search on the midpoints to find the nearest midpoint, and then a seek through the entries to find the
 entry or entries that match. Increasing this value decreases the second part of the operation and increase the
@@ -198,12 +198,12 @@ entries. Most clusters should not need to change this setting.
 |:---------------------|:-------------------------------|
 | Command line         | `--skip-index-verify`          |
 | YAML                 | `SkipIndexVerify`              |
-| Environment variable | `EVENTSTORE_SKIP_INDEX_VERIFY` | 
+| Environment variable | `EVENTSTORE_SKIP_INDEX_VERIFY` |
 
 **Default**: `false`
 
 `SkipIndexVerify` skips reading and verification of index file hashes during startup. Instead of recalculating
-midpoints when EventStoreDB reads the file, it reads the midpoints directly from the footer of the index file.
+midpoints when TrogonEventStore reads the file, it reads the midpoints directly from the footer of the index file.
 You can set `SkipIndexVerify` to `true` to reduce startup time in exchange for the acceptance of a small risk
 that the index file becomes corrupted. This corruption could lead to a failure if you read the corrupted
 entries, and a message saying the index needs to be rebuilt. You can safely disable this setting for ZFS on
@@ -218,12 +218,12 @@ indexes from scratch.
 |:---------------------|:----------------------------------------|
 | Command line         | `--max-auto-merge-index-level`          |
 | YAML                 | `MaxAutoMergeIndexLevel`                |
-| Environment variable | `EVENTSTORE_MAX_AUTO_MERGE_INDEX_LEVEL` | 
+| Environment variable | `EVENTSTORE_MAX_AUTO_MERGE_INDEX_LEVEL` |
 
 **Default**: `2147483647`
 
 `MaxAutoMergeIndexLevel` allows you to specify the maximum index file level to automatically merge. By default
-EventStoreDB merges all levels. Depending on the specification of the host running EventStoreDB, at some point
+TrogonEventStore merges all levels. Depending on the specification of the host running TrogonEventStore, at some point
 index merges will use a large amount of disk IO.
 
 For example:
@@ -236,7 +236,7 @@ For example:
 |:---------------------|:------------------------------------------|
 | Command line         | `--stream-existence-filter-size`          |
 | YAML                 | `StreamExistenceFilterSize`               |
-| Environment variable | `EVENTSTORE_STREAM_EXISTENCE_FILTER_SIZE` | 
+| Environment variable | `EVENTSTORE_STREAM_EXISTENCE_FILTER_SIZE` |
 
 **Default**: `256000000`
 
@@ -245,7 +245,7 @@ filter. This should be set to roughly the maximum number of streams you expect t
 if you expect to have a max of 500 million streams, use a value of 500000000. The value you select should also
 fit entirely in memory to avoid any performance degradation. Use 0 to disable the filter.
 
-Upgrading to a version of EventStoreDB that supports the Stream Existence Filter requires the filter to be
+Upgrading to a version of TrogonEventStore that supports the Stream Existence Filter requires the filter to be
 built - unless it is disabled. This will take approximately as long as it takes to read through the whole
 index.
 
@@ -257,7 +257,7 @@ Resizing the filter will also cause a full rebuild of the filter.
 |:---------------------|:------------------------------|
 | Command line         | `--index-cache-size`          |
 | YAML                 | `IndexCacheSize`              |
-| Environment variable | `EVENTSTORE_INDEX_CACHE_SIZE` | 
+| Environment variable | `EVENTSTORE_INDEX_CACHE_SIZE` |
 
 **Default**: `0`
 
@@ -273,7 +273,7 @@ The index LRU cache is only created for index files that have Bloom filters.
 |:---------------------|:-------------------------------------|
 | Command line         | `--use-index-bloom-filters`          |
 | YAML                 | `UseIndexBloomFilters`               |
-| Environment variable | `EVENTSTORE_USE_INDEX_BLOOM_FILTERS` | 
+| Environment variable | `EVENTSTORE_USE_INDEX_BLOOM_FILTERS` |
 
 **Default**: `true`
 
@@ -281,17 +281,17 @@ The index LRU cache is only created for index files that have Bloom filters.
 be necessary and this flag will be removed in a future release, but is provided for safety since the index
 Bloom filters are a new feature. Please contact EventStore if you discover some need to disable this feature.
 
-Unless this flag is set to false, EventStoreDB creates a `.bloomfilter` file for each new PTable. The Bloom
-filter describes which streams are present in the PTable. This speeds up stream reads since EventStoreDB can
+Unless this flag is set to false, TrogonEventStore creates a `.bloomfilter` file for each new PTable. The Bloom
+filter describes which streams are present in the PTable. This speeds up stream reads since TrogonEventStore can
 avoid searching in index files do not contain the stream.
 
-Note that immediately after upgrading to a version of EventStoreDB that produces index Bloom filters, no Bloom
+Note that immediately after upgrading to a version of TrogonEventStore that produces index Bloom filters, no Bloom
 filters will yet exist. Either wait for new PTables to be produced with Bloom filters in the natural course of
 writing/merging/scavenging PTables, or rebuild the index for immediate generation.
 
 ## Tuning indexes
 
-For most EventStoreDB clusters, the default settings are enough to give consistent and good performance. For
+For most TrogonEventStore clusters, the default settings are enough to give consistent and good performance. For
 clusters with larger numbers of events, or those that run in constrained environments the configuration
 options allow for some tuning to meet operational constraints.
 
@@ -305,4 +305,4 @@ cluster.
 
 For example:
 
-> A cluster with 3000 256b IOPS can read/write about 0.73Gb/sec (This level of IOPS represents a small cloud instance). Assuming sustained read/write throughput of 0.73Gb/s. When an index merge of level 7 or above starts, it consumes as many IOPS up to all on the node until it completes. Because EventStoreDB has a shared nothing architecture for clustering this operation is likely to cause all nodes to appear to stall simultaneously as they all try and perform an index merge at the same time. By setting `MaxAutoMergeLevel` to 6 or below you can avoid this, and you can run the merge on each node individually keeping read/write latency in the cluster consistent.
+> A cluster with 3000 256b IOPS can read/write about 0.73Gb/sec (This level of IOPS represents a small cloud instance). Assuming sustained read/write throughput of 0.73Gb/s. When an index merge of level 7 or above starts, it consumes as many IOPS up to all on the node until it completes. Because TrogonEventStore has a shared nothing architecture for clustering this operation is likely to cause all nodes to appear to stall simultaneously as they all try and perform an index merge at the same time. By setting `MaxAutoMergeLevel` to 6 or below you can avoid this, and you can run the merge on each node individually keeping read/write latency in the cluster consistent.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -89,6 +89,8 @@ variables. See [Configuration](configuration.md).
 TrogonEventStore can run under the Windows Service Control Manager, but the
 source build does not register itself automatically.
 
+The node handles Service Control Manager stop requests through graceful shutdown.
+
 Example service registration:
 
 ```powershell:no-line-numbers
@@ -96,13 +98,10 @@ sc.exe create TrogonDB binPath= "C:\TrogonDB\EventStore.ClusterNode.exe --config
 sc.exe start TrogonDB
 ```
 
-If the HTTP listener needs a URL ACL, configure it explicitly:
-
-```powershell:no-line-numbers
-netsh http add urlacl url=http://+:2113/ user=DOMAIN\username
-```
-
-For more information, refer to Microsoft's `add urlacl` documentation.
+Do not rely on Service Control Manager failure actions alone to keep the service running. Some server workflows
+intentionally exit successfully, including the restart required after database truncation, and successful exits
+do not trigger failure recovery. Use an external service monitor or scheduled start command when automatic
+recovery is required.
 
 ## Cluster startup
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,261 +2,115 @@
 title: "Installation"
 ---
 
-## Quick start
+# Installation
 
-EventStoreDB can run as a single node or as a highly-available cluster. For the cluster deployment, you'd need
-three server nodes.
+TrogonEventStore can run as a single node for local development or as a cluster
+for production-like deployments.
 
-The installation procedure consists of the following steps:
-
-- Create a configuration file for each cluster node.
-- Install EventStoreDB on each node using one of the available methods.
-- Obtain SSL certificates, either signed by a publicly trusted or private certificate authority.
-- Copy the configuration files and SSL certificates to each node.
-- Start the EventStoreDB service on each node.
-- Check the cluster status using the Admin UI on any node.
-
-### Default access
+## Default access
 
 | User  | Password |
 |-------|----------|
 | admin | changeit |
 | ops   | changeit |
 
-## Linux
+Change the default credentials before using a node outside a disposable local
+environment.
 
-### Install from PackageCloud
+## Local development
 
-EventStoreDB has pre-built [packages available for Debian-based distributions](https://packagecloud.io/EventStore/EventStore-OSS), or you can [build from source](https://github.com/EventStore/EventStore#linux). The package name to install is `eventstore-oss`.
-
-Commercial version with additional features is available as a separate package `eventstore-commercial`.
-
-Before installing the package from Packagecloud, add the repository to your system:
+Build the cluster node from source:
 
 ```bash:no-line-numbers
-curl -s https://packagecloud.io/install/repositories/EventStore/EventStore-OSS/script.deb.sh | sudo bash
+dotnet build -c Release src
 ```
 
-For the commercial version:
+Start a single local node:
 
 ```bash:no-line-numbers
-curl -s https://<key>@packagecloud.io/install/repositories/EventStore/EventStore-Commercial/script.deb.sh | sudo bash
+dotnet ./src/EventStore.ClusterNode/bin/Release/net10.0/EventStore.ClusterNode.dll \
+  --dev \
+  --db ./tmp/data \
+  --index ./tmp/index \
+  --log ./tmp/log
 ```
 
-Then, install the package:
+The `--dev` option is intended for disposable local development. For any shared
+or production-like environment, configure certificates and authentication
+explicitly.
+
+## Docker
+
+Build a local Docker image from the repository:
 
 ```bash:no-line-numbers
-sudo apt install eventstore-oss
+docker build --tag trogondb-local . \
+  --build-arg CONTAINER_RUNTIME=noble \
+  --build-arg RUNTIME=linux-x64
 ```
 
-For the commercial version:
+Run a single local node:
 
 ```bash:no-line-numbers
-sudo apt install eventstore-commercial
+docker run --rm --name trogondb-node -it -p 2113:2113 \
+  trogondb-local \
+  --dev \
+  --db /var/lib/trogondb/data \
+  --index /var/lib/trogondb/index \
+  --log /var/log/trogondb
 ```
 
-::: tip
-RPM packages are not available as part of the [EventStore/EventStore-OSS](https://packagecloud.io/EventStore/EventStore-OSS/) Packagecloud repository
-::: 
+For durable local data, mount database, index, and log directories into the
+container.
 
-If you installed from a pre-built package, the server is registered as a service. Therefore, you can start EventStoreDB with:
+## Production checklist
 
-```bash:no-line-numbers
-sudo systemctl start eventstore
-```
+Before running a durable node or cluster:
 
-When you install the EventStoreDB package, the service doesn't start by default. This allows you to change the configuration located at `etc/eventstore/eventstore.conf` and to prevent creating database and index files in the default location.
+- Provide node certificates explicitly.
+- Decide whether clients use TLS and configure the connection strings
+  accordingly.
+- Configure authentication methods in [Security](security.md).
+- Store data, index, and logs on durable volumes.
+- Expose `/-/liveness`, `/-/readiness`, and `/-/metrics` to the platform.
+- Use gRPC clients for application reads and writes.
 
-::: warning
-We recommend that when using Linux you set the 'open file limit' to a high number. The precise value depends on your use case, but at least between `30,000` and `60,000`.
-:::
+## Linux service notes
 
-### Building from source
+When running on Linux, set the open file limit high enough for the expected
+database size and workload. The precise value depends on the deployment, but
+operators commonly start between `30000` and `60000`.
 
-You can also build EventStoreDB from source. Before doing that, you need to install the .NET 10 SDK. EventStoreDB packages have the .NET Runtime embedded, so you don't need to install anything except the EventStoreDB package.
+Configuration can be supplied with command-line options, YAML, or environment
+variables. See [Configuration](configuration.md).
 
-### Uninstall
+## Windows service notes
 
-If you installed one of the [pre-built packages for Debian based systems](https://packagecloud.io/EventStore/EventStore-OSS), you can remove it with:
+TrogonEventStore can run under the Windows Service Control Manager, but the
+source build does not register itself automatically.
 
-```bash
-sudo apt-get purge eventstore-oss
-```
-or
-```bash
-sudo apt-get purge eventstore-commercial
-```
-
-This removes EventStoreDB completely, including any user settings.
-
-If you built EventStoreDB from source, remove it by deleting the directory containing the source and build and manually removing any environment variables.
-
-## Windows
-
-EventStoreDB can run under the Windows Service Control Manager, but it does not install itself as a service automatically.
-
-### Install from Chocolatey
-
-EventStoreDB has [Chocolatey packages](https://chocolatey.org/packages/eventstore-oss) available that you can
-install with the following command with administrator permissions.
+Example service registration:
 
 ```powershell:no-line-numbers
-choco install eventstore-oss
+sc.exe create TrogonDB binPath= "C:\TrogonDB\EventStore.ClusterNode.exe --config C:\TrogonDB\trogondb.conf"
+sc.exe start TrogonDB
 ```
 
-### Download the binaries
-
-You can also [download](https://eventstore.com/downloads/) a binary, unzip the archive and run from the folder
-location with administrator permissions.
-
-The following command starts EventStoreDB in dev mode with the database stored at the path `./db` and the logs in `./logs`.
-Read more about configuring the EventStoreDB server in the [Configuration section](configuration.md).
-
-```powershell:no-line-numbers
-EventStore.ClusterNode.exe --dev --db ./db --log ./logs
-```
-
-To run EventStoreDB as a Windows service, register the executable with the Service Control Manager and pass the same arguments you would use on the command line:
-
-```powershell:no-line-numbers
-sc.exe create EventStoreDB binPath= "C:\EventStore\EventStore.ClusterNode.exe --config C:\EventStore\eventstore.conf"
-sc.exe start EventStoreDB
-```
-
-EventStoreDB runs in an administration context because it starts an HTTP server through `http.sys`. For
-permanent or production instances, you need to provide an ACL such as:
+If the HTTP listener needs a URL ACL, configure it explicitly:
 
 ```powershell:no-line-numbers
 netsh http add urlacl url=http://+:2113/ user=DOMAIN\username
 ```
 
-For more information, refer to
-Microsoft's `add urlacl` [documentation](https://docs.microsoft.com/en-us/windows/win32/http/add-urlacl).
+For more information, refer to Microsoft's `add urlacl` documentation.
 
-To build EventStoreDB from source, refer to the
-EventStoreDB [GitHub repository](https://github.com/EventStore/EventStore#building-eventstoredb).
+## Cluster startup
 
-### Uninstall
+A production cluster normally uses three nodes. For each node:
 
-If you installed EventStoreDB with Chocolatey, you can uninstall with:
-
-```powershell:no-line-numbers
-choco uninstall eventstore-oss
-```
-
-This removes the `eventstore-oss` Chocolatey package.
-
-If you installed EventStoreDB by [downloading a binary](https://eventstore.com/downloads/), you can remove it
-by:
-
-- Deleting the `EventStore-OSS-Win-*` directory.
-- Removing the directory from your PATH.
-
-## Docker
-
-You can run EventStoreDB in a Docker container as a single node, using insecure mode. It is useful in most
-cases to try out the product and for local development purposes.
-
-It's also possible to run a three-node cluster with or without SSL using Docker Compose. Such a setup is
-closer to what you'd run in production.
-
-### Run with Docker
-
-EventStoreDB has a Docker image available for any platform that supports Docker.
-
-The following command will start the EventStoreDB node using default HTTP port, without security. You can then
-connect to it using one of the clients and the `esdb://localhost:2113?tls=false` connection string. You can also access the Admin UI by opening http://localhost:2113/ui in your browser.
-
-```bash:no-line-numbers
-docker run --name esdb-node -it -p 2113:2113 \
-    eventstore/eventstore:latest --insecure --run-projections=All
-```
-
-Then, you'd be able to connect to EventStoreDB with gRPC clients and use the Admin UI.
-
-In order to sustainably keep the data, we also recommend mapping the database and index volumes.
-
-### Use Docker Compose
-
-You can also run a single-node instance or a three-node secure cluster locally using Docker Compose.
-
-#### Insecure single node
-
-You can use Docker Compose to run EventStoreDB in the same setup as the `docker run` command mentioned before.
-
-Create file `docker-compose.yaml` with following content:
-
-@[code{curl}](@samples/docker-compose.yaml)
-
-Run the instance:
-
-```bash:no-line-numbers
-docker-compose up
-```
-
-The command above would run EventStoreDB as a single node without SSL.
-
-::: warning
-The legacy TCP client protocol is disabled by default and will no longer be available since version 24.2. 
-To enable it in versions lower than 24.2, add the environment variable to the yaml file: 
-EVENTSTORE_ENABLE_EXTERNAL_TCP=true
-:::
-
-#### Secure cluster
-
-With Docker Compose, you can also run a three-node cluster with security enabled. That kind of setup is
-something you'd expect to use in production.
-
-Create file `docker-compose.yaml` with following content:
-
-@[code{curl}](@samples/docker-compose-cluster.yaml)
-
-Quite a few settings are shared between the nodes and we use the `env` file to avoid repeating those settings.
-So, add the `vars.env` file to the same location:
-
-@[code{curl}](@samples/vars.env)
-
-Containers will use the shared volume using the local `./certs` directory for certificates. However, if you
-let Docker create the directory on startup, the container won't be able to get write access to it.
-Therefore, you should create the `certs` directory manually. You only need to do it once.
-
-```bash:no-line-numbers
-mkdir certs
-```
-
-Now you are ready to start the cluster.
-
-```bash:no-line-numbers
-docker-compose up
-```
-
-Watching the log messages, you will see that after some time, the elections process completes. Then you're able to connect to each
-node using the Admin UI. Nodes should be accessible on the loopback address (`127.0.0.1` or `localhost`) over
-HTTP, using ports specified below:
-
-| Node  | HTTP port |
-|:------|:----------|
-| node1 | 2111      |
-| node2 | 2112      |
-| node3 | 2113      |
-
-You have to tell your client to use secure connection.
-
-| Protocol | Connection string                                                                  |
-|:---------|:-----------------------------------------------------------------------------------|
-| gRPC     | `esdb://localhost:2111,localhost:2112,localhost:2113?tls=true&tlsVerifyCert=false` |
-
-As you might've noticed, the connection string has a setting to disable the certificate validation (`tlsVerifyCert=false`). It would prevent the invalid certificate error since the cluster uses a private, auto-generated CA.
-
-However, **we do not recommend using this setting in production**. Instead, you can either add the CA certificate to the trusted root CA store or instruct your application to use such a certificate. See the [security section](security.md#certificate-installation-on-a-client-environment) for detailed instructions.
-
-## Compatibility notes
-
-Depending on how your EventStoreDB instance is configured, some features might not work. Below are some features that are unavailable due to the specified options.
-
-| Feature                       | Options impact                                                                                                                                                                          |
-|:------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Connection without SSL or TLS | EventStoreDB 20.6+ is secure by default. Your clients need to establish a secure connection, unless you use the `Insecure` option.                                                      |
-| Authentication and ACLs       | When using the `Insecure` option for the server, all security is disabled. User management workflows are unavailable because there is no authentication subsystem to manage.             |
-| Projections                   | Running projections is disabled by default. Projection workflows require enabling projections explicitly by using the `RunProjections` option.                                         |
-| Stream browser                | The Admin UI stream browser uses the server management surface. Application clients should use gRPC for event access.                                                                  |
+1. Create a node-specific configuration file.
+2. Provide node certificates and trusted roots.
+3. Configure gossip addresses for the cluster members.
+4. Start the node.
+5. Check readiness on `/-/readiness`.
+6. Check the cluster view in the Admin UI.

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -4,19 +4,22 @@ title: Networking
 
 ## Network configuration
 
-EventStoreDB provides two interfaces: 
+TrogonEventStore provides two interfaces:
 - HTTP(S) for gRPC communication, the Admin UI, and operational endpoints such as health checks and metrics
 - TCP for cluster replication (internal)
 
 Nodes in the cluster replicate with each other using the TCP protocol, but use gRPC for [discovering other cluster nodes](cluster.md#discovering-cluster-members).
 
-Server nodes separate internal and external TCP communication explicitly, but use a single HTTP binding. Replication between the cluster nodes is considered internal, and all the TCP clients that connect to the database are external. EventStoreDB allows you to separate network configurations for internal and external communication. For example, you can use different network interfaces on the node. All the internal communication can go over the isolated private network, but access for external clients can be configured on another interface, which is connected to a more open network. You can set restrictions on those external interfaces to make your deployment more secure.
+Server nodes use a single HTTP binding for gRPC, the Admin UI, health, metrics,
+and supported diagnostics. Replication between cluster nodes is internal and can
+be placed on a private network interface. Keep public client access on gRPC and
+avoid exposing replication ports outside the cluster network.
 
 For gRPC and HTTP, there's no internal vs external separation of traffic.
 
 ## HTTP configuration
 
-HTTP is the primary protocol for EventStoreDB. It carries gRPC communication, the Admin UI, health checks, metrics, and supported diagnostics endpoints.
+HTTP is the primary protocol for TrogonEventStore. It carries gRPC communication, the Admin UI, health checks, metrics, and supported diagnostics endpoints.
 The HTTP endpoint always binds to the IP address configured in the `NodeIp` setting (previously referred to as `ExtIp`).
 
 | Format               | Syntax               |
@@ -25,7 +28,7 @@ The HTTP endpoint always binds to the IP address configured in the `NodeIp` sett
 | YAML                 | `NodeIp`             |
 | Environment variable | `EVENTSTORE_NODE_IP` |
 
-When the `NodeIp` setting is not provided, EventStoreDB will use the first available non-loopback address. You can also bind HTTP to all available interfaces using `0.0.0.0` as the setting value. If you do that, you'd need to configure the `NodeHostAdvertiseAs` (previously `ExtHostAdvertiseAs`) setting (read more [here](#network-address-translation)), since `0.0.0.0` is not a valid IP address to connect from the outside world.
+When the `NodeIp` setting is not provided, TrogonEventStore will use the first available non-loopback address. You can also bind HTTP to all available interfaces using `0.0.0.0` as the setting value. If you do that, you'd need to configure the `NodeHostAdvertiseAs` (previously `ExtHostAdvertiseAs`) setting (read more [here](#network-address-translation)), since `0.0.0.0` is not a valid IP address to connect from the outside world.
 
 ::: warning
 Please note that the `ExtIp` parameter has been deprecated as of version 23.10.0 and will be removed in future versions. It is recommended to use the `NodeIp` parameter instead.
@@ -53,7 +56,7 @@ If your network setup requires any kind of IP address, DNS name and port transla
 
 The reliability of the connection between the client application and database is crucial for the stability of the solution. If the network is not stable or has some periodic issues, the client may drop the connection. Stability is essential for stream subscriptions where a client is listening to database notifications. Having an existing connection open when an app resumes activity allows for the initial gRPC calls to be made quickly, without any delay caused by the reestablished connection.
 
-EventStoreDB supports the built-in gRPC mechanism for keeping the connection alive. If the other side does not acknowledge the ping within a certain period, the connection will be closed. Note that pings are only necessary when there's no activity on the connection.
+TrogonEventStore supports the built-in gRPC mechanism for keeping the connection alive. If the other side does not acknowledge the ping within a certain period, the connection will be closed. Note that pings are only necessary when there's no activity on the connection.
 
 Keepalive pings are enabled by default, with the default interval set to 10 seconds. The default value is based on the [gRPC proposal](https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md#extending-for-basic-health-checking) that suggests 10 seconds as the minimum. It's a compromise value to ensure that the connection is open and not making too many redundant network calls.
 
@@ -83,7 +86,7 @@ After having pinged for keepalive check, the server waits for a duration of `kee
 
 **Default**: `10000` (ms, 10 sec)
 
-As a general rule, we do not recommend putting EventStoreDB behind a load balancer. However, if you are using it and want to benefit from the Keepalive feature, then you should make sure if the compatible settings are properly set. Some load balancers may also override the Keepalive settings. Most of them require setting the idle timeout larger/longer than the `keepAliveTimeout`. We suggest checking the load balancer documentation before using Keepalive pings.
+As a general rule, we do not recommend putting TrogonEventStore behind a load balancer. However, if you are using it and want to benefit from the Keepalive feature, then you should make sure if the compatible settings are properly set. Some load balancers may also override the Keepalive settings. Most of them require setting the idle timeout larger/longer than the `keepAliveTimeout`. We suggest checking the load balancer documentation before using Keepalive pings.
 
 ### HTTP caching
 
@@ -91,11 +94,11 @@ As a general rule, we do not recommend putting EventStoreDB behind a load balanc
 This section is about caching HTTP resources such as the Admin UI. It does not affect the server performance directly and cannot be used with gRPC clients.
 :::
 
-Most static resources that EventStoreDB emits are immutable and can be cached safely.
+Most static resources that TrogonEventStore emits are immutable and can be cached safely.
 
 This caching behavior is great for performance in a production environment and we recommended you use it, but in a developer environment it can become confusing.
 
-To avoid this during development it's best to run EventStoreDB with the `--disable-http-caching` command line option. This disables all caching and solves the issue.
+To avoid this during development it's best to run TrogonEventStore with the `--disable-http-caching` command line option. This disables all caching and solves the issue.
 
 The option can be set as follows:
 
@@ -109,7 +112,7 @@ The option can be set as follows:
 
 ### Kestrel Settings
 
-It's generally not expected that you'll need to update the Kestrel configuration that EventStoreDB has set by default, but it's good to know that you can update the following settings if needed.
+It's generally not expected that you'll need to update the Kestrel configuration that TrogonEventStore has set by default, but it's good to know that you can update the following settings if needed.
 
 Kestrel uses the `kestrelsettings.json` configuration file. This file should be located in the [default configuration directory](configuration.md#configuration-file).
 
@@ -143,13 +146,13 @@ This is configured with `Kestrel.Limits.Http2.InitialStreamWindowSize` in the se
 
 ## Replication protocol
 
-Replication between cluster nodes uses a proprietary TCP-based protocol. Options for configuring the internal replication protocol are described below.
+Replication between cluster nodes uses an internal TCP-based protocol. Options for configuring the internal replication protocol are described below.
 
 ### Interface and port
 
 Internal TCP binds to the IP address specified in the `ReplicationIp` setting (previously `IntIp`). It must be configured if you run a multi-node cluster.
 
-By default, EventStoreDB binds its internal networking on the loopback interface only (`127.0.0.1`). You can change this behaviour and tell EventStoreDB to listen on a specific internal IP address. To do that set the `ReplicationIp` to `0.0.0.0` or the IP address of the network interface.
+By default, TrogonEventStore binds its internal networking on the loopback interface only (`127.0.0.1`). You can change this behaviour and tell TrogonEventStore to listen on a specific internal IP address. To do that set the `ReplicationIp` to `0.0.0.0` or the IP address of the network interface.
 
 | Format               | Syntax                      |
 |:---------------------|:----------------------------|
@@ -165,7 +168,7 @@ If you keep this setting to its default value, cluster nodes won't be able to ta
 Please note that the `IntIp` parameter has been deprecated as of version 23.10.0 and will be removed in future versions. It is recommended to use the `ReplicationIp` parameter instead.
 :::
 
-By default, EventStoreDB uses port `1112` for internal TCP. You can change this by specifying the `ReplicationPort` setting (previously `IntTcpPort` setting).
+By default, TrogonEventStore uses port `1112` for internal TCP. You can change this by specifying the `ReplicationPort` setting (previously `IntTcpPort` setting).
 
 | Format               | Syntax                        |
 |:---------------------|:------------------------------|
@@ -197,9 +200,9 @@ If your network setup requires any kind of IP address, DNS name and port transla
 
 Due to NAT (network address translation), or other reasons a node may not be bound to the address it is reachable from other nodes. For example, the machine has an IP address of `192.168.1.13`, but the node is visible to other nodes as `10.114.12.112`.
 
-Options described below allow you to tell the node that even though it is bound to a given address it should not gossip that address. When returning links over HTTP, EventStoreDB will also use the specified addresses instead of physical addresses, so the clients that use HTTP can follow those links.
+Options described below allow you to tell the node that even though it is bound to a given address it should not gossip that address. When returning links over HTTP, TrogonEventStore will also use the specified addresses instead of physical addresses, so the clients that use HTTP can follow those links.
 
-Another case when you might want to specify the advertised address although there's no address translation involved. When you configure EventStoreDB to bind to `0.0.0.0`, it will use the first non-loopback address for gossip. It might or might not be the address you want it to use. Whilst the best way to avoid such a situation is to configure the binding properly using the `NodeIp` and `ReplicationIp` settings, you can also use address translation setting with the correct IP address or DNS name.
+Another case when you might want to specify the advertised address although there's no address translation involved. When you configure TrogonEventStore to bind to `0.0.0.0`, it will use the first non-loopback address for gossip. It might or might not be the address you want it to use. Whilst the best way to avoid such a situation is to configure the binding properly using the `NodeIp` and `ReplicationIp` settings, you can also use address translation setting with the correct IP address or DNS name.
 
 Also, even if you specified the `NodeIp` and `ReplicationIp` settings in the configuration, you might still want to override the advertised address if you want to use hostnames and not IP addresses. That might be needed when running a secure cluster with certificates that only contain DNS names of the nodes.
 
@@ -213,7 +216,7 @@ By default, a cluster node will advertise itself using `NodeIp` and `NodePort`. 
 |:---------------------|:------------------------------------|
 | Command line         | `--node-port-advertise-as`          |
 | YAML                 | `NodePortAdvertiseAs`               |
-| Environment variable | `EVENTSTORE_NODE_PORT_ADVERTISE_AS` | 
+| Environment variable | `EVENTSTORE_NODE_PORT_ADVERTISE_AS` |
 
 ::: warning
 Please note that the `HttpPortAdvertiseAs` parameter has been deprecated as of version 23.10.0 and will be removed in future versions. It is recommended to use the `NodePortAdvertiseAs` parameter instead.
@@ -225,7 +228,7 @@ If you want the node to advertise itself using the hostname rather than its IP a
 |:---------------------|:------------------------------------|
 | Command line         | `--node-host-advertise-as`          |
 | YAML                 | `NodeHostAdvertiseAs`               |
-| Environment variable | `EVENTSTORE_NODE_HOST_ADVERTISE_AS` | 
+| Environment variable | `EVENTSTORE_NODE_HOST_ADVERTISE_AS` |
 
 ::: warning
 Please note that the `ExtHostAdvertiseAs` parameter has been deprecated as of version 23.10.0 and will be removed in future versions. It is recommended to use the `NodeHostAdvertiseAs` parameter instead.
@@ -239,7 +242,7 @@ TCP ports used for replication can be advertised using custom values:
 |:---------------------|:-----------------------------------------------|
 | Command line         | `--replication-tcp-port-advertise-as`          |
 | YAML                 | `ReplicationTcpPortAdvertiseAs`                |
-| Environment variable | `EVENTSTORE_REPLICATION_TCP_PORT_ADVERTISE_AS` | 
+| Environment variable | `EVENTSTORE_REPLICATION_TCP_PORT_ADVERTISE_AS` |
 
 ::: warning
 Please note that the `IntTcpPortAdvertiseAs` parameter has been deprecated as of version 23.10.0 and will be removed in future versions. It is recommended to use the `ReplicationTcpPortAdvertiseAs` and `NodeTcpPortAdvertiseAs` parameters instead, respectively.
@@ -251,7 +254,7 @@ If you want to change how the node TCP address is advertised internally, use the
 |:---------------------|:-------------------------------------------|
 | Command line         | `--replication-host-advertise-as`          |
 | YAML                 | `ReplicationHostAdvertiseAs`               |
-| Environment variable | `EVENTSTORE_REPLICATION_HOST_ADVERTISE_AS` | 
+| Environment variable | `EVENTSTORE_REPLICATION_HOST_ADVERTISE_AS` |
 
 ::: warning
 Please note that the `IntHostAdvertiseAs` parameter has been deprecated as of version 23.10.0 and will be removed in future versions. It is recommended to use the `ReplicationHostAdvertiseAs` parameter instead.
@@ -269,7 +272,7 @@ Specify the advertised hostname or IP address:
 |:---------------------|:-----------------------------------------|
 | Command line         | `--advertise-host-to-client-as`          |
 | YAML                 | `AdvertiseHostToClientAs`                |
-| Environment variable | `EVENTSTORE_ADVERTISE_HOST_TO_CLIENT_AS` | 
+| Environment variable | `EVENTSTORE_ADVERTISE_HOST_TO_CLIENT_AS` |
 
 Specify the advertised HTTP(S) port (previously `AdvertiseHttpPortToClientAs` setting):
 
@@ -285,11 +288,11 @@ Please note that the `AdvertiseHttpPortToClientAs` parameter has been deprecated
 
 ## Heartbeat timeouts
 
-EventStoreDB uses heartbeats over all TCP connections to discover dead clients and nodes. Heartbeat timeouts should not be too short, as short timeouts will produce false positives. At the same time, setting too long timeouts will prevent discovering dead nodes and clients in time.
+TrogonEventStore uses heartbeats over all TCP connections to discover dead clients and nodes. Heartbeat timeouts should not be too short, as short timeouts will produce false positives. At the same time, setting too long timeouts will prevent discovering dead nodes and clients in time.
 
-Each heartbeat has two points of configuration. The first is the _interval;_ this represents how often the system should consider a heartbeat. EventStoreDB doesn't send a heartbeat for every interval, but only if it has not heard from a node within the configured interval. In a busy cluster, you may never see any heartbeats.
+Each heartbeat has two points of configuration. The first is the _interval;_ this represents how often the system should consider a heartbeat. TrogonEventStore doesn't send a heartbeat for every interval, but only if it has not heard from a node within the configured interval. In a busy cluster, you may never see any heartbeats.
 
-The second point of configuration is the _timeout_. This determines how long EventStoreDB server waits for a client or node to respond to a heartbeat request.
+The second point of configuration is the _timeout_. This determines how long TrogonEventStore server waits for a client or node to respond to a heartbeat request.
 
 Different environments need different values for these settings. The defaults are likely fine on a LAN. If you experience frequent elections in your environment, you can try to increase both interval and timeout, for example:
 
@@ -306,7 +309,7 @@ Replication/Internal TCP heartbeat (between cluster nodes):
 |:---------------------|:--------------------------------------------|
 | Command line         | `--replication-heartbeat-interval`          |
 | YAML                 | `ReplicationHeartbeatInterval`              |
-| Environment variable | `EVENTSTORE_REPLICATION_HEARTBEAT_INTERVAL` | 
+| Environment variable | `EVENTSTORE_REPLICATION_HEARTBEAT_INTERVAL` |
 
 **Default**: `700` (ms)
 
@@ -314,7 +317,7 @@ Replication/Internal TCP heartbeat (between cluster nodes):
 |:---------------------|:-------------------------------------------|
 | Command line         | `--replication-heartbeat-timeout`          |
 | YAML                 | `ReplicationHeartbeatTimeout`              |
-| Environment variable | `EVENTSTORE_REPLICATION_HEARTBEAT_TIMEOUT` | 
+| Environment variable | `EVENTSTORE_REPLICATION_HEARTBEAT_TIMEOUT` |
 
 **Default**: `700` (ms)
 
@@ -324,7 +327,7 @@ Please note that the `IntTcpHeartbeatInterval` and `IntTcpHeartbeatTimeout` para
 
 ### gRPC heartbeats
 
-For the gRPC heartbeats, EventStoreDB and its gRPC clients use the protocol feature called _Keepalive ping_. Read more about it on the [HTTP configuration page](#keep-alive-pings).
+For the gRPC heartbeats, TrogonEventStore and its gRPC clients use the protocol feature called _Keepalive ping_. Read more about it on the [HTTP configuration page](#keep-alive-pings).
 
 ## Exposing endpoints
 
@@ -350,96 +353,11 @@ You can disable the Prometheus metrics endpoint by setting `DisableStatsOnHttp` 
 
 **Default**: `false`, the Prometheus metrics endpoint is enabled on `/-/metrics`.
 
-## External TCP 
+## Application protocol boundary
 
-<wbr><Badge type="warning" text="Commercial" vertical="middle"/>
+TrogonEventStore does not document an external TCP client protocol. Application
+reads and writes should use gRPC clients.
 
-The TCP client protocol plugin enables client applications based on the external TCP API to run without any changes. This provides developers a mechanism to migrate to gRPC clients. This bridge solution enables development teams to plan for the End Of Life (EOL) of the external TCP API. Past the EOL, the external TCP API will no longer be supported.
-
-### Enabling the plugin
-
-Refer to the general [plugins configuration](./configuration.md#plugins-configuration) guide to see how to configure plugins with JSON files and environment variables.
-
-To enable the TCP API plugin, save the following configuration in a JSON file, for example `<esdb-installation-directory>/config/tcp-plugin-config.json`, in the EventStoreDB installation directory for a node:
-
-```json
-{
-  "EventStore": {
-    "TcpPlugin": {
-      "EnableExternalTcp": true
-    }
-  }
-}
-```
-
-Once the plugin is enabled, the server will log a message similar to the one below:
-
-```text
-[11212, 1,18:44:34.070,INF] "TcpApi" "24.6.0.0" plugin enabled.
-```
-
-### Other parameters
-
-The following options can be set in the json configuration:
-
-1. `NodeHeartbeatTimeout` - defaults to: 1000
-2. `NodeHeartbeatInterval` - defaults to: 2000
-3. `NodeTcpPort` - defaults to: 1113
-4. `NodeTcpPortAdvertiseAs` - defaults to: 1113
-
-The above default values can be overridden, for example:
-
-```json
-{
-  "EventStore": {
-    "TcpPlugin": {
-      "EnableExternalTcp": true,
-      "NodeTcpPort": 8113,
-      "NodeTcpPortAdvertiseAs": 8113,
-      "NodeHeartbeatInterval": 2000,
-      "NodeHeartbeatTimeout": 1000
-    }
-  }
-}
-```
-
-### Troubleshooting
-
-#### Plugin doesn't load
-
-The plugin has to be located in a subdirectory of the server's plugins directory. To check this:
-
-1. Go to the installation directory of a node, the directory containing the EventStoreDb executable.
-2. In this directory, there should be a directory called `plugins`, create it if this is not the case.
-3. The `plugins` directory should have a subdirectory for the TCP API plugin, for example `EventStore.TcpPlugin`. Create it if it doesn't exist.
-4. The binaries of the plugin should be located in that same subdirectory.
-
-You can verify which plugins have been found and loaded by searching for log entries similar to the following:
-
-```text
-[11212, 1,18:44:30.420,INF] Plugins path: "C:\\EventStore\\plugins"
-[11212, 1,18:44:30.420,INF] Adding: "C:\\EventStore\\plugins" to the plugin catalog.
-[11212, 1,18:44:30.422,INF] Adding: "C:\\EventStore\\plugins\\EventStore.Licensing" to the plugin catalog.
-[11212, 1,18:44:30.432,INF] Adding: "C:\\EventStore\\plugins\\EventStore.POC.ConnectedSubsystemsPlugin" to the plugin catalog.
-[11212, 1,18:44:30.433,INF] Adding: "C:\\EventStore\\plugins\\EventStore.POC.ConnectorsPlugin" to the plugin catalog.
-[11212, 1,18:44:30.436,INF] Adding: "C:\\EventStore\\plugins\\EventStore.TcpPlugin" to the plugin catalog.
-[11212, 1,18:44:30.479,INF] Loaded SubsystemsPlugin plugin: "licensing" "24.10.0.0".
-[11212, 1,18:44:30.483,INF] Loaded SubsystemsPlugin plugin: "connected" "0.0.5".
-[11212, 1,18:44:30.496,INF] Loaded ConnectedSubsystemsPlugin plugin: "connectors" "0.0.5".
-[11212, 1,18:44:30.504,INF] Loaded SubsystemsPlugin plugin: "tcp-api" "24.10.0.0".
-```
-
-#### Plugin doesn't start
-
-The plugin has to be configured to be enabled.
-If you see the following log it means the plugin was found but not started:
-
-```text
-[ 5104, 1,19:03:13.807,INF] "TcpApi" "24.6.0.0" plugin disabled. "Set 'EventStore:TcpPlugin:EnableExternalTcp' to 'true' to enable"
-```
-
-When the plugin starts, you should see a log similar to the following:
-
-```text
-[11212, 1,18:44:34.070,INF] "TcpApi" "24.6.0.0" plugin enabled.
-```
+Internal replication can still use node-to-node transport that is not part of
+the public client API. Treat those settings as cluster internals, not as a
+client integration surface.

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -184,7 +184,7 @@ Please note that the `IntTcpPort` parameter has been deprecated as of version 23
 
 ### Security
 
-When the node is secured (by default), all the TCP traffic will use TLS. You can disable TLS for TCP internally and externally using the settings described below.
+When the node is secured, replication TCP uses TLS. You can disable TLS for replication TCP using the setting described below.
 
 | Format               | Syntax                                |
 |:---------------------|:--------------------------------------|

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -28,7 +28,8 @@ The HTTP endpoint always binds to the IP address configured in the `NodeIp` sett
 | YAML                 | `NodeIp`             |
 | Environment variable | `EVENTSTORE_NODE_IP` |
 
-When the `NodeIp` setting is not provided, TrogonEventStore will use the first available non-loopback address. You can also bind HTTP to all available interfaces using `0.0.0.0` as the setting value. If you do that, you'd need to configure the `NodeHostAdvertiseAs` (previously `ExtHostAdvertiseAs`) setting (read more [here](#network-address-translation)), since `0.0.0.0` is not a valid IP address to connect from the outside world.
+`NodeIp` defaults to `127.0.0.1`. Set it to `0.0.0.0` to bind all interfaces and configure a
+`NodeHostAdvertiseAs` value that clients can resolve, since `0.0.0.0` is not a connectable address.
 
 ::: warning
 Please note that the `ExtIp` parameter has been deprecated as of version 23.10.0 and will be removed in future versions. It is recommended to use the `NodeIp` parameter instead.
@@ -184,15 +185,9 @@ Please note that the `IntTcpPort` parameter has been deprecated as of version 23
 
 ### Security
 
-When the node is secured, replication TCP uses TLS. You can disable TLS for replication TCP using the setting described below.
-
-| Format               | Syntax                                |
-|:---------------------|:--------------------------------------|
-| Command line         | `--disable-internal-tcp-tls`          |
-| YAML                 | `DisableInternalTcpTls`               |
-| Environment variable | `EVENTSTORE_DISABLE_INTERNAL_TCP_TLS` |
-
-**Default**: `false`
+When TLS is enabled, replication uses the configured node certificate. Replication TLS cannot be disabled
+independently. `DisableTls` disables TLS for both HTTP and replication while preserving authentication and
+authorization.
 
 If your network setup requires any kind of IP address, DNS name and port translation for internal communication, you can use available [address translation](#network-address-translation) settings.
 
@@ -333,7 +328,7 @@ For the gRPC heartbeats, TrogonEventStore and its gRPC clients use the protocol 
 
 If you need to reduce the HTTP surface, you can disable the browser-facing Admin UI and the Prometheus metrics endpoint. Health probes and gRPC remain part of the supported HTTP listener.
 
-You can disable the Admin UI by setting `DisableAdminUi` to `true`.
+You can disable the Admin UI and its administrative API endpoints by setting `DisableAdminUi` to `true`.
 
 | Format               | Syntax                    |
 |:---------------------|:--------------------------|
@@ -341,7 +336,7 @@ You can disable the Admin UI by setting `DisableAdminUi` to `true`.
 | YAML                 | `DisableAdminUi`          |
 | Environment variable | `EVENTSTORE_DISABLE_ADMIN_UI` |
 
-**Default**: `false`, Admin UI is enabled.
+**Default**: `false`, Admin UI and administrative API endpoints are enabled.
 
 You can disable the Prometheus metrics endpoint by setting `DisableStatsOnHttp` to `true`.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -472,8 +472,7 @@ In TrogonEventStore, the certificates require updating when they have expired or
 ### Step 1: Generate new certificates
 
 The new certificates can be created in the same manner as you generated the existing certificates.
-You can use the EventStore [es-gencert-cli](https://github.com/EventStore/es-gencert-cli) tool to generate the CA and node certificates.
-You can also follow the [Configurator](https://configurator.eventstore.com/) to create commands for generating the certificates based on your cluster's configuration.
+Use the same CA process that issued the current certificates, and verify that each replacement satisfies the [certificate requirements](security.md#certificate-generation) for the node's current DNS names and IP addresses.
 
 ::: tip
 As of version 23.10.0, it is possible to do a rolling update with new certificates having a Common Name (CN) that's different from the original certificates. If `CertificateReservedNodeCommonName` was set in your configuration, any changes to its value will be taken into consideration during a config reload.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -97,10 +97,18 @@ Scavenging does place extra load on the server, especially in terms of disk IO. 
 
 ### Archive storage
 
-Archive mode stores completed chunks outside the local database directory before retention can remove them locally.
-The supported archive backend is the S3 API. This includes AWS S3 and S3-compatible services that expose the same object-storage API.
+Archive mode lets archive-enabled nodes read completed chunks from S3 and remove local copies during scavenging
+after the retention conditions are met. The supported archive backend is the S3 API, including compatible
+object-storage services.
+
+One designated Archiver node uploads completed, committed chunks in log order. In a multi-node cluster, the
+Archiver must be a read-only replica. Configure `ReadOnlyReplica: true` and `Archiver: true` on that node, and
+configure the same `Archive` storage on every node that must read archived chunks.
 
 ```yaml
+ClusterSize: 3
+ReadOnlyReplica: true
+Archiver: true
 Archive:
   Enabled: true
   StorageType: S3
@@ -122,6 +130,22 @@ Deployments that use explicit S3 credentials must provide these keys in each env
 The same keys can be supplied with environment variables such as `EventStore__Archive__S3__AccessKeyId`,
 `EventStore__Archive__S3__SecretAccessKey`, `EventStore__Archive__S3__SessionToken`, and
 `EventStore__Archive__S3__ServiceUrl`.
+
+Archiving is asynchronous. Upload and checkpoint failures retry every minute. Shutdown cancels current work;
+completed local chunks are discovered again after restart.
+
+Reads for chunks no longer stored locally issue object-storage requests. Their latency and availability depend
+on the S3 service and network. When read concurrency is limited, slower archive reads may cause other reads to
+wait.
+
+There are currently no dedicated archive queue-depth or archive-checkpoint metrics. The
+`eventstore-logical-chunk-read-distribution` metric measures how far reads are from the log tail when event-read
+metrics are enabled.
+
+Archive storage supplements backups; it does not replace them. Only completed, committed chunks through the
+archive checkpoint are uploaded. Keep normal database and index backups. During startup, an archive-enabled
+node whose writer checkpoint is behind the archive downloads missing chunks through that checkpoint before
+joining the cluster.
 
 ## Scavenging algorithm
 
@@ -311,7 +335,7 @@ rewriting unrelated business history.
 
 ## Backup and restore
 
-Backing up an TrogonEventStore database is straightforward but relies on carrying out the steps below in the
+Backing up a TrogonEventStore database is straightforward but relies on carrying out the steps below in the
 correct order.
 
 ### Types of backups
@@ -358,7 +382,7 @@ By default, there are two directories containing data that needs to be included 
 The exact name and location are dependent on your configuration.
 
 - `db/ ` contains:
-  - the chunks files named `chk-X.Y` where `X` is the chunk number and `Y` the version.
+  - the chunk files named `chunk-X.Y` where `X` is the chunk number and `Y` the version.
   - the checkpoints files `*.chk` (`chaser.chk`, `epoch.chk`, `proposal.chk`, `truncate.chk`, `writer.chk`)
 - `index/ ` contains:
   - the index map: `indexmap`

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,17 +1,17 @@
 # Maintenance
 
-EventStoreDB requires regular maintenance with three operational concerns:
+TrogonEventStore requires regular maintenance with three operational concerns:
 
 - [Scavenging](#scavenging) for freeing up space after deleting events.
 - [Backup and restore](#backup-and-restore) for disaster recovery.
 - [Certificate update](#certificate-update-upon-expiry) to renew certificates.
 
-You might also be interested learning about EventStoreDB [diagnostics](diagnostics/README.md)
+You might also be interested learning about TrogonEventStore [diagnostics](diagnostics/README.md)
 and [indexes](./indexes.md), which might require some Ops attention.
 
 ## Scavenging
 
-In EventStoreDB, events are no longer present in stream reads or subscriptions after they have been deleted or they have expired according to the metadata of the stream.
+In TrogonEventStore, events are no longer present in stream reads or subscriptions after they have been deleted or they have expired according to the metadata of the stream.
 
 The events are, however, still present in the database and will be visible in reads and subscriptions to the `$all` stream.
 
@@ -296,74 +296,22 @@ The default value is 100000.
 | YAML                 | `ScavengeHashUsersCacheCapacity`                |
 | Environment variable | `EVENTSTORE_SCAVENGE_HASH_USERS_CACHE_CAPACITY` |
 
-## Redaction <Badge text="Commercial" type="warning" vertical="middle"/>
+## Removing sensitive event data
 
-In EventStoreDB, events are immutable and cannot be changed after they are written. Usually, when you have an event with data that needs to be deleted you should take the following steps:
+Events are immutable once written. If event data must no longer be retained,
+prefer an event-sourcing correction flow:
 
-- Rewrite the stream to a new stream without the data to be removed.
-- Delete the old stream.
-- Run a scavenge to remove the data from disk on each node in turn.
+- Write replacement events or replacement streams that omit the sensitive data.
+- Stop using the old stream in application code.
+- Delete the old stream when it is no longer needed.
+- Run scavenging on each node to reclaim deleted data from disk.
 
-If this procedure is impractical for your use case, then you can use the redaction tool (the "redactor") to blank out the data of specific events.
-
-::: warning
-Use the redactor as a last resort and only if you know what you're doing. Redacting events may lead to unintended consequences in your subscriptions and projections!
-:::
-
-### Prerequisites
-
-Using redaction has the following prerequisites:
-
-- A commercial license.
-- EventStoreDB version 23.6.0 or above. If running on Windows, Windows Server 2019 or above is required.
-- Server configuration option: `EnableUnixSocket: True`.
-- The redactor tool (see steps below on how to get it).
-
-### Getting the redactor
-
-Redaction requires a commercial license. Due to its sensitive nature, the tool is available only upon request. Please [contact us here](https://www.eventstore.com/contact) if you do not have commercial support, or reach out to our support team if you do.
-
-### Running the redactor
-
-The binary needs to be extracted and run locally on an EventStoreDB node. Similar to scavenging, redaction affects only the node where it's running. Thus, it must be run once on each node of the cluster.
-
-The redactor takes two mandatory parameters as input:
-
-| Parameter  | Description                                                                             |
-| :--------- | --------------------------------------------------------------------------------------- |
-| `--db`     | The path to the database directory containing the chunk files.                          |
-| `--events` | A comma-separated list of events to be redacted in the format: `eventNumber@streamName` |
-
-Specify `--help` to see the full list of options.
-
-The redactor will blank out the data section of the specified events with one bits (0xFF bytes) keeping the data size exactly the same as it was before. It will also set a flag (`IsRedacted`) on the event's record to indicate that the event has been redacted. All other properties of the event such as the event type, event metadata, and timestamp will remain unchanged.
-
-![Redactor run](./images/redaction-run.png)
-
-If you read the data of a redacted event from an external client, you should see data composed of only 0xFF bytes. The Admin UI will also label redacted events.
-
-::: tip
-The redactor is not an offline tool. The EventStoreDB server must be running, as the redactor needs to communicate with it to obtain information about the events to be redacted and replace the chunk files with the redacted ones.
-:::
-
-### How the redactor works
-
-The redactor follows these steps:
-
-1. It establishes a connection to the database via a unix domain socket located in the database directory.
-
-2. It then fetches information about the events to be redacted from the server via an RPC call. This information includes the chunk file the event is in and the event's position in the chunk.
-
-3. A list is built of chunk files containing events to be redacted.
-
-4. For each chunk in the list:
-   - It is copied to a file with a .tmp extension in the database directory.
-   - The requested event(s) are redacted in the .tmp chunk file.
-   - The .tmp chunk is atomically switched into the database via an RPC call on the server.
+Design streams so sensitive data can be isolated, deleted, or replaced without
+rewriting unrelated business history.
 
 ## Backup and restore
 
-Backing up an EventStoreDB database is straightforward but relies on carrying out the steps below in the
+Backing up an TrogonEventStore database is straightforward but relies on carrying out the steps below in the
 correct order.
 
 ### Types of backups
@@ -443,7 +391,7 @@ rsync -a data/*.0* backup
 
 #### Restore
 
-1. Ensure the EventStoreDB process is stopped. Restoring a database on running instance is not possible and,
+1. Ensure the TrogonEventStore process is stopped. Restoring a database on running instance is not possible and,
    in most cases, will lead to data corruption.
 2. Copy all files to the desired location.
 3. Create a copy of `chaser.chk` and call it `truncate.chk`. This effectively overwrites the
@@ -486,7 +434,7 @@ Then backup the log:
 
 #### Restore
 
-1. Ensure the Event Store DB process is stopped. Restoring a database on running instance is not possible and,
+1. Ensure the TrogonEventStore process is stopped. Restoring a database on running instance is not possible and,
    in most cases, will lead to data corruption.
 2. Copy all files to the desired location.
 3. Create a copy of `chaser.chk` and call it `truncate.chk`.
@@ -508,7 +456,7 @@ column store. These methods would require a manual set up for restoring a cluste
 
 #### Backup cluster
 
-Use a second EventStoreDB cluster as a backup. Such a strategy is known as a primary/secondary back up scheme.
+Use a second TrogonEventStore cluster as a backup. Such a strategy is known as a primary/secondary back up scheme.
 
 The primary cluster asynchronously pushes data to the second cluster using a durable subscription. The second
 cluster is available in case of a disaster on the primary cluster.
@@ -519,7 +467,7 @@ problem.
 
 ## Certificate update upon expiry
 
-In EventStoreDB, the certificates require updating when they have expired or are going to expire soon. Follow the steps below to perform a rolling certificate update.
+In TrogonEventStore, the certificates require updating when they have expired or are going to expire soon. Follow the steps below to perform a rolling certificate update.
 
 ### Step 1: Generate new certificates
 
@@ -561,7 +509,7 @@ reload the configuration from the _Operations_ page of the Admin UI.
 
 #### Linux OS
 
-Linux users can also send the SIGHUP signal to the EventStoreDB to reload the certificates.
+Linux users can also send the SIGHUP signal to the TrogonEventStore to reload the certificates.
 
 For Example:
 
@@ -569,7 +517,7 @@ For Example:
 kill -s SIGHUP 38956
 ```
 
-Here "38956" is the Process ID (PID) of EventStoreDB on our local machine. To find the PID, use the following command in the Linux terminal.
+Here "38956" is the Process ID (PID) of TrogonEventStore on our local machine. To find the PID, use the following command in the Linux terminal.
 
 ```
 pidof eventstored
@@ -579,11 +527,11 @@ Once the configuration has been reloaded successfully, the server logs will look
 
 ```
 [108277,29,14:46:07.457,INF] Loading the node's certificate(s) from file: "/home/ubuntu/links/node.crt"
-[108277,29,14:46:07.488,INF] Loading the node's certificate. Subject: "CN=eventstoredb-node", Previous thumbprint: "05526714107700C519E24794E8964A3B30EF9BD0", New thumbprint: "BE6D5CD681D7B9281D60A5969B5A7E31AF775E9F"
-[108277,29,14:46:07.488,INF] Loading intermediate certificate. Subject: "CN=EventStoreDB Intermediate CA 78ae8d5a159b247568039cf64f4b04ad, O=Event Store Ltd, C=UK", Thumbprint: "ED4AA0C5ED4AD120DDEE2FA8B3B0CCC5A30B81E3"
+[108277,29,14:46:07.488,INF] Loading the node's certificate. Subject: "CN=trogondb-node", Previous thumbprint: "05526714107700C519E24794E8964A3B30EF9BD0", New thumbprint: "BE6D5CD681D7B9281D60A5969B5A7E31AF775E9F"
+[108277,29,14:46:07.488,INF] Loading intermediate certificate. Subject: "CN=TrogonDB Intermediate CA 78ae8d5a159b247568039cf64f4b04ad, O=Straw Hat, LLC, C=US", Thumbprint: "ED4AA0C5ED4AD120DDEE2FA8B3B0CCC5A30B81E3"
 [108277,29,14:46:07.489,INF] Loading trusted root certificates.
 [108277,29,14:46:07.490,INF] Loading trusted root certificate file: "/home/ubuntu/links/ca/ca.crt"
-[108277,29,14:46:07.491,INF] Loading trusted root certificate. Subject: "CN=EventStoreDB CA c39fece76b4efcb65846145c942c037c, O=Event Store Ltd, C=UK", Thumbprint: "5F020804E8D7C419F9FC69ED3B4BC72DD79A5996"
+[108277,29,14:46:07.491,INF] Loading trusted root certificate. Subject: "CN=TrogonDB CA c39fece76b4efcb65846145c942c037c, O=Straw Hat, LLC, C=US", Thumbprint: "5F020804E8D7C419F9FC69ED3B4BC72DD79A5996"
 [108277,29,14:46:07.493,INF] Certificate chain verification successful.
 [108277,29,14:46:07.493,INF] All certificates successfully loaded.
 [108277,29,14:46:07.494,INF] The node's configuration was successfully reloaded
@@ -607,8 +555,8 @@ Now update the certificates on the other nodes.
 
 ### Step 5: Monitor the cluster
 
-The connection between nodes in EventStoreDB reset every 10 minutes so the new configuration won’t take immediate effect. Use this time to update the certificates on all of the nodes. It is advisable to monitor the cluster after this timeframe to make sure everything is working as expected.
-The EventStoreDB will log certificate errors if the certificates are not reloaded on all of the nodes before the connection resets.
+The connection between nodes in TrogonEventStore reset every 10 minutes so the new configuration won’t take immediate effect. Use this time to update the certificates on all of the nodes. It is advisable to monitor the cluster after this timeframe to make sure everything is working as expected.
+The TrogonEventStore will log certificate errors if the certificates are not reloaded on all of the nodes before the connection resets.
 
 ```
 [108277,29,14:59:47.489,ERR] eventstoredb-node : A certificate chain could not be built to a trusted root authority.

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "esdb-docs",
+  "name": "trogoneventstore-docs",
   "version": "1.0.0",
   "private": true,
-  "author": "Event Store Ltd",
+  "author": "Straw Hat, LLC",
   "devDependencies": {
     "@types/markdown-it": "^14.1.2",
     "eslint": "^10.6.0",

--- a/docs/persistent-subscriptions.md
+++ b/docs/persistent-subscriptions.md
@@ -34,7 +34,7 @@ Clients must acknowledge (or not acknowledge) messages as they are handled. If m
 
 ## Parked messages
 
-Messages that have been retried too often will be parked in the persistent subscription's parked message stream. This stream is named `$persistentsubscription-{groupname}::{streamname}-parked`. You can easily see the number of parked events in the persistent subscription statistics or browse and replay parked messages from the Admin UI _Subscriptions_ page.
+Messages that have been retried too often are parked in `$persistentsubscription-{streamname}::{groupname}-parked`. You can easily see the number of parked events in the persistent subscription statistics or browse and replay parked messages from the Admin UI _Subscriptions_ page.
 
 If you want to retry the parked messages, you can `Replay` the parked messages for that subscription. This will push the parked messages to subscribers before any new events on the subscription.
 
@@ -44,7 +44,7 @@ If you don't want to replay any of the parked messages for a subscription and wa
 
 ## Checkpointing
 
-Once a persistent subscription has handled enough events, it will write a checkpoint. If the subscription is restarted, for example due to a Leader change, then the persistent subscription will continue processing from the last checkpoint. This means that some events my be received multiple times by consumers.
+Checkpoints are `$SubscriptionCheckpoint` events stored in `$persistentsubscription-{streamname}::{groupname}-checkpoint`. On restart, the subscription loads the latest checkpoint and resumes after that position. Events processed after the last durable checkpoint may therefore be delivered again. For compatibility, the server also reads checkpoints using the earlier `SubscriptionCheckpoint` event type.
 
 If a persistent subscription has a filter, then the persistent subscription will checkpoint when enough events are either handled or skipped by the filter.
 

--- a/docs/persistent-subscriptions.md
+++ b/docs/persistent-subscriptions.md
@@ -8,7 +8,7 @@ A common operation is to subscribe to a stream and receive notifications for cha
 
 You can only subscribe to one stream or the `$all` stream. You can use server-side projections for linking events to new aggregated streams. System projections create pre-defined streams that aggregate events by type or by category and are available out-of-the box. Learn more about system and user-defined projections [here](projections.md).
 
-Persistent subscriptions run on the Leader node and are not dropped when the connection is closed. Moreover, this subscription type supports the "[competing consumers](https://www.enterpriseintegrationpatterns.com/patterns/messaging/CompetingConsumers.html)" messaging pattern and are useful when you need to distribute messages to many workers. EventStoreDB saves the subscription state server-side and allows for at-least-once delivery guarantees across multiple consumers on the same stream. It is possible to have many groups of consumers compete on the same stream, with each group getting an at-least-once guarantee.
+Persistent subscriptions run on the Leader node and are not dropped when the connection is closed. Moreover, this subscription type supports the "[competing consumers](https://www.enterpriseintegrationpatterns.com/patterns/messaging/CompetingConsumers.html)" messaging pattern and are useful when you need to distribute messages to many workers. TrogonEventStore saves the subscription state server-side and allows for at-least-once delivery guarantees across multiple consumers on the same stream. It is possible to have many groups of consumers compete on the same stream, with each group getting an at-least-once guarantee.
 
 ::: tip
 The Admin UI _Subscriptions_ page can create, update, delete, and inspect persistent subscriptions for streams and the `$all` stream.
@@ -72,7 +72,7 @@ This option can be seen as a fall-back scenario for high availability, when a si
 
 For use with an indexing projection such as the [system](projections.md#by-category) `$by_category` projection.
 
-EventStoreDB inspects the event for its source stream id, hashing the id to one of 1024 buckets assigned to individual clients. When a client disconnects its buckets are assigned to other clients. When a client connects, it is assigned some existing buckets. This naively attempts to maintain a balanced workload.
+TrogonEventStore inspects the event for its source stream id, hashing the id to one of 1024 buckets assigned to individual clients. When a client disconnects its buckets are assigned to other clients. When a client connects, it is assigned some existing buckets. This naively attempts to maintain a balanced workload.
 
 The main aim of this strategy is to decrease the likelihood of concurrency and ordering issues while maintaining load balancing. This is not a guarantee, and you should handle the usual ordering and concurrency issues.
 

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -4,7 +4,7 @@ title: Projections
 
 ## Introduction
 
-Projections is an EventStoreDB subsystem that lets you append new events or link existing events to streams in
+Projections is an TrogonEventStore subsystem that lets you append new events or link existing events to streams in
 a reactive manner.
 
 Projections are good at solving one specific query type, a category known as 'temporal correlation queries'.
@@ -52,7 +52,7 @@ meet the criteria. The output of all queries is a stream, you can listen to this
 
 ### Types of projections
 
-There are two types of projections in EventStoreDB:
+There are two types of projections in TrogonEventStore:
 
 - [Built in (system) projections](#system-projections)
 - [User-defined JavaScript projections](#user-defined-projections) which you create via the API or the admin
@@ -98,7 +98,7 @@ something else did.
 
 ## System projections
 
-EventStoreDB ships with five built in projections:
+TrogonEventStore ships with five built in projections:
 
 - [By Category](#by-category) (`$by_category`)
 - [By Event Type](#by-event-type) (`$by_event_type`)
@@ -108,7 +108,7 @@ EventStoreDB ships with five built in projections:
 
 ### Enabling system projections
 
-When you start EventStoreDB from a fresh database, these projections are present but disabled and querying
+When you start TrogonEventStore from a fresh database, these projections are present but disabled and querying
 their statuses returns `Stopped`. You can enable a projection from the Admin UI or through the projection
 management gRPC surface, which switches the status of the projection from `Stopped` to `Running`.
 
@@ -314,7 +314,7 @@ handler. The event provided through the handler contains the following propertie
 
 ## Configuring projections
 
-By changing these settings, you can lessen the amount of pressure projections put on an EventStoreDB node or
+By changing these settings, you can lessen the amount of pressure projections put on an TrogonEventStore node or
 improve projection performance. You can change these settings on a case-by-case basis, and monitor potential
 improvements.
 
@@ -332,7 +332,7 @@ Admin UI _Projections_ page.
 These options control how projections append events.
 
 In busy systems, projections can put a lot of extra pressure on the master node. This is especially true for
-EventStoreDB servers that also have persistent subscriptions running, which only the master node can process.
+TrogonEventStore servers that also have persistent subscriptions running, which only the master node can process.
 If you see a lot of commit timeouts and slow writes from your projections and other clients, then start with
 these settings.
 
@@ -348,7 +348,7 @@ you see an error message like the following:
 'emit' is not allowed by the projection/configuration/mode
 ```
 
-EventStoreDB disables this setting by default, and is usually set when you create the projection and if you
+TrogonEventStore disables this setting by default, and is usually set when you create the projection and if you
 need the projection to emit events.
 
 #### Track emitted streams
@@ -361,7 +361,7 @@ should only the setting if you intend to delete a projection and create new ones
 stream.
 
 ::: warning 
-By default, EventStoreDB disables the `trackemittedstreams` setting for projections. When enabled,
+By default, TrogonEventStore disables the `trackemittedstreams` setting for projections. When enabled,
 an event appended records the stream name (in `$projections-{projection_name}-emittedstreams`) of each event
 emitted by the projection. This means that write amplification is a possibility, as each event that the
 projection emits appends a separate event. As such, this option is not recommended for projections that emit a
@@ -369,7 +369,7 @@ lot of events, and you should enable only where necessary.
 :::
 
 ::: tip 
-Between EventStoreDB versions 3.8.0 and 4.0.2, this option was enabled by default when a projection
+Between TrogonEventStore versions 3.8.0 and 4.0.2, this option was enabled by default when a projection
 was created through the UI. If you have any projections created during this time frame, it's worth checking
 whether this option is enabled.
 :::
@@ -470,7 +470,7 @@ projection from the same node view.
 ### Logging from within a projection
 
 For debugging purposes, projections includes a log method which, when called, sends messages to the configured
-EventStoreDB logger (the default is `NLog`, to a file, and `stdout`).
+TrogonEventStore logger (the default is `NLog`, to a file, and `stdout`).
 
 You might find printing out the structure of the event body for inspection useful.
 
@@ -521,7 +521,7 @@ Use _Edit source_ to change the persistent projection definition.
 Settings in this section concern projections that are running on the server.
 
 ::: warning 
-Server-side projections impact the performance of the EventStoreDB server. For example, some
+Server-side projections impact the performance of the TrogonEventStore server. For example, some
 standard [system projections](#system-projections) like Category or Event Type projections produce new (link)
 events that are stored in the database in addition to the original event. This effectively doubles or triples
 the number of events appended and therefore creates pressure on the IO of the server node. We often call this
@@ -554,7 +554,7 @@ projections.
 
 The option accepts three values: `None`, `System` and `All`.
 
-When the option value is set to `None`, the projections subsystem of EventStoreDB will be completely disabled
+When the option value is set to `None`, the projections subsystem of TrogonEventStore will be completely disabled
 and projection workflows in the Admin UI will be unavailable.
 
 By using the `System` value for this option, you can instruct the server to enable system projections when the

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -96,6 +96,35 @@ etc. If anyone can append to the emitted streams, then the projection would have
 in terms of processing. Therefore, it can no longer trust that the projection itself emitted that event or if
 something else did.
 
+### Resetting a projection
+
+Resetting a projection advances its epoch. The next start ignores checkpoints from the previous epoch and
+processes its source again from the beginning.
+
+Reset does not delete the projection definition or immediately delete all of its streams. When the new epoch
+emits to an existing output stream, the runtime updates that stream's metadata so the previous logical output is
+truncated before replacement events are appended.
+
+### Projection streams
+
+The projection subsystem uses reserved streams for definitions, checkpoints, ordering, and results.
+
+| Purpose                          | Stream                                                         |
+|:---------------------------------|:---------------------------------------------------------------|
+| Registration                     | `$projections-$all`                                            |
+| Definition and configuration     | `$projections-{projection-name}`                               |
+| Checkpoint                       | `$projections-{projection-name}-checkpoint`                    |
+| Default result                   | `$projections-{projection-name}-result`                        |
+| Partition result                 | `$projections-{projection-name}-{partition}-result`            |
+| Partition checkpoint             | `$projections-{projection-name}-{partition}-checkpoint`        |
+| Partition catalog                | `$projections-{projection-name}-partitions`                    |
+| Multi-stream ordering            | `$projections-{projection-name}-order`                         |
+| Emitted-stream tracking          | `$projections-{projection-name}-emittedstreams`                |
+| Emitted-stream deletion progress | `$projections-{projection-name}-emittedstreams-checkpoint`     |
+
+`resultStreamName` can override the default result stream. Projection handlers can also use `emit()` and
+`linkTo()` to target other streams.
+
 ## System projections
 
 TrogonEventStore ships with five built in projections:
@@ -451,15 +480,11 @@ projection starts reading again.
 
 **Default:** `5000` (events).
 
-#### Projection Execution Timeout
+#### Per-projection execution timeout
 
-The `ProjectionExecutionTimeout` setting specifies per event projection processing timeout. If an event is not processed within the specified duration, the projection will fault and won't process further events.
-
-::: tip 
-Increase value of this setting if projection handler is compute intensive or server is under heavy load
-:::
-
-**Default:** `250` (ms).
+A projection's optional `ProjectionExecutionTimeout` value specifies a positive timeout in milliseconds. When
+set, it overrides the node-wide projection execution timeout. When omitted, the projection inherits the
+node-wide value. A projection faults and stops processing when a handler exceeds the effective timeout.
 
 ## Debugging
 
@@ -527,6 +552,15 @@ events that are stored in the database in addition to the original event. This e
 the number of events appended and therefore creates pressure on the IO of the server node. We often call this
 effect "write amplification".
 :::
+
+### Projection execution timeout
+
+The node-wide `ProjectionExecutionTimeout` applies to projections without a per-projection override. Its default
+is `250` milliseconds.
+
+A projection faulted by a timeout can be restarted to resume from its latest checkpoint. If the limit is still
+insufficient, it will fault again. Changing the node-wide value requires restarting the server. A faulted
+projection's individual override can be updated and the projection restarted without restarting the server.
 
 ### Projection runtime
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -52,6 +52,24 @@ For this to work, you can use the `Insecure` option:
 When running with protocol security disabled, everything is sent unencrypted over the wire. In the previous version it included the server credentials. Sending username and password over the wire without encryption is not secure by definition, but it might give a false sense of security. To make things explicit, TrogonEventStore v20+ **does not use any authentication and authorisation** (including ACLs) when running insecure.
 :::
 
+### Disable TLS
+
+Use `DisableTls` when authentication and authorization must remain enabled while transport encryption is
+disabled.
+
+| Format               | Syntax                   |
+|:---------------------|:-------------------------|
+| Command line         | `--disable-tls`          |
+| YAML                 | `DisableTls`             |
+| Environment variable | `EVENTSTORE_DISABLE_TLS` |
+
+**Default**: `false`
+
+::: warning
+`DisableTls` sends credentials and all other traffic without encryption. Use it only on a trusted network or
+when another network layer provides transport security.
+:::
+
 ### Set initial passwords
 
 We are adding an ability to set default admin and ops passwords on the first run of the database. It will not impact the existing credentials, the user can log into their accounts with existing passwords.
@@ -157,7 +175,7 @@ If you are running on Windows, you can also load the trusted root certificate fr
 
 | Format               | Syntax                                      |
 |:---------------------|:--------------------------------------------|
-| Command line         | `--trusted-root-certificates-paths`         |
+| Command line         | `--trusted-root-certificates-path`          |
 | YAML                 | `TrustedRootCertificatesPath`               |
 | Environment variable | `EVENTSTORE_TRUSTED_ROOT_CERTIFICATES_PATH` |
 
@@ -286,11 +304,16 @@ For a multi-node deployment, provision:
 - Subject alternative names for every DNS name and IP address used by clients or replication traffic.
 - A common-name policy that matches `CertificateReservedNodeCommonName`.
 
+Node certificates require Digital Signature plus either Key Encipherment or Key Agreement. If an Extended Key
+Usage extension is present, it must contain both Server Authentication (`1.3.6.1.5.5.7.3.1`) and Client
+Authentication (`1.3.6.1.5.5.7.3.2`). Certificates without an Extended Key Usage extension remain accepted for
+compatibility.
+
 Keep CA private keys outside the node and client environments. Install only the CA certificate, node certificate, and node private key required by each machine.
 
 ::: warning
-If you are running TrogonEventStore on Linux, remember that all certificate files should have restrictive rights, otherwise the OS won't allow using them.
-Usually, you'd need to change rights for each certificate file to prevent the "permissions are too open" error.
+Keep certificate private keys readable only by the account running TrogonEventStore. Restrictive permissions
+reduce the risk of another local account reading the key.
 
 You can do it by running the following command:
 
@@ -444,19 +467,11 @@ Import-Certificate -FilePath .\ca.crt -CertStoreLocation Cert:\LocalMachine\CA
 :::
 ::::
 
-### TCP protocol security
+### Replication protocol security
 
-Cluster nodes use TCP for replication. Unless TrogonEventStore is running without transport security, replication TCP uses the configured node certificates.
-
-You can disable TLS for replication TCP with the following setting.
-
-| Format               | Syntax                                |
-|:---------------------|:--------------------------------------|
-| Command line         | `--disable-internal-tcp-tls`          |
-| YAML                 | `DisableInternalTcpTls`               |
-| Environment variable | `EVENTSTORE_DISABLE_INTERNAL_TCP_TLS` |
-
-**Default**: `false`
+When TLS is enabled, cluster replication uses the configured node certificate. Replication TLS cannot be
+disabled independently. Use [`DisableTls`](#disable-tls) to disable transport encryption for both HTTP and
+replication while preserving authentication and authorization.
 
 ## Authentication
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -4,10 +4,10 @@ title: "Security"
 
 ## Security
 
-For production use, it is important to configure EventStoreDB security features to prevent unauthorised access
+For production use, it is important to configure TrogonEventStore security features to prevent unauthorised access
 to your data.
 
-Security features of EventStoreDB include:
+Security features of TrogonEventStore include:
 
 - [User management](#authentication) for allowing users with different roles to access the database
 - [Access Control Lists](#access-control-lists) to restrict access to specific event streams
@@ -15,9 +15,10 @@ Security features of EventStoreDB include:
 
 ### Protocol security
 
-EventStoreDB supports gRPC and the proprietary TCP protocol for high-throughput real-time communication. It
-also has some HTTP endpoints for the management operations like scavenging, creating projections and so on.
-EventStoreDB also uses HTTP for the gossip seed endpoint, both internally for the cluster gossip, and
+TrogonEventStore supports gRPC for client communication and internal TCP for
+cluster replication. It also has HTTP endpoints for the Admin UI, health,
+metrics, and supported operator workflows.
+TrogonEventStore also uses HTTP for the gossip seed endpoint, both internally for the cluster gossip, and
 internally for clients that connect to the cluster using discovery mode.
 
 All those protocols support encryption with TLS and SSL. Each protocol has its own security configuration, but
@@ -25,7 +26,7 @@ you can only use one set of certificates for both TLS and HTTPS.
 
 The protocol security configuration depends a lot on the deployment topology and platform. We have created an
 interactive [configuration tool](installation.md), which also has instructions on how to generate and install
-the certificates and configure EventStoreDB nodes to use them.
+the certificates and configure TrogonEventStore nodes to use them.
 
 ## Security options
 
@@ -33,9 +34,9 @@ Below you can find more details about each of the available security options.
 
 ### Running without security
 
-Unlike previous versions, EventStoreDB v20+ is secure by default. It means that you have to supply valid certificates and configuration for the database node to work.
+Unlike previous versions, TrogonEventStore v20+ is secure by default. It means that you have to supply valid certificates and configuration for the database node to work.
 
-We realise that many users want to try out the latest version with their existing applications, and also run a previous version of EventStoreDB without any security in their internal networks.
+We realise that many users want to try out the latest version with their existing applications, and also run a previous version of TrogonEventStore without any security in their internal networks.
 
 For this to work, you can use the `Insecure` option:
 
@@ -48,7 +49,7 @@ For this to work, you can use the `Insecure` option:
 **Default**: `false`
 
 ::: warning
-When running with protocol security disabled, everything is sent unencrypted over the wire. In the previous version it included the server credentials. Sending username and password over the wire without encryption is not secure by definition, but it might give a false sense of security. To make things explicit, EventStoreDB v20+ **does not use any authentication and authorisation** (including ACLs) when running insecure.
+When running with protocol security disabled, everything is sent unencrypted over the wire. In the previous version it included the server credentials. Sending username and password over the wire without encryption is not secure by definition, but it might give a false sense of security. To make things explicit, TrogonEventStore v20+ **does not use any authentication and authorisation** (including ACLs) when running insecure.
 :::
 
 ### Set initial passwords
@@ -126,10 +127,10 @@ In this section, you can find settings related to protocol security (HTTPS and T
 
 SSL certificates can be created with a common name (CN), which is an arbitrary string. Usually it contains the DNS name for which the certificate is issued.
 
-When cluster nodes connect to each other, they need to ensure that they indeed talk to another node and not something that pretends to be a node. To achieve that, EventStoreDB authenticates a connecting node by ensuring that it supplies a trusted client certificate having a CN that matches exactly with the CN in its own certificate. This essentially means that the CN must be the same across all node certificates by default. For example, when using the Event Store [certificate generator](#certificate-generation-tool), the CN is set to `eventstoredb-node` in all node certificates.
+When cluster nodes connect to each other, they need to ensure that they indeed talk to another node and not something that pretends to be a node. To achieve that, TrogonEventStore authenticates a connecting node by ensuring that it supplies a trusted client certificate having a CN that matches exactly with the CN in its own certificate. This essentially means that the CN must be the same across all node certificates by default. For example, generated local-development certificates commonly use `trogondb-node` in all node certificates.
 
 ::: note
-Prior to version 23.10.0, the `CertificateReservedNodeCommonName` setting needed to be configured if a user had certificates with a CN other than `eventstoredb-node`. EventStoreDB will now, by default, automatically read the CN from the node's certificate and use it as the `CertificateReservedNodeCommonName`. However, if you still choose to specify the `CertificateReservedNodeCommonName` in your configuration, it will take precedence.
+Prior to version 23.10.0, the `CertificateReservedNodeCommonName` setting needed to be configured if a user had certificates with a CN other than `eventstoredb-node`. TrogonEventStore will now, by default, automatically read the CN from the node's certificate and use it as the `CertificateReservedNodeCommonName`. However, if you still choose to specify the `CertificateReservedNodeCommonName` in your configuration, it will take precedence.
 :::
 
 In practice, it's not always possible to obtain certificates where the CN is the same across all nodes. For instance, when using a public CA, single-domain certificates are very common and these certificates cannot be used on multiple nodes as they are valid for exactly one host. In this case, the `CertificateReservedNodeCommonName` setting can be configured with a wildcard as per the following example:
@@ -150,7 +151,7 @@ Server certificates **must** have the internal and external IP addresses (`Repli
 
 When getting an incoming connection, the server needs to ensure if the certificate used for the connection can be trusted. For this to work, the server needs to know where trusted root certificates are located.
 
-EventStoreDB will use the default trusted root certificates location of `/etc/ssl/certs` when running on Linux only. So if you are running on Windows or a platform with a different default certificates location, you'd need to explicitly tell the node to use the OS default root certificate store. For certificates signed by a private CA, you just provide the path to the CA certificate file (but not the filename).
+TrogonEventStore will use the default trusted root certificates location of `/etc/ssl/certs` when running on Linux only. So if you are running on Windows or a platform with a different default certificates location, you'd need to explicitly tell the node to use the OS default root certificate store. For certificates signed by a private CA, you just provide the path to the CA certificate file (but not the filename).
 
 If you are running on Windows, you can also load the trusted root certificate from the Windows Certificate Store. The available options for configuring this are described [below](#certificate-store-windows).
 
@@ -264,7 +265,7 @@ If using the thumbprint, the server expects to only find one trusted root certif
 | Environment variable | `EVENTSTORE_TRUSTED_ROOT_CERTIFICATE_THUMBPRINT` |
 
 The subject name matches any certificate that contains the specified name. This means that multiple matching certificates could be found.
-To match any root certificate made through the es-gencert-cli, you can set the Subject Name to `EventStoreDB CA`.
+To match any root certificate made through the es-gencert-cli, you can set the Subject Name to `TrogonEventStore CA`.
 
 If multiple matching root certificates are found, then the root certificate with the latest expiry date will be selected.
 
@@ -276,7 +277,7 @@ If multiple matching root certificates are found, then the root certificate with
 
 ### Certificate generation tool
 
-Event Store provides the interactive Certificate Generation CLI, which creates certificates signed by a private, auto-generated CA for EventStoreDB. You can use the [configuration wizard](installation.md), that will provide you exact CLI commands that you need to run to generate certificates matching your configuration.
+Use your platform certificate tooling, public CA, or private CA process to create certificates that match your deployment. For local development, generated certificates can be useful as long as the resulting node and trust settings are explicit.
 
 #### Getting started
 
@@ -297,7 +298,7 @@ Getting help for a specific command:
 ```
 
 ::: warning
-If you are running EventStoreDB on Linux, remember that all certificate files should have restrictive rights, otherwise the OS won't allow using them.
+If you are running TrogonEventStore on Linux, remember that all certificate files should have restrictive rights, otherwise the OS won't allow using them.
 Usually, you'd need to change rights for each certificate file to prevent the "permissions are too open" error.
 
 You can do it by running the following command:
@@ -365,7 +366,7 @@ You can customise generated cert by providing following params:
 While generating the certificate, you need to remember to pass internal end external:
 - IP addresses to `-ip-addresses`: e.g. `127.0.0.1,172.20.240.1` and/or
 - DNS names to `-dns-names`: e.g. `localhost,node1.eventstore`
-  that will match the URLs that you will be accessing EventStoreDB nodes.
+  that will match the URLs that you will be accessing TrogonEventStore nodes.
   :::
 
 Sample:
@@ -409,11 +410,11 @@ services:
       - ./certs:/certs
 ```
 
-See more in the [complete sample of docker-compose secured cluster configuration.](installation.md#use-docker-compose)
+See more in the [cluster startup guidance.](installation.md#cluster-startup)
 
 ### Certificate installation on a client environment
 
-To connect to EventStoreDB, you need to install the auto-generated CA certificate file on the client machine (e.g. machine where the client is hosted, or your dev environment).
+To connect to TrogonEventStore, you need to install the auto-generated CA certificate file on the client machine (e.g. machine where the client is hosted, or your dev environment).
 
 #### Linux (Ubuntu, Debian)
 
@@ -533,16 +534,16 @@ ii) To improve performance by preventing certificate downloads if your certifica
 
 :::: tabs
 ::: tab Linux
-The following script assumes EventStoreDB is running under the `eventstore` account.
+The following script assumes TrogonEventStore is running under the same service account that owns the node process.
 
 ```bash
-sudo su eventstore --shell /bin/bash
+sudo su <service-account> --shell /bin/bash
 dotnet tool install --global dotnet-certificate-tool
  ~/.dotnet/tools/certificate-tool add -s CertificateAuthority -l CurrentUser --file /path/to/intermediate.crt
 ```
 :::
 ::: tab Windows
-To import the intermediate certificate in the `Intermediate Certification Authorities` certificate store, run the following PowerShell command under the same account as EventStoreDB is running:
+To import the intermediate certificate in the `Intermediate Certification Authorities` certificate store, run the following PowerShell command under the same account as TrogonEventStore is running:
 
 ```powershell
 Import-Certificate -FilePath .\path\to\intermediate.crt -CertStoreLocation Cert:\CurrentUser\CA
@@ -558,7 +559,7 @@ Import-Certificate -FilePath .\ca.crt -CertStoreLocation Cert:\LocalMachine\CA
 
 ### TCP protocol security
 
-Although TCP is disabled by default for external connections (clients), cluster nodes still use TCP for replication. If you aren't running EventStoreDB in insecure mode, all TCP communication will use TLS using the same certificates as SSL.
+Although TCP is disabled by default for external connections (clients), cluster nodes still use TCP for replication. If you aren't running TrogonEventStore in insecure mode, all TCP communication will use TLS using the same certificates as SSL.
 
 You can, however, disable TLS for both internal and external TCP.
 
@@ -572,7 +573,7 @@ You can, however, disable TLS for both internal and external TCP.
 
 ## Authentication
 
-EventStoreDB supports authentication based on usernames and passwords out of the box. Nodes can also enable
+TrogonEventStore supports authentication based on usernames and passwords out of the box. Nodes can also enable
 OAuth bearer-token authentication as a built-in authentication method. This follows PostgreSQL's model of
 making the database authentication method explicit, so password and OAuth access can be reasoned about side by side.
 
@@ -637,19 +638,19 @@ Auth:
 
 ### Default users
 
-EventStoreDB provides two default users, `$ops` and `$admin`.
+TrogonEventStore provides two default users, `$ops` and `$admin`.
 
-`$admin` has full access to everything in EventStoreDB. It can read and write to protected streams, which is
+`$admin` has full access to everything in TrogonEventStore. It can read and write to protected streams, which is
 any stream that starts with \$, such as `$projections-master`. Protected streams are usually system streams,
 for example, `$projections-master` manages some projections' states. The `$admin` user can also run
-operational commands, such as scavenges and shutdowns on EventStoreDB.
+operational commands, such as scavenges and shutdowns on TrogonEventStore.
 
 An `$ops` user can do everything that an `$admin` can do except manage users and read from system streams (
 except for `$scavenges` and `$scavenges-streams`).
 
 ### New users
 
-New users created in EventStoreDB are standard non-admin users. They can call endpoints permitted by the
+New users created in TrogonEventStore are standard non-admin users. They can call endpoints permitted by the
 authorization policy, including default anonymous endpoints such as `/-/liveness` and `/-/readiness`.
 
 Internal cluster endpoints, such as election and gossip updates, are only available to system node traffic.
@@ -659,18 +660,18 @@ By default, any user can read any non-protected stream unless there is an ACL pr
 ### Externalised authentication
 
 You can also use the trusted intermediary header for externalized authentication that allows you to integrate
-almost any authentication system with EventStoreDB. Read more
+almost any authentication system with TrogonEventStore. Read more
 about [the trusted intermediary header](#trusted-intermediary).
 
 ## Access control lists
 
-By default, authenticated users have access to the whole EventStoreDB database. In addition to that, it allows
+By default, authenticated users have access to the whole TrogonEventStore database. In addition to that, it allows
 you to use Access Control Lists (ACLs) to set up more granular access control. In fact, the default access
 level is also controlled by a special ACL, which is called the [default ACL](#default-acl).
 
 ### Stream ACL
 
-EventStoreDB keeps the ACL of a stream in the stream metadata as JSON with the below definition:
+TrogonEventStore keeps the ACL of a stream in the stream metadata as JSON with the below definition:
 
 ```json
 {
@@ -767,18 +768,18 @@ Refer to the documentation of the SDK of your choice for more information about 
 
 ## Trusted intermediary
 
-The trusted intermediary header helps EventStoreDB to support a common security architecture. There are
+The trusted intermediary header helps TrogonEventStore to support a common security architecture. There are
 thousands of possible methods for handling authentication and it is impossible for us to support them all. The
-header allows you to configure a trusted intermediary to handle the authentication instead of EventStoreDB.
+header allows you to configure a trusted intermediary to handle the authentication instead of TrogonEventStore.
 
 A sample configuration is to enable OAuth2 with the following steps:
 
-- Configure EventStoreDB to run on the local loopback.
+- Configure TrogonEventStore to run on the local loopback.
 - Configure nginx to handle OAuth2 authentication.
-- After authenticating the user, nginx rewrites the request and forwards it to the loopback to EventStoreDB
+- After authenticating the user, nginx rewrites the request and forwards it to the loopback to TrogonEventStore
   that serves the request.
 
-The header has the form of `{user}; group, group1` and the EventStoreDB ACLs use the information to handle
+The header has the form of `{user}; group, group1` and the TrogonEventStore ACLs use the information to handle
 security.
 
 ```http:no-line-numbers
@@ -793,255 +794,17 @@ Use the following option to enable this feature:
 | YAML                 | `EnableTrustedAuth`              |
 | Environment variable | `EVENTSTORE_ENABLE_TRUSTED_AUTH` |
 
-## FIPS 140-2 <Badge type="warning" vertical="middle" text="Commercial"/>
+## Supported authentication boundary
 
-EventStoreDB runs on FIPS 140-2 enabled operating systems, this feature requires a commercial licence.
+TrogonEventStore documents the authentication methods built into this
+distribution:
 
-The Federal Information Processing Standards (FIPS) of the United States are a set of publicly announced standards that the National Institute of Standards and Technology (NIST) has developed for use in computer systems of non-military United States government agencies and contractors.
+- Local username and password authentication.
+- OAuth methods configured in the server.
+- Trusted intermediary authentication for deployments that terminate
+  authentication in a trusted local proxy.
 
-The 140 series of FIPS (FIPS 140) are U.S. government computer security standards that specify requirements for cryptography modules.
-
-To run EventStoreDB on FIPS 140-2 enabled operating systems, the following is required:
-
-1. The FIPS plugin must be installed. It is available on our [commercial downloads page](https://developers.eventstore.org/). To install it, unzip it in the `plugins` directory inside the server installation directory and restart the server.
-2. The node's certificates & keys must be FIPS 140-2 compliant
-    - Our certificate generation tool, [es-gencert-cli](https://github.com/EventStore/es-gencert-cli/releases), generates FIPS 140-2 compliant certificates & keys as from version 1.2.0 (only the linux build).
-    - If you want to manually generate your certificates or keys with openssl, you must use openssl 3 or later.
-    - If you want to use PKCS #12 bundles (.p12/.pfx extension), you must use a FIPS 140-2 compliant encryption algorithm (e.g AES-256) & hash algorithm (e.g SHA-256) to encrypt the bundle's contents.
-
-Note that EventStoreDB will also likely run properly on FIPS 140-3 compliant systems with the above steps but this cannot reliably be confirmed at the moment as FIPS 140-3 certification is still ongoing for several operating systems.
-
-## LDAP authentication <Badge type="warning" vertical="middle" text="Commercial"/>
-
-The LDAP Authentication plugin enables EventStoreDB to use LDAP-based directory services for authentication. 
-
-### Configuration steps
-
-To set up EventStoreDB with LDAP authentication, follow these steps on the [database node's configuration file](@server/configuration.md). Remember to stop the service before making changes, and then start it. 
-
-1. Change the authentication type to `ldaps`.
-2. Add a section named `LdapsAuth` for LDAP-specific settings. 
-
-Example configuration file in YAML format:
-
-```yaml
-AuthenticationType: ldaps
-LdapsAuth:
-  Host: 13.88.9.49
-  Port: 636 #to use plaintext protocol, set Port to 389 and UseSSL to false 
-  UseSSL: true
-  ValidateServerCertificate: false #set this to true to validate the certificate chain
-  AnonymousBind: false
-  BindUser: cn=binduser,dc=mycompany,dc=local
-  BindPassword: p@ssw0rd!
-  BaseDn: ou=Lab,dc=mycompany,dc=local
-  ObjectClass: organizationalPerson
-  Filter: sAMAccountName
-  RequireGroupMembership: false #set this to true to allow authentication only if the user is a member of the group specified by RequiredGroupDn
-  GroupMembershipAttribute: memberOf
-  RequiredGroupDn: cn=ES-Users,dc=mycompany,dc=local
-  PrincipalCacheDurationSec: 60
-  LdapGroupRoles:
-      'cn=ES-Accounting,ou=Staff,dc=mycompany,dc=local': accounting
-      'cn=ES-Operations,ou=Staff,dc=mycompany,dc=local': it
-      'cn=ES-Admins,ou=Staff,dc=mycompany,dc=local': '$admins'
-```
-
-Upon successful LDAP authentication, users are assigned roles based on their domain group memberships, as specified in the `LdapGroupRoles` section. EventStoreDB supports two built-in roles: `$admins` and `$ops`, which can be assigned to users. 
-
-### Troubleshooting 
-
-If you encounter issues, check the server's log. Common problems include: 
-
-| Error                                                                                       | Solution                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-|:--------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Invalid Bind Credentials Specified                                                          | Confirm the `BindUser` and `BindPassword`.                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Exception During Search - 'No such Object' or 'The object does not exist'                   | Verify the `BaseDn`.                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| 'Server Certificate Error' or 'Connect Error - The authentication or decryption has failed' | Verify that the server certificate is valid. If it is a self-signed certificate, set `ValidateServerCertificate` to `false`.                                                                                                                                                                                                                                                                                                                    |
-| LDAP Server Unavailable                                                                     | Verify connectivity to the LDAP server from an EventStoreDB node (e.g. using `netcat` or `telnet`). Verify the `Host` and `Port` parameters.                                                                                                                                                                                                                                                                                                    |
-| Error Authenticating with LDAP server                                                       | Verify the `ObjectClass` and `Filter` parameters. If you have set `RequireGroupMembership` to `true`, verify that the user is part of the group specified by `RequiredGroupDn` and that the LDAP record has `GroupMembershipAttribute` set to `memberOf`.                                                                                                                                                                                       |
-| Error Authenticating with LDAP server. System.AggregateException                            | This packaging error may occur when setting `UseSSL: true` on Windows. Extract `Mono.Security.dll` to the _EventStore_ folder (where _EventStore.ClusterNode.exe_ is located) as a workaround.                                                                                                                                                                                                                                                  |
-| No Errors in Server Logs But Cannot Login                                                   | <ul><li>Verify that the user is part of the group specified by `RequiredGroupDn` and that the LDAP record has `GroupMembershipAttribute` set to `memberOf`.</li><li>Verify the `ObjectClass` and `Filter` parameters.</li><li>If you have set `RequireGroupMembership` to `true`, verify that the user is part of the group specified by `RequiredGroupDn` and that the LDAP record has `GroupMembershipAttribute` set to `memberOf`.</li></ul> |
-
-
-## User X.509 Certificates <Badge type="warning" vertical="middle" text="Commercial"/>
-
-The User Certificates plugin allows authentication through an X.509 user certificate in addition to username and password. User certificates work across any cluster that shares a trusted root Certificate Authority (CA) with the user's certificate. This means that you can have a single user certificate that is valid across multiple clusters.
-
-### Configuration steps
-
-Refer to the general [plugins configuration](configuration.md#plugins-configuration) guide to see how to configure plugins with JSON files and environment variables.
-
-Sample json configuration:
-```json
-{
-  "EventStore": {
-    "Plugins": {
-      "UserCertificates": {
-        "Enabled": true
-      }
-    }
-  }
-}
-```
-
-If the plugin is enabled, the server will log the following on startup:
-
-```:no-line-numbers
-UserCertificatesPlugin: user X.509 certificate authentication is enabled
-```
-
-### Connecting with a user certificate
-
-Use the following command as an example authenticated request using `curl`:
-
-```bash
-curl -i https://localhost:2113/-/metrics --cert user-admin.crt --key user-admin.key
-```
-
-For using X.509 user certificate with EventStoreDB client from an application, refer to the client's documentation.
-
-### Creating a user certificate
-
-The user certificate must adhere to the following requirements:
-
-- The certificate has a root CA in common with the node certificate.
-- The root CA that they have in common is trusted by the node.
-- The certificate has the ClientAuth EKU, and not the ServerAuth EKU.
-- The certificate must be in date.
-- The CN is the username of a user that exists in the database.
-
-::: tip
-Certificates can also authenticate `admin` and `ops` users.
-:::
-
-You can generate a user certificate with the [es-gencert-cli](https://github.com/EventStore/es-gencert-cli/):
-
-For example, to generate a user certificate with the username `ouro`:
-
-```:no-line-numbers
-./es-gencert-cli.exe create-user -username ouro -ca-certificate ca.crt -ca-key ca.key -days 10
-```
-
-::: details Click to view a sample user certificate
-
-```
-X509 Certificate:
-Version: 3
-Serial Number: 6339e77cacd508002e45cf38418e4f69
-Signature Algorithm:
-    Algorithm ObjectId: 1.2.840.113549.1.1.11 sha256RSA
-    Algorithm Parameters:
-    05 00
-Issuer:
-    CN=EventStoreDB CA f2993c31201bd4bb5a59f3e580d32865
-    O=Event Store Ltd
-    C=UK
-  Name Hash(sha1): cd4323cbb5259cfee1e1e01aaf472552cf18cbf2
-  Name Hash(md5): 993adcf28aa235c593611234e6abc1fc
-
- NotBefore: 2024-02-26 5:24 PM
- NotAfter: 2024-03-07 5:24 PM
-
-Subject:
-    CN=ouro
-  Name Hash(sha1): fe1463b6b0edf7f66dd22101c7d1c38f14d1292e
-  Name Hash(md5): f40719c54125d3a27290bb48d6f73b15
-
-Public Key Algorithm:
-    Algorithm ObjectId: 1.2.840.113549.1.1.1 RSA
-    Algorithm Parameters:
-    05 00
-Public Key Length: 2048 bits
-Public Key: UnusedBits = 0
-    0000  30 82 01 0a 02 82 01 01  00 9d 7b f2 25 72 0c b6
-    0010  65 01 02 16 37 60 b9 22  14 04 bf fc 54 b2 e9 6f
-    0020  c7 bc 43 8d c0 ca 3d 55  86 b4 3e 24 88 fc 70 7e
-    0030  f6 f4 38 d3 52 2d 57 a0  48 8e 91 7b f4 10 8b fd
-    0040  95 6b 41 99 d7 9b e4 d9  42 c8 c5 47 5e d1 0c 4c
-    0050  3a 5a ff a3 db ea 0d 11  89 0c 3d 7f fb 9c e5 6c
-    0060  4a 04 e7 f7 48 ff 0f 2f  63 fa be bf f5 f3 76 a1
-    0070  ea 02 27 4c ca 27 82 64  40 b5 ef f6 6f fe f2 02
-    0080  8b 16 ea 45 54 fd ba 80  2c 72 02 d0 14 41 d5 cd
-    0090  db ae 6e 4d 9b 67 60 63  ae 92 ab 2d f4 8b 70 70
-    00a0  d0 4f b1 97 66 71 9b c9  2a 5e 7a e3 d0 f5 0b eb
-    00b0  9e 37 81 09 75 fa 81 d6  3c 9f 6a e6 56 8b 1f 73
-    00c0  d0 61 4c f5 51 16 44 da  dd 3b b1 2b b9 f2 44 94
-    00d0  53 a2 08 5a 8d 4a 4e cb  d7 cb f7 0c ca 7a 1a fb
-    00e0  21 db 00 3e 75 85 c6 d3  95 bd 39 61 d1 ff 89 e7
-    00f0  88 ab b0 58 ff ce e8 d7  19 a9 75 62 dc 98 a8 8f
-    0100  58 31 a7 7c 1d 88 ba 51  5d 02 03 01 00 01
-Certificate Extensions: 5
-    2.5.29.15: Flags = 1(Critical), Length = 4
-    Key Usage
-        Digital Signature, Key Encipherment (a0)
-
-    2.5.29.37: Flags = 0, Length = c
-    Enhanced Key Usage
-        Client Authentication (1.3.6.1.5.5.7.3.2)
-
-    2.5.29.19: Flags = 1(Critical), Length = 2
-    Basic Constraints
-        Subject Type=End Entity
-        Path Length Constraint=None
-
-    2.5.29.14: Flags = 0, Length = 22
-    Subject Key Identifier
-        01fc7f1e364f1767b759dae23d43bbb1cbf2d75deabe605737969489b8de201d
-
-    2.5.29.35: Flags = 0, Length = 24
-    Authority Key Identifier
-        KeyID=5e13f92550df9af08cdab327161ef2d2ef764b77fc4246bc2b172e1d9ed81b2f
-
-Signature Algorithm:
-    Algorithm ObjectId: 1.2.840.113549.1.1.11 sha256RSA
-    Algorithm Parameters:
-    05 00
-Signature: UnusedBits=0
-    0000  8f a4 00 65 f1 a5 53 54  a8 ed de 98 cc 51 f9 1c
-    0010  49 7d f0 7c d6 9f 14 fa  13 b4 db b3 8b 56 59 6a
-    0020  d1 67 a7 e3 21 d5 2d e3  c9 73 9b 09 a9 25 74 35
-    0030  79 16 a2 ce 62 ff fd f1  5e 05 0c b6 29 3d c8 ab
-    0040  1f 7f 87 66 d3 a1 a1 23  7e 11 03 1f 28 eb af d2
-    0050  ac ef 7b 2c 0f b2 18 b4  59 b1 5a ba c9 35 5a b6
-    0060  58 ef 55 4f e7 8c 43 35  1f 22 5c 6d 65 ff 6d 7c
-    0070  af 32 3c b5 ba 00 c4 74  91 73 32 54 22 4c 52 f5
-    0080  de cf f4 ed 71 37 f6 4a  5f 3b ba 37 2c 29 77 9a
-    0090  ad a0 6f c9 a0 26 b3 a6  d3 0c 99 d6 1c f2 f0 b9
-    00a0  29 51 c7 cc 8e 47 2c 04  0f b4 6f aa 09 5b c6 a4
-    00b0  e3 b9 0b 07 3c 49 e6 62  b7 78 3b ff 81 d1 8c 26
-    00c0  3e af 24 ae 01 54 91 33  96 a1 aa 14 05 b4 0a 5b
-    00d0  42 3c 11 f1 f1 2c 93 9d  6d 8b b8 ec eb c6 e5 e7
-    00e0  a4 9a d4 59 fb ff b7 ba  e1 33 c2 f8 09 52 80 c6
-    00f0  95 95 51 35 08 1a 65 41  76 bc c2 62 2b 71 b3 65
-Non-root Certificate
-Key Id Hash(rfc-sha1): 8a3c17e6662711175142740cfeb0f52d2bdd3596
-Key Id Hash(sha1): 87a30feaaeabd616f4dad92a9f1b44a43e2d0b52
-Subject Key Id (precomputed): 01fc7f1e364f1767b759dae23d43bbb1cbf2d75deabe605737969489b8de201d
-Key Id Hash(bcrypt-sha1): b808b4e710e4f6f158a837155838a295cfbb17bf
-Key Id Hash(bcrypt-sha256): eaf799bb5f3d57dbb3afc0f5357a8723574c8c254bf159fce1c95d76f6085ae5
-Key Id Hash(md5): fbb024d546e2039af7f3e01c71278313
-Key Id Hash(sha256): ca10f7cb5af9bf9dff8f2ad43c3cbdb0647da1173631018cb8551812c425d575
-Key Id Hash(pin-sha256): MZu7Waanp4kbJ/Hx3/tpgMb6L3GnXB3PrMY+9MDBmSg=
-Key Id Hash(pin-sha256-hex): 319bbb59a6a7a7891b27f1f1dffb6980c6fa2f71a75c1dcfacc63ef4c0c19928
-Cert Hash(md5): 1719850bd6f5f09c3610e4c33d13f7c2
-Cert Hash(sha1): 12c5293973bda1df2c74ab280d492135171c8ab6
-Cert Hash(sha256): a37767096f10697fb0fcf94a3872d0984aeed4754a295c5320679876e00def32
-Signature Hash: 6d922badaba2372070f13c69b620286262eab1d8d2d2156a271a1d73aaaf64e4
-```
-
-:::
-
-### Limitations
-
-1. Requests authenticated with user certificates cannot be forwarded between nodes. This affects Writes, Persistent Subscription operations, and Projections operations. These requests will need to be performed on the Leader node only.
-
-2. The X.509 authentication cannot be used in conjunction with any of the other authentication plugins, such as the LDAP plugin.
-
-### Troubleshooting
-
-| Error                                     | Solution                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-|:------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Plugin not loaded                         | The plugin is only available in commercial editions. Check that it is present in `<installation-directory/plugins`.<br/><br/> If it is present, on startup the server will log a message similar to: `Loaded SubsystemsPlugin plugin: "user-certificates"`.                                                                                                                                                                                                                                                                |
-| Plugin not enabled                        | The plugin has to be enabled in order to authenticate user requests.<br/><br/> The following log indicates that the plugin was found but not enabled: `UserCertificatesPlugin is not enabled`.                                                                                                                                                                                                                                                                                                                             |
-| Plugin enabled and user not authenticated | If the plugin has been enabled but there are still access denied errors, check the following: <ul><li>The user exists and is enabled in the EventStoreDB database. Can you log in with the username and password?</li><li>The user certificate is valid, and has a valid chain up to a trusted root CA.</li><li>The user certificate and node certificate share a common root CA.</li><li>Use 'requires leader' (which is the default) in your client configuration to rule out issues with forwarding requests.</li></ul> |
+Do not configure undocumented authentication plugins as part of the supported
+security model. If a deployment needs directory integration or certificate-based
+user identity, model that requirement through OAuth, a trusted intermediary, or
+a separate product decision before exposing it as server documentation.

--- a/docs/security.md
+++ b/docs/security.md
@@ -226,7 +226,7 @@ If using the thumbprint, the server expects to only find one certificate file ma
 | Environment variable | `EVENTSTORE_CERTIFICATE_THUMBPRINT` |
 
 The subject name matches any certificate that contains the specified name. This means that multiple matching certificates could be found.
-To match any certificate made by the es-gencert-cli, you can set the subject name to `eventstoredb-node`.
+Set it to the subject used by your node certificates, such as `trogondb-node` for a private development CA.
 
 If multiple matching certificates are found, then the certificate with the latest expiry date will be selected.
 
@@ -265,7 +265,7 @@ If using the thumbprint, the server expects to only find one trusted root certif
 | Environment variable | `EVENTSTORE_TRUSTED_ROOT_CERTIFICATE_THUMBPRINT` |
 
 The subject name matches any certificate that contains the specified name. This means that multiple matching certificates could be found.
-To match any root certificate made through the es-gencert-cli, you can set the Subject Name to `TrogonEventStore CA`.
+Set it to the subject used by your trusted root certificate, such as `TrogonEventStore CA` for a private development CA.
 
 If multiple matching root certificates are found, then the root certificate with the latest expiry date will be selected.
 
@@ -275,27 +275,18 @@ If multiple matching root certificates are found, then the root certificate with
 | YAML                 | `TrustedRootCertificateSubjectName`                |
 | Environment variable | `EVENTSTORE_TRUSTED_ROOT_CERTIFICATE_SUBJECT_NAME` |
 
-### Certificate generation tool
+### Certificate generation
 
-Use your platform certificate tooling, public CA, or private CA process to create certificates that match your deployment. For local development, generated certificates can be useful as long as the resulting node and trust settings are explicit.
+Use your platform certificate tooling, public CA, or private CA process to create certificates that match your deployment. The built-in development mode can generate a certificate for one secure node on localhost, but it is not a cluster PKI bootstrap mechanism.
 
-#### Getting started
+For a multi-node deployment, provision:
 
-The CLI is available as Open Source project in the [Github Repository](https://github.com/EventStore/es-gencert-cli). The latest release can be found under the [GitHub releases page.](https://github.com/EventStore/es-gencert-cli/releases)
+- A trusted CA certificate available to every node and client.
+- A separate certificate and private key for each node.
+- Subject alternative names for every DNS name and IP address used by clients or replication traffic.
+- A common-name policy that matches `CertificateReservedNodeCommonName`.
 
-We're releasing binaries for Windows, Linux and macOS. We also publish the tool as a Docker image.
-
-Basic usage for the Certificate Generation CLI:
-
-```bash
-./es-gencert-cli [options] <command> [args]
-```
-
-Getting help for a specific command:
-
-```bash
-./es-gencert-cli -help <command>
-```
+Keep CA private keys outside the node and client environments. Install only the CA certificate, node certificate, and node private key required by each machine.
 
 ::: warning
 If you are running TrogonEventStore on Linux, remember that all certificate files should have restrictive rights, otherwise the OS won't allow using them.
@@ -308,117 +299,13 @@ chmod 600 [file]
 ```
 :::
 
-#### Generating the CA certificate
-
-As the first step CA certificate needs to be generated. It'll need to be trusted for each of the nodes and client environment.
-
-By default, the tool will create the `ca` directory in the `certs` directory you created. Two keys will be generated:
-- `ca.crt` - public file that need to be used also for the nodes and client configuration,
-- `ca.key` - private key file that should be used only in the node configuration. **Do not copy it to client environment**.
-
-CA certificate will be generated with pre-defined CN `eventstoredb-node`.
-
-To generate CA certificate run:
-
-```bash
-./es-gencert-cli create-ca
-```
-
-You can customise generated cert by providing following params:
-
-| Param   | Description                                                       |
-|:--------|:------------------------------------------------------------------|
-| `-days` | The validity period of the certificate in days (default: 5 years) |
-| `-out`  | The output directory (default: ./ca)                              |
-
-Example:
-
-```bash
-./es-gencert-cli create-ca -out ./es-ca
-```
-
-#### Generating the Node certificate
-
-You need to generate certificates signed by the CA for each node. They should be installed only on the specific node machine.
-
-By default, the tool will create the `ca` directory in the `certs` directory you created. Two keys will be generated:
-- `node.crt` - the public file that needs to be also used for the nodes and client configuration,
-- `node.key` - the private key file that should be used only in the node's configuration. **Do not copy it to client environment**.
-
-To generate node certificate run command:
-
-```bash
-./es-gencert-cli -help create_node
-```
-
-You can customise generated cert by providing following params:
-
-| Param             | Description                                                                   |
-|:------------------|:------------------------------------------------------------------------------|
-| `-ca-certificate` | The path to the CA certificate file (default: `./ca/ca.crt`)                  |
-| `-ca-key`         | The path to the CA key file (default: `./ca/ca.key`)                          |
-| `-days`           | The output directory (default: `./nodeX` where X is an auto-generated number) |
-| `-out`            | The output directory (default: `./ca`)                                        |
-| `-ip-addresses`   | Comma-separated list of IP addresses of the node                              |
-| `-dns-names`      | Comma-separated list of DNS names of the node                                 |
-
-::: warning
-While generating the certificate, you need to remember to pass internal end external:
-- IP addresses to `-ip-addresses`: e.g. `127.0.0.1,172.20.240.1` and/or
-- DNS names to `-dns-names`: e.g. `localhost,node1.eventstore`
-  that will match the URLs that you will be accessing TrogonEventStore nodes.
-  :::
-
-Sample:
-
-```
-./es-gencert-cli-cli create-node \
-    -ca-certificate ./es-ca/ca.crt \
-    -ca-key ./es-ca/ca.key \
-    -out ./node1 \
-    -ip-addresses 127.0.0.1,172.20.240.1 \
-    -dns-names localhost,node1.eventstore
-```
-
-#### Running with Docker
-
-You could also run the tool using Docker interactive container:
-
-```bash
-docker run --rm -i eventstore/es-gencert-cli <command> <options>
-```
-
-One useful scenario is to use the Docker Compose file tool to generate all the necessary certificates before starting cluster nodes.
-
-Sample:
-
-```yaml
-services:
-  setup:
-    image: eventstore/es-gencert-cli:1.0.2
-    entrypoint: bash
-    user: "1000:1000"
-    command: >
-      -c "mkdir -p ./certs && cd /certs
-      && es-gencert-cli create-ca
-      && es-gencert-cli create-node -out ./node1 -ip-addresses 127.0.0.1,172.20.240.1 -dns-names localhost,node1.eventstore
-      && es-gencert-cli create-node -out ./node2 -ip-addresses 127.0.0.1,172.20.240.2 -dns-names localhost,node2.eventstore
-      && es-gencert-cli create-node -out ./node3 -ip-addresses 127.0.0.1,172.20.240.3 -dns-names localhost,node3.eventstore
-      && find . -type f -print0 | xargs -0 chmod 666"
-    container_name: setup
-    volumes:
-      - ./certs:/certs
-```
-
-See more in the [cluster startup guidance.](installation.md#cluster-startup)
-
 ### Certificate installation on a client environment
 
-To connect to TrogonEventStore, you need to install the auto-generated CA certificate file on the client machine (e.g. machine where the client is hosted, or your dev environment).
+To connect to TrogonEventStore when using a private CA, install its certificate on the client machine, such as the machine where the client is hosted or your development environment.
 
 #### Linux (Ubuntu, Debian)
 
-1. Copy auto-generated CA file to dir `/usr/local/share/ca-certificates/`, e.g. using command:
+1. Copy the private CA certificate to `/usr/local/share/ca-certificates/`, for example:
   ```bash
   sudo cp ca.crt /usr/local/share/ca-certificates/event_store_ca.crt
   ```
@@ -449,7 +336,7 @@ sudo security add-certificates -k /Library/Keychains/System.keychain ca.crt
 
 Intermediate CA certificates are supported by loading them from a [PEM](https://datatracker.ietf.org/doc/html/rfc1422) or [PKCS #12](https://datatracker.ietf.org/doc/html/rfc7292) bundle specified by the [`CertificateFile` configuration parameter](#certificate-file). To make sure that the configuration is correct, the certificate chain is validated on startup with the node's own certificate.
 
-If you've used the [certificate generation tool](#certificate-generation-tool) with the default settings to generate your CA and node certificates, then you're not using intermediate CA certificates.
+If your root CA directly signed the node certificate, then the certificate chain has no intermediate CA certificate.
 
 However, if you're using a public certificate authority (e.g [Let's Encrypt](https://letsencrypt.org/)) to generate your node certificates there is a chance that you're using intermediate CA certificates without knowing. This is due to the [Authority Information Access (AIA)](https://datatracker.ietf.org/doc/html/rfc4325#section-2) extension which allows intermediate certificates to be fetched from a remote server.
 
@@ -559,9 +446,9 @@ Import-Certificate -FilePath .\ca.crt -CertStoreLocation Cert:\LocalMachine\CA
 
 ### TCP protocol security
 
-Although TCP is disabled by default for external connections (clients), cluster nodes still use TCP for replication. If you aren't running TrogonEventStore in insecure mode, all TCP communication will use TLS using the same certificates as SSL.
+Cluster nodes use TCP for replication. Unless TrogonEventStore is running without transport security, replication TCP uses the configured node certificates.
 
-You can, however, disable TLS for both internal and external TCP.
+You can disable TLS for replication TCP with the following setting.
 
 | Format               | Syntax                                |
 |:---------------------|:--------------------------------------|

--- a/docs/server-settings.md
+++ b/docs/server-settings.md
@@ -1,20 +1,20 @@
 ---
 id: server-settings
-title: Server settings | v24.6
+title: Server settings
 sidebar_label: Server settings
 ---
 
-# Server settings with ESDB v24.6
+# Server settings
 
-EventStoreDB server settings allow you to tweak the behavior of the database server during the startup and at run-time. You may want to adjust these settings if performance issues occur.
+TrogonEventStore server settings allow you to tweak the behavior of the database server during the startup and at run-time. You may want to adjust these settings if performance issues occur.
 
 ## Default directories
 
-The default directories used by EventStoreDB vary by platform to fit with the common practices each platform.
+The default directories used by TrogonEventStore vary by platform to fit with the common practices each platform.
 
 ### Linux
 
-When you install EventStoreDB from PackageCloud on Linux, the following locations apply:
+When TrogonEventStore is installed as a Linux service, the following locations are commonly used:
 
 - **Application:** `/usr/bin`
 - **Content:** `/usr/share/eventstore`
@@ -38,7 +38,7 @@ When you install EventStoreDB from PackageCloud on Linux, the following location
 
 ### Local binaries
 
-When running EventStoreDB using local binaries, either downloaded or built from source, the server will use its location and place the necessary files inside it:
+When running TrogonEventStore using local binaries, either downloaded or built from source, the server will use its location and place the necessary files inside it:
 
 - **Configuration:** `./`
 - **Data:** `./data`
@@ -48,15 +48,15 @@ When running EventStoreDB using local binaries, either downloaded or built from 
 - **Projections:** `./projections`
 - **Prelude:** `./Prelude`
 
-Depending on the platform and installation type, the location of EventStoreDB executables, configuration and other necessary files vary.
+Depending on the platform and installation type, the location of TrogonEventStore executables, configuration and other necessary files vary.
 
 ## Database settings
 
 ### Database location
 
-EventStoreDB has a single database, which is spread across ever-growing number of physical files on the file system. Those files are called chunks and new data is always appended to the end of the latest chunk. When the chunk grows over 256 MiB, the server closes the chunk and opens a new one.
+TrogonEventStore has a single database, which is spread across ever-growing number of physical files on the file system. Those files are called chunks and new data is always appended to the end of the latest chunk. When the chunk grows over 256 MiB, the server closes the chunk and opens a new one.
 
-Normally, you'd want to keep the database files separated from the OS and other application files. The `Db` setting tells EventStoreDB where to put those chunk files. If the database server doesn't find anything at the specified location, it will create a new database.
+Normally, you'd want to keep the database files separated from the OS and other application files. The `Db` setting tells TrogonEventStore where to put those chunk files. If the database server doesn't find anything at the specified location, it will create a new database.
 
 | Format               | Syntax          |
 | :------------------- | :-------------- |
@@ -64,11 +64,11 @@ Normally, you'd want to keep the database files separated from the OS and other 
 | YAML                 | `Db`            |
 | Environment variable | `EVENTSTORE_DB` |
 
-**Default**: the default database location is platform specific. On Windows, the database will be stored in the `data` directory inside the EventStoreDB installation location. On Linux, it will be `/var/lib/eventstore`.
+**Default**: the default database location is platform specific. On Windows, the database will be stored in the `data` directory inside the TrogonEventStore installation location. On Linux, it will be `/var/lib/eventstore`.
 
 ### Skip database verification
 
-When the database node restarts, it checks the database files to ensure they aren't corrupted. It is a lengthy process and can take hours on a large database. EventStoreDB normally flushes every write to disk, so database files are unlikely to get corrupted. In an environment where nodes restart often for some reason, you might want to disable the database verification to allow faster startup of the node.
+When the database node restarts, it checks the database files to ensure they aren't corrupted. It is a lengthy process and can take hours on a large database. TrogonEventStore normally flushes every write to disk, so database files are unlikely to get corrupted. In an environment where nodes restart often for some reason, you might want to disable the database verification to allow faster startup of the node.
 
 | Format               | Syntax                      |
 | :------------------- | :-------------------------- |
@@ -136,9 +136,9 @@ Depending on your client operation timeout settings (default is 7 seconds), incr
 Using this option might cause data loss.
 :::
 
-This will prevent EventStoreDB from forcing the flush to disk after writes. Please note that this is unsafe in case of a power outage.
+This will prevent TrogonEventStore from forcing the flush to disk after writes. Please note that this is unsafe in case of a power outage.
 
-With this option enabled, EventStoreDB will still write data to the disk at the application level but not necessarily at the OS level. Usually, the OS should flush its buffers at regular intervals or when a process exits but it is something that's opaque to EventStoreDB.
+With this option enabled, TrogonEventStore will still write data to the disk at the application level but not necessarily at the OS level. Usually, the OS should flush its buffers at regular intervals or when a process exits but it is something that's opaque to TrogonEventStore.
 
 | Format               | Syntax                                    |
 | :------------------- | :---------------------------------------- |
@@ -209,11 +209,11 @@ Increasing the count of reader threads can improve performance up to a point, bu
 This section is about caching HTTP resources such as the Admin UI. It does not affect the server performance directly and cannot be used with gRPC clients.
 :::
 
-Most static resources that EventStoreDB emits are immutable and can be cached safely.
+Most static resources that TrogonEventStore emits are immutable and can be cached safely.
 
 This caching behavior is great for performance in a production environment and we recommended you use it, but in a developer environment it can become confusing.
 
-To avoid this during development it's best to run EventStoreDB with the `--disable-http-caching` command line option. This disables all caching and solves the issue.
+To avoid this during development it's best to run TrogonEventStore with the `--disable-http-caching` command line option. This disables all caching and solves the issue.
 
 The option can be set as follows:
 

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -1,6 +1,6 @@
 # Event streams
 
-EventStoreDB is purpose-built for event storage. Unlike traditional state-based databases, which retain only the most recent entity state, EventStoreDB allows you to store each state alteration as an independent event.
+TrogonEventStore is purpose-built for event storage. Unlike traditional state-based databases, which retain only the most recent entity state, TrogonEventStore allows you to store each state alteration as an independent event.
 
 These **events** are logically organized into **streams**, typically only one stream per entity.
 
@@ -8,11 +8,11 @@ These **events** are logically organized into **streams**, typically only one st
 
 ## Stream metadata
 
-In EventStoreDB, every stream and event is accompanied by metadata, distinguished by the **`$$`** prefix. For example, the stream metadata for a stream named **`foo`** is **`$$foo`**. You can modify specific metadata values and write your data to the metadata, which can be referenced in your code.
+In TrogonEventStore, every stream and event is accompanied by metadata, distinguished by the **`$$`** prefix. For example, the stream metadata for a stream named **`foo`** is **`$$foo`**. You can modify specific metadata values and write your data to the metadata, which can be referenced in your code.
 
 ### Reserved names
 
-EventStoreDB uses a **`$`** prefix for all internal data, such as **`$maxCount`** in a stream's metadata. Do not use a **`$`** prefix for event names, metadata keys, or stream names, except as detailed below.
+TrogonEventStore uses a **`$`** prefix for all internal data, such as **`$maxCount`** in a stream's metadata. Do not use a **`$`** prefix for event names, metadata keys, or stream names, except as detailed below.
 
 The supported internal settings are:
 
@@ -51,24 +51,24 @@ All names starting with **`$`** are reserved for internal use. The currently sup
 | **`$correlationId`** | The application-level correlation ID for the message. |
 | **`$causationId`**   | The application-level causation ID for the message.   |
 
-Projections within EventStoreDB adhere to both the **`correlationId`** and **`causationId`** patterns for any events they internally produce (e.g., through functions like `linkTo` and `emit`).
+Projections within TrogonEventStore adhere to both the **`correlationId`** and **`causationId`** patterns for any events they internally produce (e.g., through functions like `linkTo` and `emit`).
 
 ## Deleting streams and events
 
-In EventStoreDB, metadata can determine whether an event is deleted or not. You can use [stream metadata](#metadata-and-reserved-names) elements such as **`TruncateBefore`**, **`MaxAge`**, and **`MaxCount`** to
+In TrogonEventStore, metadata can determine whether an event is deleted or not. You can use [stream metadata](#metadata-and-reserved-names) elements such as **`TruncateBefore`**, **`MaxAge`**, and **`MaxCount`** to
 filter events marked as deleted. During a stream read, the index references the stream's metadata to determine if any events have been deleted.
 
 ::: note
-In EventStoreDB, you cannot selectively delete events from the middle of a stream. It only allows truncating the stream.
+In TrogonEventStore, you cannot selectively delete events from the middle of a stream. It only allows truncating the stream.
 :::
 
-When you delete a stream, EventStoreDB offers two options: **soft delete** or **hard delete**.
+When you delete a stream, TrogonEventStore offers two options: **soft delete** or **hard delete**.
 
 **Soft delete** triggers scavenging, removing all events from the stream during the subsequent scavenging process. This allows for the reopening of the stream by appending new events.
 
 It's worth noting that the **`$all`** stream circumvents index checking. Deleted events within this stream remain readable until a scavenging process removes them. To understand the prerequisites for successful event removal through scavenging, refer to the [scavenging guide](operations.md#scavenging).
 
-Even if a stream has been deleted, EventStoreDB retains one event within the stream to indicate the stream's existence and provide information about the last event version. As a best practice, consider appending a specific event like **`StreamDeleted`** and then setting the **`MaxCount`** to 1 to delete the stream. Keep this in mind, especially when dealing with streams containing sensitive data that you want to erase thoroughly and without a trace.
+Even if a stream has been deleted, TrogonEventStore retains one event within the stream to indicate the stream's existence and provide information about the last event version. As a best practice, consider appending a specific event like **`StreamDeleted`** and then setting the **`MaxCount`** to 1 to delete the stream. Keep this in mind, especially when dealing with streams containing sensitive data that you want to erase thoroughly and without a trace.
 
 ### Soft delete and TruncateBefore
 
@@ -151,7 +151,7 @@ Learn more about the default ACL in the [access control lists](security.md#defau
 
 ### **`$stats`**
 
-EventStoreDB offers debugging and statistical information about a cluster within the **`$stats`** stream. Find out
+TrogonEventStore offers debugging and statistical information about a cluster within the **`$stats`** stream. Find out
 more in [the stats guide](diagnostics/README.md#statistics).
 
 ### **`$scavenges`**

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -2,137 +2,72 @@
 title: "Upgrade Guide"
 ---
 
-# Upgrade guide for EventStoreDB 24.6
+# Upgrade Guide
 
-EventStoreDB 24.6 is now available for download. You can install it using [Packagecloud](https://packagecloud.io/EventStore/EventStore-OSS), [Chocolatey](https://chocolatey.org/packages/eventstore-oss), or [Docker](https://hub.docker.com/r/eventstore/eventstore/tags?page=1&name=24.6).  Packages are available on our [website](https://www.eventstore.com/downloads) with detailed instructions for each platform.
+Use this guide when moving a TrogonEventStore node or cluster to a newer build
+from this repository.
 
-### Should you upgrade?
+## Before upgrading
 
-Version 24.6 is an interim release that will be supported until the launch of version 24.10 in October 2024.
-We recommend upgrading to 24.6 if you are interested in using the new features introduced in this release.
+- Back up the database and index directories.
+- Record the current server version, configuration file, container image, and
+  command-line arguments.
+- Check that clients are using gRPC.
+- Review changed configuration keys before restarting a durable node.
+- Verify that health probes use `/-/liveness` and `/-/readiness`.
+- Verify that metrics scraping uses `/-/metrics`.
 
-::: warning
-Do not upgrade to version 24.6 if your applications rely on the external TCP API. This has been removed in 24.2. See the [breaking changes](#external-tcp-api-removed) for more information. You can prevent automatic upgrades by pinning the version in your package manager. Find out about package holding on Linux [here](https://askubuntu.com/questions/18654/how-to-prevent-updating-of-a-specific-package).
-
-The commercial version of EventStoreDB 24.6 includes a plugin that enables the TCP client protocol. 
-:::
-
-### Security update
-
-If you are not upgrading to 24.6, please ensure that you are running a patch of EventStoreDB with the security release addressing [CVE-2024-26133](https://www.eventstore.com/blog/eventstoredb-security-release-23.10-22.10-21.10-and-20.10-for-cve-2024-26133):
-
-- **Version 23.10.0:** Upgrade to at least 23.10.1.
-- **Versions 22.10.x:** Upgrade to at least 22.10.5 or 23.10.1.
-- **Versions 21.10.x:** Upgrade to at least 21.10.11 for the security fix, or 22.10.5 for ongoing support.
-- **Versions 20.10.x:** Upgrade to at least 20.10.6 for the security fix, or 22.10.5 for ongoing support.
-
-### Upgrade procedure
-
-You can perform an online rolling upgrade directly to 24.6 from these versions of EventStoreDB:
-- 24.2
-- 23.10
-- 22.10
-- 21.10
-
-Follow the upgrade procedure below on each node, starting with a follower node:
+## Single-node upgrade
 
 1. Stop the node.
-2. Upgrade EventstoreDB to 24.6 and update configuration.
+2. Replace the binary or container image.
+3. Review configuration against [Configuration](configuration.md).
+4. Start the node.
+5. Wait for `/-/readiness` to return success.
+6. Check logs for truncation, index rebuild, or certificate errors.
+7. Confirm the Admin UI and gRPC clients can connect.
+
+## Cluster upgrade
+
+Upgrade one node at a time, starting with a follower or read-only replica.
+
+1. Stop one non-leader node.
+2. Replace the binary or container image.
 3. Start the node.
-4. Wait for the node to become a follower or read-only replica.
-5. Repeat the process for the next node.
+4. Wait for the node to rejoin the cluster and become ready.
+5. Repeat for the next non-leader node.
+6. Upgrade the leader last.
 
-As illustrated below:
+During the rollout:
 
-![EventStoreDB upgrade procedure for each node](./images/upgrade-procedure.png)
+- Client connections can be interrupted when a node restarts or elections occur.
+- Write availability depends on cluster quorum.
+- Catch-up work can temporarily increase load on the leader.
 
-Upgrading the cluster in this manner keeps the cluster online and able to service requests. There may still be disruptions to your services during the upgrade, namely:
-- Client connections may be disconnected when nodes go offline, or when elections take place.
-- The cluster is less fault-tolerant while a node is offline for an upgrade because the cluster requires a quorum of nodes to be online to service write requests.
-- Replicating large amounts of data to a node can have a performance impact on the Leader in the cluster.
+## Configuration review
 
-::: warning
-If you modified the Linux service file to increase the open files limit, those changes will be overridden during the upgrade. You will need to reapply them after the upgrade.
-:::
+Before upgrading, search for obsolete client and HTTP-management settings. The
+current product direction is:
 
-### Breaking changes
+- gRPC for application event access.
+- HTTP for Admin UI, health, metrics, and infrastructure concerns.
+- No external TCP client protocol.
+- No proprietary plugin configuration.
 
-#### From version 23.10 and earlier
+If a setting is no longer documented, remove it rather than carrying it forward
+silently.
 
-##### External TCP API removed
+## Authentication review
 
-The external TCP API has been removed in 24.2.0. This affects external clients using the TCP API and configurations related to it.
+Check [Security](security.md) for the current authentication model. Local
+username/password authentication and OAuth methods can coexist as configured
+methods. Avoid depending on undocumented authentication plugins.
 
-A number of configuration options have been removed as part of this. EventStoreDB will not start by default if any of the following options are present in the database configuration:
-- `AdvertiseTcpPortToClientAs`
-- `DisableExternalTcpTls`
-- `EnableExternalTcp`
-- `ExtHostAdvertiseAs`
-- `ExtTcpHeartbeatInterval`
-- `ExtTcpHeartbeatTimeout`
-- `ExtTcpPort`
-- `ExtTcpPortAdvertiseAs`
-- `NodeHeartbeatInterval`
-- `NodeHeartbeatTimeout`
-- `NodeTcpPort`
-- `NodeTcpPortAdvertiseAs`
+## Observability review
 
-#### From version 22.10 and earlier
+Use [OpenTelemetry integration](diagnostics/integrations.md) for explicit OTLP
+export and [Metrics](diagnostics/metrics.md) for Prometheus scraping.
 
-The updates to anonymous access described in the [release notes](https://www.eventstore.com/blog/23.10.0-release-notes) have introduced some breaking changes. We have also removed, renamed, and deprecated some options in EventStoreDB.
-
-None of these changes will prevent you from performing an online rolling upgrade of the cluster, but you will need to take them into account before you perform an upgrade.
-
-When upgrading from 22.10 and earlier, you will need to account for the following breaking changes:
-
-##### Clients must be authenticated by default
-
-We have disabled anonymous access to streams by default in this version. This means that read and write requests from clients need to be authenticated.
-
-If you see authentication errors when connecting to EventStoreDB after upgrading, please ensure that you are either using default credentials on the connection, or are providing user credentials with the request itself.
-
-If you want to revert back to the old behavior, you can enable the `AllowAnonymousStreamAccess` and `AllowAnonymousEndpointAccess` options in EventStoreDB.
-Like with anonymous access to streams, anonymous access to gRPC and protected HTTP endpoints has been disabled by default. The HTTP exceptions are `/-/liveness`, `/-/readiness`, static UI content, and redirects.
-
-Any tools or monitoring scripts still using legacy HTTP diagnostics endpoints must move to the supported metrics and gRPC monitoring surfaces in this release.
-
-##### PrepareCount and CommitCount options have been removed
-
-We have removed the `PrepareCount` and `CommitCount` options from EventStoreDB. EventStoreDB will now fail if these options are present in the config on startup.
-
-These options did not have any effect and can be safely removed from your configuration file if you have them defined.
-
-##### Persistent subscriptions config event has been renamed
-
-We have renamed the event type used to store a persistent subscriptions configuration from `PersistentConfig1` to `$PersistentConfig`. This event type is a system event, so naming it as such will allow certain filters to exclude it correctly.
-
-If you have any tools or clients relying on this event type, then you will need to update them before you upgrade.
-
-#### From 21.10 and earlier
-
-If you are upgrading from version 21.10 and earlier, then you need to be aware of a breaking change in the TCP proto:
-
-##### Proto2 upgraded to Proto3 (TCP)
-
-The server now uses Proto3 for messages sent over TCP. This affects replication between servers in a cluster.
-
-EventStoreDB nodes on version 22.10 cannot replicate data to version 21.10 and below, but older nodes can still replicate to version 22.10 and above.
-Follow the [upgrade procedure](#upgrade-procedure) and ensure that the Leader node is the last node to be upgraded to avoid any issues.
-
-##### Deprecated configuration options
-
-Several options are deprecated and slated for removal in future releases. See the table below for guidance.
-
-| Deprecated Option             | Use Instead                     |
-|:------------------------------|:--------------------------------|
-| `ExtIp`                       | `NodeIp`                        |
-| `ExtPort`                     | `NodePort`                      |
-| `HttpPortAdvertiseAs`         | `NodePortAdvertiseAs`           |
-| `ExtHostAdvertiseAs`          | `NodeHostAdvertiseAs`           |
-| `AdvertiseHttpPortToClientAs` | `AdvertiseNodePortToClientAs`   |
-| `IntIp`                       | `ReplicationIp`                 |
-| `IntTcpPort`                  | `ReplicationTcpPort`            |
-| `IntTcpPortAdvertiseAs`       | `ReplicationTcpPortAdvertiseAs` |
-| `IntHostAdvertiseAs`          | `ReplicationHostAdvertiseAs`    |
-| `IntTcpHeartbeatTimeout`      | `ReplicationHeartbeatTimeout`   |
-| `IntTcpHeartbeatInterval`     | `ReplicationHeartbeatInterval`  |
+Legacy usage telemetry is separate from OTLP observability. See
+[Usage telemetry](usage-telemetry.md) before running a node in an environment
+that should not make outbound telemetry calls.

--- a/docs/usage-telemetry.md
+++ b/docs/usage-telemetry.md
@@ -1,103 +1,37 @@
-# Usage telemetry
+# Usage Telemetry
 
-Starting with version 23.10 LTS, EventStoreDB has introduced a telemetry feature. This collects anonymous, aggregated usage statistics and sends them periodically to Event Store Ltd. Telemetry data helps us refine and improve our product based on real usage patterns.
+TrogonEventStore has two different observability concepts:
 
-## What is usage telemetry
+- OpenTelemetry and metrics, which operators explicitly configure for their own
+  monitoring systems.
+- Legacy usage telemetry, which is an inherited service and should not be
+  treated as the primary TrogonEventStore observability path.
 
-EventStoreDB telemetry only tracks non-Personally-Identifiable Information. Collected data does not allow Event Store to fingerprint the users by any of the collected data points.
+Use [OpenTelemetry integration](diagnostics/integrations.md) and
+[Metrics](diagnostics/metrics.md) for production instrumentation.
 
-Examples of the telemetry data collected:
+## Operator guidance
 
-* EventStoreDB version number
-* Cluster or instance size
-* Node machine size
-* Is cluster or instance configured in secure mode
-* Legacy TCP client protocol enabled
-* Number of running projections
-* Number of running persistent subscriptions
+If your environment should not send usage telemetry, set:
 
-What EventStoreDB **does not** track:
-
-* Stream names
-* Stream metadata
-* Event payloads
-* Event metadata
-* Usernames and passwords
-
-Here's an example of a full telemetry message from a single-node instance:
-
-```json
-{
-  "version": "23.10.0.0",
-  "tag": "v23.10.0",
-  "uptime": "00:01:11.0115732",
-  "cluster": {
-    "leaderId": "81e9ca2a-8acc-41ed-b9d0-65a652b36801",
-    "nodeId": "81e9ca2a-8acc-41ed-b9d0-65a652b36801",
-    "nodeState": "Leader"
-  },
-  "configuration": {
-    "clusterSize": 1,
-    "enableExternalTcp": true,
-    "insecure": false,
-    "runProjections": "None"
-  },
-  "database": {
-    "epochNumber": 29,
-    "firstEpochId": "b02f1ba6-98a3-473f-ade7-dcd1476b2149",
-    "activeChunkNumber": 2
-  },
-  "environment": {
-    "coreCount": 24,
-    "isContainer": false,
-    "isKubernetes": false,
-    "processorArchitecture": "X64",
-    "totalDiskSpace": 1000186310656,
-    "totalMemory": 68631052288
-  },
-  "gossip": {
-    "81e9ca2a-8acc-41ed-b9d0-65a652b36801": "Leader"
-  },
-  "persistentSubscriptions": {
-    "count": 0
-  },
-  "projections": {
-    "customProjectionCount": 0,
-    "standardProjectionCount": 5,
-    "customProjectionRunningCount": 0,
-    "standardProjectionRunningCount": 5,
-    "totalCount": 5,
-    "totalRunningCount": 5
-  }
-}
+```bash:no-line-numbers
+EVENTSTORE_TELEMETRY_OPTOUT=true
 ```
 
-## Disclosure
+The option name currently keeps the inherited `EVENTSTORE_` prefix for runtime
+compatibility.
 
-On startup, EventStoreDB produces a message to the console and to the diagnostic logs, which looks similar to:
+## What to use instead
 
-```
-Telemetry
----------
-EventStoreDB collects usage data in order to improve your experience. The data is anonymous and collected by Event Store Ltd.
-You can opt out of sending telemetry by setting the EVENTSTORE_TELEMETRY_OPTOUT environment variable to true.
-For more information visit https://eventstore.com/telemetry
-```
+For normal operations:
 
-If telemetry collection is disabled (see below), the disclosure is still shown with a different text:
+- Scrape Prometheus metrics from `/-/metrics`.
+- Export OTLP logs, metrics, and traces to your collector.
+- Use server logs for startup, shutdown, certificate, and cluster diagnostics.
+- Use the Admin UI for operator workflows.
 
-```
-Telemetry
----------
-EventStoreDB collects usage data in order to improve your experience. The data is anonymous and collected by EventStore Ltd.
-You have opted out of sending telemetry by setting the EVENTSTORE_TELEMETRY_OPTOUT environment variable to true.
-For more information visit https://eventstore.com/telemetry
-```
+## Future policy
 
-## Reporting frequency
-
-To avoid tracking short-lived instances (like containers used for tests), telemetry data is sent one hour after the cluster node starts. Following this, updates are sent every 24 hours. All transmissions are logged for transparency to the server console and in the log file.
-
-## How to opt out
-
-Telemetry transmission can be disabled by setting the `EVENTSTORE_TELEMETRY_OPTOUT` environment variable to `true`. EventStoreDB will still collect the information required to produce telemetry messages, and those messages will be produced to console and diagnostic log, but they will not be sent to Event Store Ltd.
+Usage telemetry should be revisited as a Trogon-owned product policy before it
+is documented as a recommended production feature. Until then, OTLP and metrics
+are the preferred observability surfaces.

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,149 +1,39 @@
 # What's New
 
-This page describes new features and other changes in EventStoreDB 24.6.
+This page summarizes the current TrogonEventStore documentation baseline. It is
+not a release-note mirror for another distribution.
 
-## New features
+## Current baseline
 
-- **Legacy TCP Client API plugin** <Badge type="warning" text="Commercial" vertical="middle" />
-- **macOS arm64 support for development purposes**
-- **Additional metrics**
+- TrogonEventStore is documented as a FOSS-only server distribution.
+- Application event access is documented as gRPC-first.
+- HTTP documentation is limited to browser UI, health probes, metrics, and
+  infrastructure concerns.
+- Health probes are exposed on `/-/liveness` and `/-/readiness`.
+- Prometheus scraping is exposed on `/-/metrics`.
+- OpenTelemetry documentation covers explicit OTLP export for logs, metrics,
+  and traces.
+- The Admin UI is the embedded Blazor UI served by the node.
+- User-defined projection execution, connector runtimes, SQL-like query
+  surfaces, and rich read models are documented as external component work by
+  default.
 
-### Legacy TCP Client API plugin <Badge type="warning" text="Commercial" vertical="middle" />
+## Recent documentation cleanup
 
-EventStoreDB v23.10 is the last release to natively support the legacy TCP-based client protocol.
-Version 24.2 removed it completely.
+The documentation has been consolidated around the current local product shape:
 
-This release introduces a new plugin that allows to connect to the database with the legacy TCP API.
-This is a stop-gap solution for customers who have not yet upgraded to the gRPC API.
+- Installation now focuses on source builds, local Docker images, and explicit
+  production configuration.
+- Upgrade guidance now focuses on safe local rollout practices instead of stale
+  historical release notes.
+- Security documentation now focuses on supported authentication methods and
+  avoids unsupported plugin surfaces.
+- Diagnostics documentation points operators to logs, metrics, and
+  OpenTelemetry rather than legacy HTTP management endpoints.
 
-Read more about enabling and configuration of the TCP API plugin in the [documentation](networking.md#external-tcp).
+## Compatibility note
 
-### Apple Silicon support for development
-
-An alpha build was available for running EventStoreDB on arm64 processors since EventStoreDB v22.10 using a [Docker image](https://hub.docker.com/r/eventstore/eventstore/tags?page=&page_size=&ordering=&name=arm64).
-
-Since version 24.6, EventStoreDB can now be built from source and executed on macOS with Apple Silicon.
-
-### Additional metrics
-
-Continuing the work on observability, the following [metrics](diagnostics/metrics.md) are now available.
-
-* [Election counter](diagnostics/metrics.md#elections-count): `eventstore_elections_count`
-* [Projections](diagnostics/metrics.md#projections).
-    * Projection status: `eventstore_projection_status`
-    * Percent progress: `eventstore_projection_progress`
-    * Events processed since restart: `eventstore_projection_events_processed_after_restart_total`
-* [Persistent Subscriptions](diagnostics/metrics.md#persistent-subscriptions):
-    * Connection count: `eventstore_persistent_sub_connections`
-    * Total in-flight messages : `eventstore_persistent_sub_in_flight_messages`
-    * Total number of parked messages: `eventstore_persistent_sub_parked_messages`
-    * Oldest Parked Message: `eventstore_persistent_sub_oldest_parked_message_seconds`
-    * Total Number of Item processed: `eventstore_persistent_sub_items_processed`
-    * Last Seen Message:
-        * `eventstore_persistent_sub_last_known_event_number`
-        * `eventstore_persistent_sub_last_known_event_commit_position`
-    * Last checkpoint event:
-        * `eventstore_persistent_sub_checkpointed_event_number`
-        * `eventstore_persistent_sub_checkpointed_event_commit_position`
-
-## Feature enhancements
-
-- **Performance improvements**
-- **X.509 authentication in client libraries**
-- **Metric support for Linux, FreeBSD, macOS**
-- **Allow specifying the status Code for health requests**
-- **Fix: Events in explicit transactions can be missing in `$all` reads**
-- **Miscellaneous**
-
-### Performance improvements
-
-Several performance and compatibility improvements have been made to EventStoreDB and client SDKs, described below.
-
-#### Reduced FileHandle usage by 80%
-
-The number of file handles used by the database has been reduced by 80%. On large databases it results in:
-* Reduced likelihood of hitting the default OS file handle limit
-* Lower overall memory footprint
-
-#### Faster Startup For Scavenged databases
-
-Large database with thousands of scavenged chunks now starts faster.
-A 10x improvement has been observed in testing.
-
-### X.509 authentication in client APIs <Badge type="warning" text="Commercial" vertical="middle" />
-
-Refer to the [user certificate documentation](security.md#connecting-with-a-user-certificate) for instructions on how to enable and use X.509 certificates with EventStoreDB clients.
-
-### Metrics support for Linux, FreeBSD, OSX
-
-The following [System metrics](diagnostics/metrics.md#system) are now available on the following platforms:
-* `eventstore_sys_load_avg`: Linux, FreeBSD, macOS, Windows
-* `eventstore_sys_cpu`: Linux, FreeBSD, macOS
-
-The following [Process metrics](diagnostics/metrics.md#process) are now available on the following platforms:
-* `eventstore_disk_io_bytes`: Linux, Windows and macOS
-
-### Health probe endpoints
-
-The HTTP health probes are exposed on `/-/liveness` and `/-/readiness`.
-
-Use `/-/liveness` when a platform needs to know whether the process is still alive, and `/-/readiness` when it needs to know whether the node is ready to accept traffic.
-
-### Fix - Events in explicit transactions can be missing from $all reads
-
-This bug only appears with events written in explicit transactions with the deprecated TCP API.
-They will not appear on filtered $all reads and subscriptions under specific circumstances.
-
-This [fix](https://github.com/EventStore/EventStore/pull/4251) will also be back ported to v23.10.2 and v22.10.6.
-
-### Miscellaneous
-
-* Index merge will now continue without bloom filters if there is not enough memory to store them.
-* Node advertise address is used for identifying nodes in the scavenge log.
-* Incomplete scavenges that previously got status `Failed` will now be marked as `Interrupted`.
-* Error will be logged when the node certificate does not have the necessary usages.
-* More information made available in the current database options API response.
-* Projections will now log a warning when the projection state size becomes greater than 8 MB.
-
-## Breaking changes
-
-### Persistent subscription checkpoint event type
-
-The persistent subscription checkpoint event type has been changed from `SubscriptionCheckpoint` to `$SubscriptionCheckpoint`.  
-Checkpoints written before upgrading will still have the old event type and will continue to work.
-
-### Deposed leader truncation: Two restarts needed
-
-Previously a deposed leader that needed offline truncation would:
-* Set a truncate checkpoint and shutdown
-* Upon restart, truncate its log and join the cluster
-
-The process is now:
-* Set a truncate checkpoint and shutdown
-* Upon restart, truncate its log, shutdown
-
-This will affect nodes that run under a Service Manager configured to disallow successive stops of the process, like [systemd](https://systemd.io/) with `StartLimitIntervalSec` and `StartLimitBurst`.
-
-### File-copy backup and restore: Two restarts needed
-
-Part of the file copy [backup and restore procedure](operations.md#simple-full-backup-restore) requires copying the chaser checkpoint file over the truncate checkpoint file.   
-This might trigger the database to truncate the log on startup.
-
-Previously the process was:
-* Set the truncate checkpoint
-* Start the node.
-
-The process is now:
-* Set the truncate checkpoint
-* Start the node
-    * if needed, the log will be truncated and the node will shut down
-* Start the node
-
-This will affect nodes that run under a Service Manager configured to disallow successive stops of the process, like [systemd](https://systemd.io/) with `StartLimitIntervalSec` and `StartLimitBurst`
-
-### Unbuffered config setting
-
-The `--unbuffered` config setting is deprecated and has no effect when set to `true`.
-This option was used to enable unbuffered and direct IO when writing to the file system, and it is no longer supported.
-
-You can read more about any breaking changes and what you should be aware of during an upgrade in the [Upgrade Guide](upgrade-guide.md).
+The server still uses some `EventStore` namespaces, configuration prefixes, and
+wire-compatible concepts internally. Those names are part of the inherited
+runtime and client compatibility surface. User-facing documentation should still
+describe the distribution as TrogonEventStore or TrogonDB.

--- a/samples/server/docker-compose-cluster.yaml
+++ b/samples/server/docker-compose-cluster.yaml
@@ -1,36 +1,28 @@
+# Before starting, provide certs/ca/ca.crt and node.crt/node.key under each node directory.
+# Each node certificate must include localhost, its service DNS name, and its configured replication IP in its
+# subject alternative names. The replication IPs are 172.30.240.11, 172.30.240.12, and 172.30.240.13.
+# Keep each node private key readable only by the account running the container.
 services:
-  setup:
-    image: eventstore/es-gencert-cli:1.0.2
-    entrypoint: bash
-    user: "1000:1000"
-    command: >
-      -c "mkdir -p ./certs && cd /certs
-      && es-gencert-cli create-ca
-      && es-gencert-cli create-node -out ./node1 -ip-addresses 127.0.0.1,172.30.240.11 -dns-names localhost
-      && es-gencert-cli create-node -out ./node2 -ip-addresses 127.0.0.1,172.30.240.12 -dns-names localhost
-      && es-gencert-cli create-node -out ./node3 -ip-addresses 127.0.0.1,172.30.240.13 -dns-names localhost
-      && find . -type f -print0 | xargs -0 chmod 666"
-    container_name: setup
-    volumes:
-      - ./certs:/certs
-
   node1.eventstore: &template
-    image: eventstore/eventstore:24.2.0-jammy
+    build:
+      context: ../..
     container_name: node1.eventstore
     env_file:
       - vars.env
     environment:
-      - EVENTSTORE_INT_IP=172.30.240.11
-      - EVENTSTORE_ADVERTISE_HTTP_PORT_TO_CLIENT_AS=2111
+      - EVENTSTORE_REPLICATION_IP=172.30.240.11
+      - EVENTSTORE_ADVERTISE_NODE_PORT_TO_CLIENT_AS=2111
       - EVENTSTORE_GOSSIP_SEED=172.30.240.12:2113,172.30.240.13:2113
       - EVENTSTORE_TRUSTED_ROOT_CERTIFICATES_PATH=/certs/ca
-      - EVENTSTORE_CERTIFICATE_FILE=/certs/node1/node.crt
-      - EVENTSTORE_CERTIFICATE_PRIVATE_KEY_FILE=/certs/node1/node.key
+      - EVENTSTORE_CERTIFICATE_FILE=/certs/node/node.crt
+      - EVENTSTORE_CERTIFICATE_PRIVATE_KEY_FILE=/certs/node/node.key
+      - EVENTSTORE_DEFAULT_ADMIN_PASSWORD=${EVENTSTORE_DEFAULT_ADMIN_PASSWORD:?set EVENTSTORE_DEFAULT_ADMIN_PASSWORD}
+      - EVENTSTORE_DEFAULT_OPS_PASSWORD=${EVENTSTORE_DEFAULT_OPS_PASSWORD:?set EVENTSTORE_DEFAULT_OPS_PASSWORD}
     healthcheck:
       test:
         [
           "CMD-SHELL",
-          "curl --fail --insecure https://node1.eventstore:2113/-/liveness || curl --fail http://node1.eventstore:2113/-/liveness || exit 1",
+          "curl --fail --cacert /certs/ca/ca.crt https://node1.eventstore:2113/-/liveness || exit 1",
         ]
       interval: 5s
       timeout: 5s
@@ -38,9 +30,10 @@ services:
     ports:
       - 2111:2113
     volumes:
-      - ./certs:/certs
-    depends_on:
-      - setup
+      - ./certs/ca:/certs/ca:ro
+      - ./certs/node1:/certs/node:ro
+      - node1-data:/var/lib/eventstore
+      - node1-logs:/var/log/eventstore
     restart: always
     networks:
       clusternetwork:
@@ -49,26 +42,31 @@ services:
   node2.eventstore:
     <<: *template
     container_name: node2.eventstore
-    env_file:
-      - vars.env
     environment:
-      - EVENTSTORE_INT_IP=172.30.240.12
-      - EVENTSTORE_ADVERTISE_HTTP_PORT_TO_CLIENT_AS=2112
+      - EVENTSTORE_REPLICATION_IP=172.30.240.12
+      - EVENTSTORE_ADVERTISE_NODE_PORT_TO_CLIENT_AS=2112
       - EVENTSTORE_GOSSIP_SEED=172.30.240.11:2113,172.30.240.13:2113
       - EVENTSTORE_TRUSTED_ROOT_CERTIFICATES_PATH=/certs/ca
-      - EVENTSTORE_CERTIFICATE_FILE=/certs/node2/node.crt
-      - EVENTSTORE_CERTIFICATE_PRIVATE_KEY_FILE=/certs/node2/node.key
+      - EVENTSTORE_CERTIFICATE_FILE=/certs/node/node.crt
+      - EVENTSTORE_CERTIFICATE_PRIVATE_KEY_FILE=/certs/node/node.key
+      - EVENTSTORE_DEFAULT_ADMIN_PASSWORD=${EVENTSTORE_DEFAULT_ADMIN_PASSWORD:?set EVENTSTORE_DEFAULT_ADMIN_PASSWORD}
+      - EVENTSTORE_DEFAULT_OPS_PASSWORD=${EVENTSTORE_DEFAULT_OPS_PASSWORD:?set EVENTSTORE_DEFAULT_OPS_PASSWORD}
     healthcheck:
       test:
         [
           "CMD-SHELL",
-          "curl --fail --insecure https://node2.eventstore:2113/-/liveness || curl --fail http://node2.eventstore:2113/-/liveness || exit 1",
+          "curl --fail --cacert /certs/ca/ca.crt https://node2.eventstore:2113/-/liveness || exit 1",
         ]
       interval: 5s
       timeout: 5s
       retries: 24
     ports:
       - 2112:2113
+    volumes:
+      - ./certs/ca:/certs/ca:ro
+      - ./certs/node2:/certs/node:ro
+      - node2-data:/var/lib/eventstore
+      - node2-logs:/var/log/eventstore
     networks:
       clusternetwork:
         ipv4_address: 172.30.240.12
@@ -77,30 +75,45 @@ services:
     <<: *template
     container_name: node3.eventstore
     environment:
-      - EVENTSTORE_INT_IP=172.30.240.13
-      - EVENTSTORE_ADVERTISE_HTTP_PORT_TO_CLIENT_AS=2113
+      - EVENTSTORE_REPLICATION_IP=172.30.240.13
+      - EVENTSTORE_ADVERTISE_NODE_PORT_TO_CLIENT_AS=2113
       - EVENTSTORE_GOSSIP_SEED=172.30.240.11:2113,172.30.240.12:2113
       - EVENTSTORE_TRUSTED_ROOT_CERTIFICATES_PATH=/certs/ca
-      - EVENTSTORE_CERTIFICATE_FILE=/certs/node3/node.crt
-      - EVENTSTORE_CERTIFICATE_PRIVATE_KEY_FILE=/certs/node3/node.key
+      - EVENTSTORE_CERTIFICATE_FILE=/certs/node/node.crt
+      - EVENTSTORE_CERTIFICATE_PRIVATE_KEY_FILE=/certs/node/node.key
+      - EVENTSTORE_DEFAULT_ADMIN_PASSWORD=${EVENTSTORE_DEFAULT_ADMIN_PASSWORD:?set EVENTSTORE_DEFAULT_ADMIN_PASSWORD}
+      - EVENTSTORE_DEFAULT_OPS_PASSWORD=${EVENTSTORE_DEFAULT_OPS_PASSWORD:?set EVENTSTORE_DEFAULT_OPS_PASSWORD}
     healthcheck:
       test:
         [
           "CMD-SHELL",
-          "curl --fail --insecure https://node3.eventstore:2113/-/liveness || curl --fail http://node3.eventstore:2113/-/liveness || exit 1",
+          "curl --fail --cacert /certs/ca/ca.crt https://node3.eventstore:2113/-/liveness || exit 1",
         ]
       interval: 5s
       timeout: 5s
       retries: 24
     ports:
       - 2113:2113
+    volumes:
+      - ./certs/ca:/certs/ca:ro
+      - ./certs/node3:/certs/node:ro
+      - node3-data:/var/lib/eventstore
+      - node3-logs:/var/log/eventstore
     networks:
       clusternetwork:
         ipv4_address: 172.30.240.13
 
+volumes:
+  node1-data:
+  node1-logs:
+  node2-data:
+  node2-logs:
+  node3-data:
+  node3-logs:
+
 networks:
   clusternetwork:
-    name: eventstoredb.local
+    name: trogoneventstore.local
     driver: bridge
     ipam:
       driver: default

--- a/samples/server/docker-compose.yaml
+++ b/samples/server/docker-compose.yaml
@@ -1,11 +1,13 @@
 services:
   eventstore.db:
-    image: eventstore/eventstore:24.2.0-jammy
+    build:
+      context: ../..
     environment:
       - EVENTSTORE_CLUSTER_SIZE=1
       - EVENTSTORE_RUN_PROJECTIONS=All
       - EVENTSTORE_START_STANDARD_PROJECTIONS=true
       - EVENTSTORE_NODE_PORT=2113
+      # Local development only: Insecure disables TLS, authentication, and authorization.
       - EVENTSTORE_INSECURE=true
     ports:
       - "2113:2113"


### PR DESCRIPTION
- Keeps the documentation focused on the local FOSS distribution instead of stale release and proprietary-feature guidance.
- Reduces operator confusion around supported install, protocol, auth, telemetry, and diagnostics surfaces.
- Consolidates deferred documentation cleanup into one reviewable pass without copying external release notes.