### PR TITLE
chore(deps): reduce observability dependency drift

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -43,7 +43,7 @@
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.4" />
     <PackageVersion Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.661903" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.5" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.8.0" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.10" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.2" />
@@ -56,11 +56,11 @@
     <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />
     <PackageVersion Include="NUnit" Version="3.14.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.16.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.17.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
     <PackageVersion Include="Quickenshtein" Version="1.5.1" />
     <PackageVersion Include="Scrutor" Version="7.0.0" />
     <PackageVersion Include="Serilog" Version="4.4.0" />

--- a/src/EventStore.Core.Tests/Services/Transport/Http/http_service_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/http_service_should.cs
@@ -97,6 +97,24 @@ public class http_service_should : SpecificationWithDirectory
 		Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
 		Assert.That(result.Content.Headers.ContentType?.MediaType, Is.EqualTo("text/plain"));
 	}
+
+	[Test]
+	[Category("Network")]
+	public async Task serve_openmetrics_when_requested()
+	{
+		await using var node = new MiniNode<LogFormat.V2, string>(PathName);
+		await node.Start();
+
+		var request = new HttpRequestMessage(HttpMethod.Get, "/-/metrics");
+		request.Headers.Accept.ParseAdd("application/openmetrics-text; version=1.0.0");
+
+		var result = await node.HttpClient.SendAsync(request);
+		var body = await result.Content.ReadAsStringAsync();
+
+		Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
+		Assert.That(result.Content.Headers.ContentType?.MediaType, Is.EqualTo("application/openmetrics-text"));
+		Assert.That(body, Does.EndWith("# EOF\n"));
+	}
 }
 
 [TestFixture]


### PR DESCRIPTION
- Stale observability dependencies delay exporter correctness and interoperability fixes.
- Keeping telemetry components aligned reduces incompatibility risk across tracing and metrics.
- Explicit scrape-contract coverage protects monitoring integrations as the exporter evolves.