### PR TITLE
fix(telemetry): align resource identity across signals

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/OpenTelemetry/TelemetryServiceIdentityTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/OpenTelemetry/TelemetryServiceIdentityTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+using EventStore.Common.Utils;
+using EventStore.Core.Diagnostics;
+using FluentAssertions;
+using TrogonEventStore.SemanticConventions;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.OpenTelemetry;
+
+public class TelemetryServiceIdentityTests
+{
+	[Fact]
+	public void UsesTheSameIdentityForAttributeDictionariesAndResources()
+	{
+		var identity = TelemetryServiceIdentity.ForComponent("test-node");
+		var dictionary = identity.CreateAttributeDictionary();
+		var resource = identity.CreateResourceBuilder().Build().Attributes
+			.ToDictionary(attribute => attribute.Key, attribute => attribute.Value);
+
+		dictionary.Should().Contain(AttributeNames.ServiceName, "eventstore");
+		dictionary.Should().Contain(AttributeNames.ServiceInstanceId, "test-node");
+		dictionary.Should().Contain(AttributeNames.ServiceVersion, VersionInfo.Version);
+		resource.Should().Contain(dictionary);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData(" ")]
+	public void RejectsMissingComponentNames(string componentName)
+	{
+		var action = () => TelemetryServiceIdentity.ForComponent(componentName);
+
+		action.Should().Throw<ArgumentException>();
+	}
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -25,6 +25,7 @@ using EventStore.Core.Certificates;
 using EventStore.Core.Cluster;
 using EventStore.Core.Data;
 using EventStore.Core.DataStructures;
+using EventStore.Core.Diagnostics;
 using EventStore.Core.Helpers;
 using EventStore.Core.Index;
 using EventStore.Core.Index.Hashes;
@@ -1761,6 +1762,7 @@ public class ClusterVNode<TStreamId> :
 			options.Interface.DisableStatsOnHttp,
 			configuration,
 			trackers,
+			TelemetryServiceIdentity.ForComponent(options.GetComponentName()),
 			nodeInformationProvider,
 			options.Cluster.DiscoverViaDns ? options.Cluster.ClusterDns : null,
 			ConfigureNodeServices,

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -7,6 +7,7 @@ using EventStore.Common.Configuration;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Configuration;
+using EventStore.Core.Diagnostics;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Services.Transport.Grpc;
@@ -27,7 +28,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
-using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using ClientGossip = EventStore.Core.Services.Transport.Grpc.Gossip;
 using ClusterGossip = EventStore.Core.Services.Transport.Grpc.Cluster.Gossip;
@@ -51,6 +51,7 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 	private readonly IExpiryStrategy _expiryStrategy;
 	private readonly IConfiguration _configuration;
 	private readonly Trackers _trackers;
+	private readonly TelemetryServiceIdentity _telemetryServiceIdentity;
 	private readonly NodeHealthState _nodeHealthState;
 	private readonly NodeInformationProvider _nodeInformationProvider;
 	private readonly bool _disableHttpMetrics;
@@ -73,6 +74,7 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 		bool disableHttpMetrics,
 		IConfiguration configuration,
 		Trackers trackers,
+		TelemetryServiceIdentity telemetryServiceIdentity,
 		NodeInformationProvider nodeInformationProvider,
 		string clusterDns,
 		Func<IServiceCollection, IServiceCollection> configureNodeServices,
@@ -106,6 +108,8 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 		_disableHttpMetrics = disableHttpMetrics;
 		_configuration = configuration;
 		_trackers = trackers;
+		_telemetryServiceIdentity = telemetryServiceIdentity ??
+			throw new ArgumentNullException(nameof(telemetryServiceIdentity));
 		_nodeInformationProvider =
 			nodeInformationProvider ?? throw new ArgumentNullException(nameof(nodeInformationProvider));
 		_clusterDns = clusterDns;
@@ -225,8 +229,15 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 			.AddSingleton<ServerFeatures>()
 
 			.AddOpenTelemetry()
-			.WithMetrics(meterOptions => ConfigureMetrics(meterOptions, metricsConfiguration, _configuration))
-			.WithTracing(tracerOptions => ConfigureTracing(tracerOptions, _configuration))
+			.WithMetrics(meterOptions => ConfigureMetrics(
+				meterOptions,
+				metricsConfiguration,
+				_configuration,
+				_telemetryServiceIdentity))
+			.WithTracing(tracerOptions => ConfigureTracing(
+				tracerOptions,
+				_configuration,
+				_telemetryServiceIdentity))
 			.Services
 			.AddGrpcHealthChecks(options =>
 			{
@@ -285,10 +296,11 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 	private static void ConfigureMetrics(
 		MeterProviderBuilder meterOptions,
 		MetricsConfiguration metricsConfiguration,
-		IConfiguration configuration)
+		IConfiguration configuration,
+		TelemetryServiceIdentity serviceIdentity)
 	{
 		meterOptions
-			.SetResourceBuilder(CreateResourceBuilder())
+			.SetResourceBuilder(serviceIdentity.CreateResourceBuilder())
 			.AddMeter(metricsConfiguration.Meters)
 			.AddView(i =>
 			{
@@ -377,9 +389,10 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 
 	private static void ConfigureTracing(
 		TracerProviderBuilder tracerOptions,
-		IConfiguration configuration)
+		IConfiguration configuration,
+		TelemetryServiceIdentity serviceIdentity)
 	{
-		tracerOptions.SetResourceBuilder(CreateResourceBuilder());
+		tracerOptions.SetResourceBuilder(serviceIdentity.CreateResourceBuilder());
 
 		if (!configuration.OtlpTracesEnabled())
 		{
@@ -393,11 +406,6 @@ public class ClusterVNodeStartup<TStreamId> : IInternalStartup, IHandle<SystemMe
 				OpenTelemetryConfiguration.OtlpTracesOtlpPrefix,
 				exporterOptions));
 	}
-
-	private static ResourceBuilder CreateResourceBuilder() =>
-		ResourceBuilder.CreateDefault().AddService(
-			serviceName: "eventstore",
-			serviceVersion: VersionInfo.Version);
 
 	public void Handle(SystemMessage.SystemReady _) => _nodeHealthState.MarkReady();
 

--- a/src/EventStore.Core/Diagnostics/TelemetryServiceIdentity.cs
+++ b/src/EventStore.Core/Diagnostics/TelemetryServiceIdentity.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using EventStore.Common.Utils;
+using OpenTelemetry.Resources;
+using TrogonEventStore.SemanticConventions;
+
+namespace EventStore.Core.Diagnostics;
+
+public sealed record TelemetryServiceIdentity
+{
+	private const string DefaultServiceName = "eventstore";
+
+	public string ServiceName { get; }
+	public string ServiceInstanceId { get; }
+	public string ServiceVersion { get; }
+
+	private TelemetryServiceIdentity(string name, string instanceId, string version)
+	{
+		ServiceName = name;
+		ServiceInstanceId = instanceId;
+		ServiceVersion = version;
+	}
+
+	public static TelemetryServiceIdentity ForComponent(string componentName)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(componentName);
+		return new TelemetryServiceIdentity(DefaultServiceName, componentName, VersionInfo.Version);
+	}
+
+	public Dictionary<string, object> CreateAttributeDictionary() =>
+		new(GetAttributes());
+
+	public ResourceBuilder CreateResourceBuilder() =>
+		ResourceBuilder.CreateDefault().AddAttributes(GetAttributes());
+
+	private IEnumerable<KeyValuePair<string, object>> GetAttributes()
+	{
+		yield return new KeyValuePair<string, object>(AttributeNames.ServiceName, ServiceName);
+		yield return new KeyValuePair<string, object>(AttributeNames.ServiceInstanceId, ServiceInstanceId);
+		yield return new KeyValuePair<string, object>(AttributeNames.ServiceVersion, ServiceVersion);
+	}
+}

--- a/src/EventStore.Core/Log/OpenTelemetryLogger.cs
+++ b/src/EventStore.Core/Log/OpenTelemetryLogger.cs
@@ -1,14 +1,12 @@
 using System;
-using System.Collections.Generic;
-using EventStore.Common.Utils;
 using EventStore.Core.Configuration;
+using EventStore.Core.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
 using Serilog;
 using Serilog.Filters;
 using Serilog.Sinks.OpenTelemetry;
-using TrogonEventStore.SemanticConventions;
 
 namespace EventStore.Common.Log;
 
@@ -18,6 +16,17 @@ public static class OpenTelemetryLogger
 		this LoggerConfiguration loggerConfiguration,
 		IConfiguration configuration,
 		string componentName,
+		Action<OtlpExporterOptions> configureOtlp = null) =>
+		AddOpenTelemetryLogger(
+			loggerConfiguration,
+			configuration,
+			TelemetryServiceIdentity.ForComponent(componentName),
+			configureOtlp);
+
+	private static LoggerConfiguration AddOpenTelemetryLogger(
+		LoggerConfiguration loggerConfiguration,
+		IConfiguration configuration,
+		TelemetryServiceIdentity serviceIdentity,
 		Action<OtlpExporterOptions> configureOtlp = null)
 	{
 		if (configuration is null || !configuration.OtlpLogsEnabled())
@@ -36,12 +45,7 @@ public static class OpenTelemetryLogger
 			.Filter.ByExcluding(Matching.FromSource("REGULAR-STATS-LOGGER"))
 			.WriteTo.OpenTelemetry(options =>
 			{
-				options.ResourceAttributes = new Dictionary<string, object>
-				{
-					[AttributeNames.ServiceName] = "eventstore",
-					[AttributeNames.ServiceInstanceId] = componentName,
-					[AttributeNames.ServiceVersion] = VersionInfo.Version
-				};
+				options.ResourceAttributes = serviceIdentity.CreateAttributeDictionary();
 				options.Protocol = otlpExporterConfig.Protocol switch
 				{
 					OtlpExportProtocol.Grpc => OtlpProtocol.Grpc,


### PR DESCRIPTION
- Operators need logs, metrics, and traces to identify the same node consistently during incident correlation.
- A single resource contract prevents signal-specific identity drift as instrumentation expands.