### PR TITLE
fix(telemetry): report current meter scope version

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/OpenTelemetry/TelemetryMeterFactoryTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/OpenTelemetry/TelemetryMeterFactoryTests.cs
@@ -1,5 +1,5 @@
 using System;
-using EventStore.Common.Utils;
+using System.Reflection;
 using EventStore.Core.Diagnostics;
 using FluentAssertions;
 using Xunit;
@@ -12,9 +12,12 @@ public class TelemetryMeterFactoryTests
 	public void UsesTheCurrentServerVersionForTheInstrumentationScope()
 	{
 		using var meter = TelemetryMeterFactory.Create("test-scope");
+		var informationalVersion = typeof(TelemetryMeterFactory).Assembly
+			.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
+			.InformationalVersion;
 
 		meter.Name.Should().Be("test-scope");
-		meter.Version.Should().Be(VersionInfo.Version);
+		meter.Version.Should().Be(informationalVersion.Split('+', 2)[0]);
 	}
 
 	[Theory]

--- a/src/EventStore.Core.XUnit.Tests/OpenTelemetry/TelemetryMeterFactoryTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/OpenTelemetry/TelemetryMeterFactoryTests.cs
@@ -1,0 +1,30 @@
+using System;
+using EventStore.Common.Utils;
+using EventStore.Core.Diagnostics;
+using FluentAssertions;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.OpenTelemetry;
+
+public class TelemetryMeterFactoryTests
+{
+	[Fact]
+	public void UsesTheCurrentServerVersionForTheInstrumentationScope()
+	{
+		using var meter = TelemetryMeterFactory.Create("test-scope");
+
+		meter.Name.Should().Be("test-scope");
+		meter.Version.Should().Be(VersionInfo.Version);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData(" ")]
+	public void RejectsMissingInstrumentationScopeNames(string instrumentationScopeName)
+	{
+		var action = () => TelemetryMeterFactory.Create(instrumentationScopeName);
+
+		action.Should().Throw<ArgumentException>();
+	}
+}

--- a/src/EventStore.Core/Diagnostics/TelemetryMeterFactory.cs
+++ b/src/EventStore.Core/Diagnostics/TelemetryMeterFactory.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Diagnostics.Metrics;
+using EventStore.Common.Utils;
+
+namespace EventStore.Core.Diagnostics;
+
+public static class TelemetryMeterFactory
+{
+	public static Meter Create(string instrumentationScopeName)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(instrumentationScopeName);
+		return new Meter(instrumentationScopeName, VersionInfo.Version);
+	}
+}

--- a/src/EventStore.Core/Diagnostics/TelemetryMeterFactory.cs
+++ b/src/EventStore.Core/Diagnostics/TelemetryMeterFactory.cs
@@ -1,14 +1,29 @@
 using System;
 using System.Diagnostics.Metrics;
-using EventStore.Common.Utils;
+using System.Reflection;
 
 namespace EventStore.Core.Diagnostics;
 
 public static class TelemetryMeterFactory
 {
+	private static readonly string InstrumentationScopeVersion = GetInstrumentationScopeVersion();
+
 	public static Meter Create(string instrumentationScopeName)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(instrumentationScopeName);
-		return new Meter(instrumentationScopeName, VersionInfo.Version);
+		return new Meter(instrumentationScopeName, InstrumentationScopeVersion);
+	}
+
+	private static string GetInstrumentationScopeVersion()
+	{
+		var informationalVersion = typeof(TelemetryMeterFactory).Assembly
+			.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+			.InformationalVersion;
+		if (string.IsNullOrWhiteSpace(informationalVersion))
+		{
+			throw new InvalidOperationException("The telemetry assembly has no informational version.");
+		}
+
+		return informationalVersion.Split('+', 2)[0];
 	}
 }

--- a/src/EventStore.Core/MetricsBootstrapper.cs
+++ b/src/EventStore.Core/MetricsBootstrapper.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Metrics;
 using System.Linq;
 using EventStore.Core.Bus;
+using EventStore.Core.Diagnostics;
 using EventStore.Core.Index;
 using EventStore.Core.Metrics;
 using EventStore.Core.Services.VNode;
@@ -84,7 +84,7 @@ public static class MetricsBootstrapper
 			return;
 		}
 
-		var coreMeter = new Meter("EventStore.Core", version: "1.0.0");
+		var coreMeter = TelemetryMeterFactory.Create("EventStore.Core");
 		var statusMetric = new StatusMetric(coreMeter, "eventstore-statuses");
 		var grpcMethodMetric = new DurationMetric(coreMeter, "eventstore-grpc-method-duration");
 		var gossipLatencyMetric = new DurationMetric(coreMeter, "eventstore-gossip-latency");

--- a/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Threading.Tasks;
 using DotNext;
@@ -9,6 +8,7 @@ using EventStore.Common.Options;
 using EventStore.Core;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
+using EventStore.Core.Diagnostics;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.AwakeReaderService;
@@ -205,7 +205,7 @@ public sealed class ProjectionsSubsystem : ISubsystem,
 			return;
 		}
 
-		var projectionMeter = new Meter("EventStore.Projections.Core", version: "1.0.0");
+		var projectionMeter = TelemetryMeterFactory.Create("EventStore.Projections.Core");
 
 		var tracker = new ProjectionTracker();
 		_projectionTracker = tracker;


### PR DESCRIPTION
- Telemetry consumers need instrumentation scope metadata to identify the release that produced each metric stream.
- A stale scope version obscures release correlation across core and projection diagnostics.