### PR TITLE
fix(transaction-log): prevent retry format drift

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/PrepareLogRecordTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/LogRecords/PrepareLogRecordTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using DotNext.Buffers;
+using DotNext.IO;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.LogCommon;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.TransactionLog.LogRecords;
+
+public class PrepareLogRecordTests
+{
+	[Theory]
+	[InlineData(LogRecordVersion.LogRecordV0)]
+	[InlineData(LogRecordVersion.LogRecordV1)]
+	public void copy_for_retry_preserves_record_version(byte version)
+	{
+		var record = new PrepareLogRecord(
+			logPosition: 100,
+			correlationId: Guid.NewGuid(),
+			eventId: Guid.NewGuid(),
+			transactionPosition: 100,
+			transactionOffset: 0,
+			eventStreamId: "stream",
+			eventStreamIdSize: null,
+			expectedVersion: 0,
+			timeStamp: DateTime.UtcNow,
+			flags: PrepareFlags.SingleWrite,
+			eventType: "event-type",
+			eventTypeSize: null,
+			data: new byte[] { 1, 2, 3 },
+			metadata: new byte[] { 4, 5, 6 },
+			prepareRecordVersion: version);
+
+		var retry = record.CopyForRetry(logPosition: 200, transactionPosition: 200);
+
+		Assert.Equal(version, retry.Version);
+
+		var writer = new BufferWriterSlim<byte>();
+		retry.WriteTo(ref writer);
+
+		using var recordBuffer = writer.DetachOrCopyBuffer();
+		var reader = new SequenceReader(new(recordBuffer.Memory));
+		var parsed = Assert.IsType<PrepareLogRecord>(LogRecord.ReadFrom(ref reader));
+
+		Assert.Equal(version, parsed.Version);
+	}
+}

--- a/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
@@ -240,7 +240,8 @@ public sealed class PrepareLogRecord : LogRecord, IEquatable<PrepareLogRecord>, 
 			eventType: EventType,
 			eventTypeSize: _eventTypeSize,
 			data: _dataOnDisk,
-			metadata: Metadata);
+			metadata: Metadata,
+			prepareRecordVersion: Version);
 	}
 
 	public override void WriteTo(ref BufferWriterSlim<byte> writer)


### PR DESCRIPTION
- Retried prepares must retain their persisted format so chunk-boundary rewrites cannot silently change record encoding.