### PR TITLE
chore(deps): reduce patch-level dependency drift

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="EventStore.Client.Grpc.Streams" Version="23.3.9" />
     <!--Version 8 and beyond are free for open-source projects and non-commercial use, but commercial use requires a paid license-->
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
-    <PackageVersion Include="AWSSDK.Core" Version="4.0.100.4" />
+    <PackageVersion Include="AWSSDK.Core" Version="4.0.100.6" />
     <PackageVersion Include="FluentStorage.AWS" Version="7.1.1" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.4">
       <PrivateAssets>all</PrivateAssets>
@@ -34,22 +34,18 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2026.2.0" />
     <PackageVersion Include="Jint" Version="4.12.0" />
     <PackageVersion Include="librdkafka.redist" Version="2.15.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.10" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
-    <!--
-      NOTE: Do not upgrade beyond version 1.1.1
-      Newer versions mark 'XUnitVerifier' as obsolete, which breaks existing tests.
-    -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
-    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.10" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.4" />
     <PackageVersion Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.661903" />
-    <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.4" />
+    <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.5" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.10" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.2" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.19.2" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
@@ -81,10 +77,10 @@
     <PackageVersion Include="Serilog.Sinks.TextWriter" Version="3.0.0" />
     <PackageVersion Include="SharpDotYaml.Extensions.Configuration" Version="0.4.0" />
     <PackageVersion Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.25306.1" />
-    <PackageVersion Include="System.ComponentModel.Composition" Version="10.0.9" />
-    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="10.0.9" />
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.9" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+    <PackageVersion Include="System.ComponentModel.Composition" Version="10.0.10" />
+    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="10.0.10" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.10" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageVersion Include="System.ServiceModel.Http" Version="10.0.652802" />
     <PackageVersion Include="TrogonEventStore.Plugins" Version="24.10.10" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/src/EventStore.SourceGenerators.Tests/EventStore.SourceGenerators.Tests.csproj
+++ b/src/EventStore.SourceGenerators.Tests/EventStore.SourceGenerators.Tests.csproj
@@ -26,7 +26,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="GitHubActionsTestLogger" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="Newtonsoft.Json" />

--- a/src/EventStore.SourceGenerators.Tests/Messaging/CSharpSourceGeneratorVerifier.cs
+++ b/src/EventStore.SourceGenerators.Tests/Messaging/CSharpSourceGeneratorVerifier.cs
@@ -3,7 +3,7 @@ using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Testing;
 
 namespace EventStore.SourceGenerators.Tests.Messaging;
 
@@ -12,7 +12,7 @@ public static class CSharpSourceGeneratorVerifier<TSourceGenerator>
 	where TSourceGenerator : ISourceGenerator, new()
 {
 
-	public class Test : CSharpSourceGeneratorTest<TSourceGenerator, XUnitVerifier>
+	public class Test : CSharpSourceGeneratorTest<TSourceGenerator, DefaultVerifier>
 	{
 		public Test()
 		{


### PR DESCRIPTION
- Patch drift delays maintenance and security fixes without adding meaningful stability.
- Keeping low-risk dependencies current reduces the size and uncertainty of future migrations.
- Supported test infrastructure avoids relying on an obsolete framework-specific verification path.